### PR TITLE
tar up the right directory

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -26,7 +26,7 @@ deploy:
 
     - script:
       name: bundle static files
-      code: tar -cvzf sdui.tgz ${WERCKER_OUTPUT_DIR}/dist
+      code: tar -cvzf sdui.tgz ${WERCKER_ROOT}/dist
 
     - script:
       name: get highest version from tags


### PR DESCRIPTION
hopefully root is more accurate than output_dir. If this doesn't work, we'll rework the `ember build` command.