### PR TITLE
fix(527): fix builds endpoint

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -16,7 +16,7 @@ Router.map(function route() {
   this.route('pipeline', { path: '/pipelines/:pipeline_id' }, function secretsRoute() {
     this.route('secrets');
     this.route('builds', { path: '/' }, function buildRoute() {
-      this.route('build', { path: 'build/:build_id' });
+      this.route('build', { path: 'builds/:build_id' });
     });
     this.route('options');
   });

--- a/tests/acceptance/build-test.js
+++ b/tests/acceptance/build-test.js
@@ -170,15 +170,15 @@ moduleForAcceptance('Acceptance | build', {
   }
 });
 
-test('visiting /pipelines/:id/build/:id', function (assert) {
+test('visiting /pipelines/:id/builds/:id', function (assert) {
   const $ = Ember.$;
   const first = new RegExp(`${timeFormat}\\s+bad stuff`);
   const second = new RegExp(`${timeFormat}\\s+fancy stuff`);
 
-  visit('/pipelines/abcd/build/1234');
+  visit('/pipelines/abcd/builds/1234');
 
   andThen(() => {
-    assert.equal(currentURL(), '/pipelines/abcd/build/1234');
+    assert.equal(currentURL(), '/pipelines/abcd/builds/1234');
     assert.equal(find('a h1').text().trim(), 'foo/bar', 'incorrect pipeline name');
     assert.equal(find('.headerbar h1').text().trim(), 'PR-50', 'incorrect job name');
     assert.equal(find('span.sha').text().trim(), '#abcdef', 'incorrect sha');


### PR DESCRIPTION
## Context
The API endpoint is `/v4/builds/{id}` but the UI endpoint is `/pipelines/{pipeline.id}/build/{id}`. "builds" and "build" difference may make confuse us.

## Object
Fix endpoint to "builds" from "build".

## Misc.
If another repository of code that should fix exist, please teach me.

Related: https://github.com/screwdriver-cd/screwdriver/issues/527