### PR TITLE
Added lines to load the new lua module in nginx.conf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN set -x \
    # Missing https for some magic reason
    && apk add --no-cache --update ca-certificates \
    && apk add --virtual .build-dependencies wget \
-   && apk add nginx-mod-http-lua nginx-lua \
+   && apk add nginx-mod-http-lua \
    && wget -q -O - https://github.com/screwdriver-cd/ui/releases/latest \
        | egrep -o '/screwdriver-cd/ui/releases/download/v[0-9.]*/sdui.tgz' \
        | wget --base=http://github.com/ -i - -O sdui.tgz \

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,3 +1,5 @@
+load_module /usr/lib/nginx/modules/ndk_http_module.so;
+load_module /usr/lib/nginx/modules/ngx_http_lua_module.so;
 user  nginx;
 worker_processes  1;
 


### PR DESCRIPTION
- Borrowed from here https://github.com/openresty/lua-nginx-module#installation
- I don't have any idea if this will work in the intended way, but I do
  know that nginx starts with this config in place.