### PR TITLE
Add a pipeline create page

### DIFF
--- a/app/application/adapter.js
+++ b/app/application/adapter.js
@@ -1,7 +1,9 @@
 import DS from 'ember-data';
 import ENV from 'screwdriver-ui/config/environment';
+import Ember from 'ember';
 
 export default DS.RESTAdapter.extend({
+  session: Ember.inject.service('session'),
   namespace: ENV.APP.SDAPI_NAMESPACE,
   host: ENV.APP.SDAPI_HOSTNAME,
 
@@ -22,5 +24,13 @@ export default DS.RESTAdapter.extend({
     };
 
     return this._super(url, method, finalHash);
-  }
+  },
+
+  /**
+   * Compute the headers to add the auth token in
+   * @property {Object}
+   */
+  headers: Ember.computed(function cHeaders() {
+    return { Authorization: `Bearer ${this.get('session').get('data.authenticated.token')}` };
+  }).volatile()
 });

--- a/app/authenticators/screwdriver-api.js
+++ b/app/authenticators/screwdriver-api.js
@@ -1,7 +1,5 @@
 import Ember from 'ember';
 import Base from 'ember-simple-auth/authenticators/base';
-// eslint-disable-next-line camelcase
-import { jwt_decode } from 'ember-cli-jwt-decode';
 
 import ENV from 'screwdriver-ui/config/environment';
 const loginUrl = `${ENV.APP.SDAPI_HOSTNAME}/${ENV.APP.SDAPI_NAMESPACE}/auth/login/web`;
@@ -19,7 +17,7 @@ export default Base.extend({
     const properties = Ember.Object.create(data);
 
     return new Ember.RSVP.Promise((resolve, reject) => {
-      if (!Ember.isEmpty(properties.get('username'))) {
+      if (!Ember.isEmpty(properties.get('token'))) {
         return resolve(data);
       }
 
@@ -51,7 +49,7 @@ export default Base.extend({
               withCredentials: true
             }
           })
-          .done(jwt => resolve(jwt_decode(jwt.token)))
+          .done(jwt => resolve(jwt))
           .fail(() => reject('Could not get a token'));
         }
       }, 100);

--- a/app/components/build-step-view/component.js
+++ b/app/components/build-step-view/component.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 
 export default Ember.Component.extend({
+  className: ['buildStepView'],
   classNameBindings: ['status'],
   isOpen: false,
 

--- a/app/components/create-pipeline-data/component.js
+++ b/app/components/create-pipeline-data/component.js
@@ -1,0 +1,86 @@
+import Ember from 'ember';
+import git from '../../utils/git';
+
+/**
+ * Animates the input to indicate whether the value is a valid scm url or not
+ * @method indicateValidScmUrl
+ * @param  {String}         elementSelector jQuery selector of the input element
+ * @param  {String}         val             value of the input element aka the scm url
+ * @return {Boolean}                        whether or not the input is valid
+ */
+function indicateValidScmUrl(elementSelector, val = '') {
+  if (val.length !== 0 && !git.parse(val).valid) {
+    Ember.$(elementSelector).addClass('bad-text-input');
+  } else if (val.length !== 0) {
+    Ember.$(elementSelector).addClass('good-text-input');
+
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Enables/disables the 'use this repository' button based on the validity of inputs
+ * @method validateScmInput
+ * @param  {String}         scmUrl   The scmUrl entered by the user
+ * @return {Boolean}                 True if the scmUrl is valid
+ */
+function validateScmInput(scmUrl) {
+  Ember.$('.text-input').removeClass('bad-text-input');
+  Ember.$('.text-input').removeClass('good-text-input');
+  Ember.$('.blue-button').prop('disabled', true);
+
+  let checkScmUrl = indicateValidScmUrl('.scm-url', scmUrl);
+
+  if (checkScmUrl) {
+    Ember.$('.blue-button').prop('disabled', false);
+
+    return true;
+  }
+
+  return false;
+}
+
+export default Ember.Component.extend({
+  /**
+   * Fires before the template is originally drawn
+   * @event willInsertElement
+   */
+  willInsertElement() {
+    let scmUrl = this.get('scmUrl');
+
+    if (validateScmInput(scmUrl)) {
+      this.sendAction('updateData', scmUrl);
+    }
+  },
+
+  /**
+   * Fires after the template is drawn, needed trigger appropriate styling on good/bad input
+   * @event didInsertElement
+   */
+  didInsertElement() {
+    validateScmInput(this.get('scmUrl'));
+  },
+
+  actions: {
+    /**
+     * Handles when a git url is entered in step 1
+     * @method scmChange
+     * @param  {String} val     The value of the input box
+     */
+    scmChange(val) {
+      this.set('scmUrl', val.trim());
+      this.get('returnToStep')(1);
+      validateScmInput(this.get('scmUrl'));
+    },
+
+    /**
+     * Handles when a git url is entered in step 1
+     * @method updateData
+     */
+    updateData() {
+      this.get('updateData')(this.get('scmUrl'));
+    }
+  }
+});

--- a/app/components/create-pipeline-data/template.hbs
+++ b/app/components/create-pipeline-data/template.hbs
@@ -1,0 +1,8 @@
+{{input
+  class="text-input scm-url"
+  name="scm-url"
+  key-up="scmChange"
+  placeholder="Enter your repository link (eg: git@github.com:screwdriver-cd/ui.git#master)"
+  value=scmUrl
+}}
+<input type="button" class="blue-button" disabled="true" {{action "updateData"}} name="use-repository" value="Use this repository">

--- a/app/components/create-step/component.js
+++ b/app/components/create-step/component.js
@@ -1,0 +1,22 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  classNames: ['create-step'],
+  classNameBindings: ['statusClass'],
+  statusClass: Ember.computed('currentStep', 'step', {
+    get() {
+      const currentStep = this.get('currentStep');
+      const step = this.get('step');
+
+      if (currentStep < step) {
+        return 'step-hidden';
+      }
+
+      if (currentStep > step) {
+        return 'step-done';
+      }
+
+      return '';
+    }
+  })
+});

--- a/app/components/create-step/styles.scss
+++ b/app/components/create-step/styles.scss
@@ -1,0 +1,262 @@
+$animate: 300ms;
+$animate-delay: 250ms;
+$animate-done: 600ms;
+@mixin transition($prop, $duration, $delay: 0ms, $easing: ease) {
+  -webkit-transition: $prop $duration $delay $easing;
+  -moz-transition: $prop $duration $delay $easing;
+  -ms-transition: $prop $duration $delay $easing;
+  -o-transition: $prop $duration $delay $easing;
+  transition: $prop $duration $delay $easing;
+}
+@mixin scale($amt) {
+  -webkit-transform: scale($amt);
+  -moz-transform: scale($amt);
+  -ms-transform: scale($amt);
+  -o-transform: scale($amt);
+  transform: scale($amt);
+}
+
+& {
+  position: relative;
+  overflow: hidden;
+  padding-bottom: 30px;
+  margin-bottom: 0;
+  left: 0;
+
+  &:not(.step-hidden) {
+    .step-content:hover {
+      opacity: 1;
+    }
+  }
+
+  .step-title {
+    position: absolute;
+    height: 40px;
+    line-height: 45px;
+    top: 0;
+    left: 65px;
+    font-size: 1.5em;
+    font-weight: 450;
+    color: $ycolor-gray-a;
+  }
+
+  .step-line {
+    height: 0;
+    @include transition(all, $animate-done);
+  }
+
+  .step-content {
+    padding-top: 50px;
+    margin-bottom: 10px;
+    padding-left: 65px;
+    color: $ycolor-gray-e;
+    @include transition(opacity, 200ms);
+    opacity: 1;
+    max-height: 1000px;
+  }
+
+  .step-number {
+    text-align: center;
+    border: 3px solid $ycolor-green-6a;
+    color: $ycolor-green-6a;
+    font-weight: 500;
+    border-radius: 100%;
+    width: 40px;
+    height: 40px;
+    line-height: 40px;
+    font-size: 1.2em;
+    background: #fff;
+    position: absolute;
+    top: 0;
+    left: 0;
+
+    span {
+      color: $ycolor-green-6a;
+      opacity: 1;
+    }
+
+    i.fa {
+      position: absolute;
+      font-size: 27px;
+      right: 6px;
+      top: 6px;
+      opacity: 0;
+      color: $ycolor-green-6a;
+    }
+  }
+
+  &.step-hidden {
+    margin-bottom: -5px;
+    padding-bottom: 0;
+
+    .step-number {
+      border-color: $ycolor-gray-h;
+      color: $ycolor-gray-h;
+
+      span {
+        color: $ycolor-gray-h;
+      }
+    }
+
+    .step-title {
+      color: $ycolor-gray-h;
+    }
+
+    .step-content {
+      opacity: 0;
+      max-height: 0;
+
+      * {
+        margin: 0;
+      }
+    }
+
+    .blue-button {
+      display: none;
+    }
+  }
+
+  &.step-done {
+    .step-title {
+      color: $ycolor-gray-g;
+    }
+
+    .step-line {
+      background: $ycolor-green-6a;
+      width: 3px;
+      height: 100%;
+      position: absolute;
+      top: 40px;
+      left: 22px;
+    }
+
+    .step-number {
+      span {
+        opacity: 0;
+      }
+
+      i.fa {
+        opacity: 1;
+      }
+    }
+
+    .step-content {
+      opacity: 0.6;
+    }
+
+    .blue-button {
+      display: none;
+    }
+
+    .hide-when-done {
+      display: none;
+    }
+  }
+
+  .text-input {
+    &.good-text-input:not(:focus) {
+      background: $ycolor-gray-h;
+      border-color: transparent;
+      border-radius: 1px;
+    }
+  }
+}
+
+.text-input {
+  box-sizing: border-box;
+  margin-top: 10px;
+  outline: 0;
+  height: 45px;
+  width: 95%;
+  border-radius: 2px;
+  border: 2px solid $ycolor-gray-h;
+  font-size: 16px;
+  padding-left: 10px;
+  color: $ycolor-gray-b;
+
+  &:focus {
+    border-color: $ycolor-blue-10a;
+  }
+
+  &::-webkit-input-placeholder {
+    color: $ycolor-gray-g;
+  }
+
+  &:-moz-placeholder {
+    color: $ycolor-gray-g;
+  }
+
+  &::-moz-placeholder {
+    color: $ycolor-gray-g;
+  }
+
+  &:-ms-input-placeholder {
+    color: $ycolor-gray-g;
+  }
+
+  &.bad-text-input {
+    border-color: $ycolor-red-2a;
+  }
+
+  &.good-text-input {
+    border-color: $ycolor-green-6a;
+  }
+}
+
+.blue-button {
+  border: none;
+  border-radius: 3px;
+  height: 45px;
+  padding: 0 30px;
+  color: #fff;
+  font-size: 16px;
+  margin-top: 20px;
+  background: $ycolor-blue-10a;
+  @include transition(all, 50ms);
+
+  &:focus {
+    outline: none;
+  }
+
+  &:hover {
+    background: $ycolor-neutral-blue;
+  }
+
+  &:disabled {
+    background: $ycolor-gray-g;
+  }
+
+  .saving-loading {
+    display: none;
+  }
+
+  &.saving {
+    .saving-loading {
+      display: block;
+    }
+
+    .button-label {
+      display: none;
+    }
+  }
+
+  &:active {
+    &:not(:disabled) {
+      @include scale(0.97);
+    }
+  }
+}
+
+.fuji-spinner {
+  display: inline-block;
+  vertical-align: middle;
+  height: 45px;
+}
+
+input[type="button"] {
+  outline: 0;
+}
+
+.capitalize {
+  text-transform: capitalize;
+}

--- a/app/components/create-step/template.hbs
+++ b/app/components/create-step/template.hbs
@@ -1,0 +1,11 @@
+<div class="step-header">
+  <div class="step-line"></div>
+  <div class="step-number">
+    <span>{{step}}</span>
+    {{fa-icon "fa-check"}}
+  </div>
+  <div class="step-title">{{title}}</div>
+</div>
+<div class="step-content">
+  {{yield}}
+</div>

--- a/app/components/info-message/component.js
+++ b/app/components/info-message/component.js
@@ -1,0 +1,13 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  classNames: ['info-message'],
+  classNameBindings: ['hasMessage:enabled:disabled', 'type'],
+  icon: 'fa-info',
+  type: 'info',
+  hasMessage: Ember.computed('message', {
+    get() {
+      return this.get('message').length > 0;
+    }
+  })
+});

--- a/app/components/info-message/styles.scss
+++ b/app/components/info-message/styles.scss
@@ -1,0 +1,44 @@
+& {
+  width: 93%;
+  min-height: 20px;
+  border-radius: 3px;
+  margin-bottom: 30px;
+  padding: 10px;
+
+  i.fa {
+    font-size: 26px;
+  }
+
+  span {
+    display: inline-block;
+    vertical-align: middle;
+  }
+
+  &.disabled {
+    display: none;
+  }
+
+  &.error {
+    border: 2px solid $ycolor-red-2a;
+
+    i.fa {
+      color: $ycolor-red-2a;
+    }
+  }
+
+  &.warning {
+    border: 2px solid $ycolor-yellow-5a;
+
+    i.fa {
+      color: $ycolor-yellow-5a;
+    }
+  }
+
+  &.info {
+    border: 2px solid $ycolor-blue-10a;
+
+    i.fa {
+      color: $ycolor-blue-10a;
+    }
+  }
+}

--- a/app/components/info-message/template.hbs
+++ b/app/components/info-message/template.hbs
@@ -1,0 +1,2 @@
+{{fa-icon icon}}
+<span>{{message}}</span>

--- a/app/components/pipeline-create-form/component.js
+++ b/app/components/pipeline-create-form/component.js
@@ -1,0 +1,88 @@
+/* global localStorage*/
+import Ember from 'ember';
+import git from '../../utils/git';
+
+let LOCALSTORAGE_KEY = 'create-pipeline-data';
+
+export default Ember.Component.extend({
+  currentStep: 1,
+
+  /**
+   * Fires before the template is originally drawn
+   * @event willInsertElement
+   */
+  init() {
+    let scmUrl = this.get('scmUrl');
+
+    if (git.parse(scmUrl).valid) {
+      this.set('currentStep', 2);
+    }
+
+    this._super(...arguments);
+  },
+
+  savingChanged: Ember.observer('saveSuccess', function observe() {
+    // Remove stored data when no longer saving and no errors
+    if (this.get('saveSuccess')) {
+      localStorage.removeItem(LOCALSTORAGE_KEY);
+    }
+  }),
+
+  /**
+   * Fetches project data from localstorage or return default
+   * @property {Object} scmUrl
+   */
+  scmUrl: Ember.computed(() => {
+    let storedData = '';
+
+    try {
+      storedData = JSON.parse(localStorage.getItem(LOCALSTORAGE_KEY)) || storedData;
+    // eslint-disable-next-line no-empty
+    } catch (ignore) {}
+
+    return storedData;
+  }),
+
+  actions: {
+    /**
+     * Call Api to save project
+     * @event saveData
+     * @param  {Object} data Project attributes
+     */
+    saveData() {
+      const scmUrl = this.get('scmUrl');
+
+      this.get('onCreatePipeline')(scmUrl);
+    },
+
+    /**
+     * Saves the user data if the urls are valid
+     * @event rememberProjectData
+     * @param  {Object}            data scmUrl, extConfigUrl, repoUrl
+     */
+    rememberProjectData(scmUrl) {
+      let scmUrlCheck = git.parse(scmUrl);
+
+      // validate the url data
+      if (!scmUrlCheck.valid) {
+        // invalid urls, exit
+        return;
+      }
+
+      // store scmUrl,etc data
+      localStorage.setItem(LOCALSTORAGE_KEY, JSON.stringify(scmUrl));
+
+      this.set('scmUrl', scmUrl);
+      this.set('currentStep', 2);
+    },
+
+    /**
+     * Updates current step
+     * @event updateStep
+     * @param  {Number}   step
+     */
+    updateStep(step) {
+      this.set('currentStep', step);
+    }
+  }
+});

--- a/app/components/pipeline-create-form/styles.scss
+++ b/app/components/pipeline-create-form/styles.scss
@@ -1,0 +1,7 @@
+& {
+  padding: 10px 25px 0;
+  font-size: 16px;
+  padding-bottom: 40px;
+  width: 980px;
+  margin: 0 auto;
+}

--- a/app/components/pipeline-create-form/template.hbs
+++ b/app/components/pipeline-create-form/template.hbs
@@ -1,0 +1,13 @@
+{{info-message message=errorMessage type="error" icon="exclamation-triangle"}}
+{{#create-step step=1 currentStep=currentStep title="Select a Repository" }}
+  {{create-pipeline-data updateData=(action "rememberProjectData") returnToStep=(action "updateStep") scmUrl=scmUrl}}
+{{/create-step}}
+{{#create-step step=2 currentStep=currentStep title="Create Pipeline" }}
+  <button {{action "saveData"}} disabled={{isSaving}} class="blue-button {{if isSaving 'saving'}}">
+    <div class="saving-loading">
+      Creating Pipeline
+    </div>
+    <div class="button-label">Create Pipeline</div>
+  </button>
+  {{#if isSaving}}{{fa-icon "fa-spin fa-spinner"}}{{/if}}
+{{/create-step}}

--- a/app/create/controller.js
+++ b/app/create/controller.js
@@ -1,0 +1,25 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  isSaving: false,
+  errorMessage: '',
+  saveSuccess: false,
+
+  actions: {
+    createPipeline(scmUrl) {
+      let pipeline = this.store.createRecord('pipeline', { scmUrl, configUrl: scmUrl });
+
+      this.set('isSaving', true);
+
+      pipeline.save()
+        .then(() => {
+          this.set('saveSuccess', true);
+          this.transitionToRoute('pipeline', pipeline.get('id'));
+        }, (err) => {
+          this.set('errorMessage', err.errors.message);
+        }).finally(() => {
+          this.set('isSaving', false);
+        });
+    }
+  }
+});

--- a/app/create/route.js
+++ b/app/create/route.js
@@ -1,0 +1,4 @@
+import Ember from 'ember';
+import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+
+export default Ember.Route.extend(AuthenticatedRouteMixin);

--- a/app/create/template.hbs
+++ b/app/create/template.hbs
@@ -1,0 +1,2 @@
+{{pipeline-create-form isSaving=isSaving onCreatePipeline=(action "createPipeline") errorMessage=errorMessage saveSuccess=saveSuccess}}
+{{outlet}}

--- a/app/pipeline/adapter.js
+++ b/app/pipeline/adapter.js
@@ -1,6 +1,11 @@
 import Adapter from '../application/adapter';
+
 export default Adapter.extend({
   handleResponse: (status, headers, payload, requestData) => {
+    if (payload.error) {
+      return Adapter.prototype.handleResponse(status, headers, { errors: payload }, requestData);
+    }
+
     let data = {};
     let key = 'pipeline';
 

--- a/app/pipeline/model.js
+++ b/app/pipeline/model.js
@@ -3,7 +3,7 @@ import Ember from 'ember';
 
 export default DS.Model.extend({
   scmUrl: DS.attr('string'),
-  configUrl: DS.attr('string'),
+  configUrl: DS.attr('string', { defaultValue: '' }),
   createTime: DS.attr('date'),
   admins: DS.attr(),
   secrets: DS.hasMany('secret', { async: true }),

--- a/app/pipeline/serializer.js
+++ b/app/pipeline/serializer.js
@@ -1,0 +1,17 @@
+import DS from 'ember-data';
+import Ember from 'ember';
+
+export default DS.RESTSerializer.extend({
+  /**
+   * Override the serializeIntoHash method because our screwed up API doesn't have model names as a root key
+   * See http://emberjs.com/api/data/classes/DS.RESTSerializer.html#method_serializeIntoHash
+   * @method serializeIntoHash
+   */
+  serializeIntoHash(hash, typeClass, snapshot, options) {
+    if (!snapshot.id) {
+      return Ember.merge(hash, { scmUrl: snapshot.attr('scmUrl') });
+    }
+
+    return Ember.merge(hash, this.serialize(snapshot, options));
+  }
+});

--- a/app/router.js
+++ b/app/router.js
@@ -15,6 +15,7 @@ Router.map(function route() {
     this.route('secrets');
   });
   this.route('login');
+  this.route('create');
 });
 /* eslint-enable array-callback-return */
 

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -1,4 +1,5 @@
 @import "font-awesome";
+@import "fuji-colors";
 @import "pod-styles";
 
 .container {

--- a/app/styles/fuji-colors.scss
+++ b/app/styles/fuji-colors.scss
@@ -1,0 +1,115 @@
+/**
+ * FUJI
+ * Color Definitions
+ */
+
+/*
+YDesign has organized color by property into primary, tone1, tone2, sub1, sub2.
+But many of those colors are shared, so we abstract them out here.
+
+These colors comprise all the colors in the Yahoo Color Wheel, and are the
+only color values allowed at Yahoo.
+
+The color names are meaningful. The color names, such as "salmon", are imprecise
+but provide some indication of what sort of color you're dealing with. The
+alphanumeric suffix (e.g., "5c") indicates where on the wheel the color falls.
+For instance, 1a is the innermost color (a) of the first slice (1) starting at
+the noon position, if you think of the wheel as a clockface.
+
+The grayscale colors also start at darkest and increment to lightest.
+
+The neutral colors, visualized as a ring around the yahoo purple ring, are
+self-explanatory.
+*/
+
+/* grayscale, from darkest to lightest */
+$ycolor-gray-a: #262626;
+$ycolor-gray-b: #37373a;
+$ycolor-gray-c: #4b4b4e;
+$ycolor-gray-d: #737376;
+$ycolor-gray-e: #828285;
+$ycolor-gray-f: #a8a8ac;
+$ycolor-gray-g: #cfcfd1;
+$ycolor-gray-h: #e2e2e6;
+$ycolor-gray-i: #f1f1f5;
+$ycolor-gray-j: #fbfbff;
+
+/* colors,starting at noon position and moving clockwise in 1/18 slices */
+$ycolor-pink-1a: #f80e5d;
+$ycolor-pink-1b: #e6004e;
+$ycolor-pink-1c: #c60646;
+
+$ycolor-red-2a: #f0162f;
+$ycolor-red-2b: #dc142d;
+
+$ycolor-salmon-3a: #ff4d52;
+$ycolor-salmon-3b: #ff333a;
+
+$ycolor-orange-4a: #ff8b12;
+$ycolor-orange-4b: #ff7b12;
+$ycolor-orange-4c: #ff520d;
+
+$ycolor-yellow-5a: #ffd333;
+$ycolor-yellow-5b: #ffc700;
+$ycolor-yellow-5c: #ffb700;
+
+$ycolor-green-6a: #11d360;
+$ycolor-green-6b: #1ac567;
+
+$ycolor-bluegreen-7a: #00cd7a;
+$ycolor-bluegreen-7b: #00c073;
+
+$ycolor-turquoise-8a: #30d3b6;
+$ycolor-turquoise-8b: #00c1a5;
+
+$ycolor-teal-9a: #00a098;
+$ycolor-teal-9b: #008f88;
+
+$ycolor-blue-10a: #0078ff;
+$ycolor-blue-10b: #0f69ff;
+
+$ycolor-blue-11a: #145aff;
+$ycolor-blue-11b: #144aff;
+
+$ycolor-blueviolet-12a: #003abc;
+
+$ycolor-indigo-13a: #0034a3;
+$ycolor-indigo-13b: #001a5a;
+
+$ycolor-purple-14a: #7300ff;
+$ycolor-purple-14b: #5a00c8;
+$ycolor-purple-14c: #400090;
+$ycolor-purple-master: $ycolor-purple-14c; /* synonym */
+
+$ycolor-deeppurple-15a: #2e0066;
+
+$ycolor-deeppurple-16a: #2a004e;
+
+$ycolor-magenta-17a: #be0067;
+$ycolor-magenta-17b: #940050;
+$ycolor-magenta-17c: #800045;
+
+$ycolor-fuchsia-18a: #cc008c;
+$ycolor-fuchsia-18b: #b3007b;
+
+/* neutrals */
+$ycolor-neutral-red: #ff8189;
+$ycolor-neutral-yellow: #f3ea9b;
+$ycolor-neutral-gray: #d3ccbd;
+$ycolor-neutral-blue: #00abf0;
+$ycolor-neutral-purple: #8762f9;
+
+/*
+Property swatch cards,
+reflecting how colors are organized/defined/labeled in YDesign's styleguide.
+*/
+
+$color-default-primary: $ycolor-blue-10b;
+$color-default-tone-1: $ycolor-blue-11b;
+$color-default-tone-2: $ycolor-blue-11a;
+$color-default-sub-1: $ycolor-blue-11b;
+$color-default-sub-2: $ycolor-blue-11a;
+
+$color-default-system-error: $ycolor-salmon-3a;
+$color-default-system-affirm: $ycolor-bluegreen-7a;
+$color-default-system-caution: $ycolor-yellow-5a;

--- a/app/utils/git.js
+++ b/app/utils/git.js
@@ -1,0 +1,32 @@
+/**
+ * Parse a git url and get info about the repo
+ * @method git
+ * @param  {String}  scmUrl Url to parse
+ * @return {Object}         Data about the url
+ */
+export default {
+  parse(scmUrl) {
+    const match = scmUrl.match(/^git@([^:]+):([^/]+)\/([^/]+)\.git(#(.+))?/);
+
+    if (!match) {
+      return {
+        valid: false
+      };
+    }
+
+    const result = {
+      server: match[1],
+      owner: match[2],
+      repo: match[3],
+      branch: match[5] || 'master',
+      link: `https://${match[1]}/${match[2]}/${match[3]}`,
+      valid: true
+    };
+
+    if (result.branch !== 'master') {
+      result.link += `/tree/${result.branch}`;
+    }
+
+    return result;
+  }
+};

--- a/tests/.eslintrc.js
+++ b/tests/.eslintrc.js
@@ -3,6 +3,7 @@ module.exports = {
     'embertest': true
   },
   rules: {
-    "func-names": 'off'
+    'func-names': 'off',
+    'prefer-arrow-callback': 'off'
   }
 };

--- a/tests/acceptance/create-page-test.js
+++ b/tests/acceptance/create-page-test.js
@@ -1,0 +1,96 @@
+import { test } from 'qunit';
+import moduleForAcceptance from 'screwdriver-ui/tests/helpers/module-for-acceptance';
+import { authenticateSession } from 'screwdriver-ui/tests/helpers/ember-simple-auth';
+import Pretender from 'pretender';
+let server;
+
+moduleForAcceptance('Acceptance | create', {
+  beforeEach() {
+    server = new Pretender();
+  },
+  afterEach() {
+    server.shutdown();
+  }
+});
+
+test('/create a pipeline: not logged in will redirect', function (assert) {
+  visit('/create');
+
+  andThen(() => {
+    assert.equal(currentURL(), '/login');
+  });
+});
+
+test('/create a pipeline: SUCCESS', function (assert) {
+  server.post('http://localhost:8080/v3/pipelines', () => [
+    200,
+    { 'Content-Type': 'application/json' },
+    JSON.stringify({
+      id: 'abcd'
+    })
+  ]);
+
+  server.get('http://localhost:8080/v3/pipelines/abcd', () => [
+    200,
+    { 'Content-Type': 'application/json' },
+    JSON.stringify({
+      id: 'abcd'
+    })
+  ]);
+  server.get('http://localhost:8080/v3/builds', () => [
+    200,
+    { 'Content-Type': 'application/json' },
+    JSON.stringify([])
+  ]);
+  server.get('http://localhost:8080/v3/pipelines/abcd/jobs', () => [
+    200,
+    { 'Content-Type': 'application/json' },
+    JSON.stringify([])
+  ]);
+  authenticateSession(this.application, { token: 'faketoken' });
+
+  visit('/create');
+
+  andThen(() => {
+    assert.equal(currentURL(), '/create');
+    fillIn('.scm-url', 'git@github.com:foo/bar.git');
+    triggerEvent('.scm-url', 'keyup');
+    click('input.blue-button');
+    andThen(() => {
+      click('button');
+      andThen(() => {
+        assert.equal(currentURL(), '/pipelines/abcd');
+      });
+    });
+  });
+});
+
+test('/create a pipeline: FAILURE', function (assert) {
+  server.post('http://localhost:8080/v3/pipelines', () => [
+    409,
+    { 'Content-Type': 'application/json' },
+    JSON.stringify({
+      statusCode: 409,
+      error: 'Conflict',
+      message: 'something conflicting'
+    })
+  ]);
+
+  authenticateSession(this.application, { token: 'faketoken' });
+
+  visit('/create');
+
+  andThen(() => {
+    assert.equal(currentURL(), '/create');
+    fillIn('.scm-url', 'git@github.com:foo/bar.git');
+    triggerEvent('.scm-url', 'keyup');
+    click('input.blue-button');
+    andThen(() => {
+      click('button');
+      andThen(() => {
+        assert.equal(currentURL(), '/create');
+        assert.equal(find('.info-message span').text(), 'something conflicting');
+      });
+    });
+  });
+});

--- a/tests/integration/components/build-step/component-test.js
+++ b/tests/integration/components/build-step/component-test.js
@@ -70,8 +70,85 @@ test('it starts open when step failed', function (assert) {
   assert.equal(this.$('div.ember-view.failure').length, 1, 'has step view');
   // step-logs
   assert.equal(this.$('.logs').length, 1, 'has log view');
+  assert.equal(this.$('.is-open').length, 1);
 
   return wait().then(() => {
     assert.equal(this.$('.logs').text().trim(), 'hello, world');
+
+    this.$('.name').click();
+
+    return wait().then(() => {
+      assert.equal(this.$('.is-open').length, 0);
+    });
+  });
+});
+
+test('it starts open when step is running', function (assert) {
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+  const buildMock = Ember.Object.extend({
+    reload() {}
+  }).create({
+    id: '1',
+    status: 'RUNNING'
+  });
+  const stepMock = {
+    name: 'banana',
+    code: null,
+    startTime: '2016-08-26T20:49:42.531Z',
+    endTime: null
+  };
+
+  this.set('buildMock', buildMock);
+  this.set('stepMock', stepMock);
+
+  this.render(hbs`{{build-step build=buildMock step=stepMock}}`);
+
+  // step-view
+  assert.equal(this.$('div.ember-view.failure').length, 1, 'has step view');
+  // step-logs
+  assert.equal(this.$('.logs').length, 1, 'has log view');
+  assert.equal(this.$('.is-open').length, 1);
+
+  return wait().then(() => {
+    assert.equal(this.$('.logs').text().trim(), 'hello, world');
+  });
+});
+
+test('it can be opened', function (assert) {
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+  const buildMock = Ember.Object.extend({
+    reload() {}
+  }).create({
+    id: '1',
+    status: 'SUCCESS'
+  });
+  const stepMock = {
+    name: 'banana',
+    code: 0,
+    startTime: '2016-08-26T20:49:42.531Z',
+    endTime: '2016-08-26T20:50:52.531Z'
+  };
+
+  this.set('buildMock', buildMock);
+  this.set('stepMock', stepMock);
+
+  this.render(hbs`{{build-step build=buildMock step=stepMock}}`);
+
+  // step-view
+  assert.equal(this.$('div.ember-view.success').length, 1, 'has step view');
+  // step-logs
+  assert.equal(this.$('.logs').length, 1, 'has log view');
+  assert.equal(this.$('.is-open').length, 0);
+
+  this.$('.name').click();
+
+  return wait().then(() => {
+    assert.ok(this.$('.is-open').length, 1);
+
+    return wait().then(() => {
+      assert.equal(this.$('.logs').text().trim(), 'hello, world');
+    });
   });
 });

--- a/tests/integration/components/create-pipeline-data/component-test.js
+++ b/tests/integration/components/create-pipeline-data/component-test.js
@@ -1,0 +1,68 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('create-pipeline-data', 'Integration | Component | create pipeline data', {
+  integration: true
+});
+
+test('it renders', function (assert) {
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{create-pipeline-data}}`);
+
+  assert.equal(this.$('.scm-url').prop('placeholder').trim(),
+    'Enter your repository link (eg: git@github.com:screwdriver-cd/ui.git#master)');
+  assert.equal(this.$('.blue-button').val().trim(), 'Use this repository');
+  assert.equal(this.$('.blue-button').prop('disabled'), true);
+});
+
+test('it handles successful submission of scmUrl', function (assert) {
+  assert.expect(5);
+  const scm = 'git@github.com:foo/bar.git';
+
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+  this.set('scmData', scm);
+  this.set('rememberProjectData', (scmUrl) => {
+    assert.equal(scmUrl, scm);
+  });
+  // eslint-disable-next-line max-len
+  this.render(hbs`{{create-pipeline-data scmUrl=scmData updateData=(action rememberProjectData)}}`);
+
+  assert.equal(this.$('.scm-url').val().trim(), scm);
+  assert.equal(this.$('.scm-url').hasClass('good-text-input'), true);
+  assert.equal(this.$('.blue-button').prop('disabled'), false);
+  this.$('.blue-button').click();
+});
+
+test('it handles bad scmUrl', function (assert) {
+  assert.expect(3);
+  const scm = 'git@github.com/foo/bar.git';
+
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+  this.set('scmData', scm);
+  // eslint-disable-next-line max-len
+  this.render(hbs`{{create-pipeline-data scmUrl=scmData}}`);
+
+  assert.equal(this.$('.scm-url').val().trim(), scm);
+  assert.equal(this.$('.scm-url').hasClass('bad-text-input'), true);
+  assert.equal(this.$('.blue-button').prop('disabled'), true);
+});
+
+test('it handles updating scmUrl', function (assert) {
+  assert.expect(3);
+  const scm = 'git@github.com:foo/bar.git';
+
+  this.set('updateStep', (step) => {
+    assert.equal(step, 1);
+  });
+
+  // eslint-disable-next-line max-len
+  this.render(hbs`{{create-pipeline-data scmUrl=scmData returnToStep=(action updateStep)}}`);
+
+  this.$('.scm-url').val(scm).keyup();
+  assert.equal(this.$('.scm-url').hasClass('good-text-input'), true);
+  assert.equal(this.$('.blue-button').prop('disabled'), false);
+});

--- a/tests/integration/components/create-step/component-test.js
+++ b/tests/integration/components/create-step/component-test.js
@@ -1,0 +1,38 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('create-step', 'Integration | Component | create step', {
+  integration: true
+});
+
+test('it renders', function (assert) {
+  const $ = this.$;
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{create-step currentStep="1" step="1" title="batman"}}`);
+
+  assert.equal($('.step-line').length, 1);
+  assert.equal($('.step-number span').text().trim(), '1');
+  assert.ok($($('.step-number i')[0]).hasClass('fa-check'));
+  assert.equal($('.step-title').text().trim(), 'batman');
+
+  // Template block usage:
+  this.render(hbs`
+    {{#create-step step="1" title="batman"}}
+    hello
+    {{/create-step}}
+  `);
+
+  assert.equal(this.$('.step-content').text().trim(), 'hello');
+});
+
+test('it renders hidden', function (assert) {
+  this.render(hbs`{{create-step currentStep="1" step="5" title="batman"}}`);
+  assert.equal(this.$('.create-step').hasClass('step-hidden'), true);
+});
+
+test('it renders done', function (assert) {
+  this.render(hbs`{{create-step currentStep="5" step="1" title="batman"}}`);
+  assert.equal(this.$('.create-step').hasClass('step-done'), true);
+});

--- a/tests/integration/components/info-message/component-test.js
+++ b/tests/integration/components/info-message/component-test.js
@@ -1,0 +1,17 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('info-message', 'Integration | Component | info message', {
+  integration: true
+});
+
+test('it renders', function (assert) {
+  const $ = this.$;
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{info-message icon="fa-check" message="batman"}}`);
+
+  assert.equal($().text().trim(), 'batman');
+  assert.ok($($('i')[0]).hasClass('fa-check'));
+});

--- a/tests/integration/components/pipeline-create-form/component-test.js
+++ b/tests/integration/components/pipeline-create-form/component-test.js
@@ -1,0 +1,65 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+const storageKey = 'create-pipeline-data';
+
+moduleForComponent('pipeline-create-form', 'Integration | Component | pipeline create form', {
+  integration: true,
+
+  beforeEach() {
+    localStorage.removeItem(storageKey);
+  }
+});
+
+test('it renders', function (assert) {
+  const $ = this.$;
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{pipeline-create-form errorMessage="" isSaving=false saveSuccess=false}}`);
+
+  assert.equal($($('.step-number span')[0]).text().trim(), '1');
+  assert.equal($($('.step-number span')[1]).text().trim(), '2');
+  assert.equal($($('.step-title')[0]).text().trim(), 'Select a Repository');
+  assert.equal($($('.step-title')[1]).text().trim(), 'Create Pipeline');
+  assert.equal($('.button-label').text().trim(), 'Create Pipeline');
+});
+
+test('it handles the entire ui flow', function (assert) {
+  assert.expect(1);
+  const scm = 'git@github.com:foo/bar.git';
+
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+  this.set('scmUrl', scm);
+  this.set('createPipeline', (scmUrl) => {
+    assert.equal(scmUrl, scm);
+  });
+
+  // eslint-disable-next-line max-len
+  this.render(hbs`{{pipeline-create-form errorMessage="" isSaving=false saveSuccess=false onCreatePipeline=(action createPipeline)}}`);
+  this.$('.scm-url').val(scm).keyup();
+  this.$('input.blue-button').click();
+  this.$('button.blue-button').click();
+});
+
+test('it handles the entire ui flow', function (assert) {
+  assert.expect(3);
+  const scm = 'git@github.com:foo/bar.git';
+
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+  this.set('scmUrl', scm);
+  this.set('createPipeline', (scmUrl) => {
+    assert.equal(scmUrl, scm);
+  });
+  this.set('save', false);
+
+  // eslint-disable-next-line max-len
+  this.render(hbs`{{pipeline-create-form errorMessage="" isSaving=false saveSuccess=save onCreatePipeline=(action createPipeline)}}`);
+  this.$('.scm-url').val(scm).keyup();
+  this.$('input.blue-button').click();
+  this.$('button.blue-button').click();
+  assert.equal(JSON.parse(localStorage.getItem(storageKey)), scm);
+  this.set('save', true);
+  assert.equal(JSON.parse(localStorage.getItem(storageKey)), undefined);
+});

--- a/tests/unit/application/adapter-test.js
+++ b/tests/unit/application/adapter-test.js
@@ -5,7 +5,8 @@ let server;
 
 moduleFor('adapter:application', 'Unit | Adapter | application', {
   // Specify the other units that are required for this test.
-  // needs: ['serializer:foo']
+  needs: ['service:session'],
+
   beforeEach() {
     server = new Pretender();
   },

--- a/tests/unit/build/adapter-test.js
+++ b/tests/unit/build/adapter-test.js
@@ -18,11 +18,10 @@ test('it wraps non-array payload with model name', function (assert) {
   SuperAdapter.prototype.handleResponse = function (status, headers, data, requestData) {
     assert.deepEqual(data, { build: { id: 1234 } });
     assert.equal(status, 'status');
-    assert.equal(headers, 'headers');
     assert.equal(requestData, 'requestData');
   };
 
-  adapter.handleResponse('status', 'headers', { id: 1234 }, 'requestData');
+  adapter.handleResponse('status', {}, { id: 1234 }, 'requestData');
 });
 
 test('it wraps array payload with model name', function (assert) {
@@ -31,9 +30,8 @@ test('it wraps array payload with model name', function (assert) {
   SuperAdapter.prototype.handleResponse = function (status, headers, data, requestData) {
     assert.deepEqual(data, { builds: [{ id: 1234 }] });
     assert.equal(status, 'status');
-    assert.equal(headers, 'headers');
     assert.equal(requestData, 'requestData');
   };
 
-  adapter.handleResponse('status', 'headers', [{ id: 1234 }], 'requestData');
+  adapter.handleResponse('status', {}, [{ id: 1234 }], 'requestData');
 });

--- a/tests/unit/create/controller-test.js
+++ b/tests/unit/create/controller-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('controller:create', 'Unit | Controller | create', {
+  // Specify the other units that are required for this test.
+  // needs: [],
+});
+
+test('it exists', function (assert) {
+  let controller = this.subject();
+
+  assert.ok(controller);
+});

--- a/tests/unit/create/route-test.js
+++ b/tests/unit/create/route-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('route:create', 'Unit | Route | create', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+test('it exists', function (assert) {
+  let route = this.subject();
+
+  assert.ok(route);
+});

--- a/tests/unit/pipeline/serializer-test.js
+++ b/tests/unit/pipeline/serializer-test.js
@@ -1,0 +1,15 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('pipeline', 'Unit | Serializer | pipeline', {
+  // Specify the other units that are required for this test.
+  needs: ['serializer:pipeline', 'model:secret', 'model:job']
+});
+
+// Replace this with your real tests.
+test('it serializes records', function (assert) {
+  let record = this.subject();
+
+  let serializedRecord = record.serialize();
+
+  assert.ok(serializedRecord);
+});

--- a/tests/unit/utils/git-test.js
+++ b/tests/unit/utils/git-test.js
@@ -1,0 +1,33 @@
+import git from 'screwdriver-ui/utils/git';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | git');
+
+// Replace this with your real tests.
+test('it works', (assert) => {
+  let result = git.parse('bananas');
+
+  assert.notOk(result.valid);
+
+  result = git.parse('git@github.com:bananas/peel.git');
+
+  assert.deepEqual(result, {
+    server: 'github.com',
+    owner: 'bananas',
+    repo: 'peel',
+    link: 'https://github.com/bananas/peel',
+    branch: 'master',
+    valid: true
+  });
+
+  result = git.parse('git@github.com:bananas/peel.git#tree');
+
+  assert.deepEqual(result, {
+    server: 'github.com',
+    owner: 'bananas',
+    repo: 'peel',
+    link: 'https://github.com/bananas/peel/tree/tree',
+    branch: 'tree',
+    valid: true
+  });
+});


### PR DESCRIPTION
Adds a create page for pipelines:
* Requires user to be logged in to visit page. Will redirect to login, and redirect back when logged in
* Saves scmUrl in localstorage until successful save
* Redirects to pipeline page for new pipeline on successful create
* displays friendly errors at top of page when create results in error (e.g. 409)

Increased code coverage with acceptance tests.

![screen shot 2016-09-14 at 2 47 10 pm](https://cloud.githubusercontent.com/assets/78533/18531243/287ea27e-7a8a-11e6-9bd2-db0095661356.png)
