### PR TITLE
Fix build page now that jobs api gives better data

### DIFF
--- a/app/pipeline/builds/index/route.js
+++ b/app/pipeline/builds/index/route.js
@@ -32,12 +32,10 @@ export default Ember.Route.extend({
   },
   model() {
     return this.get('pipeline.jobs')
-      // Get rid of disabled jobs
-      .then(jobs => jobs.filter(j => j.get('state') !== 'DISABLED'))
       // Split jobs from workflow
       .then(jobs => {
-        // filter out the PRs, reverse to get correct order
-        const workflowJobs = jobs.filter(j => !/^PR\-/.test(j.get('name'))).reverse();
+        // filter out the PRs
+        const workflowJobs = jobs.filter(j => !/^PR\-/.test(j.get('name')));
 
         // get all the builds and return results
         return getBuilds(workflowJobs).then(builds => ({


### PR DESCRIPTION
Gets rid of hackery for the pipeline/:id/jobs api call that filters disabled jobs, and reversed job order