### PR TITLE
Add page titles to routes

### DIFF
--- a/app/application/route.js
+++ b/app/application/route.js
@@ -1,3 +1,11 @@
 import Ember from 'ember';
 import ApplicationRouteMixin from 'ember-simple-auth/mixins/application-route-mixin';
-export default Ember.Route.extend(ApplicationRouteMixin);
+export default Ember.Route.extend(ApplicationRouteMixin, {
+  title(tokens) {
+    let arr = Array.isArray(tokens) ? tokens : [];
+
+    arr.push('screwdriver.cd');
+
+    return arr.join(' > ');
+  }
+});

--- a/app/create/route.js
+++ b/app/create/route.js
@@ -1,4 +1,6 @@
 import Ember from 'ember';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
-export default Ember.Route.extend(AuthenticatedRouteMixin);
+export default Ember.Route.extend(AuthenticatedRouteMixin, {
+  titleToken: 'Create Pipeline'
+});

--- a/app/index.html
+++ b/app/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>Screwdriver UI</title>
+    <title>screwdriver.cd</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 

--- a/app/login/route.js
+++ b/app/login/route.js
@@ -1,3 +1,5 @@
 import Ember from 'ember';
 import UnauthenticatedRouteMixin from 'ember-simple-auth/mixins/unauthenticated-route-mixin';
-export default Ember.Route.extend(UnauthenticatedRouteMixin);
+export default Ember.Route.extend(UnauthenticatedRouteMixin, {
+  titleToken: 'Login'
+});

--- a/app/pipeline/builds/build/route.js
+++ b/app/pipeline/builds/build/route.js
@@ -2,6 +2,9 @@ import Ember from 'ember';
 const RELOAD_TIMER = 5000;
 
 export default Ember.Route.extend({
+  titleToken(model) {
+    return `${model.job.get('name')} > #${model.build.get('sha').substr(0, 6)}`;
+  },
   model(params) {
     return this.store.findRecord('build', params.build_id).then(build => {
       // reload again in a little bit if queued

--- a/app/pipeline/route.js
+++ b/app/pipeline/route.js
@@ -1,6 +1,9 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
+  titleToken(model) {
+    return model.get('appId');
+  },
   model(params) {
     return this.get('store').findRecord('pipeline', params.pipeline_id);
   }

--- a/app/pipeline/secrets/route.js
+++ b/app/pipeline/secrets/route.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 export default Ember.Route.extend(AuthenticatedRouteMixin, {
+  titleToken: 'Secrets',
   model() {
     const pipeline = this.modelFor('pipeline');
 

--- a/app/search/route.js
+++ b/app/search/route.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
+  titleToken: 'Search',
   model() {
     return this.store.findAll('pipeline');
   }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "ember-cli-babel": "^5.1.6",
     "ember-cli-code-coverage": "0.3.2",
     "ember-cli-dependency-checker": "^1.2.0",
+    "ember-cli-document-title": "0.3.1",
     "ember-cli-eslint": "3.0.0",
     "ember-cli-htmlbars": "^1.0.3",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",

--- a/tests/unit/application/route-test.js
+++ b/tests/unit/application/route-test.js
@@ -10,3 +10,11 @@ test('it exists', function (assert) {
 
   assert.ok(route);
 });
+
+test('it calculates title', function (assert) {
+  let route = this.subject();
+
+  assert.equal(route.title(), 'screwdriver.cd');
+  assert.equal(route.title([]), 'screwdriver.cd');
+  assert.equal(route.title(['a', 'b', 'c']), 'a > b > c > screwdriver.cd');
+});

--- a/tests/unit/create/route-test.js
+++ b/tests/unit/create/route-test.js
@@ -9,4 +9,5 @@ test('it exists', function (assert) {
   let route = this.subject();
 
   assert.ok(route);
+  assert.equal(route.titleToken, 'Create Pipeline');
 });

--- a/tests/unit/login/route-test.js
+++ b/tests/unit/login/route-test.js
@@ -9,4 +9,5 @@ test('it exists', function (assert) {
   let route = this.subject();
 
   assert.ok(route);
+  assert.equal(route.titleToken, 'Login');
 });

--- a/tests/unit/pipeline/builds/build/route-test.js
+++ b/tests/unit/pipeline/builds/build/route-test.js
@@ -1,4 +1,5 @@
 import { moduleFor, test } from 'ember-qunit';
+import Ember from 'ember';
 
 moduleFor('route:pipeline/builds/build', 'Unit | Route | pipeline/builds/build', {
   // Specify the other units that are required for this test.
@@ -9,4 +10,8 @@ test('it exists', function (assert) {
   let route = this.subject();
 
   assert.ok(route);
+  assert.equal(route.titleToken({
+    job: Ember.Object.create({ name: 'main' }),
+    build: Ember.Object.create({ sha: 'abcd1234567890' })
+  }), 'main > #abcd12');
 });

--- a/tests/unit/pipeline/route-test.js
+++ b/tests/unit/pipeline/route-test.js
@@ -1,4 +1,5 @@
 import { moduleFor, test } from 'ember-qunit';
+import Ember from 'ember';
 
 moduleFor('route:pipeline', 'Unit | Route | pipeline', {
   // Specify the other units that are required for this test.
@@ -9,4 +10,7 @@ test('it exists', function (assert) {
   let route = this.subject();
 
   assert.ok(route);
+  assert.equal(route.titleToken(Ember.Object.create({
+    appId: 'foo:bar'
+  })), 'foo:bar');
 });

--- a/tests/unit/pipeline/secrets/route-test.js
+++ b/tests/unit/pipeline/secrets/route-test.js
@@ -9,4 +9,5 @@ test('it exists', function (assert) {
   let route = this.subject();
 
   assert.ok(route);
+  assert.equal(route.titleToken, 'Secrets');
 });

--- a/tests/unit/search/route-test.js
+++ b/tests/unit/search/route-test.js
@@ -9,4 +9,5 @@ test('it exists', function (assert) {
   let route = this.subject();
 
   assert.ok(route);
+  assert.equal(route.titleToken, 'Search');
 });


### PR DESCRIPTION
Uses https://github.com/kimroen/ember-cli-document-title to add titles to pages through routes. My preference would have been http://tim-evans.github.io/ember-page-title/, but this seems to be broken in more recent builds of ember.