### PR TITLE
fix: align restart button correctly

### DIFF
--- a/app/components/build-banner/styles.scss
+++ b/app/components/build-banner/styles.scss
@@ -35,6 +35,10 @@
       text-align: center;
     }
 
+    .pure-u-1-3:last-child {
+      text-align: right;
+    }
+
     h1 {
       display: inline-block;
       margin: 0;


### PR DESCRIPTION
The alignment got messed up because I changed it to use pure grid in [this PR](https://github.com/screwdriver-cd/ui/pull/115) and missed the CSS for the restart button. 

Right now:
![screen shot 2016-12-22 at 2 00 44 pm](https://cloud.githubusercontent.com/assets/3401924/21441921/8e4ed58e-c84f-11e6-950d-9e63ab224af9.png)

After
![screen shot 2016-12-22 at 2 04 39 pm](https://cloud.githubusercontent.com/assets/3401924/21441929/9d5f6552-c84f-11e6-8952-4d33c82f2069.png)

