### PR TITLE
fix: Remove white-space style in build logs

### DIFF
--- a/app/components/build-log/styles.scss
+++ b/app/components/build-log/styles.scss
@@ -1,7 +1,6 @@
 .logs {
   font-size: 1em;
   font-family: monospace;
-  white-space: pre-wrap;
   background-color: #333;
   color: #eee;
   height: 0;


### PR DESCRIPTION
This fixes screwdriver-cd/screwdriver#449. This issue seems to occur on Safari and Firefox, not occur on Chrome. I verified it resolved by removing `white-space` style for build logs components. Line breaks disappear from some build logs by this change, but I think it's better for now.