### PR TITLE
fix scrolling issues on build page

### DIFF
--- a/app/components/build-log/component.js
+++ b/app/components/build-log/component.js
@@ -64,7 +64,7 @@ export default Ember.Component.extend({
       const logNumber = this.get('lastLine');
 
       // Schedule log refresh run loop
-      Ember.run.schedule('actions', () => {
+      Ember.run.scheduleOnce('actions', () => {
         // Flag so we don't fire new requests while waiting for this to return
         this.set('isLoading', true);
 
@@ -85,9 +85,12 @@ export default Ember.Component.extend({
                 });
                 // Update the last line we processed for next load
                 this.set('lastLine', data[data.length - 1].n + 1);
+
                 // scroll to bottom of logs
-                if (this.$('.bottom').length === 1) {
-                  window.scrollTo(0, this.$('.bottom').offset().top);
+                if (this.$('.bottom').length === 1 && this.get('autoscroll')) {
+                  Ember.run.scheduleOnce('afterRender', () => {
+                    window.scrollTo(0, this.$('.bottom').offset().top);
+                  });
                 }
               }
               // Set flag for done based on headers
@@ -95,7 +98,7 @@ export default Ember.Component.extend({
 
               if (this.get('finishedLoading') && build.get('status') === 'RUNNING') {
                 // if build is running and step is done, reload build
-                build.reload();
+                Ember.run.scheduleOnce('afterRender', () => build.reload());
               }
             });
           })

--- a/app/components/build-step-collection/component.js
+++ b/app/components/build-step-collection/component.js
@@ -1,5 +1,36 @@
 import Ember from 'ember';
 
 export default Ember.Component.extend({
-  classNames: ['build-step-collection']
+  classNames: ['build-step-collection'],
+  autoscroll: true,
+
+  /**
+   * Set up scroll listener when component has been rendered
+   * @method didRender
+   */
+  didRender() {
+    this._super(...arguments);
+
+    const w = this.$(window);
+    const d = this.$(window.document);
+
+    d.scroll(() => {
+      const scrollPercentage = ((d.scrollTop() + w.height()) / d.height()) * 100;
+
+      if (scrollPercentage > 99) {
+        Ember.run(() => this.set('autoscroll', true));
+      } else {
+        Ember.run(() => this.set('autoscroll', false));
+      }
+    });
+  },
+
+  /**
+   * Remove scroll listener when component is destroyed
+   * @method willDestroyElement
+   */
+  willDestroyElement() {
+    this._super(...arguments);
+    this.$(window.document).off('scroll');
+  }
 });

--- a/app/components/build-step-collection/styles.scss
+++ b/app/components/build-step-collection/styles.scss
@@ -1,5 +1,6 @@
 & {
   margin-top: 20px;
+  margin-bottom: 2em;
   padding: 0 25px;
 }
 

--- a/app/components/build-step-collection/template.hbs
+++ b/app/components/build-step-collection/template.hbs
@@ -12,7 +12,7 @@
   </div>
 </div>
 {{#each steps as |step|}}
-  {{build-step step=step build=build}}
+  {{build-step step=step build=build autoscroll=autoscroll}}
 {{/each}}
 
 {{yield}}

--- a/app/components/build-step/template.hbs
+++ b/app/components/build-step/template.hbs
@@ -1,2 +1,2 @@
 {{build-step-view step=step build=build isOpen=isOpen onToggle=(action "toggleOpen")}}
-{{build-log step=step build=build isOpen=isOpen}}
+{{build-log step=step build=build isOpen=isOpen autoscroll=autoscroll}}

--- a/app/components/loading-view/component.js
+++ b/app/components/loading-view/component.js
@@ -66,7 +66,8 @@ export default Ember.Component.extend({
     'Looking for exact change',
     'All your web browser are belong to us',
     'Eating brownie points...',
-    'Finding cat pictures...'
+    'Finding cat pictures...',
+    'Calculating route through hyperspace...'
   ],
   /**
    * Get a random quote

--- a/app/components/pipeline-build-view/styles.scss
+++ b/app/components/pipeline-build-view/styles.scss
@@ -34,6 +34,7 @@ h6 {
   background-color: $ycolor-green-6b;
   border-color: $ycolor-green-6b;
 }
+.ABORTED .job,
 .FAILURE .job {
   background-color: $ycolor-red-2b;
   border-color: $ycolor-red-2b;

--- a/app/pipeline/builds/build/route.js
+++ b/app/pipeline/builds/build/route.js
@@ -9,7 +9,7 @@ export default Ember.Route.extend({
     return this.store.findRecord('build', params.build_id).then(build => {
       // reload again in a little bit if queued
       const reloadQueuedBuild = () => {
-        if (build.get('status') === 'QUEUED') {
+        if (build.get('status') === 'QUEUED' || build.get('status') === 'RUNNING') {
           Ember.run.later(this, () => {
             if (!build.get('isDeleted')) {
               build.reload().then(reloadQueuedBuild);


### PR DESCRIPTION
It looked like after the last set of changes to log component, the log lines were added to the page after the scroll action occurred, resulting in scrolling appearing to be misaligned. This has been resolved by scheduling the scroll action to occur after the "render" event.

The autoscroll behavior made it difficult for a user to view parts of the log not at the end of the page. The autoscroll behavior is now turned off when the user has scrolled up at least 1% of the document height, and restores autoscroll when they scroll back to the bottom of the page.

* Wait until after rendering to scroll
* Wait until after render to reload builds
* Continue reloading build if still `RUNNING` and no steps are remaining to execute
* Discontinue scrolling when user has scrolled up > 1% from bottom of open log
* Added some padding to bottom of page
* Fixed build list displaying empty circle for aborted builds

Addresses https://github.com/screwdriver-cd/screwdriver/issues/235