### PR TITLE
Cleanup pipeline header links

### DIFF
--- a/app/components/pipeline-header/template.hbs
+++ b/app/components/pipeline-header/template.hbs
@@ -1,2 +1,2 @@
-<a href="{{pipeline.hubUrl}}">{{fa-icon "fa-github"}}<h1>{{pipeline.appId}}</h1></a>
-<span class="branch">{{fa-icon "fa-code-fork"}} {{pipeline.repoData.branch}}</span>
+{{#link-to "pipeline" pipeline.id}}<h1>{{pipeline.appId}}</h1>{{/link-to}}
+<a href="{{pipeline.hubUrl}}" class="branch">{{fa-icon "fa-code-fork"}} {{pipeline.repoData.branch}}</a>

--- a/app/components/pipeline-pr-list/template.hbs
+++ b/app/components/pipeline-pr-list/template.hbs
@@ -2,3 +2,6 @@
 {{#each pullRequests as |job|}}
   {{pipeline-pr-view job=job}}
 {{/each}}
+{{#unless pullRequests.length}}
+<span>No open pull requests</span>
+{{/unless}}

--- a/tests/integration/components/pipeline-header/component-test.js
+++ b/tests/integration/components/pipeline-header/component-test.js
@@ -6,6 +6,7 @@ moduleForComponent('pipeline-header', 'Integration | Component | pipeline header
 });
 
 test('it renders', function (assert) {
+  const $ = this.$;
   // Set any properties with this.set('myProperty', 'value');
   // Handle any actions with this.on('myAction', function(val) { ... });
   const pipelineMock = {
@@ -19,7 +20,7 @@ test('it renders', function (assert) {
   this.set('pipelineMock', pipelineMock);
   this.render(hbs`{{pipeline-header pipeline=pipelineMock}}`);
 
-  assert.equal(this.$('h1').text().trim(), 'batman/batmobile');
-  assert.equal(this.$('.branch').text().trim(), 'master');
-  assert.equal(this.$('a')[0].href, 'http://example.com/batman/batmobile');
+  assert.equal($('h1').text().trim(), 'batman/batmobile');
+  assert.equal($($('a').get(1)).text().trim(), 'master');
+  assert.equal($($('a').get(1)).attr('href'), 'http://example.com/batman/batmobile');
 });


### PR DESCRIPTION
Makes the pipeline appId a link to pipeline page. 
Instead, the branch links to github page.

Added some text to PR column when no PRs are present.