### PR TITLE
fix: resolve deprecation warnings by configuring routes specifically

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -13,18 +13,6 @@ App = Ember.Application.extend({
   Resolver
 });
 
-// Detect and store previous path for redirection after login
-Ember.Route.reopen({
-  afterModel: function(resolvedModel, transition) {
-    transition.then(() => {
-      App.currentPath = this.get('router.url');
-    });
-  },
-  deactivate() {
-    App.previousPath = App.currentPath;
-  }
-});
-
 loadInitializers(App, config.modulePrefix);
 
 export default App;

--- a/app/application/route.js
+++ b/app/application/route.js
@@ -1,13 +1,7 @@
 import Ember from 'ember';
 import ApplicationRouteMixin from 'ember-simple-auth/mixins/application-route-mixin';
-import App from '../app';
-export default Ember.Route.extend(ApplicationRouteMixin, {
-  sessionAuthenticated() {
-    // set the previous path to redirect
-    this.routeAfterAuthentication = App.previousPath;
 
-    return this._super(...arguments);
-  },
+export default Ember.Route.extend(ApplicationRouteMixin, {
   title(tokens) {
     let arr = Array.isArray(tokens) ? tokens : [];
 

--- a/app/create/route.js
+++ b/app/create/route.js
@@ -2,5 +2,6 @@ import Ember from 'ember';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
 export default Ember.Route.extend(AuthenticatedRouteMixin, {
-  titleToken: 'Create Pipeline'
+  titleToken: 'Create Pipeline',
+  routeAfterAuthentication: 'create'
 });

--- a/app/login/route.js
+++ b/app/login/route.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import UnauthenticatedRouteMixin from 'ember-simple-auth/mixins/unauthenticated-route-mixin';
 export default Ember.Route.extend(UnauthenticatedRouteMixin, {
-  titleToken: 'Login'
+  titleToken: 'Login',
+  routeIfAlreadyAuthenticated: 'home'
 });

--- a/app/pipeline/builds/build/route.js
+++ b/app/pipeline/builds/build/route.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
+  routeAfterAuthentication: 'pipeline.build.build',
   beforeModel() {
     this.set('pipeline', this.modelFor('pipeline'));
   },

--- a/app/pipeline/builds/index/route.js
+++ b/app/pipeline/builds/index/route.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
+  routeAfterAuthentication: 'pipeline',
   beforeModel() {
     this.set('pipeline', this.modelFor('pipeline'));
   },

--- a/app/pipeline/builds/route.js
+++ b/app/pipeline/builds/route.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
+  routeAfterAuthentication: 'pipeline'
 });

--- a/app/pipeline/options/route.js
+++ b/app/pipeline/options/route.js
@@ -2,6 +2,7 @@ import Ember from 'ember';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
 export default Ember.Route.extend(AuthenticatedRouteMixin, {
+  routeAfterAuthentication: 'pipeline.options',
   model() {
     return this.modelFor('pipeline');
   }

--- a/app/pipeline/route.js
+++ b/app/pipeline/route.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
+  routeAfterAuthentication: 'pipeline',
   titleToken(model) {
     return model.get('appId');
   },

--- a/app/pipeline/secrets/route.js
+++ b/app/pipeline/secrets/route.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 export default Ember.Route.extend(AuthenticatedRouteMixin, {
+  routeAfterAuthentication: 'pipeline.secrets',
   titleToken: 'Secrets',
   model() {
     const pipeline = this.modelFor('pipeline');

--- a/app/search/route.js
+++ b/app/search/route.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
+  routeAfterAuthentication: 'search',
   titleToken: 'Search',
   queryParams: {
     query: {

--- a/config/environment.js
+++ b/config/environment.js
@@ -60,11 +60,6 @@ module.exports = (environment) => {
     ENV.APP.SDSTORE_HOSTNAME = 'https://store.screwdriver.cd';
   }
 
-  ENV['ember-simple-auth'] = {
-    routeAfterAuthentication: 'home',
-    routeIfAlreadyAuthenticated: 'home'
-  };
-
   ENV['ember-cli-toggle'] = {
     includedThemes: ['light'],
     defaultTheme: 'light',


### PR DESCRIPTION
ember-simple-auth deprecated the application-wide settings of session auth routing.
This should resolve issue https://github.com/screwdriver-cd/screwdriver/issues/425, and reverts #148.