### PR TITLE
fix: pin back ember-data

### DIFF
--- a/app/application/route.js
+++ b/app/application/route.js
@@ -2,6 +2,7 @@ import Ember from 'ember';
 import ApplicationRouteMixin from 'ember-simple-auth/mixins/application-route-mixin';
 
 export default Ember.Route.extend(ApplicationRouteMixin, {
+  routeAfterAuthentication: 'home',
   title(tokens) {
     let arr = Array.isArray(tokens) ? tokens : [];
 

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^1.2.0",
     "ember-component-css": "^0.2.2",
-    "ember-data": "^2.12.0",
+    "ember-data": "2.12.0",
     "ember-export-application-global": "^1.0.5",
     "ember-font-awesome": "~3.0.2",
     "ember-highlight": "1.2.5",


### PR DESCRIPTION
Ember data seems to have made a breaking change in the way it handles errors. It now requires AdapterErrors to be supplied in JSONAPI format. This will be addressed when the ember2.13.x PR is ready, but for now we are pinning back.

I'm not sure what has regressed, but the login flow is now broken. Adjusted the routeAfterAuthenticated config in application adapter to fix.