### PR TITLE
fix: Update badge links

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ Code licensed under the BSD 3-Clause license. See LICENSE file for terms.
 [version-url]: https://github.com/screwdriver-cd/ui/releases/
 [downloads-image]: https://img.shields.io/docker/pulls/screwdrivercd/ui.svg
 [license-image]: https://img.shields.io/github/license/screwdriver-cd/ui.svg
-[issues-image]: https://img.shields.io/github/issues/screwdriver-cd/ui.svg
-[issues-url]: https://github.com/screwdriver-cd/ui/issues
-[build-image]: https://cd.screwdriver.cd/pipelines/6975e4f82b0532e90fea2ac15cc1679e22764842/badge
-[build-url]: https://cd.screwdriver.cd/pipelines/6975e4f82b0532e90fea2ac15cc1679e22764842/
+[issues-image]: https://img.shields.io/github/issues/screwdriver-cd/screwdriver.svg
+[issues-url]: https://github.com/screwdriver-cd/screwdriver/issues
+[build-image]: https://cd.screwdriver.cd/pipelines/7/badge
+[build-url]: https://cd.screwdriver.cd/pipelines/7/
 [daviddm-image]: https://david-dm.org/screwdriver-cd/ui.svg?theme=shields.io
 [daviddm-url]: https://david-dm.org/screwdriver-cd/ui

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "ember-load-initializers": "^0.6.2",
     "ember-modal-dialog": "0.9.0",
     "ember-moment": "~7.0.3",
-    "ember-resolver": "^2.0.3",
+    "ember-resolver": "2.1.0",
     "ember-simple-auth": "1.1.0",
     "eslint": "^3.9.1",
     "eslint-config-screwdriver": "^2.0.9",


### PR DESCRIPTION
- Update badge links
- Temporarily pin resolver to version to `2.1.0` since the new version broke our tests. Will leave the fix to a different PR as I'm not sure why and it's out of the scope of this PR. 

```
not ok 1 PhantomJS 2.1 - Global error: Error: Compile Error: ansiColorize is not a helper at http://localhost:7357/assets/vendor.js, line 67394
15:46:15
    ---
15:46:15
        Log: |
15:46:15
            { type: 'warn',
15:46:15
              text: '\'WARNING: Attempted to lookup "helper:ansiColorize" which was not found. In previous versions of ember-resolver, a bug would have caused the module at "screwdriver-ui/helpers/ansi-colorize" to be returned for this camel case helper name. This has been fixed. Use the dasherized name to resolve the module that would have been returned in previous versions.\'\n' }
15:46:15
            { type: 'error',
15:46:15
              text: 'Error: Compile Error: ansiColorize is not a helper at http://localhost:7357/assets/vendor.js, line 67394\n' }
15:46:15
    ...
15:46:15
not ok 2 PhantomJS 2.1 - Global error: Error: Assertion Failed: You modified isOpen twice on <screwdriver-ui@component:build-step::ember866> in a single render. This was unreliable and slow in Ember 1.x and is no longer supported. See https://github.com/emberjs/ember.js/issues/13948 for more details. at http://localhost:7357/assets/vendor.js, line 20570
15:46:15
    ---
15:46:15
        Log: |
15:46:15
            { type: 'error',
15:46:15
              text: 'Error: Assertion Failed: You modified isOpen twice on <screwdriver-ui@component:build-step::ember866> in a single render. This was unreliable and slow in Ember 1.x and is no longer supported. See https://github.com/emberjs/ember.js/issues/13948 for more details. at http://localhost:7357/assets/vendor.js, line 20570\n' }
15:46:15
    ...