### PR TITLE
Logs should stop loading when x-more-data is false

### DIFF
--- a/app/components/build-log/template.hbs
+++ b/app/components/build-log/template.hbs
@@ -1,2 +1,2 @@
-<div class="logs">{{yield}}</div>
+<div class="logs">{{yield}}{{logContent}}</div>
 <div class="bottom"></div>

--- a/tests/integration/components/build-log/component-test.js
+++ b/tests/integration/components/build-log/component-test.js
@@ -54,6 +54,7 @@ test('it renders closed', function (assert) {
 });
 
 test('it renders open when told to', function (assert) {
+  assert.expect(1);
   // Set any properties with this.set('myProperty', 'value');
   // Handle any actions with this.on('myAction', function(val) { ... });
   const stepMock = {
@@ -70,10 +71,12 @@ test('it renders open when told to', function (assert) {
   });
 
   server.map(singleRequest);
+
   this.set('stepMock', stepMock);
   this.set('buildMock', buildMock);
+  this.set('open', true);
 
-  this.render(hbs`{{build-log build=buildMock step=stepMock isOpen=true}}`);
+  this.render(hbs`{{build-log build=buildMock step=stepMock isOpen=open}}`);
 
   return wait().then(() => {
     assert.equal(this.$().text().trim(), 'hello, world');


### PR DESCRIPTION
Logging component would not continue if x-more-data=false when no log lines were delivered. This made builds look like they were stuck until the page was refreshed.

Added scheduling of async work in Ember (https://guides.emberjs.com/v2.8.0/applications/run-loop/). This makes ember a little happier when running prod code, and makes tests happier when running async code.