### PR TITLE
Remove fingerprint of unknown_user image

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -9,7 +9,7 @@ module.exports = function (defaults) {
       useScss: true // for ember-cli-sass
     },
     fingerprint: {
-      exclude: ['supplementary_config']
+      exclude: ['supplementary_config', 'unknown_user']
     },
     svg: {
       paths: ['public/assets/svg']


### PR DESCRIPTION
allows us to access /assets/unknown_user.png without knowing a fingerprint.