### PR TITLE
feat: add support for search filter

### DIFF
--- a/app/components/search-list/component.js
+++ b/app/components/search-list/component.js
@@ -3,11 +3,38 @@ import Ember from 'ember';
 export default Ember.Component.extend({
   pipelineSorting: ['appId', 'branch'],
   sortedPipelines: Ember.computed.sort('pipelines', 'pipelineSorting'),
-  filteredPipelines: Ember.computed('query', 'sortedPipelines', {
+  filterSet: Ember.computed('query', {
+    get() {
+      const q = this.get('query') || '';
+      const keywords = q.split(/\s+/);
+      const filters = keywords.map((k) => {
+        let pair = k.split(/:/);
+
+        if (k.match(/[A-Za-z]+:[^ :]+/)) {
+          return { key: pair[0], value: pair[1] };
+        }
+
+        // By default, search appId by keywords
+        return { key: 'appId', value: k };
+      });
+
+      return filters;
+    }
+  }),
+  filteredPipelines: Ember.computed('sortedPipelines', 'filterSet', {
     get() {
       const pipelines = this.get('sortedPipelines');
-      const q = this.get('query') || '';
-      const filtered = pipelines.filter(p => p.get('appId').indexOf(q) > -1);
+      const filterSet = this.get('filterSet');
+      let filtered = pipelines;
+
+      filterSet.forEach((filter) => {
+        filtered = filtered.filter((p) => {
+          const field = Ember.inspect(p.get(filter.key));
+
+          // skip filtering if value is empty
+          return !filter.value || (field && field.indexOf(filter.value) > -1);
+        });
+      });
 
       return filtered;
     }

--- a/tests/integration/components/search-list/component-test.js
+++ b/tests/integration/components/search-list/component-test.js
@@ -59,3 +59,57 @@ test('it filters the list', function (assert) {
   assert.equal($('td.appId').text().trim(), 'foo/bar');
   assert.equal($('td.branch').text().trim(), 'master');
 });
+
+test('it filters the list by single advanced search query', function (assert) {
+  const $ = this.$;
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+  const pipelines = [
+    Ember.Object.create({
+      id: 1,
+      appId: 'foo/bar',
+      branch: 'master'
+    }),
+    Ember.Object.create({
+      id: 2,
+      appId: 'batman/tumbler',
+      branch: 'waynecorp'
+    })
+  ];
+
+  this.set('pipelineList', pipelines);
+  this.set('q', 'branch:master');
+
+  this.render(hbs`{{search-list pipelines=pipelineList query=q}}`);
+
+  assert.ok($('tr').length, 2);
+  assert.equal($('td.appId').text().trim(), 'foo/bar');
+  assert.equal($('td.branch').text().trim(), 'master');
+});
+
+test('it filters the list by multiple advanced search queries', function (assert) {
+  const $ = this.$;
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+  const pipelines = [
+    Ember.Object.create({
+      id: 1,
+      appId: 'foo/bar',
+      branch: 'master'
+    }),
+    Ember.Object.create({
+      id: 2,
+      appId: 'batman/tumbler',
+      branch: 'waynecorp'
+    })
+  ];
+
+  this.set('pipelineList', pipelines);
+  this.set('q', 'branch:corp appId:tumbler');
+
+  this.render(hbs`{{search-list pipelines=pipelineList query=q}}`);
+
+  assert.ok($('tr').length, 2);
+  assert.equal($('td.appId').text().trim(), 'batman/tumbler');
+  assert.equal($('td.branch').text().trim(), 'waynecorp');
+});


### PR DESCRIPTION
I added the search filter feature described in screwdriver-cd/screwdriver#397. It supports multiple queries and uses `appId` as a default field.

For instance,
* `abc` => `appId:abc`
* `branch:master abc def` => `branch:master` AND `appId:abc` AND `appId:def`