### PR TITLE
Update a secret

### DIFF
--- a/app/components/secret-view/component.js
+++ b/app/components/secret-view/component.js
@@ -4,9 +4,15 @@ export default Ember.Component.extend({
   tagName: 'tr',
   buttonAction: 'Delete',
   newValue: null,
+  originalAllowInPR: null,
+  init() {
+    this._super(...arguments);
+    this.set('originalAllowInPR', this.get('secret').get('allowInPR'));
+  },
   actions: {
-    newValueDidChange() {
-      if (this.get('newValue')) {
+    secretDidChange() {
+      if (this.get('newValue')
+        || this.get('originalAllowInPR') !== this.$('.allow input').prop('checked')) {
         this.set('buttonAction', 'Update');
       } else {
         this.set('buttonAction', 'Delete');
@@ -18,7 +24,12 @@ export default Ember.Component.extend({
       if (this.get('buttonAction') === 'Delete') {
         secret.destroyRecord();
       } else {
-        secret.set('value', this.get('newValue'));
+        if (this.get('newValue')) {
+          secret.set('value', this.get('newValue'));
+        }
+        if (this.get('originalAllowInPR') !== this.$('.allow input').prop('checked')) {
+          secret.set('allowInPR', this.$('.allow input').prop('checked'));
+        }
         secret.save();
         this.set('newValue', null);
         this.set('buttonAction', 'Delete');

--- a/app/components/secret-view/template.hbs
+++ b/app/components/secret-view/template.hbs
@@ -1,4 +1,4 @@
 <td class="name">{{secret.name}}</td>
-<td class="pass">{{input type="password" placeholder="Protected" size="40" value=newValue key-up="newValueDidChange"}}</td>
-<td class="allow">{{input type="checkbox" disabled="true" checked=secret.allowInPR}}</td>
+<td class="pass">{{input type="password" placeholder="Protected" size="40" value=newValue key-up="secretDidChange"}}</td>
+<td class="allow">{{input type="checkbox" checked=secret.allowInPR click=(action "secretDidChange" )}}</td>
 <td><button {{action "modifySecret"}}>{{buttonAction}}</button></td>

--- a/app/secret/serializer.js
+++ b/app/secret/serializer.js
@@ -8,6 +8,16 @@ export default DS.RESTSerializer.extend({
    * @method serializeIntoHash
    */
   serializeIntoHash(hash, typeClass, snapshot, options) {
-    Ember.merge(hash, this.serialize(snapshot, options));
+    if (!snapshot.id) {
+      return Ember.merge(hash, this.serialize(snapshot, options));
+    }
+
+    const dirty = snapshot.changedAttributes();
+
+    Object.keys(dirty).forEach(key => {
+      dirty[key] = dirty[key][1];
+    });
+
+    return Ember.merge(hash, dirty);
   }
 });

--- a/tests/integration/components/pipeline-secret-settings/component-test.js
+++ b/tests/integration/components/pipeline-secret-settings/component-test.js
@@ -1,5 +1,6 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import Ember from 'ember';
 
 moduleForComponent('pipeline-secret-settings',
   'Integration | Component | pipeline secret settings', {
@@ -10,11 +11,14 @@ moduleForComponent('pipeline-secret-settings',
 test('it renders', function (assert) {
   // Set any properties with this.set('myProperty', 'value');
   // Handle any actions with this.on('myAction', function(val) { ... });
-  this.set('mockSecrets', [{
+  const testSecret = Ember.Object.create({
     name: 'TEST_SECRET',
-    pipelineId: 'abcd',
-    value: 'banana'
-  }]);
+    pipelineId: 123245,
+    value: 'banana',
+    allowInPR: false
+  });
+
+  this.set('mockSecrets', [testSecret]);
 
   this.set('mockPipeline', { id: 'abcd' });
   this.render(hbs`{{pipeline-secret-settings secrets=mockSecrets pipeline=mockPipeline}}`);

--- a/tests/integration/components/secret-view/component-test.js
+++ b/tests/integration/components/secret-view/component-test.js
@@ -10,18 +10,23 @@ moduleForComponent('secret-view',
 test('it renders', function (assert) {
   // Set any properties with this.set('myProperty', 'value');
   // Handle any actions with this.on('myAction', function(val) { ... });
-  this.set('mockSecret', {
+  const testSecret = Ember.Object.create({
     name: 'TEST_SECRET',
     pipelineId: 123245,
-    value: 'banana'
+    value: 'banana',
+    allowInPR: false
   });
+
+  this.set('mockSecret', testSecret);
 
   this.render(hbs`{{secret-view secret=mockSecret}}`);
   const passInput = this.$('.pass input');
+  const allowInput = this.$('.allow input');
 
   assert.equal(this.$('.name').text().trim(), 'TEST_SECRET');
   assert.equal(passInput.attr('placeholder'), 'Protected');
   assert.equal(passInput.val(), '');
+  assert.equal(allowInput.prop('checked'), false);
   assert.equal(this.$('button').text().trim(), 'Delete');
 
   // button value changes when user types a new value
@@ -31,14 +36,19 @@ test('it renders', function (assert) {
   // button value changes when user types a new value
   passInput.val('').keyup();
   assert.equal(this.$('button').text().trim(), 'Delete');
+
+  // button value changes when user click the checkbox
+  allowInput.click();
+  assert.equal(this.$('button').text().trim(), 'Update');
+
+  // button value changes when user click the checkbox again to change it back
+  allowInput.click();
+  assert.equal(this.$('button').text().trim(), 'Delete');
 });
 
 test('it trys to delete a secret', function (assert) {
   assert.expect(1);
-  this.set('mockSecret', {
-    name: 'TEST_SECRET',
-    pipelineId: 123245,
-    value: 'banana',
+  this.set('mockSecret', Ember.Object.extend({
     destroyRecord() {
       // destroy called
       assert.ok(true);
@@ -47,14 +57,19 @@ test('it trys to delete a secret', function (assert) {
       // update called: Fail!
       assert.ok(false);
     }
-  });
+  }).create({
+    name: 'TEST_SECRET',
+    pipelineId: 123245,
+    value: null,
+    allowInPR: false
+  }));
 
   this.render(hbs`{{secret-view secret=mockSecret}}`);
   this.$('button').click();
 });
 
 test('it saves changes to a secret', function (assert) {
-  assert.expect(1);
+  assert.expect(2);
   // Setting up model so `set` works as expected
   this.set('mockSecret', Ember.Object.extend({
     destroyRecord() {
@@ -64,14 +79,17 @@ test('it saves changes to a secret', function (assert) {
     save() {
       // update called
       assert.equal(this.get('value'), 'banana');
+      assert.equal(this.get('allowInPR'), true);
     }
   }).create({
     name: 'TEST_SECRET',
     pipelineId: 123245,
-    value: null
+    value: null,
+    allowInPR: false
   }));
 
   this.render(hbs`{{secret-view secret=mockSecret}}`);
   this.$('.pass input').val('banana').keyup();
+  this.$('.allow input').click();
   this.$('button').click();
 });


### PR DESCRIPTION
- Update a secret by sending only dirty fields to API
- Allow update a secret's `value` and `allowInPR` attributes
- Blocked by [PR - update secret route to API](https://github.com/screwdriver-cd/screwdriver/pull/238)

part of issue [#232](https://github.com/screwdriver-cd/screwdriver/issues/232)