### PR TITLE
Don't keep refreshing running builds

### DIFF
--- a/app/pipeline/builds/build/route.js
+++ b/app/pipeline/builds/build/route.js
@@ -9,7 +9,7 @@ export default Ember.Route.extend({
     return this.store.findRecord('build', params.build_id).then(build => {
       // reload again in a little bit if queued
       const reloadQueuedBuild = () => {
-        if (build.get('status') === 'QUEUED' || build.get('status') === 'RUNNING') {
+        if (build.get('status') === 'QUEUED') {
           Ember.run.later(this, () => {
             if (!build.get('isDeleted')) {
               build.reload().then(reloadQueuedBuild);


### PR DESCRIPTION
This has an unintended side effect of resetting logs every 5 seconds while they are loading.