### PR TITLE
add a loading panel

### DIFF
--- a/app/components/loading-view/component.js
+++ b/app/components/loading-view/component.js
@@ -1,0 +1,80 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  /**
+   * Quotes from: https://www.npmjs.com/package/funnies which has an MIT License
+   * @property {Array} funnies
+   */
+  funnies: [
+    'Reticulating splines...',
+    'Generating witty dialog...',
+    'Swapping time and space...',
+    'Spinning violently around the y-axis...',
+    'Tokenizing real life...',
+    'Bending the spoon...',
+    'Filtering morale...',
+    'Don\'t think of purple hippos...',
+    'We need a new fuse...',
+    'Have a good day.',
+    '640K ought to be enough for anybody',
+    'The architects are still drafting',
+    'The bits are breeding',
+    'We\'re building the buildings as fast as we can',
+    'Would you prefer chicken, steak, or tofu?',
+    '(Pay no attention to the man behind the curtain)',
+    '...and enjoy the elevator music...',
+    'Please wait while the little elves draw your map',
+    'Don\'t worry - a few bits tried to escape, but we caught them',
+    'Would you like fries with that?',
+    'Checking the gravitational constant in your locale...',
+    'Go ahead -- hold your breath!',
+    '...at least you\'re not on hold...',
+    'Hum something loud while others stare',
+    'You\'re not in Kansas any more',
+    'The server is powered by a lemon and two electrodes.',
+    'Please wait while a larger software vendor in Seattle takes over the world',
+    'We\'re testing your patience',
+    'As if you had any other choice',
+    'Follow the white rabbit',
+    'Why don\'t you order a sandwich?',
+    'While the satellite moves into position',
+    'The bits are flowing slowly today',
+    'Dig on the \'X\' for buried treasure... ARRR!',
+    'It\'s still faster than you could draw it',
+    'The last time I tried this the monkey didn\'t survive. Let\'s hope it works better this time.',
+    'I should have had a V8 this morning.',
+    'My other loading screen is much faster.',
+    'Testing on Timmy... We\'re going to need another Timmy.',
+    'Reconfoobling energymotron...',
+    '(Insert quarter)',
+    'Are we there yet?',
+    'Have you lost weight?',
+    'Just count to 10',
+    'Why so serious?',
+    'It\'s not you. It\'s me.',
+    'Counting backwards from Infinity',
+    'Don\'t panic...',
+    'Embiggening Prototypes',
+    'Do you come here often?',
+    'Warning: Don\'t set yourself on fire.',
+    'We\'re making you a cookie.',
+    'Creating time-loop inversion field',
+    'Spinning the wheel of fortune...',
+    'Loading the enchanted bunny...',
+    'Computing chance of success',
+    'I\'m sorry Dave, I can\'t do that.',
+    'Looking for exact change',
+    'All your web browser are belong to us'
+  ],
+  /**
+   * Get a random quote
+   * @property {String} loadingMessage
+   */
+  loadingMessage: Ember.computed({
+    get() {
+      const index = Math.floor(Math.random() * this.funnies.length);
+
+      return this.funnies[index];
+    }
+  })
+});

--- a/app/components/loading-view/styles.scss
+++ b/app/components/loading-view/styles.scss
@@ -1,0 +1,3 @@
+.loading {
+  text-align: center;
+}

--- a/app/components/loading-view/template.hbs
+++ b/app/components/loading-view/template.hbs
@@ -1,0 +1,4 @@
+<div class="loading">
+  <h2>{{fa-icon "fa-spinner fa-pulse fa-fw"}} Loading...</h2>
+  <p>{{loadingMessage}}</p>
+</div>

--- a/app/templates/loading.hbs
+++ b/app/templates/loading.hbs
@@ -1,0 +1,1 @@
+{{loading-view}}

--- a/tests/integration/components/loading-view/component-test.js
+++ b/tests/integration/components/loading-view/component-test.js
@@ -1,0 +1,16 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('loading-view', 'Integration | Component | loading view', {
+  integration: true
+});
+
+test('it renders', function (assert) {
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{loading-view}}`);
+
+  assert.equal(this.$('h2').text().trim(), 'Loading...');
+  assert.ok(this.$('p').text().trim());
+});


### PR DESCRIPTION
This will automatically fill an {{outlet}} with a loading indication when a model is slow to resolve.

<img width="1228" alt="loading" src="https://cloud.githubusercontent.com/assets/78533/18843015/f5c761c2-83cb-11e6-948c-3a6d0c335a1d.png">

