### PR TITLE
stupid implementation of builds page for pipelines

### DIFF
--- a/app/components/pipeline-build-view/component.js
+++ b/app/components/pipeline-build-view/component.js
@@ -1,0 +1,14 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  truncatedSha: Ember.computed('build.sha', {
+    get() {
+      return this.get('build.sha').substr(0, 6);
+    }
+  }),
+  jobName: Ember.computed('build.jobId', {
+    get() {
+      return this.get('jobs').filter(j => j.get('id') === this.get('build.jobId'))[0].get('name');
+    }
+  })
+});

--- a/app/components/pipeline-build-view/styles.scss
+++ b/app/components/pipeline-build-view/styles.scss
@@ -1,0 +1,15 @@
+& {
+  border-radius: 3px;
+  border: 1px solid #ddd;
+  background-color: #eee;
+  margin: 10px 10px 0;
+  padding: 10px;
+  width: 30%;
+  display: inline-block;
+}
+
+h6 {
+  margin: 0;
+  padding: 0;
+  font-size: 125%;
+}

--- a/app/components/pipeline-build-view/template.hbs
+++ b/app/components/pipeline-build-view/template.hbs
@@ -1,0 +1,19 @@
+<div class="pure-g">
+  <div class="pure-u-1-5">
+    <h6>{{#link-to "build" build.id}}{{truncatedSha}}{{/link-to}}</h6>
+  </div>
+  <div class="pure-u-1-5">
+    <span class="job">{{jobName}}</span>
+  </div>
+  <div class="pure-u-2-5">
+    <span class="cause">{{build.cause}}</span>
+  </div>
+  <div class="pure-u-1-5">
+    <span class="created">Started: {{moment-from-now build.createTime}}</span>
+  </div>
+  <div class="pure-u-1-1">
+    <span class="duration">Duration: {{moment-duration build.buildDuration}}</span>
+  </div>
+</div>
+
+{{yield}}

--- a/app/job/adapter.js
+++ b/app/job/adapter.js
@@ -1,0 +1,16 @@
+import Adapter from '../application/adapter';
+export default Adapter.extend({
+  handleResponse: (status, headers, payload, requestData) => {
+    let data = payload;
+
+    // Fix our API not returning the model name in payload
+    if (data && Array.isArray(data)) {
+      data = { jobs: data };
+    } else if (data) {
+      data = { job: data };
+    }
+
+    // Pass-through to super-class
+    return Adapter.prototype.handleResponse(status, headers, data, requestData);
+  }
+});

--- a/app/job/model.js
+++ b/app/job/model.js
@@ -1,0 +1,8 @@
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  pipelineId: DS.attr('string'),
+  name: DS.attr('string'),
+  state: DS.attr('string'),
+  permutations: DS.attr()
+});

--- a/app/pipeline/adapter.js
+++ b/app/pipeline/adapter.js
@@ -1,15 +1,33 @@
 import Adapter from '../application/adapter';
 export default Adapter.extend({
   handleResponse: (status, headers, payload, requestData) => {
-    let data = payload;
+    let data = {};
+    let key = 'pipeline';
+
+    // Unfortunately, because of the way findHasMany works with links,
+    // the parent adapter is used to parse the response instead of the adapter for the record(s) retrieved.
+    // This would be completely unnecessary if the api returned either the ids of the items we are looking for,
+    // or we had a JSONAPI response format
+    if (/\/jobs$/.test(requestData.url)) {
+      key = 'job';
+    }
+
+    if (/\/secrets$/.test(requestData.url)) {
+      key = 'secret';
+    }
 
     // Fix our API not returning the model name in payload
-    if (data && Array.isArray(data)) {
-      data = { pipelines: data };
-    } else if (data) {
-      // Give a link to load secrets from server (will resolve to 'pipelines/:id/secrets')
-      data.links = { secrets: 'secrets' };
-      data = { pipeline: data };
+    if (payload && Array.isArray(payload)) {
+      data[`${key}s`] = payload;
+    } else if (payload) {
+      data[key] = payload;
+      // Give a link to load secrets from server (will resolve to e.g. 'pipelines/:id/secrets')
+      if (key === 'pipeline') {
+        data[key].links = {
+          secrets: 'secrets',
+          jobs: 'jobs'
+        };
+      }
     }
 
     // Pass-through to super-class

--- a/app/pipeline/index/route.js
+++ b/app/pipeline/index/route.js
@@ -1,0 +1,21 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  beforeModel() {
+    this.set('pipeline', this.modelFor('pipeline'));
+  },
+  model() {
+    // Get the jobs in this pipeline, and ALL builds (since there's no jobs/:id/builds, yet)
+    return Ember.RSVP.all([this.get('pipeline.jobs'), this.store.findAll('build')])
+      .then(([jobs, builds]) => {
+        // get a list of job ids for active jobs
+        const jobIds = jobs.filter(j => j.state !== 'DISABLED').map(j => j.get('id'));
+
+        // return a list of builds that are related to those job ids
+        return {
+          builds: builds.filter(b => jobIds.contains(b.get('jobId'))),
+          jobs
+        };
+      });
+  }
+});

--- a/app/pipeline/index/template.hbs
+++ b/app/pipeline/index/template.hbs
@@ -1,0 +1,5 @@
+{{#each model.builds as |build|}}
+{{pipeline-build-view build=build jobs=model.jobs}}
+{{/each}}
+
+{{outlet}}

--- a/app/pipeline/model.js
+++ b/app/pipeline/model.js
@@ -7,6 +7,7 @@ export default DS.Model.extend({
   createTime: DS.attr('date'),
   admins: DS.attr(),
   secrets: DS.hasMany('secret', { async: true }),
+  jobs: DS.hasMany('job', { async: true }),
   repoData: Ember.computed('scmUrl', {
     get() {
       const http = /^http[s]?:\/\/([^/]+)\/([^/]+)\/([^/]+)\.git#?(.*)?/;

--- a/tests/integration/components/pipeline-build-view/component-test.js
+++ b/tests/integration/components/pipeline-build-view/component-test.js
@@ -1,0 +1,37 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import Ember from 'ember';
+
+moduleForComponent('pipeline-build-view', 'Integration | Component | pipeline build view', {
+  integration: true
+});
+
+test('it renders', function (assert) {
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+  const now = 1472244582531;
+  const buildMock = {
+    jobId: 'abcd',
+    sha: '12345678901234567890',
+    cause: 'bananas',
+    buildContainer: 'node:6',
+    createTime: now - 180000,
+    startTime: now - 175000,
+    endTime: now,
+    buildDuration: 175,
+    queuedDuration: 5
+  };
+  const jobs = [
+    Ember.Object.create({ id: 'abcd', name: 'hello' }),
+    Ember.Object.create({ id: 'efgh', name: 'world' })
+  ];
+
+  this.set('buildMock', buildMock);
+  this.set('jobsMock', jobs);
+
+  this.render(hbs`{{pipeline-build-view build=buildMock jobs=jobsMock}}`);
+
+  assert.equal(this.$('h6 a').text().trim(), '123456');
+  assert.equal(this.$('.job').text().trim(), 'hello');
+  assert.equal(this.$('.cause').text().trim(), 'bananas');
+});

--- a/tests/unit/job/adapter-test.js
+++ b/tests/unit/job/adapter-test.js
@@ -1,0 +1,13 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('adapter:job', 'Unit | Adapter | job', {
+  // Specify the other units that are required for this test.
+  // needs: ['serializer:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function (assert) {
+  let adapter = this.subject();
+
+  assert.ok(adapter);
+});

--- a/tests/unit/job/model-test.js
+++ b/tests/unit/job/model-test.js
@@ -1,0 +1,13 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('job', 'Unit | Model | job', {
+  // Specify the other units that are required for this test.
+  needs: []
+});
+
+test('it exists', function (assert) {
+  let model = this.subject();
+
+  // let store = this.store();
+  assert.ok(!!model);
+});

--- a/tests/unit/pipeline/adapter-test.js
+++ b/tests/unit/pipeline/adapter-test.js
@@ -16,7 +16,10 @@ test('it wraps non-array payload with model name and inserts link to secrets', f
   let adapter = this.subject();
 
   SuperAdapter.prototype.handleResponse = function (status, headers, data, requestData) {
-    assert.deepEqual(data, { pipeline: { id: 1234, links: { secrets: 'secrets' } } });
+    assert.deepEqual(data, { pipeline: { id: 1234, links: {
+      secrets: 'secrets',
+      jobs: 'jobs'
+    } } });
     assert.equal(status, 'status');
     assert.equal(headers, 'headers');
     assert.equal(requestData, 'requestData');

--- a/tests/unit/pipeline/index/route-test.js
+++ b/tests/unit/pipeline/index/route-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('route:pipeline/index', 'Unit | Route | pipeline/index', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+test('it exists', function (assert) {
+  let route = this.subject();
+
+  assert.ok(route);
+});

--- a/tests/unit/pipeline/model-test.js
+++ b/tests/unit/pipeline/model-test.js
@@ -3,7 +3,7 @@ import Ember from 'ember';
 
 moduleForModel('pipeline', 'Unit | Model | pipeline', {
   // Specify the other units that are required for this test.
-  needs: ['model:secret']
+  needs: ['model:secret', 'model:job']
 });
 
 test('it exists', function (assert) {


### PR DESCRIPTION
Rather silly way of fetching builds and associating the jobs they belong to. We should redo this completely when proper apis exist.

<img width="958" alt="screen shot 2016-09-08 at 9 28 31 pm" src="https://cloud.githubusercontent.com/assets/78533/18375514/cf66ea0c-760b-11e6-93b4-033aad445451.png">