### PR TITLE
fix: Remove spaces around log elements

### DIFF
--- a/app/components/build-log/template.hbs
+++ b/app/components/build-log/template.hbs
@@ -1,12 +1,8 @@
 <div class="logs">{{yield}}
   {{#each logs as |log|}}
   <span class="line">
-    <span class="time">
-      {{moment-format log.t 'HH:mm:ss'}}
-    </span>
-    <span class="content">
-      {{ansi-colorize log.m}}
-    </span>
+    <span class="time">{{moment-format log.t 'HH:mm:ss'}}</span>
+    <span class="content">{{ansi-colorize log.m}}</span>
   </span>
   {{/each}}
 </div>


### PR DESCRIPTION
I removed spaces around log elements which has the `white-space: pre-wrap` attribute. The spaces include CR or LF, so I think it causes the issue (screwdriver-cd/screwdriver#449).
This PR is another option of #140.

Chrome
![image](https://cloud.githubusercontent.com/assets/1608595/22860917/a99c3c0a-f14e-11e6-87c9-ac92fd069275.png)

FireFox (after)
![image](https://cloud.githubusercontent.com/assets/1608595/22860918/b4422b74-f14e-11e6-988b-61e9945e2d60.png)
FireFox (before)
![image](https://cloud.githubusercontent.com/assets/1608595/22860935/4c269e66-f14f-11e6-9f6b-2927736a0e3e.png)

Opera
![image](https://cloud.githubusercontent.com/assets/1608595/22860922/bb574dc2-f14e-11e6-918f-8c742b6e3ae5.png)
