### PR TITLE
fix: html entities in logs caused view issues

### DIFF
--- a/app/build-logs/service.js
+++ b/app/build-logs/service.js
@@ -21,9 +21,7 @@ export default Ember.Service.extend({
       // convert jquery's ajax promises to a real promise
       Ember.$.ajax({ url, data: { from: logNumber } })
         .done((data, textStatus, jqXHR) => {
-          // convert log lines ansi to html colors
-          if (Array.isArray(data) && data.length) {
-            data.forEach((line) => { line.m = ansi_up.ansi_to_html(line.m); });
+          if (Array.isArray(data)) {
             lines = data;
           }
           done = jqXHR.getResponseHeader('x-more-data') === 'false';

--- a/app/components/build-log/template.hbs
+++ b/app/components/build-log/template.hbs
@@ -1,2 +1,13 @@
-<div class="logs">{{yield}}{{{logContent}}}</div>
+<div class="logs">{{yield}}
+  {{#each logs as |log|}}
+  <span class="line">
+    <span class="time">
+      {{moment-format log.t 'HH:mm:ss'}}
+    </span>
+    <span class="content">
+      {{ansiColorize log.m}}
+    </span>
+  </span>
+  {{/each}}
+</div>
 <div class="bottom"></div>

--- a/app/helpers/ansi-colorize.js
+++ b/app/helpers/ansi-colorize.js
@@ -1,0 +1,15 @@
+import Ember from 'ember';
+
+/**
+ * Transform ansi color codes to html tags
+ * @method ansiColorize
+ * @param  {Array}     params   Values passed to helper
+ * @return {String}             Html string
+ */
+export function ansiColorize([message]) {
+  const m = Ember.Handlebars.Utils.escapeExpression(message);
+
+  return Ember.String.htmlSafe(ansi_up.ansi_to_html(m));
+}
+
+export default Ember.Helper.helper(ansiColorize);

--- a/config/environment.js
+++ b/config/environment.js
@@ -23,7 +23,9 @@ module.exports = (environment) => {
       SDAPI_NAMESPACE: 'v4',
       BUILD_RELOAD_TIMER: 5000,  // 5 seconds
       EVENT_RELOAD_TIMER: 90000,  // 1.5 minutes
-      NUM_EVENTS_LISTED: 5
+      LOG_RELOAD_TIMER: 1000,
+      NUM_EVENTS_LISTED: 5,
+      MAX_LOG_LINES: 1000
     },
     moment: {
       allowEmpty: true // allow empty dates

--- a/tests/acceptance/build-test.js
+++ b/tests/acceptance/build-test.js
@@ -143,6 +143,8 @@ moduleForAcceptance('Acceptance | build', {
 
 test('visiting /pipelines/:id/build/:id', function (assert) {
   const $ = Ember.$;
+  const first = new RegExp(`${timeFormat}\\s+bad stuff`);
+  const second = new RegExp(`${timeFormat}\\s+fancy stuff`);
 
   visit('/pipelines/abcd/build/1234');
 
@@ -151,8 +153,7 @@ test('visiting /pipelines/:id/build/:id', function (assert) {
     assert.equal(find('a h1').text().trim(), 'foo/bar', 'incorrect pipeline name');
     assert.equal(find('.line1 h1').text().trim(), 'PR-50', 'incorrect job name');
     assert.equal(find('span.sha').text().trim(), '#abcdef', 'incorrect sha');
-    assert.equal(find('.is-open .logs').text().trim(),
-      `${timeFormat}bad stuff`, 'incorrect logs open');
+    assert.ok(find('.is-open .logs').text().trim().match(first), 'incorrect logs open');
 
     // This looks weird, but :nth-child(n) wasn't resolving properly.
     // This does essentially the same thing by setting a context for looking up `.name`.
@@ -160,8 +161,7 @@ test('visiting /pipelines/:id/build/:id', function (assert) {
     click('.name', $('.build-step-collection > div').get(1)); // open sd-setup step
 
     andThen(() => {
-      assert.equal(find('.is-open .logs').text().trim(),
-        `${timeFormat}fancy stuff`, 'incorrect logs open');
+      assert.ok(find('.is-open .logs').text().trim().match(second), 'incorrect logs open');
     });
   });
 });

--- a/tests/integration/components/build-log/component-test.js
+++ b/tests/integration/components/build-log/component-test.js
@@ -67,7 +67,7 @@ test('it renders open when told to', function (assert) {
   assert.ok(this.$('.build-log').hasClass('is-open'));
 
   return wait().then(() => {
-    assert.equal(this.$().text().trim(), `${timeFormat1}hello${timeFormat2}world`);
+    assert.ok(this.$().text().trim().match(`${timeFormat1}\\s+hello\\s+${timeFormat2}\\s+world`));
   });
 });
 
@@ -86,7 +86,7 @@ test('it starts loading when open changes', function (assert) {
 
   return wait().then(() => {
     assert.ok(this.$('.build-log').hasClass('is-open'), 'is open');
-    assert.equal(this.$().text().trim(), `${timeFormat1}hello${timeFormat2}world`);
+    assert.ok(this.$().text().trim().match(`${timeFormat1}\\s+hello\\s+${timeFormat2}\\s+world`));
   });
 });
 

--- a/tests/integration/components/build-step/component-test.js
+++ b/tests/integration/components/build-step/component-test.js
@@ -56,7 +56,7 @@ test('it starts open when step failed', function (assert) {
   assert.equal($('.step-view.failure').length, 1, 'has step view');
   assert.equal($('.build-log').length, 1, 'has log view');
   assert.ok($('.build-step').hasClass('is-open'), 'rendered open');
-  assert.equal($('.build-log').text().trim(), `${timeFormat}hello, world`);
+  assert.ok($('.build-log').text().trim().match(`${timeFormat}\\s+hello, world`));
 
   $('.name').click();
 
@@ -82,7 +82,7 @@ test('it starts open when step is running', function (assert) {
   assert.ok(this.$('.build-step').hasClass('is-open'));
 
   return wait().then(() => {
-    assert.equal(this.$('.build-log').text().trim(), `${timeFormat}hello, world`);
+    assert.ok(this.$('.build-log').text().trim().match(`${timeFormat}\\s+hello, world`));
   });
 });
 
@@ -106,7 +106,7 @@ test('it can toggle open and closed', function (assert) {
 
   return wait().then(() => {
     assert.ok(this.$('.build-step').hasClass('is-open'), 'is open');
-    assert.equal(this.$('.build-log').text().trim(), `${timeFormat}hello, world`);
+    assert.ok(this.$('.build-log').text().trim().match(`${timeFormat}\\s+hello, world`));
 
     this.$('.name').click();
 

--- a/tests/unit/helpers/ansi-colorize-test.js
+++ b/tests/unit/helpers/ansi-colorize-test.js
@@ -1,0 +1,18 @@
+
+import { ansiColorize } from 'screwdriver-ui/helpers/ansi-colorize';
+import { module, test } from 'qunit';
+
+module('Unit | Helper | ansi colorize');
+
+// Replace this with your real tests.
+test('it escapes html', function (assert) {
+  let result = ansiColorize(['<main>']);
+
+  assert.equal(result.toString(), '&lt;main&gt;');
+});
+
+test('colorizes ansi codes', function (assert) {
+  let result = ansiColorize(['\u001b[32m<main>\u001b[0m']);
+
+  assert.equal(result.toString(), '<span style="color:rgb(0, 187, 0)">&lt;main&gt;</span>');
+});


### PR DESCRIPTION
* Moves ansi colorizing to a htmlbars helper
* Use handlebars to sanitize raw logs before applying ansi colors
* Move html markup for log lines into template
* Reload logs on next tick if MAX_LOG_LINES is returned instead of waiting for BUILD_RELOAD_TIMER

Addresses https://github.com/screwdriver-cd/screwdriver/issues/395