### PR TITLE
feat: reload content on the pipeline page periodically

### DIFF
--- a/app/components/build-bubble/component.js
+++ b/app/components/build-bubble/component.js
@@ -1,11 +1,24 @@
 import Ember from 'ember';
+import ModelReloaderMixin from 'screwdriver-ui/mixins/model-reloader';
+import ENV from 'screwdriver-ui/config/environment';
 
-export default Ember.Component.extend({
+export default Ember.Component.extend(ModelReloaderMixin, {
   tagName: 'span',
   classNames: ['build-bubble'],
   classNameBindings: ['build.id', 'small'],
+  modelToReload: 'build',
+  reloadTimeout: ENV.APP.BUILD_RELOAD_TIMER,
+  shouldReload(build) {
+    if (build) {
+      const s = build.get('status');
 
-  icon: Ember.computed('jobIsDisabled', 'build', {
+      return s === 'RUNNING' || s === 'QUEUED';
+    }
+
+    return false;
+  },
+
+  icon: Ember.computed('jobIsDisabled', 'build', 'build.status', {
     get() {
       if (this.get('jobIsDisabled')) {
         return 'pause';
@@ -49,5 +62,11 @@ export default Ember.Component.extend({
   },
   mouseLeave() {
     Ember.$('.build-bubble').removeClass('highlight');
+  },
+  willRender() {
+    this.startReloading();
+  },
+  willDestroy() {
+    this.stopReloading();
   }
 });

--- a/app/components/pipeline-event-view/component.js
+++ b/app/components/pipeline-event-view/component.js
@@ -1,3 +1,23 @@
 import Ember from 'ember';
+import ModelReloaderMixin from 'screwdriver-ui/mixins/model-reloader';
+import ENV from 'screwdriver-ui/config/environment';
 
-export default Ember.Component.extend();
+export default Ember.Component.extend(ModelReloaderMixin, {
+  modelToReload: 'event.builds',
+  reloadTimeout: ENV.APP.EVENT_RELOAD_TIMER,
+  shouldReload() {
+    const event = this.get('event');
+
+    if (event) {
+      return event.get('isRunning');
+    }
+
+    return false;
+  },
+  willRender() {
+    this.startReloading();
+  },
+  willDestroy() {
+    this.stopReloading();
+  }
+});

--- a/app/components/pipeline-events-list/component.js
+++ b/app/components/pipeline-events-list/component.js
@@ -1,4 +1,42 @@
 import Ember from 'ember';
+import ENV from 'screwdriver-ui/config/environment';
+import ModelReloaderMixin from 'screwdriver-ui/mixins/model-reloader';
 
-export default Ember.Component.extend({
+export default Ember.Component.extend(ModelReloaderMixin, {
+  modelToReload: 'events',
+  reloadTimeout: ENV.APP.EVENT_RELOAD_TIMER,
+  showAll: false,
+
+  /**
+   * Runs when a render event is triggered, usually due to a change in attribute data (events)
+   * @method willRender
+   */
+  willRender() {
+    this.startReloading();
+  },
+
+  /**
+   * Executes when the component is about to be destroyed
+   * @method willDestroy
+   */
+  willDestroy() {
+    this.stopReloading();
+  },
+
+  eventsToView: Ember.computed('events.[]', 'showAll', {
+    get() {
+      const numEvents = this.get('events.length');
+      const end = numEvents >= ENV.APP.NUM_EVENTS_LISTED && !this.get('showAll') ?
+        ENV.APP.NUM_EVENTS_LISTED : numEvents;
+
+      return this.get('events').slice(0, end);
+    }
+  }),
+
+  actions: {
+    showAllEvents() {
+      this.set('showAll', true);
+    }
+  }
+
 });

--- a/app/components/pipeline-events-list/styles.scss
+++ b/app/components/pipeline-events-list/styles.scss
@@ -9,4 +9,18 @@
     font-weight: 600;
     font-size: 20px;
   }
+
+  .showAll {
+    margin-top: 10px;
+    a {
+      color: $sd-link;
+      cursor: pointer;
+      font-size: 14px;
+      font-weight: 300;
+
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+  }
 }

--- a/app/components/pipeline-events-list/template.hbs
+++ b/app/components/pipeline-events-list/template.hbs
@@ -1,5 +1,12 @@
 <h2>Builds</h2>
-{{#each events as |event|}}
+{{#each eventsToView as |event|}}
 {{pipeline-event-view event=event}}
 {{/each}}
+{{#unless showAll}}
+{{#if events.length}}
+<div class="showAll">
+<a {{action "showAllEvents"}}>Show all events</a>
+</div>
+{{/if}}
+{{/unless}}
 {{yield}}

--- a/app/mixins/model-reloader.js
+++ b/app/mixins/model-reloader.js
@@ -1,0 +1,61 @@
+import Ember from 'ember';
+import ENV from 'screwdriver-ui/config/environment';
+
+export default Ember.Mixin.create({
+  /**
+   * Overridable function to determine if a model should be reloaded
+   * @method shouldReload
+   * @param {Object}    model  The model that is to be reloaded
+   * @return {Boolean}          True is model should be reloaded
+   */
+  shouldReload() {
+    return true;
+  },
+  /**
+   * Schedules reload of events data
+   * @method scheduleReload
+   */
+  scheduleReload() {
+    // The testing environment waits for asyncronous operations to complete.
+    // If the reloader is active during tests, the tests will always timeout.
+    // I'm not sure of a better way to handle this
+    if (ENV.environment !== 'test') {
+      const runLater = Ember.run.later(this, 'reloadModel', this.get('reloadTimeout'));
+
+      this.set('runLater', runLater);
+    }
+  },
+
+  /**
+   * Reloads the list of events
+   * @method reloadEvents
+   */
+  reloadModel() {
+    const model = this.get(this.get('modelToReload'));
+
+    if (this.shouldReload(model)) {
+      model.reload().then(() => this.scheduleReload());
+    }
+  },
+
+  /**
+   * Starts reloading if not already doing so
+   * @method startReloading
+   */
+  startReloading() {
+    if (!this.get('runLater')) {
+      this.scheduleReload();
+    }
+  },
+
+  /**
+   * Stops reloading
+   * @method stopReloading
+   */
+  stopReloading() {
+    if (this.get('runLater')) {
+      Ember.run.cancel(this.get('runLater'));
+      this.set('runLater', null);
+    }
+  }
+});

--- a/app/pipeline/builds/build/controller.js
+++ b/app/pipeline/builds/build/controller.js
@@ -10,9 +10,9 @@ export default Ember.Controller.extend({
   /**
    * Schedules a build to reload after a certain amount of time
    * @method reloadBuild
-   * @param  {Number}    [timeout=ENV.APP.RELOAD_TIMER] ms to wait before reloading (1000)
+   * @param  {Number}    [timeout=ENV.APP.BUILD_RELOAD_TIMER] ms to wait before reloading
    */
-  reloadBuild(timeout = ENV.APP.RELOAD_TIMER) {
+  reloadBuild(timeout = ENV.APP.BUILD_RELOAD_TIMER) {
     const build = this.get('model.build');
     const status = build.get('status');
 

--- a/config/coverage.js
+++ b/config/coverage.js
@@ -18,5 +18,5 @@ module.exports = {
     '**/build/route.js'
   ],
   coverageFolder: process.env.COVERAGE_DIR || 'coverage',
-  useBabelInstrumenter: false
+  useBabelInstrumenter: true
 };

--- a/config/environment.js
+++ b/config/environment.js
@@ -21,7 +21,9 @@ module.exports = (environment) => {
       // when it is created
       SDAPI_HOSTNAME: 'http://localhost:8080',
       SDAPI_NAMESPACE: 'v4',
-      RELOAD_TIMER: 5000
+      BUILD_RELOAD_TIMER: 5000,  // 5 seconds
+      EVENT_RELOAD_TIMER: 90000,  // 1.5 minutes
+      NUM_EVENTS_LISTED: 5
     },
     moment: {
       allowEmpty: true // allow empty dates
@@ -29,6 +31,7 @@ module.exports = (environment) => {
   };
 
   if (environment === 'development') {
+    ENV.APP.EVENT_RELOAD_TIMER = 5000;
     // ENV.APP.LOG_RESOLVER = true;
     // ENV.APP.LOG_ACTIVE_GENERATION = true;
     // ENV.APP.LOG_TRANSITIONS = true;

--- a/tests/unit/event/model-test.js
+++ b/tests/unit/event/model-test.js
@@ -1,4 +1,7 @@
 import { moduleForModel, test } from 'ember-qunit';
+import Ember from 'ember';
+
+const workflow = ['one', 'two', 'three', 'four'];
 
 moduleForModel('event', 'Unit | Model | event', {
   // Specify the other units that are required for this test.
@@ -9,4 +12,49 @@ test('it exists', function (assert) {
   let model = this.subject();
 
   assert.ok(!!model);
+});
+
+test('it is not completed when there are no builds', function (assert) {
+  const model = this.subject({ builds: [], workflow });
+
+  assert.notOk(model.get('isComplete'));
+});
+
+test('it is not completed when the most recent build is not complete', function (assert) {
+  Ember.run(() => {
+    const build = this.store().createRecord('build', { status: 'RUNNING' });
+    const model = this.subject({ builds: [build], workflow });
+
+    assert.notOk(model.get('isComplete'));
+  });
+});
+
+test('it is completed when the most recent build is unsuccessful', function (assert) {
+  Ember.run(() => {
+    const build = this.store().createRecord('build', { status: 'ABORTED' });
+    const model = this.subject({ builds: [build], workflow });
+
+    assert.ok(model.get('isComplete'));
+  });
+});
+
+test('it is not completed when all not all builds have run', function (assert) {
+  Ember.run(() => {
+    const build = this.store().createRecord('build', { status: 'SUCCESS' });
+    const model = this.subject({ builds: [build], workflow });
+
+    assert.notOk(model.get('isComplete'));
+  });
+});
+
+test('it is complete when all builds have run', function (assert) {
+  Ember.run(() => {
+    const build1 = this.store().createRecord('build', { status: 'SUCCESS' });
+    const build2 = this.store().createRecord('build', { status: 'SUCCESS' });
+    const build3 = this.store().createRecord('build', { status: 'SUCCESS' });
+    const build4 = this.store().createRecord('build', { status: 'SUCCESS' });
+    const model = this.subject({ builds: [build4, build3, build2, build1], workflow });
+
+    assert.ok(model.get('isComplete'));
+  });
 });

--- a/tests/unit/mixins/model-reloader-test.js
+++ b/tests/unit/mixins/model-reloader-test.js
@@ -1,0 +1,75 @@
+import Ember from 'ember';
+import ModelReloaderMixin from 'screwdriver-ui/mixins/model-reloader';
+import { module, test } from 'qunit';
+let subject;
+
+module('Unit | Mixin | model reloader mixin', {
+  beforeEach() {
+    const ModelReloaderObject = Ember.Object.extend(ModelReloaderMixin);
+
+    subject = ModelReloaderObject.create();
+  }
+});
+
+test('it mixes in to an ember object', function (assert) {
+  assert.ok(typeof subject.startReloading === 'function');
+});
+
+test('it try to start a reloading model', function (assert) {
+  subject.set('scheduleReload', () => {
+    subject.set('runLater', 'foo');
+  });
+  subject.startReloading();
+  assert.equal(subject.get('runLater'), 'foo');
+});
+
+test('it not try to start a reloading model', function (assert) {
+  subject.set('runLater', 1);
+  subject.set('scheduleReload', () => {
+    subject.set('runLater', 'foo');
+  });
+  subject.startReloading();
+  assert.equal(subject.get('runLater'), 1);
+});
+
+test('it will stop a reloading model', function (assert) {
+  subject.set('runLater', 1);
+
+  subject.stopReloading();
+  assert.notOk(subject.get('runLater'));
+});
+
+test('it calls reload on a model', function (assert) {
+  assert.expect(1);
+  subject.set('testModel', {
+    reload() {
+      assert.ok(true);
+
+      return Ember.RSVP.resolve({});
+    }
+  });
+  subject.set('modelToReload', 'testModel');
+
+  subject.reloadModel();
+});
+
+test('it should not reload a model if shouldReload returns false', function (assert) {
+  assert.expect(1);
+  const testModel = {
+    reload() {
+      assert.ok(true);
+
+      return Promise.resolve({});
+    }
+  };
+
+  subject.set('testModel', testModel);
+  subject.set('shouldReload', (m) => {
+    assert.equal(m, testModel);
+
+    return false;
+  });
+  subject.set('modelToReload', 'testModel');
+
+  subject.reloadModel();
+});


### PR DESCRIPTION
* Adds ModelReloader mixin that will schedule reload on a model periodically.
* Build-bubble, event-list, event-view all use ModelReloader to schedule various model reloads
* event-list only shows 5 (configurable) events by default. Adds a link to show all.

https://github.com/screwdriver-cd/screwdriver/issues/391