### PR TITLE
make PRs build icons less funny when build is running

### DIFF
--- a/app/components/pipeline-pr-view/styles.scss
+++ b/app/components/pipeline-pr-view/styles.scss
@@ -1,6 +1,6 @@
 .fa {
-  width: 10px;
   color: $ycolor-blue-10b;
+  font-size: 14px;
 }
 
 &.SUCCESS {
@@ -18,6 +18,7 @@
 a {
   text-decoration: none;
   color: $ycolor-gray-b;
+  font-size: 14px;
 }
 
 a span {

--- a/app/components/pipeline-pr-view/template.hbs
+++ b/app/components/pipeline-pr-view/template.hbs
@@ -1,1 +1,1 @@
-{{#link-to "pipeline.builds.build" build.id}}{{fa-icon icon}}<span>{{job.name}}</span>{{/link-to}}
+{{#link-to "pipeline.builds.build" build.id}}{{fa-icon icon fixedWidth=true}}<span>{{job.name}}</span>{{/link-to}}


### PR DESCRIPTION
The graphic looked off-center and spun in a weird way.