### PR TITLE
Add nginx configuration for ember

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM nginx:stable-alpine
+COPY nginx.conf /etc/nginx/nginx.conf
 WORKDIR /usr/share/nginx/html
 RUN set -x \
    # Missing https for some magic reason

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,38 @@
+user  nginx;
+worker_processes  1;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    server {
+        listen 80;
+        server_name localhost;
+        root /usr/share/nginx/html;
+
+        location / {
+            index index.html;
+            try_files $uri $uri/ /index.html?/$request_uri;
+        }
+    }
+}


### PR DESCRIPTION
Ember does its own routing, so nginx needs to be configured to let it do so. This is a copy of the original config https://github.com/nginxinc/docker-nginx/blob/master/mainline/alpine/nginx.conf with our server config added.