### PR TITLE
Fix error calculating buildDuration when there is no startTime

### DIFF
--- a/app/build/model.js
+++ b/app/build/model.js
@@ -25,7 +25,7 @@ export default DS.Model.extend({
   }),
   buildDuration: Ember.computed('startTime', 'endTime', {
     get() {
-      if (!this.get('endTime')) {
+      if (!this.get('endTime') || !this.get('startTime')) {
         return humanizeDuration(0);
       }
 

--- a/tests/unit/build/model-test.js
+++ b/tests/unit/build/model-test.js
@@ -32,8 +32,14 @@ test('it calculates buildDuration', function (assert) {
   });
 
   Ember.run(() => {
+    // valid duration
     assert.equal(model.get('buildDuration'), '10 seconds');
+    // no end time, so duration is 0
     model.set('endTime', null);
+    assert.equal(model.get('buildDuration'), '0 seconds');
+    // no start time, so duration is 0
+    model.set('endTime', new Date(1472244592531));
+    model.set('startTime', null);
     assert.equal(model.get('buildDuration'), '0 seconds');
   });
 });


### PR DESCRIPTION
https://cd.screwdriver.cd/pipelines/34b6834028c4c904dce3d9391c8b2dd4994ec6a9/build/ca33f5909a54d1e31583896abde4c780ca87942d and https://api.screwdriver.cd/v4/builds/ca33f5909a54d1e31583896abde4c780ca87942d