### PR TITLE
Refresh of pipeline page builds list

### DIFF
--- a/app/components/build-step-view/styles.scss
+++ b/app/components/build-step-view/styles.scss
@@ -8,13 +8,13 @@
 }
 
 &.success .status-icon {
-  color: green;
+  color: $ycolor-green-6b;
 }
 
 &.failure .status-icon {
-  color: red;
+  color: $ycolor-red-2b;
 }
 
 &.running .status-icon {
-  color: blue;
+  color: $ycolor-blue-10b;
 }

--- a/app/components/pipeline-build-view/component.js
+++ b/app/components/pipeline-build-view/component.js
@@ -1,14 +1,14 @@
 import Ember from 'ember';
 
 export default Ember.Component.extend({
-  truncatedSha: Ember.computed('build.sha', {
+  truncatedSha: Ember.computed('commit', {
     get() {
-      return this.get('build.sha').substr(0, 6);
+      return this.get('commit.sha').substr(0, 6);
     }
   }),
-  jobName: Ember.computed('build.jobId', {
+  commit: Ember.computed('workflow.0.build', {
     get() {
-      return this.get('jobs').filter(j => j.get('id') === this.get('build.jobId'))[0].get('name');
+      return this.get('workflow.0.build');
     }
   })
 });

--- a/app/components/pipeline-build-view/styles.scss
+++ b/app/components/pipeline-build-view/styles.scss
@@ -1,15 +1,43 @@
 & {
-  border-radius: 3px;
-  border: 1px solid #ddd;
-  background-color: #eee;
-  margin: 10px 10px 0;
   padding: 10px;
-  width: 30%;
-  display: inline-block;
+  border-bottom: 1px solid $ycolor-gray-h;
+  color: $ycolor-gray-c;
 }
 
 h6 {
   margin: 0;
   padding: 0;
-  font-size: 125%;
+  font-size: 16px;
+
+  a {
+    color: $ycolor-blue-10b;
+    text-decoration: none;
+  }
+}
+
+.duration {
+  font-style: italic;
+}
+
+.right {
+  text-align: right;
+}
+
+.workflow .job {
+  text-indent: -9000px;
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  border-radius: 16px;
+  background-color: $ycolor-gray-e;
+}
+
+.SUCCESS .job {
+  background-color: $ycolor-green-6b;
+}
+.FAILURE .job {
+  background-color: $ycolor-red-2b;
+}
+.RUNNING .job, .QUEUED .job {
+  background-color: $ycolor-blue-10b;
 }

--- a/app/components/pipeline-build-view/template.hbs
+++ b/app/components/pipeline-build-view/template.hbs
@@ -1,18 +1,28 @@
 <div class="pure-g">
   <div class="pure-u-1-5">
-    <h6>{{#link-to "build" build.id}}{{truncatedSha}}{{/link-to}}</h6>
+    <h6>{{#link-to "pipeline.builds.build" commit.id}}#{{truncatedSha}}{{/link-to}}</h6>
+  </div>
+  <div class="pure-u-3-5">
+    <span class="cause">{{commit.cause}}</span>
+  </div>
+  <div class="pure-u-1-5 right">
+    <span class="created" title="{{commit.createTime}}">{{moment-from-now commit.createTime}}</span>
   </div>
   <div class="pure-u-1-5">
-    <span class="job">{{jobName}}</span>
   </div>
-  <div class="pure-u-2-5">
-    <span class="cause">{{build.cause}}</span>
+  <div class="pure-u-3-5 workflow">
+    {{#each workflow as |job|}}
+    {{#if job.build}}
+      <span class="{{job.build.status}}">
+        {{#link-to "pipeline.builds.build" job.build.id class="job" title=job.name}}{{job.name}}{{/link-to}}
+      </span>
+    {{else}}
+      <span class="job">{{job.name}}</span>
+    {{/if}}
+    {{/each}}
   </div>
-  <div class="pure-u-1-5">
-    <span class="created">Started: {{moment-from-now build.createTime}}</span>
-  </div>
-  <div class="pure-u-1-1">
-    <span class="duration">Duration: {{moment-duration build.buildDuration}}</span>
+  <div class="pure-u-1-5 right">
+    <span class="duration">{{moment-duration commit.buildDuration}}</span>
   </div>
 </div>
 

--- a/app/components/pipeline-builds-list/component.js
+++ b/app/components/pipeline-builds-list/component.js
@@ -1,0 +1,66 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend(Ember.PromiseProxyMixin, {
+  workflow: Ember.computed('jobs', {
+    get() {
+      const workflow = [];
+
+      // get a sub-workflow object to clone
+      this.get('jobs').forEach(j => {
+        workflow.push({
+          id: j.get('id'),
+          name: j.get('name')
+        });
+      });
+
+      return workflow;
+    }
+  }),
+
+  builds: Ember.computed('buildList', 'workflow', {
+    get() {
+      const combined = this.get('buildList');
+      const workflow = this.get('workflow');
+
+      if (!combined || !workflow) {
+        return [];
+      }
+
+      const shas = {};
+      let result = [];
+
+      combined.forEach(build => {
+        const sha = build.get('sha');
+
+        // create a workflow based on shas
+        if (!shas[sha]) {
+          shas[sha] = Ember.copy(workflow, true);
+        }
+
+        // add the build info to correct job in the workflow
+        shas[sha].some(j => {
+          if (j.id === build.get('jobId')) {
+            j.build = build;
+
+            return true;
+          }
+
+          return false;
+        });
+      });
+
+      // put the results into an array
+      Object.keys(shas).forEach(key => {
+        result.push(shas[key]);
+      });
+
+      // sort by create time of main job
+      return result.sort((a, b) => {
+        const bBuild = b[0].build || Ember.Object.create();
+        const aBuild = a[0].build || Ember.Object.create();
+
+        return bBuild.get('number') - aBuild.get('number');
+      });
+    }
+  })
+});

--- a/app/components/pipeline-builds-list/styles.scss
+++ b/app/components/pipeline-builds-list/styles.scss
@@ -1,0 +1,10 @@
+& {
+  padding: 0 25px;
+  margin-bottom: 2em;
+}
+
+h2 {
+  color: $ycolor-gray-c;
+  margin: 0;
+  padding: 0;
+}

--- a/app/components/pipeline-builds-list/template.hbs
+++ b/app/components/pipeline-builds-list/template.hbs
@@ -1,0 +1,6 @@
+<h2>Builds</h2>
+{{#each builds as |workflow|}}
+{{pipeline-build-view workflow=workflow}}
+{{/each}}
+
+{{yield}}

--- a/app/components/pipeline-pr-list/component.js
+++ b/app/components/pipeline-pr-list/component.js
@@ -1,0 +1,4 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+});

--- a/app/components/pipeline-pr-list/styles.scss
+++ b/app/components/pipeline-pr-list/styles.scss
@@ -1,0 +1,5 @@
+h2 {
+  color: $ycolor-gray-c;
+  margin: 0;
+  padding: 0 0 10px 0;
+}

--- a/app/components/pipeline-pr-list/template.hbs
+++ b/app/components/pipeline-pr-list/template.hbs
@@ -1,0 +1,4 @@
+<h2>Pull Requests</h2>
+{{#each pullRequests as |job|}}
+  {{pipeline-pr-view job=job}}
+{{/each}}

--- a/app/components/pipeline-pr-view/component.js
+++ b/app/components/pipeline-pr-view/component.js
@@ -1,0 +1,31 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  classNameBindings: ['build.status'],
+  build: Ember.computed('job.builds', {
+    get() {
+      return this.get('job.builds').objectAt(0);
+    }
+  }),
+  icon: Ember.computed('build.status', {
+    get() {
+      const status = this.get('build.status');
+      let icon;
+
+      switch (status) {
+      case 'QUEUED':
+      case 'RUNNING':
+        icon = 'fa-spinner fa-spin';
+        break;
+      case 'SUCCESS':
+        icon = 'fa-check';
+        break;
+      default:
+        icon = 'fa-times';
+        break;
+      }
+
+      return icon;
+    }
+  })
+});

--- a/app/components/pipeline-pr-view/styles.scss
+++ b/app/components/pipeline-pr-view/styles.scss
@@ -1,0 +1,25 @@
+.fa {
+  width: 10px;
+  color: $ycolor-blue-10b;
+}
+
+&.SUCCESS {
+  .fa {
+    color: $ycolor-green-6b;
+  }
+}
+
+&.FAILURE {
+  .fa {
+    color: $ycolor-red-2b;
+  }
+}
+
+a {
+  text-decoration: none;
+  color: $ycolor-gray-b;
+}
+
+a span {
+  margin-left: 10px;
+}

--- a/app/components/pipeline-pr-view/template.hbs
+++ b/app/components/pipeline-pr-view/template.hbs
@@ -1,0 +1,1 @@
+{{#link-to "pipeline.builds.build" build.id}}{{fa-icon icon}}<span>{{job.name}}</span>{{/link-to}}

--- a/app/components/pipeline-secret-settings/styles.scss
+++ b/app/components/pipeline-secret-settings/styles.scss
@@ -7,7 +7,7 @@
 }
 
 h2 {
-  color: #666;
+  color: $ycolor-gray-c;
 }
 
 tbody tr {

--- a/app/pipeline/builds/index/route.js
+++ b/app/pipeline/builds/index/route.js
@@ -1,21 +1,50 @@
 import Ember from 'ember';
 
+/**
+ * fetch and combine the list of all builds for the workflow
+ * @method getBuilds
+ * @param  {Ember.NativeArray}  jobs List of jobs
+ * @return {Promise}
+ */
+function getBuilds(jobs) {
+  const buildList = [];
+
+  jobs.forEach(j => {
+    buildList.push(j.get('builds'));
+  });
+
+  // fetch all the builds
+  return Ember.RSVP.all(buildList).then(builds => {
+    let combined = [];
+
+    // put all the builds in a single array
+    builds.forEach(b => {
+      combined = combined.concat(b.slice());
+    });
+
+    return combined;
+  });
+}
+
 export default Ember.Route.extend({
   beforeModel() {
     this.set('pipeline', this.modelFor('pipeline'));
   },
   model() {
-    // Get the jobs in this pipeline, and ALL builds (since there's no jobs/:id/builds, yet)
-    return Ember.RSVP.all([this.get('pipeline.jobs'), this.store.findAll('build')])
-      .then(([jobs, builds]) => {
-        // get a list of job ids for active jobs
-        const jobIds = jobs.filter(j => j.state !== 'DISABLED').map(j => j.get('id'));
+    return this.get('pipeline.jobs')
+      // Get rid of disabled jobs
+      .then(jobs => jobs.filter(j => j.get('state') !== 'DISABLED'))
+      // Split jobs from workflow
+      .then(jobs => {
+        // filter out the PRs, reverse to get correct order
+        const workflowJobs = jobs.filter(j => !/^PR\-/.test(j.get('name'))).reverse();
 
-        // return a list of builds that are related to those job ids
-        return {
-          builds: builds.filter(b => jobIds.contains(b.get('jobId'))),
-          jobs
-        };
+        // get all the builds and return results
+        return getBuilds(workflowJobs).then(builds => ({
+          jobs: workflowJobs,
+          builds,
+          pullRequests: jobs.filter(j => /^PR\-/.test(j.get('name')))
+        }));
       });
   }
 });

--- a/app/pipeline/builds/index/template.hbs
+++ b/app/pipeline/builds/index/template.hbs
@@ -1,6 +1,13 @@
 {{pipeline-workflow jobs=model.jobs}}
-{{#each model.builds as |build|}}
-{{pipeline-build-view build=build jobs=model.jobs}}
-{{/each}}
+
+<div class="pure-g">
+  <div class="pure-u-3-4">
+    {{pipeline-builds-list buildList=model.builds jobs=model.jobs}}
+  </div>
+  <div class="pure-u-1-4">
+    {{pipeline-pr-list pullRequests=model.pullRequests}}
+  </div>
+</div>
+
 
 {{outlet}}

--- a/tests/integration/components/pipeline-build-view/component-test.js
+++ b/tests/integration/components/pipeline-build-view/component-test.js
@@ -10,28 +10,48 @@ test('it renders', function (assert) {
   // Set any properties with this.set('myProperty', 'value');
   // Handle any actions with this.on('myAction', function(val) { ... });
   const now = 1472244582531;
-  const buildMock = {
-    jobId: 'abcd',
-    sha: '12345678901234567890',
-    cause: 'bananas',
-    buildContainer: 'node:6',
-    createTime: now - 180000,
-    startTime: now - 175000,
-    endTime: now,
-    buildDuration: 175,
-    queuedDuration: 5
-  };
-  const jobs = [
-    Ember.Object.create({ id: 'abcd', name: 'hello' }),
-    Ember.Object.create({ id: 'efgh', name: 'world' })
+
+  const workflowMock = [
+    {
+      id: 'abcd',
+      name: 'main',
+      build: Ember.Object.create({
+        jobId: 'abcd',
+        sha: '12345678901234567890',
+        cause: 'bananas',
+        buildContainer: 'node:6',
+        createTime: now - 180000,
+        startTime: now - 175000,
+        endTime: now - 165000,
+        buildDuration: 5,
+        queuedDuration: 5,
+        status: 'SUCCESS'
+      })
+    },
+    {
+      id: 'abcde',
+      name: 'publish',
+      build: Ember.Object.create({
+        jobId: 'abcde',
+        sha: '12345678901234567890',
+        cause: 'bananas',
+        buildContainer: 'node:6',
+        createTime: now - 165000,
+        startTime: now - 155000,
+        endTime: now,
+        buildDuration: 155,
+        queuedDuration: 5,
+        status: 'SUCCESS'
+      })
+    }
   ];
 
-  this.set('buildMock', buildMock);
-  this.set('jobsMock', jobs);
+  this.set('workflowMock', workflowMock);
 
-  this.render(hbs`{{pipeline-build-view build=buildMock jobs=jobsMock}}`);
+  this.render(hbs`{{pipeline-build-view workflow=workflowMock}}`);
 
-  assert.equal(this.$('h6 a').text().trim(), '123456');
-  assert.equal(this.$('.job').text().trim(), 'hello');
+  assert.equal(this.$('h6 a').text().trim(), '#123456');
   assert.equal(this.$('.cause').text().trim(), 'bananas');
+  assert.equal(this.$('.job').length, 2, 'not enough work being done');
+  assert.equal(this.$('.SUCCESS').length, 2, 'not successful enough');
 });

--- a/tests/integration/components/pipeline-builds-list/component-test.js
+++ b/tests/integration/components/pipeline-builds-list/component-test.js
@@ -1,0 +1,57 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import Ember from 'ember';
+const now = 1472244582531;
+
+moduleForComponent('pipeline-builds-list', 'Integration | Component | pipeline builds list', {
+  integration: true
+});
+
+test('it renders', function (assert) {
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+  const builds = [
+    Ember.Object.create({
+      jobId: 'abcd',
+      sha: '12345678901234567890',
+      cause: 'bananas',
+      buildContainer: 'node:6',
+      createTime: now - 180000,
+      startTime: now - 175000,
+      endTime: now - 165000,
+      buildDuration: 5,
+      queuedDuration: 5,
+      status: 'SUCCESS'
+    }),
+    Ember.Object.create({
+      jobId: 'abcde',
+      sha: '12345678901234567890',
+      cause: 'bananas',
+      buildContainer: 'node:6',
+      createTime: now - 165000,
+      startTime: now - 155000,
+      endTime: now,
+      buildDuration: 155,
+      queuedDuration: 5,
+      status: 'SUCCESS'
+    })
+  ];
+  const jobs = [
+    Ember.Object.create({
+      id: 'abcd',
+      name: 'main'
+    }),
+    Ember.Object.create({
+      id: 'abcde',
+      name: 'publish'
+    })
+  ];
+
+  this.set('buildsMock', builds);
+  this.set('jobsMock', jobs);
+
+  this.render(hbs`{{pipeline-builds-list buildList=buildsMock jobs=jobsMock}}`);
+
+  assert.equal(this.$('h2').text().trim(), 'Builds');
+  assert.equal(this.$('> div').length, 1);
+});

--- a/tests/integration/components/pipeline-pr-list/component-test.js
+++ b/tests/integration/components/pipeline-pr-list/component-test.js
@@ -1,0 +1,37 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import Ember from 'ember';
+
+moduleForComponent('pipeline-pr-list', 'Integration | Component | pipeline pr list', {
+  integration: true
+});
+
+test('it renders', function (assert) {
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+  const jobs = [
+    Ember.Object.create({
+      id: 'abcd',
+      name: 'main',
+      builds: [{
+        id: '1234',
+        status: 'SUCCESS'
+      }]
+    }),
+    Ember.Object.create({
+      id: 'abcde',
+      name: 'publish',
+      builds: [{
+        id: '1234',
+        status: 'FAILURE'
+      }]
+    })
+  ];
+
+  this.set('jobsMock', jobs);
+
+  this.render(hbs`{{pipeline-pr-list jobs=jobsMock}}`);
+
+  assert.equal(this.$('h2').text().trim(), 'Pull Requests');
+  assert.equal(this.$('> div').length, 1);
+});

--- a/tests/integration/components/pipeline-pr-view/component-test.js
+++ b/tests/integration/components/pipeline-pr-view/component-test.js
@@ -1,0 +1,87 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import Ember from 'ember';
+
+moduleForComponent('pipeline-pr-view', 'Integration | Component | pipeline pr view', {
+  integration: true
+});
+
+test('it renders a successful PR', function (assert) {
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+  const job = Ember.Object.create({
+    id: 'abcd',
+    name: 'PR-1234',
+    builds: [{
+      id: '1234',
+      status: 'SUCCESS'
+    }]
+  });
+
+  this.set('jobMock', job);
+
+  this.render(hbs`{{pipeline-pr-view job=jobMock}}`);
+
+  assert.equal(this.$().text().trim(), 'PR-1234');
+  assert.equal(this.$('.fa-check').length, 1);
+});
+
+test('it renders a failed PR', function (assert) {
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+  const job = Ember.Object.create({
+    id: 'abcd',
+    name: 'PR-1234',
+    builds: [{
+      id: '1234',
+      status: 'FAILURE'
+    }]
+  });
+
+  this.set('jobMock', job);
+
+  this.render(hbs`{{pipeline-pr-view job=jobMock}}`);
+
+  assert.equal(this.$().text().trim(), 'PR-1234');
+  assert.equal(this.$('.fa-times').length, 1);
+});
+
+test('it renders a queued PR', function (assert) {
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+  const job = Ember.Object.create({
+    id: 'abcd',
+    name: 'PR-1234',
+    builds: [{
+      id: '1234',
+      status: 'QUEUED'
+    }]
+  });
+
+  this.set('jobMock', job);
+
+  this.render(hbs`{{pipeline-pr-view job=jobMock}}`);
+
+  assert.equal(this.$().text().trim(), 'PR-1234');
+  assert.equal(this.$('.fa-spinner').length, 1);
+});
+
+test('it renders a running PR', function (assert) {
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+  const job = Ember.Object.create({
+    id: 'abcd',
+    name: 'PR-1234',
+    builds: [{
+      id: '1234',
+      status: 'RUNNING'
+    }]
+  });
+
+  this.set('jobMock', job);
+
+  this.render(hbs`{{pipeline-pr-view job=jobMock}}`);
+
+  assert.equal(this.$().text().trim(), 'PR-1234');
+  assert.equal(this.$('.fa-spinner').length, 1);
+});


### PR DESCRIPTION
Redesign of build list, separates PRs from workflow builds.
Computes workflow, and adds a UI to builds to display workflow status

Extra hackery to get around /pipeline/:id/jobs not being complete.

![screen shot 2016-09-19 at 6 14 58 pm](https://cloud.githubusercontent.com/assets/78533/18654400/ab730f62-7e95-11e6-9b8b-83163f8b33fb.png)
