### PR TITLE
feat(396): Add prev and next links to build banner

### DIFF
--- a/app/components/build-banner/component.js
+++ b/app/components/build-banner/component.js
@@ -3,6 +3,8 @@ import Ember from 'ember';
 export default Ember.Component.extend({
   classNames: ['build-banner'],
   classNameBindings: ['buildStatus'],
+  isPR: Ember.computed.match('jobName', /^PR-/),
+  jobNames: Ember.computed.mapBy('jobs', 'name'),
 
   buildAction: Ember.computed('buildStatus', {
     get() {
@@ -27,6 +29,29 @@ export default Ember.Component.extend({
       }
 
       return false;
+    }
+  }),
+
+  previous: Ember.computed('eventBuilds', 'jobs', 'jobName', {
+    get() {
+      if (this.get('isPR')) {
+        return null;
+      }
+      const prevIndex = this.get('jobNames').indexOf(this.get('jobName')) - 1;
+
+      return prevIndex < 0 ? null : this.get('eventBuilds').objectAt(prevIndex);
+    }
+  }),
+
+  next: Ember.computed('eventBuilds', 'jobs', 'jobName', {
+    get() {
+      if (this.get('isPR')) {
+        return null;
+      }
+      const nextIndex = this.get('jobNames').indexOf(this.get('jobName')) + 1;
+
+      return nextIndex >= this.get('jobs').length
+      ? null : this.get('eventBuilds').objectAt(nextIndex);
     }
   }),
 

--- a/app/components/build-banner/styles.scss
+++ b/app/components/build-banner/styles.scss
@@ -1,7 +1,25 @@
 & {
   margin: 10px 25px 0;
 
-  .line1 {
+  .prevnext {
+    font-size: 14px;
+    margin-bottom: 3px;
+    color: $sd-link;
+
+    .pure-u-1-2:first-child {
+      text-align: left;
+    }
+
+    .pure-u-1-2:last-child {
+      text-align: right;
+    }
+
+    a {
+      color: $sd-link;
+    }
+  }
+
+  .headerbar {
     border-radius: 3px;
     @include backgroundGradient(to right, $sd-running-gradient-start, $sd-running-gradient-end);
     color: #fff;
@@ -11,6 +29,10 @@
     .sha {
       font-weight: 300;
       font-size: 20px;
+    }
+
+    .pure-u-1-3:nth-child(2) {
+      text-align: center;
     }
 
     h1 {
@@ -74,7 +96,7 @@
     }
   }
 
-  .line2 {
+  .commit {
     margin-bottom: 5px;
     font-size: 14px;
     color: $sd-text-med;
@@ -84,17 +106,22 @@
     }
   }
 
-  .line3 {
+  .event {
     color: $sd-text-med;
     line-height: 20px;
     vertical-align: middle;
 
-    li {
+    .pure-u-1-3 {
       font-size: 14px;
-    }
 
-    .duration {
-      font-style: italic;
+      &:nth-child(2) {
+        text-align: center;
+      }
+
+      &:last-child {
+        font-style: italic;
+        text-align: right;
+      }
     }
   }
 }

--- a/app/components/build-banner/template.hbs
+++ b/app/components/build-banner/template.hbs
@@ -1,16 +1,24 @@
-<div class="line1">
-  <ul>
-    <li></li>
-    <li><h1>{{jobName}}</h1></li>
-    <li>{{#if isAuthenticated}}{{#if hasButton}}<button {{action "toggleBuild"}}>{{buildAction}}</button>{{/if}}{{/if}}</li>
-  </ul>
+<div class="prevnext">
+  <div class="pure-g">
+    <div class="pure-u-1-2">{{#if previous}}{{#link-to "build" previous.id}}{{fa-icon "fa-backward fa-1x"}} Previous Job {{/link-to}}{{/if}}</div>
+    <div class="pure-u-1-2">{{#if next}}{{#link-to "build" next.id}}Next Job {{fa-icon "fa-forward fa-1x"}}{{/link-to}}{{/if}}</div>
+  </div>
 </div>
-<div class="line2">
+<div class="headerbar">
+  <div class="pure-g">
+    <div class="pure-u-1-3"></div>
+    <div class="pure-u-1-3"><h1>{{jobName}}</h1></div>
+    <div class="pure-u-1-3">{{#if isAuthenticated}}{{#if hasButton}}<button {{action "toggleBuild"}}>{{buildAction}}</button>{{/if}}{{/if}}</div>
+  </div>
+</div>
+<div class="commit">
   <a href="{{event.commit.url}}"><span class="sha">#{{event.truncatedSha}}</span></a>
   <span class="message" title="{{event.commit.message}}">{{event.truncatedMessage}}</span>
 </div>
-<ul class="line3">
-  <li>{{user-link user=event.creator causeMessage=event.causeMessage}}</li>
-  <li><span class="container">{{buildContainer}}</span></li>
-  <li><span class="duration">{{duration}}</span></li>
-</ul>
+<div class="event">
+  <div class="pure-g">
+    <div class="pure-u-1-3">{{user-link user=event.creator causeMessage=event.causeMessage}}</div>
+    <div class="pure-u-1-3">{{buildContainer}}</div>
+    <div class="pure-u-1-3">{{duration}}</div>
+  </div>
+</div>

--- a/app/pipeline/builds/build/route.js
+++ b/app/pipeline/builds/build/route.js
@@ -1,15 +1,23 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
+  beforeModel() {
+    this.set('pipeline', this.modelFor('pipeline'));
+  },
   titleToken(model) {
     return `${model.job.get('name')} > #${model.build.get('sha').substr(0, 6)}`;
   },
   model(params) {
     return this.store.findRecord('build', params.build_id).then(build => Ember.RSVP.all([
       this.store.findRecord('job', build.get('jobId')),
-      this.store.findRecord('event', build.get('eventId'))
-    ]).then(([job, event]) => ({
-      build, job, event, pipeline: this.modelFor('pipeline')
+      this.store.findRecord('event', build.get('eventId')),
+      this.get('pipeline.jobs')
+    ]).then(([job, event, jobs]) => ({
+      build,
+      job,
+      event,
+      pipeline: this.get('pipeline'),
+      jobs: jobs.filter(j => !/^PR-/.test(j.get('name')))
     })));
   }
 });

--- a/app/pipeline/builds/build/template.hbs
+++ b/app/pipeline/builds/build/template.hbs
@@ -8,6 +8,8 @@
   onStart=(action "startBuild")
   onStop=(action "stopBuild")
   reloadBuild=(action "reload")
+  jobs=model.jobs
+  eventBuilds=model.event.buildsReversed
 }}
 
 {{#if stepList}}

--- a/tests/acceptance/build-test.js
+++ b/tests/acceptance/build-test.js
@@ -29,49 +29,78 @@ moduleForAcceptance('Acceptance | build', {
       })
     ]);
 
+    server.get('http://localhost:8080/v4/pipelines/abcd/jobs', () => [
+      200,
+      { 'Content-Type': 'application/json' },
+      JSON.stringify([{
+        id: 'aabbcc',
+        name: 'main',
+        permutations: [{
+          environment: {},
+          secrets: [],
+          commands: [{
+            name: 'install',
+            command: 'npm install'
+          }],
+          image: 'node:6'
+        }],
+        pipelineId: 'abcd',
+        state: 'ENABLED',
+        archived: false
+      }])
+    ]);
+
+    const buildData = {
+      id: '1234',
+      jobId: 'aabbcc',
+      eventId: 'eeeeee',
+      number: 1474649580274,
+      container: 'node:6',
+      cause: 'Started by user petey',
+      sha: 'c96f36886e084d18bd068b8156d095cd9b31e1d6',
+      createTime: '2016-09-23T16:53:00.274Z',
+      startTime: '2016-09-23T16:53:08.601Z',
+      endTime: '2016-09-23T16:58:47.355Z',
+      meta: {},
+      steps: [{
+        startTime: '2016-09-23T16:53:07.497654442Z',
+        name: 'sd-setup',
+        code: 0,
+        endTime: '2016-09-23T16:53:12.46806858Z'
+      }, {
+        startTime: '2016-09-23T16:53:12.902784483Z',
+        name: 'install',
+        code: 137,
+        endTime: '2016-09-23T16:58:46.924844475Z'
+      }, {
+        name: 'bower'
+      }, {
+        name: 'test'
+      }],
+      status: 'FAILURE',
+      commit: {
+        url: 'https://github.com/commit',
+        message: 'merge this'
+      }
+    };
+
+    server.get('http://localhost:8080/v4/events/eeeeee/builds', () => [
+      200,
+      { 'Content-Type': 'application/json' },
+      JSON.stringify([buildData])
+    ]);
+
     server.get('http://localhost:8080/v4/builds/1234', () => [
       200,
       { 'Content-Type': 'application/json' },
-      JSON.stringify({
-        id: '1234',
-        jobId: 'aabbcc',
-        eventId: 'eeeeee',
-        number: 1474649580274,
-        container: 'node:6',
-        cause: 'Started by user petey',
-        sha: 'c96f36886e084d18bd068b8156d095cd9b31e1d6',
-        createTime: '2016-09-23T16:53:00.274Z',
-        startTime: '2016-09-23T16:53:08.601Z',
-        endTime: '2016-09-23T16:58:47.355Z',
-        meta: {},
-        steps: [{
-          startTime: '2016-09-23T16:53:07.497654442Z',
-          name: 'sd-setup',
-          code: 0,
-          endTime: '2016-09-23T16:53:12.46806858Z'
-        }, {
-          startTime: '2016-09-23T16:53:12.902784483Z',
-          name: 'install',
-          code: 137,
-          endTime: '2016-09-23T16:58:46.924844475Z'
-        }, {
-          name: 'bower'
-        }, {
-          name: 'test'
-        }],
-        status: 'FAILURE',
-        commit: {
-          url: 'https://github.com/commit',
-          message: 'merge this'
-        }
-      })
+      JSON.stringify(buildData)
     ]);
 
     server.get('http://localhost:8080/v4/events/eeeeee', () => [
       200,
       { 'Content-Type': 'application/json' },
       JSON.stringify({
-        id: 'abcd',
+        id: 'eeeeee',
         causeMessage: 'Merged by batman',
         commit: {
           message: 'Merge pull request #2 from batcave/batmobile',
@@ -149,7 +178,7 @@ test('visiting /pipelines/:id/build/:id', function (assert) {
   andThen(() => {
     assert.equal(currentURL(), '/pipelines/abcd/build/1234');
     assert.equal(find('a h1').text().trim(), 'foo/bar', 'incorrect pipeline name');
-    assert.equal(find('.line1 h1').text().trim(), 'PR-50', 'incorrect job name');
+    assert.equal(find('.headerbar h1').text().trim(), 'PR-50', 'incorrect job name');
     assert.equal(find('span.sha').text().trim(), '#abcdef', 'incorrect sha');
     assert.equal(find('.is-open .logs').text().trim(),
       `${timeFormat}bad stuff`, 'incorrect logs open');

--- a/tests/integration/components/build-banner/component-test.js
+++ b/tests/integration/components/build-banner/component-test.js
@@ -1,7 +1,8 @@
+import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
-const eventMock = {
+const eventMock = Ember.Object.create({
   id: 'abcd',
   causeMessage: 'Merged by batman',
   commit: {
@@ -26,8 +27,19 @@ const eventMock = {
   sha: 'abcdef1029384',
   truncatedSha: 'abcdef',
   type: 'pipeline',
-  workflow: ['main', 'publish']
-};
+  workflow: ['main', 'publish'],
+  builds: ['build1', 'build2']
+});
+
+const jobMock = [
+  Ember.Object.create({
+    id: '1',
+    name: 'main'
+  }), Ember.Object.create({
+    id: '2',
+    name: 'publish'
+  })
+];
 
 moduleForComponent('build-banner', 'Integration | Component | build banner', {
   integration: true
@@ -44,6 +56,7 @@ test('it renders', function (assert) {
   });
 
   this.set('eventMock', eventMock);
+  this.set('jobMock', jobMock);
   this.render(hbs`{{build-banner
     buildContainer="node:6"
     buildStatus="SUCCESS"
@@ -52,28 +65,30 @@ test('it renders', function (assert) {
     isAuthenticated=false
     jobName="PR-671"
     reloadBuild=(action willRender)
+    jobs=jobMock
+    eventBuilds=eventMock.builds
   }}`);
 
   assert.equal($('h1').text().trim(), 'PR-671');
-  assert.equal($('.line2 a').prop('href'),
+  assert.equal($('.commit a').prop('href'),
     'http://example.com/batcave/batmobile/commit/abcdef1029384');
-  assert.equal($('.line2 a').text().trim(), '#abcdef');
+  assert.equal($('.commit a').text().trim(), '#abcdef');
   assert.equal($('.message').text().trim(),
     'Merge it');
   assert.equal($('.message').prop('title'),
     'Merge pull request #2 from batcave/batmobile');
-  assert.equal($('.container').text().trim(), 'node:6');
-  assert.equal($('.duration').text().trim(), '5 seconds');
+  assert.equal($('.event .pure-u-1-3:nth-child(2)').text().trim(), 'node:6');
+  assert.equal($('.event .pure-u-1-3:nth-child(3)').text().trim(), '5 seconds');
   assert.equal($('button').length, 0);
 });
 
-test('it does not render a restart button for non-PR jobs when authenticated', function (assert) {
+test('it does not render a restart button for main job when authenticated', function (assert) {
   assert.expect(2);
   this.set('willRender', () => {
     assert.ok(true);
   });
-
   this.set('eventMock', eventMock);
+  this.set('jobMock', jobMock);
   this.render(hbs`{{build-banner
     buildContainer="node:6"
     buildStatus="ABORTED"
@@ -82,6 +97,30 @@ test('it does not render a restart button for non-PR jobs when authenticated', f
     isAuthenticated=true
     jobName="main"
     reloadBuild=(action willRender)
+    jobs=jobMock
+    eventBuilds=eventMock.builds
+  }}`);
+
+  assert.equal(this.$('button').length, 0);
+});
+
+test('it does not render a restart button for publish job when authenticated', function (assert) {
+  assert.expect(2);
+  this.set('willRender', () => {
+    assert.ok(true);
+  });
+  this.set('eventMock', eventMock);
+  this.set('jobMock', jobMock);
+  this.render(hbs`{{build-banner
+    buildContainer="node:6"
+    buildStatus="ABORTED"
+    duration="5 seconds"
+    event=eventMock
+    isAuthenticated=true
+    jobName="publish"
+    reloadBuild=(action willRender)
+    jobs=jobMock
+    eventBuilds=eventMock.builds
   }}`);
 
   assert.equal(this.$('button').length, 0);
@@ -98,6 +137,7 @@ test('it renders a restart button for PR jobs when authenticated', function (ass
   });
 
   this.set('eventMock', eventMock);
+  this.set('jobMock', jobMock);
   this.render(hbs`{{build-banner
     buildContainer="node:6"
     buildStatus="ABORTED"
@@ -107,6 +147,8 @@ test('it renders a restart button for PR jobs when authenticated', function (ass
     jobName="PR-671"
     reloadBuild=(action willRender)
     onStart=(action externalStart)
+    jobs=jobMock
+    eventBuilds=eventMock.builds
   }}`);
 
   assert.equal(this.$('button').text().trim(), 'Restart');
@@ -122,8 +164,8 @@ test('it renders a stop button for job when authenticated', function (assert) {
   this.set('externalStop', () => {
     assert.ok(true);
   });
-
   this.set('eventMock', eventMock);
+  this.set('jobMock', jobMock);
   this.render(hbs`{{build-banner
     buildContainer="node:6"
     buildStatus="RUNNING"
@@ -133,6 +175,8 @@ test('it renders a stop button for job when authenticated', function (assert) {
     jobName="main"
     reloadBuild=(action willRender)
     onStop=(action externalStop)
+    jobs=jobMock
+    eventBuilds=eventMock.builds
   }}`);
 
   assert.equal(this.$('button').text().trim(), 'Stop');


### PR DESCRIPTION
Add `Previous Job` and `Next Job` links to build banner.
Pass in builds of the current event and get the previous and next build IDs. If there is no previous job, it won't display. Same as next job.  

![screen shot 2016-12-15 at 12 08 18 pm](https://cloud.githubusercontent.com/assets/3401924/21240234/40df69c0-c2bf-11e6-97aa-931ce45c8c52.png)

![screen shot 2016-12-15 at 12 08 26 pm](https://cloud.githubusercontent.com/assets/3401924/21240246/4ab28554-c2bf-11e6-98ab-21c4edbfbc57.png)

Related to https://github.com/screwdriver-cd/screwdriver/issues/396
