### PR TITLE
start/stop buttons

### DIFF
--- a/app/build/serializer.js
+++ b/app/build/serializer.js
@@ -1,0 +1,17 @@
+import DS from 'ember-data';
+import Ember from 'ember';
+
+export default DS.RESTSerializer.extend({
+  /**
+   * Override the serializeIntoHash method because our screwed up API doesn't have model names as a root key
+   * See http://emberjs.com/api/data/classes/DS.RESTSerializer.html#method_serializeIntoHash
+   * @method serializeIntoHash
+   */
+  serializeIntoHash(hash, typeClass, snapshot) {
+    if (!snapshot.id) {
+      return Ember.merge(hash, { jobId: snapshot.attr('jobId') });
+    }
+
+    return Ember.merge(hash, { status: snapshot.attr('status') });
+  }
+});

--- a/app/components/build-banner/component.js
+++ b/app/components/build-banner/component.js
@@ -8,5 +8,41 @@ export default Ember.Component.extend({
     get() {
       return this.get('build.sha').substr(0, 6);
     }
-  })
+  }),
+
+  buildAction: Ember.computed('build.status', {
+    get() {
+      const status = this.get('build.status');
+
+      if (status === 'RUNNING' || status === 'QUEUED') {
+        return 'Stop';
+      }
+
+      return 'Restart';
+    }
+  }),
+
+  hasButton: Ember.computed('buildAction', 'job.name', {
+    get() {
+      if (this.get('buildAction') === 'Stop') {
+        return true;
+      }
+
+      if (/^PR\-/.test(this.get('job.name'))) {
+        return true;
+      }
+
+      return false;
+    }
+  }),
+
+  actions: {
+    toggleBuild() {
+      if (this.get('buildAction') === 'Stop') {
+        this.get('onStop')();
+      } else {
+        this.get('onStart')();
+      }
+    }
+  }
 });

--- a/app/components/build-banner/styles.scss
+++ b/app/components/build-banner/styles.scss
@@ -8,6 +8,7 @@
   &.SUCCESS {
     background-color: $ycolor-green-6b;
   }
+  &.ABORTED,
   &.FAILURE {
     background-color: $ycolor-red-2b;
   }
@@ -23,6 +24,10 @@ li {
   display: inline-block;
   width: 50%;
   font-size: 16px;
+  text-align: center;
+}
+li:first-child {
+  text-align: left;
 }
 li:last-child {
   text-align: right;
@@ -37,6 +42,13 @@ h1 {
 .line1 {
   margin-bottom: 5px;
 
+  li {
+    vertical-align: middle;
+    width: 33%;
+  }
+  li:last-child {
+    width: 34%;
+  }
   span {
     font-size: 2em;
   }
@@ -46,4 +58,18 @@ a {
   color: #fff;
   cursor: pointer;
   text-decoration: none;
+}
+
+button {
+  font-size: 16px;
+  background-color: $ycolor-gray-i;
+  color: #000;
+  border: none;
+  border-radius: 3px;
+  padding: 5px;
+}
+
+button:hover {
+  background-color: $ycolor-gray-g;
+  color: #000;
 }

--- a/app/components/build-banner/template.hbs
+++ b/app/components/build-banner/template.hbs
@@ -2,6 +2,9 @@
   <ul>
     <li><a class="sha" href="{{pipeline.hubUrl}}"><span class="sha">#{{truncatedSha}}</span></a></li>
     <li><h1>{{job.name}}</h1></li>
+    {{#if session.isAuthenticated}}
+    <li>{{#if hasButton}}<button {{action "toggleBuild"}}>{{buildAction}}</button>{{/if}}</li>
+    {{/if}}
   </ul>
 </div>
 <ul>

--- a/app/components/pipeline-workflow/component.js
+++ b/app/components/pipeline-workflow/component.js
@@ -8,5 +8,11 @@ export default Ember.Component.extend({
 
       return Ember.String.htmlSafe(`width:${width}%`);
     }
-  })
+  }),
+
+  actions: {
+    startBuild() {
+      this.get('onStartBuild')();
+    }
+  }
 });

--- a/app/components/pipeline-workflow/styles.scss
+++ b/app/components/pipeline-workflow/styles.scss
@@ -79,3 +79,19 @@ a {
   margin-right: -20px;
   border-left: 19px solid white;
 }
+
+.right {
+  text-align: right;
+}
+
+button {
+  background-color: $ycolor-gray-f;
+  border: none;
+  border-radius: 3px;
+  padding: 5px;
+}
+
+button:hover {
+  background-color: $color-default-primary;
+  color: #fff;
+}

--- a/app/components/pipeline-workflow/template.hbs
+++ b/app/components/pipeline-workflow/template.hbs
@@ -1,5 +1,20 @@
+{{#if session.isAuthenticated}}
+<div class="pure-g">
+  <div class="pure-u-23-24">
+    <ul>
+      {{#each jobs as |job|}}
+      <li class={{ get (get-last-build job.builds) "status" }} style={{jobWidth}}>{{#link-to "build" (get (get-last-build job.builds) "id")}}{{job.name}}{{/link-to}}<div class="arrow-right"></div><div class="arrow-right shadow"></div></li>
+      {{/each}}
+    </ul>
+  </div>
+  <div class="pure-u-1-24 right">
+    <button {{action "startBuild"}}>Start</button>
+  </div>
+</div>
+{{else}}
 <ul>
   {{#each jobs as |job|}}
   <li class={{ get (get-last-build job.builds) "status" }} style={{jobWidth}}>{{#link-to "build" (get (get-last-build job.builds) "id")}}{{job.name}}{{/link-to}}<div class="arrow-right"></div><div class="arrow-right shadow"></div></li>
   {{/each}}
 </ul>
+{{/if}}

--- a/app/pipeline/builds/build/controller.js
+++ b/app/pipeline/builds/build/controller.js
@@ -1,0 +1,21 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  session: Ember.inject.service('session'),
+
+  actions: {
+    stopBuild() {
+      const build = this.get('model.build');
+
+      build.set('status', 'ABORTED');
+      build.save();
+    },
+
+    startBuild() {
+      const jobId = this.get('model.build.jobId');
+      const build = this.store.createRecord('build', { jobId });
+
+      build.save().then(() => this.transitionToRoute('pipeline.builds.build', build.get('id')));
+    }
+  }
+});

--- a/app/pipeline/builds/build/template.hbs
+++ b/app/pipeline/builds/build/template.hbs
@@ -1,4 +1,11 @@
-{{build-banner build=model.build pipeline=model.pipeline job=model.job}}
+{{build-banner
+  build=model.build
+  pipeline=model.pipeline
+  job=model.job
+  session=session
+  onStart=(action "startBuild")
+  onStop=(action "stopBuild")
+}}
 
 {{#if model.build.steps}}
 {{build-step-collection steps=model.build.steps build=model.build}}

--- a/app/pipeline/builds/index/controller.js
+++ b/app/pipeline/builds/index/controller.js
@@ -1,0 +1,23 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  session: Ember.inject.service('session'),
+  actions: {
+    startMainBuild() {
+      const main = this.get('model.jobs').objectAt(0);
+      const lastBuild = main.get('builds').objectAt(0);
+      const status = lastBuild.get('status');
+
+      // build is already running, just go to the build
+      if (status === 'QUEUED' || status === 'RUNNING') {
+        return this.transitionToRoute('pipeline.builds.build', lastBuild.get('id'));
+      }
+
+      const newBuild = this.store.createRecord('build', { jobId: main.get('id') });
+
+      return newBuild.save().then(b =>
+        this.transitionToRoute('pipeline.builds.build', b.get('id'))
+      );
+    }
+  }
+});

--- a/app/pipeline/builds/index/template.hbs
+++ b/app/pipeline/builds/index/template.hbs
@@ -1,4 +1,4 @@
-{{pipeline-workflow jobs=model.jobs}}
+{{pipeline-workflow jobs=model.jobs onStartBuild=(action "startMainBuild") session=session}}
 
 <div class="pure-g">
   <div class="pure-u-3-4">

--- a/config/coverage.js
+++ b/config/coverage.js
@@ -5,7 +5,15 @@ module.exports = {
   // Templates are pre-compiled from hbs to js, so istanbul sees them as template.js
   // We have no desire to get full coverage on handlebars code, so exclude them
   // This is supposed to be done by ember-cli-code-coverage automatically, but doesn't work
-  excludes: ['*/components/**/template.js'],
+  excludes: [
+    '*/components/**/template.js',
+    '*/create/template.js',
+    '*/home/template.js',
+    '*/application/template.js',
+    '*/login/template.js',
+    '*/pipeline/template.js',
+    '*/pipeline/**/template.js'
+  ],
   coverageFolder: process.env.COVERAGE_DIR || 'coverage',
   useBabelInstrumenter: false
 };

--- a/tests/integration/components/build-banner/component-test.js
+++ b/tests/integration/components/build-banner/component-test.js
@@ -1,5 +1,6 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import Ember from 'ember';
 
 moduleForComponent('build-banner', 'Integration | Component | build banner', {
   integration: true
@@ -23,14 +24,145 @@ test('it renders', function (assert) {
     branch: 'master',
     hubUrl: 'http://github.com/foo/bar'
   };
+  const sessionMock = {
+    isAuthenticated: false
+  };
 
   this.set('buildMock', buildMock);
   this.set('jobMock', jobMock);
   this.set('pipelineMock', pipelineMock);
-  this.render(hbs`{{build-banner build=buildMock job=jobMock pipeline=pipelineMock}}`);
+  this.set('sessionMock', sessionMock);
+  this.render(hbs`{{build-banner
+    build=buildMock
+    job=jobMock
+    pipeline=pipelineMock
+    session=sessionMock}}`);
 
   assert.equal($('h1').text().trim(), 'PR-671');
   assert.equal($('span.sha').text().trim(), '#abcd12');
   assert.equal($('.cause').text().trim(), 'monkeys with typewriters');
   assert.equal($('.duration').text().trim(), '5 seconds');
+  assert.equal($('button').length, 0);
+});
+
+test('it does not render a restart button for non-PR jobs when authenticated', function (assert) {
+  const $ = this.$;
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+  const buildMock = Ember.Object.create({
+    status: 'ABORTED',
+    cause: 'monkeys with typewriters',
+    sha: 'abcd1234567890',
+    buildDuration: '5 seconds'
+  });
+  const jobMock = Ember.Object.create({
+    name: 'main'
+  });
+  const pipelineMock = Ember.Object.create({
+    appId: 'foo:bar',
+    branch: 'master',
+    hubUrl: 'http://github.com/foo/bar'
+  });
+  const sessionMock = Ember.Object.create({
+    isAuthenticated: true
+  });
+
+  this.set('buildMock', buildMock);
+  this.set('jobMock', jobMock);
+  this.set('pipelineMock', pipelineMock);
+  this.set('sessionMock', sessionMock);
+  this.render(hbs`{{build-banner
+    build=buildMock
+    job=jobMock
+    pipeline=pipelineMock
+    session=sessionMock
+  }}`);
+
+  assert.equal($('button').length, 0);
+});
+
+test('it renders a restart button for PR jobs when authenticated', function (assert) {
+  assert.expect(2);
+  const $ = this.$;
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+  const buildMock = Ember.Object.create({
+    status: 'ABORTED',
+    cause: 'monkeys with typewriters',
+    sha: 'abcd1234567890',
+    buildDuration: '5 seconds'
+  });
+  const jobMock = Ember.Object.create({
+    name: 'PR-1234'
+  });
+  const pipelineMock = Ember.Object.create({
+    appId: 'foo:bar',
+    branch: 'master',
+    hubUrl: 'http://github.com/foo/bar'
+  });
+  const sessionMock = Ember.Object.create({
+    isAuthenticated: true
+  });
+  const startAction = () => {
+    assert.ok(true);
+  };
+
+  this.set('buildMock', buildMock);
+  this.set('jobMock', jobMock);
+  this.set('pipelineMock', pipelineMock);
+  this.set('sessionMock', sessionMock);
+  this.set('externalStart', startAction);
+  this.render(hbs`{{build-banner
+    build=buildMock
+    job=jobMock
+    pipeline=pipelineMock
+    session=sessionMock
+    onStart=(action externalStart)
+  }}`);
+
+  assert.equal($('button').text().trim(), 'Restart');
+  $('button').click();
+});
+
+test('it renders a stop button for job when authenticated', function (assert) {
+  assert.expect(2);
+  const $ = this.$;
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+  const buildMock = Ember.Object.create({
+    status: 'RUNNING',
+    cause: 'monkeys with typewriters',
+    sha: 'abcd1234567890',
+    buildDuration: '5 seconds'
+  });
+  const jobMock = Ember.Object.create({
+    name: 'main'
+  });
+  const pipelineMock = Ember.Object.create({
+    appId: 'foo:bar',
+    branch: 'master',
+    hubUrl: 'http://github.com/foo/bar'
+  });
+  const sessionMock = Ember.Object.create({
+    isAuthenticated: true
+  });
+  const stopAction = () => {
+    assert.ok(true);
+  };
+
+  this.set('buildMock', buildMock);
+  this.set('jobMock', jobMock);
+  this.set('pipelineMock', pipelineMock);
+  this.set('sessionMock', sessionMock);
+  this.set('externalStop', stopAction);
+  this.render(hbs`{{build-banner
+    build=buildMock
+    job=jobMock
+    pipeline=pipelineMock
+    session=sessionMock
+    onStop=(action externalStop)
+  }}`);
+
+  assert.equal($('button').text().trim(), 'Stop');
+  $('button').click();
 });

--- a/tests/integration/components/pipeline-workflow/component-test.js
+++ b/tests/integration/components/pipeline-workflow/component-test.js
@@ -36,4 +36,40 @@ test('it renders', function (assert) {
   assert.equal(this.$('li').attr('style'), 'width:100%');
   assert.equal(this.$('li').attr('class'), 'SUCCESS');
   assert.equal(this.$('a').attr('href'), '/builds/123');
+  assert.equal(this.$('button').length, 0);
+});
+
+test('it renders a button when logged in', function (assert) {
+  assert.expect(6);
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+  // eslint-disable-next-line new-cap
+  const builds = Ember.A([
+    Ember.Object.create({ id: '123', status: 'SUCCESS' })
+  ]);
+
+  const jobs = [
+    Ember.Object.create({ id: 'abcd', name: 'hello', builds })
+  ];
+
+  this.set('sessionMock', {
+    isAuthenticated: true
+  });
+  this.set('jobsMock', jobs);
+  this.set('externalStart', () => {
+    assert.ok(true);
+  });
+
+  this.render(hbs`{{pipeline-workflow
+    jobs=jobsMock
+    session=sessionMock
+    onStartBuild=(action externalStart)
+  }}`);
+
+  assert.equal(this.$('a').text().trim(), 'hello');
+  assert.equal(this.$('li').attr('style'), 'width:100%');
+  assert.equal(this.$('li').attr('class'), 'SUCCESS');
+  assert.equal(this.$('a').attr('href'), '/builds/123');
+  assert.equal(this.$('button').text().trim(), 'Start');
+  this.$('button').click();
 });

--- a/tests/unit/build/serializer-test.js
+++ b/tests/unit/build/serializer-test.js
@@ -1,0 +1,72 @@
+import { moduleForModel, test } from 'ember-qunit';
+import Pretender from 'pretender';
+import Ember from 'ember';
+import wait from 'ember-test-helpers/wait';
+let server;
+
+moduleForModel('build', 'Unit | Serializer | build', {
+  // Specify the other units that are required for this test.
+  needs: ['serializer:build'],
+
+  beforeEach() {
+    server = new Pretender();
+  },
+
+  afterEach() {
+    server.shutdown();
+  }
+});
+
+test('it POSTs only a jobId for create', function (assert) {
+  assert.expect(2);
+  server.post('/builds', function () {
+    return [200, {}, JSON.stringify({ build: { id: 'abcd' } })];
+  });
+
+  Ember.run(() => {
+    const build = this.store().createRecord('build', { jobId: '1234' });
+
+    build.save().then(() => {
+      assert.equal(build.get('id'), 'abcd');
+    });
+  });
+
+  return wait().then(() => {
+    const [request] = server.handledRequests;
+    const payload = JSON.parse(request.requestBody);
+
+    assert.deepEqual(payload, { jobId: '1234' });
+  });
+});
+
+test('it PUTs only a status for update', function (assert) {
+  assert.expect(1);
+  server.patch('/builds/1234', function () {
+    return [200, {}, JSON.stringify({ build: { id: 1234 } })];
+  });
+
+  Ember.run(() => {
+    this.store().push({
+      data: {
+        id: 1234,
+        type: 'build',
+        attributes: {
+          jobId: 'abcd',
+          status: 'RUNNING'
+        }
+      }
+    });
+
+    const build = this.store().peekRecord('build', 1234);
+
+    build.set('status', 'ABORTED');
+    build.save();
+  });
+
+  return wait().then(() => {
+    const [request] = server.handledRequests;
+    const payload = JSON.parse(request.requestBody);
+
+    assert.deepEqual(payload, { status: 'ABORTED' });
+  });
+});

--- a/tests/unit/pipeline/builds/build/controller-test.js
+++ b/tests/unit/pipeline/builds/build/controller-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('controller:pipeline/builds/build', 'Unit | Controller | pipeline/builds/build', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+test('it exists', function (assert) {
+  let controller = this.subject();
+
+  assert.ok(controller);
+});

--- a/tests/unit/pipeline/builds/index/controller-test.js
+++ b/tests/unit/pipeline/builds/index/controller-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('controller:pipeline/builds/index', 'Unit | Controller | pipeline/builds/index', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+test('it exists', function (assert) {
+  let controller = this.subject();
+
+  assert.ok(controller);
+});

--- a/tests/unit/secret/serializer-test.js
+++ b/tests/unit/secret/serializer-test.js
@@ -1,8 +1,19 @@
 import { moduleForModel, test } from 'ember-qunit';
+import Pretender from 'pretender';
+import Ember from 'ember';
+import wait from 'ember-test-helpers/wait';
+let server;
 
 moduleForModel('secret', 'Unit | Serializer | secret', {
   // Specify the other units that are required for this test.
-  needs: ['serializer:secret']
+  needs: ['serializer:secret'],
+  beforeEach() {
+    server = new Pretender();
+  },
+
+  afterEach() {
+    server.shutdown();
+  }
 });
 
 // Replace this with your real tests.
@@ -12,4 +23,35 @@ test('it serializes records', function (assert) {
   let serializedRecord = record.serialize();
 
   assert.ok(serializedRecord);
+});
+
+test('it does not post with model name as key', function (assert) {
+  assert.expect(2);
+  server.post('/secrets', function () {
+    return [200, {}, JSON.stringify({ secret: { id: 'abcd' } })];
+  });
+
+  Ember.run(() => {
+    const secret = this.store().createRecord('secret', {
+      pipelineId: 'aabb',
+      name: 'foo',
+      value: 'bar'
+    });
+
+    secret.save().then(() => {
+      assert.equal(secret.get('id'), 'abcd');
+    });
+  });
+
+  return wait().then(() => {
+    const [request] = server.handledRequests;
+    const payload = JSON.parse(request.requestBody);
+
+    assert.deepEqual(payload, {
+      pipelineId: 'aabb',
+      name: 'foo',
+      value: 'bar',
+      allowInPR: false
+    });
+  });
 });


### PR DESCRIPTION
* Add a start button to pipeline.builds page [redirects to build page if build already running]
* Add a [re]start button to build page for pull requests 
* Add a stop button to build page for all running builds
* Fixed some colors for aborted builds
* Removed template.hbs files from code coverage in routes

**Build Page**
![screen shot 2016-09-21 at 4 08 52 pm](https://cloud.githubusercontent.com/assets/78533/18732136/c7a0f308-8015-11e6-878c-0bdbc271f35e.png)

**Pipeline Page**
![screen shot 2016-09-21 at 4 09 07 pm](https://cloud.githubusercontent.com/assets/78533/18732147/cc888098-8015-11e6-8426-ba98168454ef.png)


