### PR TITLE
fix: Small UI improvements on the secrets page and create page

### DIFF
--- a/app/components/pipeline-create-form/template.hbs
+++ b/app/components/pipeline-create-form/template.hbs
@@ -1,6 +1,8 @@
 {{info-message message=errorMessage type="error" icon="exclamation-triangle"}}
 
 <h1>Create Pipeline</h1>
+<p>Add a Git repository to Screwdriver by pasting your repository link below.<br>
+  We accept both HTTPS and SSH URLs.</p>
 <div>
 {{input
   class="text-input"

--- a/app/components/pipeline-secret-settings/component.js
+++ b/app/components/pipeline-secret-settings/component.js
@@ -22,7 +22,8 @@ export default Ember.Component.extend({
      */
     addNewSecret() {
       if (!/^[A-Z_][A-Z0-9_]*$/.test(this.get('newName'))) {
-        this.set('errorMessage', 'Secret name does not meet requirements /^[A-Z_][A-Z0-9_]*$/');
+        this.set('errorMessage', 'Secret keys can only consist of numbers, ' +
+        'uppercase letters and underscores, and cannot begin with a number.');
 
         return false;
       }

--- a/app/components/pipeline-secret-settings/template.hbs
+++ b/app/components/pipeline-secret-settings/template.hbs
@@ -1,4 +1,13 @@
 {{info-message message=errorMessage type="error" icon="exclamation-triangle"}}
+<h1>
+  Secrets
+  <a href="http://docs.screwdriver.cd/user-guide/configuration/secrets/">
+    <i class="fa fa-question-circle" title="More information"></i>
+  </a>
+</h1>
+<p>
+  User secrets must also be added to the Screwdriver YAML.
+</p>
 <table class="secrets">
   <thead>
     <tr>
@@ -14,9 +23,9 @@
   </tbody>
   <tfoot>
     <tr class="new">
-      <td class="key">{{input placeholder="key" size="40" value=newName key-up="enableButton"}}</td>
-      <td class="pass">{{input type="password" placeholder="value" size="40" value=newValue key-up="enableButton"}}</td>
-      <td class="allow">{{input type="checkbox" checked=newAllow title="Check to allow this secret to be used in pull-requests"}}</td>
+      <td class="key">{{input placeholder="SECRET_KEY" size="40" value=newName key-up="enableButton" title="Secret keys can only consist of numbers, uppercase letters and underscores, and cannot begin with a number."}}</td>
+      <td class="pass">{{input type="password" placeholder="SECRET_VALUE" size="40" value=newValue key-up="enableButton"}}</td>
+      <td class="allow"><div title="Check to allow this secret to be used in pull-requests">{{input type="checkbox" checked=newAllow}}</div></td>
       <td><button disabled={{isButtonDisabled}} {{action "addNewSecret"}}>Add</button></td>
     </tr>
   </tfoot>

--- a/tests/integration/components/pipeline-secret-settings/component-test.js
+++ b/tests/integration/components/pipeline-secret-settings/component-test.js
@@ -96,5 +96,6 @@ test('it displays an error', function (assert) {
 
   // and clears the new secret form elements
   assert.equal(this.$('.info-message span').text().trim(),
-    'Secret name does not meet requirements /^[A-Z_][A-Z0-9_]*$/');
+    'Secret keys can only consist of numbers, uppercase letters and underscores, ' +
+    'and cannot begin with a number.');
 });


### PR DESCRIPTION
Resolves to https://github.com/screwdriver-cd/screwdriver/issues/489
Resolves https://github.com/screwdriver-cd/screwdriver/issues/541

* add some text to the "create" page

<img width="651" alt="screen shot 2017-05-03 at 4 36 22 pm" src="https://cloud.githubusercontent.com/assets/7689953/25685869/25195ba6-301f-11e7-8472-e4d7b4ae0b71.png">

* Add a title and some text to the "secrets" page
* make the placeholder text in the secret page valid as a secret key

<img width="1422" alt="screen shot 2017-05-04 at 1 10 53 pm" src="https://cloud.githubusercontent.com/assets/7689953/25723030/46197550-30cb-11e7-928b-47632d7bca91.png">


* fix the error message when entering an invalid secret key

<img width="1897" alt="screen shot 2017-05-04 at 1 13 18 pm" src="https://cloud.githubusercontent.com/assets/7689953/25723093/7af6a5c2-30cb-11e7-9080-82f8b228d8cc.png">


* add tooltips specifying what a valid key looks like, and what the "allow in PR" box is for
<img width="356" alt="screen shot 2017-05-03 at 4 37 10 pm" src="https://cloud.githubusercontent.com/assets/7689953/25685904/5b12f99c-301f-11e7-90cd-23f3303fc9a2.png">
<img width="360" alt="screen shot 2017-05-03 at 4 38 35 pm" src="https://cloud.githubusercontent.com/assets/7689953/25685907/603f0942-301f-11e7-85c1-1a303dc030a8.png">
