### PR TITLE
Adapt to v14 data-schema

### DIFF
--- a/app/build/model.js
+++ b/app/build/model.js
@@ -44,5 +44,6 @@ export default DS.Model.extend({
   parameters: DS.attr(),
   meta: DS.attr(),
   steps: DS.attr(),
-  status: DS.attr('string')
+  status: DS.attr('string'),
+  commit: DS.attr()
 });

--- a/app/components/pipeline-header/template.hbs
+++ b/app/components/pipeline-header/template.hbs
@@ -1,2 +1,2 @@
 {{#link-to "pipeline" pipeline.id}}<h1>{{pipeline.appId}}</h1>{{/link-to}}
-<a href="{{pipeline.hubUrl}}" class="branch">{{fa-icon "fa-code-fork"}} {{pipeline.repoData.branch}}</a>
+<a href="{{pipeline.hubUrl}}" class="branch">{{fa-icon "fa-code-fork"}} {{pipeline.branch}}</a>

--- a/app/components/search-list/template.hbs
+++ b/app/components/search-list/template.hbs
@@ -3,7 +3,7 @@
   <li>
     {{#link-to "pipeline" pipeline.id}}
       <span class="appId">{{pipeline.appId}}</span>
-      <span class="branch">{{fa-icon "fa-code-fork"}}{{pipeline.repoData.branch}}</span>
+      <span class="branch">{{fa-icon "fa-code-fork"}}{{pipeline.branch}}</span>
     {{/link-to}}
   </li>
   {{/each}}

--- a/app/pipeline/model.js
+++ b/app/pipeline/model.js
@@ -4,43 +4,30 @@ import Ember from 'ember';
 export default DS.Model.extend({
   scmUrl: DS.attr('string'),
   configUrl: DS.attr('string', { defaultValue: '' }),
+  scmUri: DS.attr('string'),
   createTime: DS.attr('date'),
   admins: DS.attr(),
   secrets: DS.hasMany('secret', { async: true }),
   jobs: DS.hasMany('job', { async: true }),
-  repoData: Ember.computed('scmUrl', {
+  scmRepo: DS.attr(),
+  scmRepoObject: Ember.computed('scmRepo', {
     get() {
-      const http = /^http[s]?:\/\/([^/]+)\/([^/]+)\/([^/]+)\.git#?(.*)?/;
-      const git = /^git@([^:]+):([^/]+)\/([^/]+)\.git#?(.*)?/;
-      const scmUrl = this.get('scmUrl');
-      const matches = /^git@/.test(scmUrl) ? scmUrl.match(git) : scmUrl.match(http);
-      let host;
-      let owner;
-      let repo;
-      let branch;
-
-      if (matches) {
-        host = matches[1];
-        owner = matches[2];
-        repo = matches[3];
-        branch = matches[4] || 'master';
-      }
-
-      return { host, owner, repo, branch };
+      return Ember.Object.create(this.get('scmRepo'));
     }
   }),
-  appId: Ember.computed('repoData', {
+  appId: Ember.computed('scmRepoObject', {
     get() {
-      const data = this.get('repoData');
-
-      return `${data.owner}:${data.repo}`;
+      return this.get('scmRepoObject').name;
     }
   }),
-  hubUrl: Ember.computed('repoData', {
+  hubUrl: Ember.computed('scmRepoObject', {
     get() {
-      const data = this.get('repoData');
-
-      return `https://${data.host}/${data.owner}/${data.repo}`;
+      return this.get('scmRepoObject').url;
+    }
+  }),
+  branch: Ember.computed('scmRepoObject', {
+    get() {
+      return this.get('scmRepoObject').branch;
     }
   })
 });

--- a/app/pipeline/serializer.js
+++ b/app/pipeline/serializer.js
@@ -8,6 +8,6 @@ export default DS.RESTSerializer.extend({
    * @method serializeIntoHash
    */
   serializeIntoHash(hash, typeClass, snapshot) {
-    return Ember.merge(hash, { scmUrl: snapshot.attr('scmUrl') });
+    return Ember.merge(hash, { checkoutUrl: snapshot.attr('scmUrl') });
   }
 });

--- a/tests/acceptance/build-test.js
+++ b/tests/acceptance/build-test.js
@@ -15,6 +15,11 @@ moduleForAcceptance('Acceptance | build', {
       JSON.stringify({
         id: 'abcd',
         scmUrl: 'git@github.com:foo/bar.git#master',
+        scmRepo: {
+          name: 'foo/bar',
+          branch: 'master',
+          url: 'https://github.com/foo/bar'
+        },
         createTime: '2016-09-15T23:12:23.760Z',
         admins: { batman: true },
         workflow: ['main', 'publish', 'prod']
@@ -50,7 +55,11 @@ moduleForAcceptance('Acceptance | build', {
         }, {
           name: 'test'
         }],
-        status: 'FAILURE'
+        status: 'FAILURE',
+        commit: {
+          url: 'https://github.com/commit',
+          message: 'merge this'
+        }
       })
     ]);
 
@@ -105,7 +114,7 @@ test('visiting /pipelines/:id/build/:id', function (assert) {
 
   andThen(() => {
     assert.equal(currentURL(), '/pipelines/abcd/build/1234');
-    assert.equal(find('a h1').text().trim(), 'foo:bar', 'incorrect pipeline name');
+    assert.equal(find('a h1').text().trim(), 'foo/bar', 'incorrect pipeline name');
     assert.equal(find('.line1 h1').text().trim(), 'PR-50', 'incorrect job name');
     assert.equal(find('span.sha').text().trim(), '#c96f36', 'incorrect sha');
     assert.equal(find('.is-open .logs').text().trim(), 'bad stuff', 'incorrect logs open');

--- a/tests/acceptance/pipeline-builds-test.js
+++ b/tests/acceptance/pipeline-builds-test.js
@@ -96,6 +96,11 @@ moduleForAcceptance('Acceptance | pipeline builds', {
       JSON.stringify({
         id: 'abcd',
         scmUrl: 'git@github.com:foo/bar.git#master',
+        scmRepo: {
+          name: 'foo/bar',
+          branch: 'master',
+          url: 'https://github.com/foo/bar'
+        },
         createTime: '2016-09-15T23:12:23.760Z',
         admins: { batman: true },
         workflow: ['main', 'publish']
@@ -136,7 +141,7 @@ test('visiting /pipelines/abcd', function (assert) {
 
   andThen(() => {
     assert.equal(currentURL(), '/pipelines/abcd');
-    assert.equal(find('a h1').text().trim(), 'foo:bar', 'incorrect pipeline name');
+    assert.equal(find('a h1').text().trim(), 'foo/bar', 'incorrect pipeline name');
     assert.equal(find('.arrow-right').length, 4, 'not enough workflow');
     assert.equal(find('.arrow-right').length, 4, 'not enough workflow');
     assert.equal(find('button').length, 0, 'should not have a start button');

--- a/tests/integration/components/pipeline-header/component-test.js
+++ b/tests/integration/components/pipeline-header/component-test.js
@@ -12,9 +12,7 @@ test('it renders', function (assert) {
   const pipelineMock = {
     appId: 'batman/batmobile',
     hubUrl: 'http://example.com/batman/batmobile',
-    repoData: {
-      branch: 'master'
-    }
+    branch: 'master'
   };
 
   this.set('pipelineMock', pipelineMock);

--- a/tests/unit/pipeline/model-test.js
+++ b/tests/unit/pipeline/model-test.js
@@ -12,70 +12,19 @@ test('it exists', function (assert) {
   assert.ok(!!model);
 });
 
-test('it gets correct repo data', function (assert) {
-  let model = this.subject();
-
-  Ember.run(() => {
-    // http - no branch
-    model.set('scmUrl', 'http://example.com:8080/batman/batmobile.git');
-
-    assert.deepEqual(model.get('repoData'), {
-      host: 'example.com:8080',
-      owner: 'batman',
-      repo: 'batmobile',
-      branch: 'master'
-    });
-
-    // https - with branch
-    model.set('scmUrl', 'https://example.com/batman/batmobile.git#ejectorSeat');
-
-    assert.deepEqual(model.get('repoData'), {
-      host: 'example.com',
-      owner: 'batman',
-      repo: 'batmobile',
-      branch: 'ejectorSeat'
-    });
-
-    // git - with branch
-    model.set('scmUrl', 'git@example.com:batman/batmobile.git#ejectorSeat');
-
-    assert.deepEqual(model.get('repoData'), {
-      host: 'example.com',
-      owner: 'batman',
-      repo: 'batmobile',
-      branch: 'ejectorSeat'
-    });
-
-    // git - no branch
-    model.set('scmUrl', 'git@example.com:batman/batmobile.git');
-
-    assert.deepEqual(model.get('repoData'), {
-      host: 'example.com',
-      owner: 'batman',
-      repo: 'batmobile',
-      branch: 'master'
-    });
-
-    // invalid url
-    model.set('scmUrl', 'git@example.com:batman');
-
-    assert.deepEqual(model.get('repoData'), {
-      host: undefined,
-      owner: undefined,
-      repo: undefined,
-      branch: undefined
-    });
-  });
-});
-
 test('it gets correct appId', function (assert) {
   let model = this.subject();
 
   Ember.run(() => {
-    // http - no branch
-    model.set('scmUrl', 'http://example.com:8080/batman/batmobile.git');
+    const scmRepoMock = {
+      name: 'foo/bar',
+      branch: 'master',
+      url: 'https://github.com/foo/bar'
+    };
 
-    assert.equal(model.get('appId'), 'batman:batmobile');
+    model.set('scmRepo', scmRepoMock);
+
+    assert.equal(model.get('appId'), 'foo/bar');
   });
 });
 
@@ -83,9 +32,31 @@ test('it gets correct hub url', function (assert) {
   let model = this.subject();
 
   Ember.run(() => {
-    // http - no branch
-    model.set('scmUrl', 'git@example.com:batman/batmobile.git#oilSlick');
+    const scmRepoMock = {
+      name: 'foo/bar',
+      branch: 'master',
+      url: 'https://github.com/foo/bar'
+    };
 
-    assert.equal(model.get('hubUrl'), 'https://example.com/batman/batmobile');
+    model.set('scmRepo', scmRepoMock);
+
+    assert.equal(model.get('hubUrl'), 'https://github.com/foo/bar');
   });
 });
+
+test('it gets correct branch', function (assert) {
+  let model = this.subject();
+
+  Ember.run(() => {
+    const scmRepoMock = {
+      name: 'foo/bar',
+      branch: 'master',
+      url: 'https://github.com/foo/bar'
+    };
+
+    model.set('scmRepo', scmRepoMock);
+
+    assert.equal(model.get('branch'), 'master');
+  });
+});
+

--- a/tests/unit/pipeline/serializer-test.js
+++ b/tests/unit/pipeline/serializer-test.js
@@ -51,7 +51,7 @@ test('it does not post with model name as key', function (assert) {
     const payload = JSON.parse(request.requestBody);
 
     assert.deepEqual(payload, {
-      scmUrl: 'git@example.com:foo/bar.git'
+      checkoutUrl: 'git@example.com:foo/bar.git'
     });
   });
 });


### PR DESCRIPTION
- Send 'checkoutUrl' for creating pipeline
- Use `scmRepo` to get url, org/repoName, branch directly
- This PR is just making sure the UI  is compatible with the new API
- Another PR will clean up the naming of `scmUrl` to `checkoutUrl`
- Blocked by https://github.com/screwdriver-cd/screwdriver/pull/280