### PR TITLE
fix logs not scrolling and dupe logs

### DIFF
--- a/app/components/build-log/component.js
+++ b/app/components/build-log/component.js
@@ -32,6 +32,38 @@ export default Ember.Component.extend({
     }
   },
 
+  autoscroll: true,
+
+  /**
+   * Set up scroll listener when component has been rendered
+   * @method didRender
+   */
+  didRender() {
+    this._super(...arguments);
+
+    const w = this.$(window);
+    const d = this.$(window.document);
+
+    d.scroll(() => {
+      const scrollPercentage = ((d.scrollTop() + w.height()) / d.height()) * 100;
+
+      if (scrollPercentage > 99) {
+        Ember.run(() => this.set('autoscroll', true));
+      } else {
+        Ember.run(() => this.set('autoscroll', false));
+      }
+    });
+  },
+
+  /**
+   * Remove scroll listener when component is destroyed
+   * @method willDestroyElement
+   */
+  willDestroyElement() {
+    this._super(...arguments);
+    this.$(window.document).off('scroll');
+  },
+
   /**
    * Listener to determine if log loading should begin.
    * Should only kick off log loading if "isOpen" changes to true
@@ -96,7 +128,7 @@ export default Ember.Component.extend({
         // prevent updating logs when component is being destroyed
         if (!this.get('isDestroyed') && !this.get('isDestroying')) {
           if (Array.isArray(lines) && lines.length) {
-            this.set('lastLine', lines[lines.length - 1].n);
+            this.set('lastLine', lines[lines.length - 1].n + 1);
             this.updateLogContent(lines);
           }
           this.set('finishedLoading', done);

--- a/app/components/build-step-collection/component.js
+++ b/app/components/build-step-collection/component.js
@@ -1,36 +1,5 @@
 import Ember from 'ember';
 
 export default Ember.Component.extend({
-  classNames: ['build-step-collection'],
-  autoscroll: true,
-
-  /**
-   * Set up scroll listener when component has been rendered
-   * @method didRender
-   */
-  didRender() {
-    this._super(...arguments);
-
-    const w = this.$(window);
-    const d = this.$(window.document);
-
-    d.scroll(() => {
-      const scrollPercentage = ((d.scrollTop() + w.height()) / d.height()) * 100;
-
-      if (scrollPercentage > 99) {
-        Ember.run(() => this.set('autoscroll', true));
-      } else {
-        Ember.run(() => this.set('autoscroll', false));
-      }
-    });
-  },
-
-  /**
-   * Remove scroll listener when component is destroyed
-   * @method willDestroyElement
-   */
-  willDestroyElement() {
-    this._super(...arguments);
-    this.$(window.document).off('scroll');
-  }
+  classNames: ['build-step-collection']
 });

--- a/app/components/build-step/template.hbs
+++ b/app/components/build-step/template.hbs
@@ -10,6 +10,5 @@
   stepName=stepName
   buildId=buildId
   isOpen=isOpen
-  autoscroll=autoscroll
   onClick=(action "cancelAutoClose")
 }}

--- a/app/pipeline/builds/build/template.hbs
+++ b/app/pipeline/builds/build/template.hbs
@@ -19,7 +19,6 @@
       endTime=(get (index-of model.build.steps index) "endTime")
       code=(get (index-of model.build.steps index) "code")
       buildId=model.build.id
-      autoscroll=autoscroll
     }}
   {{/each}}
 {{/build-step-collection}}


### PR DESCRIPTION
* Move autoscroll handling into build-logs component, since that is what is actually doing the scrolling.
* Remove `autoscroll` passing to build-logs component
* Request `n + 1` when fetching the logs, so that you don't get duplicate lines.