### PR TITLE
fix(514): sort secrets by name in alphabetical order

### DIFF
--- a/app/components/pipeline-secret-settings/component.js
+++ b/app/components/pipeline-secret-settings/component.js
@@ -6,6 +6,8 @@ export default Ember.Component.extend({
   newAllow: false,
   isButtonDisabled: true,
   errorMessage: '',
+  secretsSorting: ['name'],
+  sortedSecrets: Ember.computed.sort('secrets', 'secretsSorting'),
   actions: {
     /**
      * Sets disabled state of "add" button

--- a/app/components/pipeline-secret-settings/template.hbs
+++ b/app/components/pipeline-secret-settings/template.hbs
@@ -8,7 +8,7 @@
     </tr>
   </thead>
   <tbody>
-    {{#each secrets as |secret|}}
+    {{#each sortedSecrets as |secret|}}
     {{secret-view secret=secret}}
     {{/each}}
   </tbody>

--- a/tests/integration/components/pipeline-secret-settings/component-test.js
+++ b/tests/integration/components/pipeline-secret-settings/component-test.js
@@ -98,3 +98,36 @@ test('it displays an error', function (assert) {
   assert.equal(this.$('.info-message span').text().trim(),
     'Secret name does not meet requirements /^[A-Z_][A-Z0-9_]*$/');
 });
+
+test('it sorts secrets by name alphabetically', function (assert) {
+  const testSecret1 = Ember.Object.create({
+    name: 'FOO',
+    pipelineId: 123245,
+    value: 'banana',
+    allowInPR: false
+  });
+
+  const testSecret2 = Ember.Object.create({
+    name: 'BAR',
+    pipelineId: 123245,
+    value: 'banana',
+    allowInPR: false
+  });
+
+  const testSecret3 = Ember.Object.create({
+    name: 'ZOO',
+    pipelineId: 123245,
+    value: 'banana',
+    allowInPR: false
+  });
+
+  this.set('mockSecrets', [testSecret1, testSecret2, testSecret3]);
+
+  this.set('mockPipeline', { id: 123245 });
+  this.render(hbs`{{pipeline-secret-settings secrets=mockSecrets pipeline=mockPipeline}}`);
+
+  // secrets are sorted by name
+  assert.equal(this.$('tbody tr:first-child td:first-child').text().trim(), 'BAR');
+  assert.equal(this.$('tbody tr:nth-child(2) td:first-child').text().trim(), 'FOO');
+  assert.equal(this.$('tbody tr:nth-child(3) td:first-child').text().trim(), 'ZOO');
+});


### PR DESCRIPTION
Previously, the secrets are sorted by id in reverse order.
Change it to sort by name in alphabetical order.

<img width="1261" alt="screen shot 2017-05-03 at 3 34 05 pm" src="https://cloud.githubusercontent.com/assets/20427140/25684412/25a42e60-3016-11e7-8ee3-f0074245e800.png">


Resolve https://github.com/screwdriver-cd/screwdriver/issues/514