### PR TITLE
make error page work for unknown paths

### DIFF
--- a/app/error/route.js
+++ b/app/error/route.js
@@ -1,3 +1,2 @@
 import Ember from 'ember';
-import UnauthenticatedRouteMixin from 'ember-simple-auth/mixins/unauthenticated-route-mixin';
-export default Ember.Route.extend(UnauthenticatedRouteMixin);
+export default Ember.Route.extend({});


### PR DESCRIPTION
UnauthenticatedRouteMixin will prevent an authenticated user from seeing a page. Since the error page had this mixin added, no authenticated user could see the error page when visiting an unknown path.