### PR TITLE
fix: fix bower import paths

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -16,8 +16,8 @@ module.exports = function (defaults) {
     }
   });
 
-  app.import('./bower_components/ansi_up/ansi_up.js');
-  app.import('./bower_components/humanize-duration/humanize-duration.js');
+  app.import('bower_components/ansi_up/ansi_up.js');
+  app.import('bower_components/humanize-duration/humanize-duration.js');
 
   // Use `app.import` to add additional libraries to the generated
   // output files.


### PR DESCRIPTION
Fix bower import paths:
The old paths won't work with [broccoli-concat](https://github.com/broccolijs/broccoli-concat)'s latest version `3.2.2` which is a dependency for `ember-cli`. 

