### PR TITLE
Add phantomjs to devdeps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,13 @@
-FROM nginx
+FROM nginx:stable-alpine
 WORKDIR /usr/share/nginx/html
 RUN set -x \
+   # Missing https for some magic reason
+   && apk add --no-cache --update ca-certificates \
+   && apk add --virtual .build-dependencies wget \
    && wget $(wget -q -O - https://api.github.com/repos/screwdriver-cd/ui/releases/latest \
        | awk '/browser_download_url/ { print $2 }' \
        | sed 's/"//g') \
    && tar -xvzf sdui.tgz \
-   && rm -rf sdui.tgz
+   && rm -rf sdui.tgz \
+   # Cleanup packages
+   && apk del --purge .build-dependencies

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
-    "loader.js": "^4.0.1"
+    "loader.js": "^4.0.1",
+    "phantomjs-prebuilt": "^2.1.12"
   }
 }

--- a/wercker.yml
+++ b/wercker.yml
@@ -4,7 +4,6 @@ build:
   steps:
     - npm-install
     - thangngoc89/bower-install@0.5.8
-    - aussiegeek/install-phantomjs@0.0.4
     - npm-test
     # Production asset build
     - thriqon/ember-build@0.1.1
@@ -26,7 +25,7 @@ deploy:
 
     - script:
       name: bundle static files
-      code: tar -cvzf sdui.tgz ${WERCKER_ROOT}/dist
+      code: tar -C ${WERCKER_ROOT}/dist -cvzf sdui.tgz .
 
     - script:
       name: get highest version from tags


### PR DESCRIPTION
* The wercker step to install phantomjs is unreliable. Made it a devdep.
* use alpine linux version of nginx (it is tiny)
* fix missing wget and tarfile generation