### PR TITLE
Bower needs a flag to install as root

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,9 +1,9 @@
 shared:
-    image: node:4
+    image: node:6
 
 jobs:
     main:
         steps:
             - install: npm install
-            - bower: npm install bower && ./node_modules/.bin/bower install
+            - bower: npm install bower && ./node_modules/.bin/bower install --allow-root
             - test: npm test


### PR DESCRIPTION
Also the UI test container needs to run in node:6. Ember is transpiled with babel down to a browser-level after testing. 