### PR TITLE
Allow checkout url to be https

### DIFF
--- a/app/utils/git.js
+++ b/app/utils/git.js
@@ -1,12 +1,13 @@
 /**
- * Parse a git url and get info about the repo
+ * Parse a git or https checkout url and get info about the repo
  * @method git
  * @param  {String}  scmUrl Url to parse
  * @return {Object}         Data about the url
  */
 export default {
   parse(scmUrl) {
-    const match = scmUrl.match(/^git@([^:]+):([^/]+)\/([^/]+)\.git(#(.+))?/);
+    // eslint-disable-next-line max-len
+    const match = scmUrl.match(/^(?:(?:https?|git):\/\/)?(?:[^@]+@)?([^/:]+)(?:\/|:)([^/]+)\/([^.#]+)(?:\.git)?(#.+)?$/);
 
     if (!match) {
       return {
@@ -18,14 +19,9 @@ export default {
       server: match[1],
       owner: match[2],
       repo: match[3],
-      branch: match[5] || 'master',
-      link: `https://${match[1]}/${match[2]}/${match[3]}`,
+      branch: match[4] ? match[4].slice(1) : 'master',
       valid: true
     };
-
-    if (result.branch !== 'master') {
-      result.link += `/tree/${result.branch}`;
-    }
 
     return result;
   }

--- a/tests/integration/components/create-pipeline-data/component-test.js
+++ b/tests/integration/components/create-pipeline-data/component-test.js
@@ -38,7 +38,7 @@ test('it handles successful submission of scmUrl', function (assert) {
 
 test('it handles bad scmUrl', function (assert) {
   assert.expect(3);
-  const scm = 'git@github.com/foo/bar.git';
+  const scm = 'git@github.com%foo/bar.git';
 
   // Set any properties with this.set('myProperty', 'value');
   // Handle any actions with this.on('myAction', function(val) { ... });

--- a/tests/unit/utils/git-test.js
+++ b/tests/unit/utils/git-test.js
@@ -15,7 +15,6 @@ test('it works', (assert) => {
     server: 'github.com',
     owner: 'bananas',
     repo: 'peel',
-    link: 'https://github.com/bananas/peel',
     branch: 'master',
     valid: true
   });
@@ -26,7 +25,6 @@ test('it works', (assert) => {
     server: 'github.com',
     owner: 'bananas',
     repo: 'peel',
-    link: 'https://github.com/bananas/peel/tree/tree',
     branch: 'tree',
     valid: true
   });


### PR DESCRIPTION
- Allow checkout url to be https
- Use regex defined in our schema
https://github.com/screwdriver-cd/data-schema/blob/master/config/regex.js#L18
- Delete the link returned in parse() because bitbucket and github have different links for branch
and we are not using the link any where
- Link to repo can be found in `scmRepo.url`
- https://api.screwdriver.cd/v4/pipelines/613a05120b3c7166749d049b549d5edece076cdf

Resolves https://github.com/screwdriver-cd/screwdriver/issues/333