### PR TITLE
fix: Search button actually searches

### DIFF
--- a/app/application/controller.js
+++ b/app/application/controller.js
@@ -6,6 +6,9 @@ export default Ember.Controller.extend({
   actions: {
     invalidateSession() {
       this.get('session').invalidate();
+    },
+    search(params) {
+      this.transitionToRoute('search', { queryParams: { query: params } });
     }
   }
 });

--- a/app/application/template.hbs
+++ b/app/application/template.hbs
@@ -1,4 +1,4 @@
-{{app-header session=session onInvalidate=(action "invalidateSession") showSearch=true}}
+{{app-header session=session onInvalidate=(action "invalidateSession") showSearch=true searchPipelines=(action "search")}}
 <div id="appContainer" class="container">
 {{outlet}}
 </div>

--- a/app/components/app-header/component.js
+++ b/app/components/app-header/component.js
@@ -25,6 +25,9 @@ export default Ember.Component.extend({
     },
     onToggleClick() {
       this.toggleMenu();
+    },
+    triggerSearch() {
+      this.get('searchPipelines')(this.$('.search-input').val());
     }
   }
 });

--- a/app/components/app-header/template.hbs
+++ b/app/components/app-header/template.hbs
@@ -7,10 +7,10 @@
 
       {{#if showSearch}}
       <div class="search">
-        <form class="search-form" action="/search" method="GET">
-          {{input class="search-input" name="query" placeholder="Enter your search terms" focus-in="onFocus" focus-out="onBlur"}}
+        <form class="search-form" {{action "triggerSearch" on="submit"}}>
+          {{input class="search-input" name="query" placeholder="Search Screwdriver pipelines " focus-in="onFocus" focus-out="onBlur"}}
         </form>
-        <div class="search-icon">
+        <div class="search-icon" {{action "triggerSearch"}}>
           {{fa-icon "fa-search"}}
         </div>
       </div>

--- a/app/search/route.js
+++ b/app/search/route.js
@@ -4,7 +4,7 @@ export default Ember.Route.extend({
   titleToken: 'Search',
   queryParams: {
     query: {
-      refreshModel: false,
+      refreshModel: true,
       replace: true
     }
   },

--- a/tests/integration/components/app-header/component-test.js
+++ b/tests/integration/components/app-header/component-test.js
@@ -55,3 +55,16 @@ test('it shows the search bar', function (assert) {
   this.$('.search input').focusout();
   assert.notOk(this.$('.search').hasClass('search-focused'), 'blurred');
 });
+
+test('it redirects to search page', function (assert) {
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+  this.set('search', () => {
+    assert.ok(true);
+  });
+
+  this.render(hbs`{{app-header showSearch=true searchPipelines=(action search)}}`);
+
+  this.$('.search input').text('myquery');
+  this.$('.search-icon').click();
+});

--- a/tests/unit/application/controller-test.js
+++ b/tests/unit/application/controller-test.js
@@ -29,3 +29,14 @@ test('it calls session.authenticate', function (assert) {
   controller.send('invalidateSession');
   assert.equal(called, 1);
 });
+
+test('it calls search in controller', function (assert) {
+  let controller = this.subject();
+
+  controller.transitionToRoute = (path, params) => {
+    assert.equal(path, 'search');
+    assert.deepEqual(params, { queryParams: { query: 'myquery' } });
+  };
+
+  controller.send('search', 'myquery');
+});


### PR DESCRIPTION
- Make the search-icon clickable
- Now both `Enter` and clicking `search-icon` will take you to the search page 
- Resolve https://github.com/screwdriver-cd/screwdriver/issues/390