### PR TITLE
build page should refresh better

### DIFF
--- a/app/build/route.js
+++ b/app/build/route.js
@@ -1,7 +1,19 @@
 import Ember from 'ember';
+const RELOAD_TIMER = 5000;
 
 export default Ember.Route.extend({
   model(params) {
-    return this.get('store').findRecord('build', params.build_id);
+    return this.get('store').findRecord('build', params.build_id).then(build => {
+      // reload again in a little bit if queued
+      const reloadQueuedBuild = () => {
+        if (build.get('status') === 'QUEUED') {
+          setTimeout(() => build.reload().then(reloadQueuedBuild), RELOAD_TIMER);
+        }
+      };
+
+      reloadQueuedBuild();
+
+      return build;
+    });
   }
 });

--- a/app/components/build-log/component.js
+++ b/app/components/build-log/component.js
@@ -57,7 +57,8 @@ export default Ember.Component.extend({
    */
   logs() {
     if (this.get('shouldLoad')) {
-      const buildId = this.get('buildId');
+      const build = this.get('build');
+      const buildId = build.get('id');
       const name = this.get('step.name');
       const logContainer = this.$('.logs');
       const logNumber = this.get('lastLine');
@@ -78,8 +79,15 @@ export default Ember.Component.extend({
             });
             // Update the last line we processed for next load
             this.set('lastLine', data[data.length - 1].n + 1);
+            // scroll to bottom of logs
+            window.scrollTo(0, this.$('.bottom').offset().top);
             // Set flag for done based on headers
             this.set('finishedLoading', jqXHR.getResponseHeader('x-more-data') === 'false');
+
+            if (this.get('finishedLoading') && build.get('status') === 'RUNNING') {
+              // if build is running and step is done, reload build
+              build.reload();
+            }
           }
         })
         .always(() => {

--- a/app/components/build-log/template.hbs
+++ b/app/components/build-log/template.hbs
@@ -1,1 +1,2 @@
 <div class="logs">{{yield}}</div>
+<div class="bottom"></div>

--- a/app/components/build-step/component.js
+++ b/app/components/build-step/component.js
@@ -9,8 +9,8 @@ export default Ember.Component.extend({
   init() {
     this._super(...arguments);
 
-    // if code is defined and not 0
-    if (this.get('step.code')) {
+    // if code is defined and not 0, or step is running
+    if (this.get('step.code') || (this.get('step.startTime') && !this.get('step.endTime'))) {
       this.isOpen = true;
     }
   },

--- a/app/components/build-step/template.hbs
+++ b/app/components/build-step/template.hbs
@@ -1,2 +1,2 @@
 {{build-step-view step=step build=build isOpen=isOpen onToggle=(action "toggleOpen")}}
-{{build-log step=step buildId=build.id isOpen=isOpen}}
+{{build-log step=step build=build isOpen=isOpen}}

--- a/tests/integration/components/build-log/component-test.js
+++ b/tests/integration/components/build-log/component-test.js
@@ -1,4 +1,5 @@
 import { moduleForComponent, test } from 'ember-qunit';
+import Ember from 'ember';
 import hbs from 'htmlbars-inline-precompile';
 import wait from 'ember-test-helpers/wait';
 import Pretender from 'pretender';
@@ -61,11 +62,18 @@ test('it renders open when told to', function (assert) {
     startTime: '2016-08-26T20:49:42.531Z',
     endTime: '2016-08-26T20:50:52.531Z'
   };
+  const buildMock = Ember.Object.extend({
+    reload() {}
+  }).create({
+    id: '1',
+    status: 'RUNNING'
+  });
 
   server.map(singleRequest);
   this.set('stepMock', stepMock);
+  this.set('buildMock', buildMock);
 
-  this.render(hbs`{{build-log buildId=1 step=stepMock isOpen=true}}`);
+  this.render(hbs`{{build-log build=buildMock step=stepMock isOpen=true}}`);
 
   return wait().then(() => {
     assert.equal(this.$().text().trim(), 'hello, world');
@@ -81,12 +89,19 @@ test('it starts loading when open changes', function (assert) {
     startTime: '2016-08-26T20:49:42.531Z',
     endTime: '2016-08-26T20:50:52.531Z'
   };
+  const buildMock = Ember.Object.extend({
+    reload() {}
+  }).create({
+    id: '1',
+    status: 'RUNNING'
+  });
 
   server.map(singleRequest);
   this.set('stepMock', stepMock);
+  this.set('buildMock', buildMock);
   this.set('open', false);
 
-  this.render(hbs`{{build-log buildId=1 step=stepMock isOpen=open}}`);
+  this.render(hbs`{{build-log build=buildMock step=stepMock isOpen=open}}`);
   this.set('open', true);
 
   return wait().then(() => {

--- a/tests/integration/components/build-step/component-test.js
+++ b/tests/integration/components/build-step/component-test.js
@@ -1,4 +1,5 @@
 import { moduleForComponent, test } from 'ember-qunit';
+import Ember from 'ember';
 import hbs from 'htmlbars-inline-precompile';
 import wait from 'ember-test-helpers/wait';
 import Pretender from 'pretender';
@@ -47,7 +48,12 @@ test('it renders', function (assert) {
 test('it starts open when step failed', function (assert) {
   // Set any properties with this.set('myProperty', 'value');
   // Handle any actions with this.on('myAction', function(val) { ... });
-  const buildMock = { id: 1 };
+  const buildMock = Ember.Object.extend({
+    reload() {}
+  }).create({
+    id: '1',
+    status: 'RUNNING'
+  });
   const stepMock = {
     name: 'banana',
     code: 127,


### PR DESCRIPTION
* Resolves #14 and #15. 
* Build model reloads after 5s when queued. 
* Build model reloads when step (logs) finish loading. 
* Log panels open when step is running or failed
* log panels scroll to bottom of logs