### PR TITLE
Add allowInPR field

### DIFF
--- a/app/components/pipeline-secret-settings/component.js
+++ b/app/components/pipeline-secret-settings/component.js
@@ -3,20 +3,39 @@ import Ember from 'ember';
 export default Ember.Component.extend({
   newName: null,
   newValue: null,
+  newAllow: false,
   isButtonDisabled: true,
+  errorMessage: '',
   actions: {
+    /**
+     * Sets disabled state of "add" button
+     * @method enableButton
+     */
     enableButton() {
       const isDisabled = !this.get('newName') || !this.get('newValue');
 
       this.set('isButtonDisabled', isDisabled);
     },
+    /**
+     * Kicks off create secret flow
+     * @method addNewSecret
+     */
     addNewSecret() {
+      if (!/^[A-Z_][A-Z0-9_]*$/.test(this.get('newName'))) {
+        this.set('errorMessage', 'Secret name does not meet requirements /^[A-Z_][A-Z0-9_]*$/');
+
+        return false;
+      }
+
       this.get('onCreateSecret')(
-        this.get('newName'), this.get('newValue'), this.get('pipeline.id')
+        this.get('newName'), this.get('newValue'), this.get('pipeline.id'), this.get('newAllow')
       );
       this.set('newName', null);
       this.set('newValue', null);
+      this.set('newAllow', false);
       this.set('isButtonDisabled', true);
+
+      return true;
     }
   }
 });

--- a/app/components/pipeline-secret-settings/styles.scss
+++ b/app/components/pipeline-secret-settings/styles.scss
@@ -2,6 +2,10 @@
   padding: 0 25px;
 }
 
+.info-message {
+  margin-top: 10px;
+}
+
 h2 {
   color: #666;
 }

--- a/app/components/pipeline-secret-settings/template.hbs
+++ b/app/components/pipeline-secret-settings/template.hbs
@@ -1,10 +1,12 @@
+{{info-message message=errorMessage type="error" icon="exclamation-triangle"}}
+
 <h2>Secrets</h2>
 <table class="secrets">
   <thead>
     <tr>
       <th>Key</th>
       <th>Value</th>
-      <th></th>
+      <th colspan="2">Allow in PR</th>
     </tr>
   </thead>
   <tbody>
@@ -16,6 +18,7 @@
     <tr class="new">
       <td class="key">{{input placeholder="key" size="40" value=newName key-up="enableButton"}}</td>
       <td class="pass">{{input type="password" placeholder="value" size="40" value=newValue key-up="enableButton"}}</td>
+      <td class="allow">{{input type="checkbox" checked=newAllow title="Check to allow this secret to be used in pull-requests"}}</td>
       <td><button disabled={{isButtonDisabled}} {{action "addNewSecret"}}>Add</button></td>
     </tr>
   </tfoot>

--- a/app/components/secret-view/template.hbs
+++ b/app/components/secret-view/template.hbs
@@ -1,3 +1,4 @@
 <td class="name">{{secret.name}}</td>
 <td class="pass">{{input type="password" placeholder="Protected" size="40" value=newValue key-up="newValueDidChange"}}</td>
+<td class="allow">{{input type="checkbox" disabled="true" checked=secret.allowInPR}}</td>
 <td><button {{action "modifySecret"}}>{{buttonAction}}</button></td>

--- a/app/pipeline/secrets/controller.js
+++ b/app/pipeline/secrets/controller.js
@@ -1,11 +1,20 @@
 import Ember from 'ember';
 
 export default Ember.Controller.extend({
+  errorMessage: '',
   actions: {
-    createSecret(name, value, pipelineId) {
-      const newSecret = this.store.createRecord('secret', { name, value, pipelineId });
+    createSecret(name, value, pipelineId, allowInPR) {
+      const newSecret = this.store.createRecord('secret', { name, value, pipelineId, allowInPR });
 
-      return newSecret.save();
+      return newSecret.save()
+        .then(s => {
+          this.set('errorMessage', '');
+          this.get('model.secrets').reload();
+
+          return s;
+        }, (err) => {
+          this.set('errorMessage', err.errors.message);
+        });
     }
   }
 });

--- a/app/pipeline/secrets/template.hbs
+++ b/app/pipeline/secrets/template.hbs
@@ -1,3 +1,8 @@
-{{pipeline-secret-settings secrets=model.secrets onCreateSecret=(action "createSecret") pipeline=model.pipeline}}
+{{pipeline-secret-settings 
+  secrets=model.secrets
+  onCreateSecret=(action "createSecret")
+  pipeline=model.pipeline
+  errorMessage=errorMessage
+}}
 
 {{outlet}}

--- a/app/secret/adapter.js
+++ b/app/secret/adapter.js
@@ -2,6 +2,10 @@ import Adapter from '../application/adapter';
 
 export default Adapter.extend({
   handleResponse: (status, headers, payload, requestData) => {
+    if (payload.error) {
+      return Adapter.prototype.handleResponse(status, headers, { errors: payload }, requestData);
+    }
+
     let data = payload;
 
     // Fix our API not returning the model name in payload

--- a/app/secret/model.js
+++ b/app/secret/model.js
@@ -3,5 +3,6 @@ import DS from 'ember-data';
 export default DS.Model.extend({
   pipelineId: DS.attr('string'), // DS.belongsTo('pipeline'),
   name: DS.attr('string'),
-  value: DS.attr('string')
+  value: DS.attr('string'),
+  allowInPR: DS.attr('boolean', { defaultValue: false })
 });


### PR DESCRIPTION
Missing allowInPR field prevented secrets from being created properly.
Added some validation on key name, since that is the most likely thing to fail.
Added component to display error messages that occur when creating keys