### PR TITLE
fix(478): redirect to a pipeline page if a build doesn't belong to the pipeline

### DIFF
--- a/app/pipeline/builds/build/route.js
+++ b/app/pipeline/builds/build/route.js
@@ -19,5 +19,13 @@ export default Ember.Route.extend({
       pipeline: this.get('pipeline'),
       jobs: jobs.filter(j => !/^PR-/.test(j.get('name')))
     })));
+  },
+  afterModel(model) {
+    const pipelineId = model.pipeline.get('id');
+
+    // Build not found for this pipeline, redirecting to the pipeline page
+    if (pipelineId !== model.job.get('pipelineId')) {
+      this.transitionTo('pipeline', pipelineId);
+    }
   }
 });

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "ember-moment": "~7.3.0",
     "ember-resolver": "~2.1.1",
     "ember-simple-auth": "1.2.0",
+    "ember-sinon-qunit": "^1.4.1",
     "ember-source": "~2.11.0",
     "eslint": "^3.13.0",
     "eslint-config-screwdriver": "^2.1.1",

--- a/tests/acceptance/build-test.js
+++ b/tests/acceptance/build-test.js
@@ -147,7 +147,7 @@ moduleForAcceptance('Acceptance | build', {
           }],
           image: 'node:6'
         }],
-        pipelineId: '34b6834028c4c904dce3d9391c8b2dd4994ec6a9',
+        pipelineId: 'abcd',
         state: 'ENABLED',
         archived: false
       })

--- a/tests/unit/pipeline/builds/build/route-test.js
+++ b/tests/unit/pipeline/builds/build/route-test.js
@@ -34,5 +34,5 @@ sinonTest('it redirects if build not found', function (assert) {
   route.afterModel(model);
 
   assert.ok(stub.calledOnce, 'transitionTo was called once');
-  assert.ok(stub.calledWithExactly('pipeline', pipelineId), 'transtion to pipeline');
+  assert.ok(stub.calledWithExactly('pipeline', pipelineId), 'transition to pipeline');
 });

--- a/tests/unit/pipeline/builds/build/route-test.js
+++ b/tests/unit/pipeline/builds/build/route-test.js
@@ -1,4 +1,5 @@
 import { moduleFor, test } from 'ember-qunit';
+import sinonTest from 'ember-sinon-qunit/test-support/test';
 import Ember from 'ember';
 
 moduleFor('route:pipeline/builds/build', 'Unit | Route | pipeline/builds/build', {
@@ -14,4 +15,24 @@ test('it exists', function (assert) {
     job: Ember.Object.create({ name: 'main' }),
     build: Ember.Object.create({ sha: 'abcd1234567890' })
   }), 'main > #abcd12');
+});
+
+sinonTest('it redirects if build not found', function (assert) {
+  const route = this.subject();
+  const stub = this.stub(route, 'transitionTo');
+  const jobId = 345;
+  const pipelineId = 123;
+  const model = {
+    pipeline: {
+      get: type => (type === 'id' ? pipelineId : null)
+    },
+    job: {
+      get: type => (type === 'id' ? jobId : null)
+    }
+  };
+
+  route.afterModel(model);
+
+  assert.ok(stub.calledOnce, 'transitionTo was called once');
+  assert.ok(stub.calledWithExactly('pipeline', pipelineId), 'transtion to pipeline');
 });


### PR DESCRIPTION
I fixed a bug described in https://github.com/screwdriver-cd/screwdriver/issues/478.
There are 2 ways to avoid this bug.
1. show 404 page
2. redirect to somewhere
  2.1 `/pipelines/:pipeline_id`
  2.2 `/pipelines/:correct_pipeline_id/build/:build_id`

I think this will happen much when the end of the URL is trimmed such as copy/paste failure, so I chose the method 2.1. 