### PR TITLE
fix(555): build bubbles and events out of order

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -5,8 +5,6 @@ import config from './config/environment';
 
 let App;
 
-Ember.MODEL_FACTORY_INJECTIONS = true;
-
 App = Ember.Application.extend({
   modulePrefix: config.modulePrefix,
   podModulePrefix: config.podModulePrefix,

--- a/app/components/pipeline-event-view/template.hbs
+++ b/app/components/pipeline-event-view/template.hbs
@@ -6,7 +6,7 @@
     <div class="cause" title="{{event.commit.message}}">{{event.truncatedMessage}}</div>
     <div>
       {{#each event.workflow as |name index|}}
-      {{build-bubble jobName=name build=(index-of event.buildsReversed index) small=true}}
+      {{build-bubble jobName=name build=(index-of event.buildsSorted index) small=true}}
       {{/each}}
     </div>
   </div>

--- a/app/event/model.js
+++ b/app/event/model.js
@@ -3,11 +3,7 @@ import Ember from 'ember';
 
 export default DS.Model.extend({
   builds: DS.hasMany('build'),
-  buildsReversed: Ember.computed('builds.[]', {
-    get() {
-      return this.get('builds').reverseObjects();
-    }
-  }),
+  buildsSorted: Ember.computed.sort('builds', (a, b) => parseInt(a.id, 10) - parseInt(b.id, 10)),
   causeMessage: DS.attr('string'),
   commit: DS.attr(),
   createTime: DS.attr('date'),

--- a/app/pipeline/builds/build/template.hbs
+++ b/app/pipeline/builds/build/template.hbs
@@ -9,7 +9,7 @@
   onStop=(action "stopBuild")
   reloadBuild=(action "reload")
   jobs=model.jobs
-  eventBuilds=model.event.buildsReversed
+  eventBuilds=model.event.buildsSorted
 }}
 
 {{#if stepList}}

--- a/app/pipeline/builds/index/controller.js
+++ b/app/pipeline/builds/index/controller.js
@@ -4,6 +4,8 @@ export default Ember.Controller.extend({
   isShowingModal: false,
   errorMessage: '',
   session: Ember.inject.service('session'),
+  eventsSorted: Ember.computed.sort('model.pipeline.events',
+    (a, b) => parseInt(b.id, 10) - parseInt(a.id, 10)),
   actions: {
     startMainBuild() {
       const main = this.get('model.jobs').objectAt(0);

--- a/app/pipeline/builds/index/template.hbs
+++ b/app/pipeline/builds/index/template.hbs
@@ -16,7 +16,7 @@
 
 <div class="pure-g">
   <div class="pure-u-1 pure-u-md-3-4">
-    {{pipeline-events-list events=model.pipeline.events}}
+    {{pipeline-events-list events=eventsSorted}}
   </div>
   <div class="pure-u-1 pure-u-md-1-4">
     {{pipeline-pr-list pullRequests=model.pullRequests}}

--- a/tests/acceptance/build-test.js
+++ b/tests/acceptance/build-test.js
@@ -12,13 +12,13 @@ moduleForAcceptance('Acceptance | build', {
   beforeEach() {
     server = new Pretender();
 
-    server.get('http://localhost:8080/v4/pipelines/abcd', () => [
+    server.get('http://localhost:8080/v4/pipelines/1', () => [
       200,
       { 'Content-Type': 'application/json' },
       JSON.stringify({
         admins: { batman: true },
         createTime: '2016-09-15T23:12:23.760Z',
-        id: 'abcd',
+        id: '1',
         scmRepo: {
           name: 'foo/bar',
           branch: 'master',
@@ -29,11 +29,11 @@ moduleForAcceptance('Acceptance | build', {
       })
     ]);
 
-    server.get('http://localhost:8080/v4/pipelines/abcd/jobs', () => [
+    server.get('http://localhost:8080/v4/pipelines/1/jobs', () => [
       200,
       { 'Content-Type': 'application/json' },
       JSON.stringify([{
-        id: 'aabbcc',
+        id: '2',
         name: 'main',
         permutations: [{
           environment: {},
@@ -44,7 +44,7 @@ moduleForAcceptance('Acceptance | build', {
           }],
           image: 'node:6'
         }],
-        pipelineId: 'abcd',
+        pipelineId: '1',
         state: 'ENABLED',
         archived: false
       }])
@@ -52,8 +52,8 @@ moduleForAcceptance('Acceptance | build', {
 
     const buildData = {
       id: '1234',
-      jobId: 'aabbcc',
-      eventId: 'eeeeee',
+      jobId: '2',
+      eventId: '3',
       number: 1474649580274,
       container: 'node:6',
       cause: 'Started by user petey',
@@ -84,7 +84,7 @@ moduleForAcceptance('Acceptance | build', {
       }
     };
 
-    server.get('http://localhost:8080/v4/events/eeeeee/builds', () => [
+    server.get('http://localhost:8080/v4/events/3/builds', () => [
       200,
       { 'Content-Type': 'application/json' },
       JSON.stringify([buildData])
@@ -96,11 +96,11 @@ moduleForAcceptance('Acceptance | build', {
       JSON.stringify(buildData)
     ]);
 
-    server.get('http://localhost:8080/v4/events/eeeeee', () => [
+    server.get('http://localhost:8080/v4/events/3', () => [
       200,
       { 'Content-Type': 'application/json' },
       JSON.stringify({
-        id: 'eeeeee',
+        id: '3',
         causeMessage: 'Merged by batman',
         commit: {
           message: 'Merge pull request #2 from batcave/batmobile',
@@ -126,11 +126,11 @@ moduleForAcceptance('Acceptance | build', {
       })
     ]);
 
-    server.get('http://localhost:8080/v4/jobs/aabbcc', () => [
+    server.get('http://localhost:8080/v4/jobs/2', () => [
       200,
       { 'Content-Type': 'application/json' },
       JSON.stringify({
-        id: 'aabbcc',
+        id: '2',
         name: 'PR-50',
         permutations: [{
           environment: {},
@@ -147,7 +147,7 @@ moduleForAcceptance('Acceptance | build', {
           }],
           image: 'node:6'
         }],
-        pipelineId: 'abcd',
+        pipelineId: '1',
         state: 'ENABLED',
         archived: false
       })
@@ -175,10 +175,10 @@ test('visiting /pipelines/:id/builds/:id', function (assert) {
   const first = new RegExp(`${timeFormat}\\s+bad stuff`);
   const second = new RegExp(`${timeFormat}\\s+fancy stuff`);
 
-  visit('/pipelines/abcd/builds/1234');
+  visit('/pipelines/1/builds/1234');
 
   andThen(() => {
-    assert.equal(currentURL(), '/pipelines/abcd/builds/1234');
+    assert.equal(currentURL(), '/pipelines/1/builds/1234');
     assert.equal(find('a h1').text().trim(), 'foo/bar', 'incorrect pipeline name');
     assert.equal(find('.headerbar h1').text().trim(), 'PR-50', 'incorrect job name');
     assert.equal(find('span.sha').text().trim(), '#abcdef', 'incorrect sha');

--- a/tests/acceptance/create-page-test.js
+++ b/tests/acceptance/create-page-test.js
@@ -26,19 +26,19 @@ test('/create a pipeline: SUCCESS', function (assert) {
     200,
     { 'Content-Type': 'application/json' },
     JSON.stringify({
-      id: 'abcd'
+      id: '1'
     })
   ]);
 
-  server.get('http://localhost:8080/v4/pipelines/abcd', () => [
+  server.get('http://localhost:8080/v4/pipelines/1', () => [
     200,
     { 'Content-Type': 'application/json' },
     JSON.stringify({
-      id: 'abcd'
+      id: '1'
     })
   ]);
 
-  server.get('http://localhost:8080/v4/pipelines/abcd/events', () => [
+  server.get('http://localhost:8080/v4/pipelines/1/events', () => [
     200,
     { 'Content-Type': 'application/json' },
     JSON.stringify([])
@@ -50,7 +50,7 @@ test('/create a pipeline: SUCCESS', function (assert) {
     JSON.stringify([])
   ]);
 
-  server.get('http://localhost:8080/v4/pipelines/abcd/jobs', () => [
+  server.get('http://localhost:8080/v4/pipelines/1/jobs', () => [
     200,
     { 'Content-Type': 'application/json' },
     JSON.stringify([])
@@ -66,7 +66,7 @@ test('/create a pipeline: SUCCESS', function (assert) {
     triggerEvent('.text-input', 'keyup');
     click('button');
     andThen(() => {
-      assert.equal(currentURL(), '/pipelines/abcd');
+      assert.equal(currentURL(), '/pipelines/1');
     });
   });
 });

--- a/tests/acceptance/pipeline-builds-test.js
+++ b/tests/acceptance/pipeline-builds-test.js
@@ -6,7 +6,7 @@ let server;
 
 const BUILD = {
   id: '1234',
-  jobId: 'aabbcc',
+  jobId: '1',
   number: 1474649580274,
   container: 'node:6',
   cause: 'Started by user batman',
@@ -35,7 +35,7 @@ const BUILD = {
 
 const events = [
   {
-    id: 'abcdf',
+    id: '2',
     causeMessage: 'Merged by batman',
     commit: {
       message: 'Merge pull request #2 from batcave/batmobile',
@@ -59,7 +59,7 @@ const events = [
     type: 'pipeline',
     workflow: ['main', 'publish']
   }, {
-    id: 'abcde',
+    id: '3',
     causeMessage: 'Merged by robin',
     commit: {
       message: 'Merge pull request #1 from batcave/batmobile',
@@ -89,21 +89,21 @@ const jobs = [
   {
     id: '12345',
     name: 'main',
-    pipelineId: 'abcd',
+    pipelineId: '4',
     state: 'ENABLED',
     archived: false
   },
   {
     id: '12346',
     name: 'publish',
-    pipelineId: 'abcd',
+    pipelineId: '4',
     state: 'ENABLED',
     archived: false
   },
   {
     id: '12347',
     name: 'PR-42',
-    pipelineId: 'abcd',
+    pipelineId: '4',
     state: 'ENABLED',
     archived: false
   }
@@ -142,11 +142,11 @@ moduleForAcceptance('Acceptance | pipeline builds', {
   beforeEach() {
     server = new Pretender();
 
-    server.get('http://localhost:8080/v4/pipelines/abcd', () => [
+    server.get('http://localhost:8080/v4/pipelines/4', () => [
       200,
       { 'Content-Type': 'application/json' },
       JSON.stringify({
-        id: 'abcd',
+        id: '4',
         scmUrl: 'git@github.com:foo/bar.git#master',
         scmRepo: {
           name: 'foo/bar',
@@ -159,28 +159,28 @@ moduleForAcceptance('Acceptance | pipeline builds', {
       })
     ]);
 
-    server.get('http://localhost:8080/v4/pipelines/abcd/jobs', () => [
+    server.get('http://localhost:8080/v4/pipelines/4/jobs', () => [
       200,
       { 'Content-Type': 'application/json' },
       JSON.stringify(jobs)
     ]);
 
-    server.get('http://localhost:8080/v4/pipelines/abcd/events', () => [
+    server.get('http://localhost:8080/v4/pipelines/4/events', () => [
       200,
       { 'Content-Type': 'application/json' },
       JSON.stringify(events)
     ]);
 
-    server.get('http://localhost:8080/v4/events/abcdf/builds', () => [
+    server.get('http://localhost:8080/v4/events/2/builds', () => [
       200,
       { 'Content-Type': 'application/json' },
-      JSON.stringify(makeBuilds('abcdf'))
+      JSON.stringify(makeBuilds('2'))
     ]);
 
-    server.get('http://localhost:8080/v4/events/abcde/builds', () => [
+    server.get('http://localhost:8080/v4/events/3/builds', () => [
       200,
       { 'Content-Type': 'application/json' },
-      JSON.stringify(makeBuilds('abcde'))
+      JSON.stringify(makeBuilds('3'))
     ]);
 
     server.get('http://localhost:8080/v4/jobs/12345/builds', () => [
@@ -206,11 +206,11 @@ moduleForAcceptance('Acceptance | pipeline builds', {
   }
 });
 
-test('visiting /pipelines/abcd', function (assert) {
-  visit('/pipelines/abcd');
+test('visiting /pipelines/4', function (assert) {
+  visit('/pipelines/4');
 
   andThen(() => {
-    assert.equal(currentURL(), '/pipelines/abcd');
+    assert.equal(currentURL(), '/pipelines/4');
     assert.equal(find('a h1').text().trim(), 'foo/bar', 'incorrect pipeline name');
     assert.equal(find('.pipelineWorkflow .build-bubble').length, 2, 'not enough workflow');
     assert.equal(find('button').length, 0, 'should not have a start button');

--- a/tests/acceptance/pipeline-options-test.js
+++ b/tests/acceptance/pipeline-options-test.js
@@ -8,11 +8,11 @@ moduleForAcceptance('Acceptance | pipeline/options', {
   beforeEach() {
     server = new Pretender();
 
-    server.get('http://localhost:8080/v4/pipelines/abcd', () => [
+    server.get('http://localhost:8080/v4/pipelines/1', () => [
       200,
       { 'Content-Type': 'application/json' },
       JSON.stringify({
-        id: 'abcd',
+        id: '1',
         scmUrl: 'git@github.com:foo/bar.git#master',
         createTime: '2016-09-15T23:12:23.760Z',
         admins: { batman: true },
@@ -20,7 +20,7 @@ moduleForAcceptance('Acceptance | pipeline/options', {
       })
     ]);
 
-    server.get('http://localhost:8080/v4/pipelines/abcd/jobs', () => [
+    server.get('http://localhost:8080/v4/pipelines/1/jobs', () => [
       200,
       { 'Content-Type': 'application/json' },
       JSON.stringify([
@@ -37,10 +37,10 @@ moduleForAcceptance('Acceptance | pipeline/options', {
 test('visiting /pipelines/:id/options', function (assert) {
   authenticateSession(this.application, { token: 'faketoken' });
 
-  visit('/pipelines/abcd/options');
+  visit('/pipelines/1/options');
 
   andThen(() => {
-    assert.equal(currentURL(), '/pipelines/abcd/options');
+    assert.equal(currentURL(), '/pipelines/1/options');
     assert.equal(find('section.jobs li').length, 2);
     assert.equal(find('section.danger li').length, 1);
   });

--- a/tests/acceptance/search-test.js
+++ b/tests/acceptance/search-test.js
@@ -11,7 +11,7 @@ moduleForAcceptance('Acceptance | search', {
       { 'Content-Type': 'application/json' },
       JSON.stringify([
         {
-          id: 'abcd',
+          id: '1',
           scmUrl: 'git@github.com:foo/bar.git#master',
           scmRepo: {
             name: 'foo/bar',
@@ -23,7 +23,7 @@ moduleForAcceptance('Acceptance | search', {
           workflow: ['main', 'publish']
         },
         {
-          id: 'bcda',
+          id: '2',
           scmUrl: 'git@github.com:foo/bar2.git#banana',
           scmRepo: {
             name: 'foo/bar2',
@@ -35,7 +35,7 @@ moduleForAcceptance('Acceptance | search', {
           workflow: ['main', 'publish']
         },
         {
-          id: 'cdab',
+          id: '3',
           scmUrl: 'git@github.com:foo/bar3.git#cucumber',
           scmRepo: {
             name: 'foo/bar3',

--- a/tests/acceptance/secrets-test.js
+++ b/tests/acceptance/secrets-test.js
@@ -8,11 +8,11 @@ moduleForAcceptance('Acceptance | secrets', {
   beforeEach() {
     server = new Pretender();
 
-    server.get('http://localhost:8080/v4/pipelines/abcd', () => [
+    server.get('http://localhost:8080/v4/pipelines/1', () => [
       200,
       { 'Content-Type': 'application/json' },
       JSON.stringify({
-        id: 'abcd',
+        id: '1',
         scmUrl: 'git@github.com:foo/bar.git#master',
         createTime: '2016-09-15T23:12:23.760Z',
         admins: { batman: true },
@@ -20,7 +20,7 @@ moduleForAcceptance('Acceptance | secrets', {
       })
     ]);
 
-    server.get('http://localhost:8080/v4/pipelines/abcd/secrets', () => [
+    server.get('http://localhost:8080/v4/pipelines/1/secrets', () => [
       200,
       { 'Content-Type': 'application/json' },
       JSON.stringify([
@@ -37,10 +37,10 @@ moduleForAcceptance('Acceptance | secrets', {
 test('visiting /pipelines/:id/secrets', function (assert) {
   authenticateSession(this.application, { token: 'faketoken' });
 
-  visit('/pipelines/abcd/secrets');
+  visit('/pipelines/1/secrets');
 
   andThen(() => {
-    assert.equal(currentURL(), '/pipelines/abcd/secrets');
+    assert.equal(currentURL(), '/pipelines/1/secrets');
     assert.equal(find('.secrets tbody tr').length, 2);
   });
 });

--- a/tests/integration/components/pipeline-event-view/component-test.js
+++ b/tests/integration/components/pipeline-event-view/component-test.js
@@ -12,7 +12,7 @@ test('it renders', function (assert) {
   // Handle any actions with this.on('myAction', function(val) { ... });
   const event = Ember.Object.create({
     id: 'abcd',
-    buildsReversed: Ember.A([]),
+    buildsSorted: Ember.A([]),
     causeMessage: 'Merged by batman',
     commit: {
       message: 'Merge pull request #2 from batcave/batmobile',

--- a/tests/integration/components/pipeline-events-list/component-test.js
+++ b/tests/integration/components/pipeline-events-list/component-test.js
@@ -12,8 +12,8 @@ test('it renders', function (assert) {
   // Handle any actions with this.on('myAction', function(val) { ... });
   const events = [
     Ember.Object.create({
-      id: 'abcd',
-      buildsReversed: Ember.A([]),
+      id: '1',
+      buildsSorted: Ember.A([]),
       causeMessage: 'Merged by batman',
       commit: {
         message: 'Merge pull request #2 from batcave/batmobile',
@@ -23,7 +23,7 @@ test('it renders', function (assert) {
           avatar: 'http://example.com/u/batman/avatar',
           url: 'http://example.com/u/batman'
         },
-        url: 'http://example.com/batcave/batmobile/commit/abcdef1029384'
+        url: 'http://example.com/batcave/batmobile/commit/1ef1029384'
       },
       createTime: '2016-11-04T20:09:41.238Z',
       creator: {
@@ -38,8 +38,8 @@ test('it renders', function (assert) {
       workflow: ['main', 'publish']
     }),
     Ember.Object.create({
-      id: 'abcd',
-      buildsReversed: Ember.A([]),
+      id: '1',
+      buildsSorted: Ember.A([]),
       causeMessage: 'Merged by robin',
       commit: {
         message: 'Merge pull request #1 from batcave/batmobile',


### PR DESCRIPTION
Context:
========
People are reporting that the build bubbles in events are displaying out of order intermitantly. Also, events sometimes appear out of order.
Investigations determined that the api returns lists of models sorted by `createTime` and this value is sometimes not very accurate. Some builds had a `createTime` value that was set after the `endTime` value. The sort by `createTime` was imposed some time ago when model ids were a hash, and thus not sortable by id.

Objective:
----------
This PR adds sorting to events and builds by model id to force them to display in the correct order regardless of the order the API returns them in.

Misc:
-----
* https://github.com/screwdriver-cd/screwdriver/issues/555
* Ember.MODEL_FACTORY_INJECTIONS removed as it is deprecated and unnecessary
* Acceptance tests updated to use numeric ids instead of hash-type ids for mock data