### PR TITLE
Refactor secrets model to be an authenticated route

### DIFF
--- a/app/pipeline/secrets/route.js
+++ b/app/pipeline/secrets/route.js
@@ -1,10 +1,13 @@
 import Ember from 'ember';
-
-export default Ember.Route.extend({
-  beforeModel() {
-    this.set('pipeline', this.modelFor('pipeline'));
-  },
+import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+export default Ember.Route.extend(AuthenticatedRouteMixin, {
   model() {
-    return this.get('pipeline.secrets').then(s => ({ secrets: s, pipeline: this.get('pipeline') }));
+    const pipeline = this.modelFor('pipeline');
+
+    return pipeline.get('secrets')
+      .then(secrets => ({
+        secrets,
+        pipeline
+      }));
   }
 });


### PR DESCRIPTION
The secrets page for a pipeline should require authentication. beforeModel messes up the AuthenticatedRouteMixin so refactoring the model function helps.