### PR TITLE
fix(584): Make search bar smaller and make pipeline page tabs easier to read

### DIFF
--- a/app/components/app-header/styles.scss
+++ b/app/components/app-header/styles.scss
@@ -71,6 +71,7 @@
       .fa {
         font-size: 15px;
         font-weight: 300;
+        padding-left: 5px;
       }
 
       &:hover {
@@ -101,12 +102,12 @@
   }
 }
 
-@media screen and (min-width: 1231px) {
+@media screen and (min-width: 962px) {
   .navbar-default .navbar-nav > li > a.icon .icontitle {
     display: none;
   }
 
   .navbar-form input {
-    width: 522px;
+    width: 326px;
   }
 }

--- a/app/components/pipeline-nav/styles.scss
+++ b/app/components/pipeline-nav/styles.scss
@@ -6,10 +6,10 @@
     a {
       border-radius: 2px 2px 0 0;
       background-color: transparent;
-      color: $sd-text-med;
+      color: $sd-text-light;
 
       &.active {
-        color: $sd-text-med;
+        color: $sd-text-light;
         background-color: transparent;
         border-bottom: 4px solid $sd-light-blue;
       }
@@ -18,13 +18,14 @@
 
   .nav > li > a:hover,
   .nav > li > a:focus {
-    background-color: transparent;
+    background-color: $sd-light-blue;
+    border-bottom: 4px solid $sd-light-blue;
   }
 
   .nav-pills > li.active > a,
   .nav-pills > li.active > a:hover,
   .nav-pills > li.active > a:focus {
     background-color: $sd-light-blue;
-    color: $sd-text-med;
+    color: $sd-text-light;
   }
 }

--- a/app/components/pipeline-start/styles.scss
+++ b/app/components/pipeline-start/styles.scss
@@ -1,6 +1,5 @@
 & {
-  text-align: right;
-  padding: 29px 25px 15px 0;
+  padding: 20px 0 0 20px;
 }
 button {
   border: 1px solid $sd-link;

--- a/app/components/pipeline-workflow/styles.scss
+++ b/app/components/pipeline-workflow/styles.scss
@@ -1,5 +1,5 @@
 & {
-  padding: 15px 0 15px 25px;
+  padding: 15px 0 15px 15px;
 }
 
 .build-bubble:last-child .dir-arrow {

--- a/app/pipeline/builds/index/template.hbs
+++ b/app/pipeline/builds/index/template.hbs
@@ -2,11 +2,15 @@
 
 {{#if session.isAuthenticated}}
 <div class="row">
-  <div class="col-xs-12 col-md-11">
-    {{pipeline-workflow jobs=model.jobs}}
-  </div>
-  <div class="col-xs-1 right">
-    {{pipeline-start startBuild=(action "startMainBuild")}}
+  <div class="col-md-9">
+    <div class="row">
+      <div class="col-xs-12 col-lg-2">
+        {{pipeline-start startBuild=(action "startMainBuild")}}
+      </div>
+      <div class="col-xs-12 col-lg-6">
+        {{pipeline-workflow jobs=model.jobs}}
+      </div>
+    </div>
   </div>
 </div>
 {{else}}

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -36,5 +36,5 @@ $animate-done: 600ms;
     overflow: hidden;
 }
 
-$grid-float-breakpoint: 1230px;
+$grid-float-breakpoint: 962px;
 @import "ember-bootstrap/bootstrap";


### PR DESCRIPTION
Addressing a few of the issues in https://github.com/screwdriver-cd/screwdriver/issues/584

 - [x] Start button is offset out of the page -> Start button has been moved to the left side of the screen
 - [x] Pipeline search bar takes up too much space -> changed to 326px
 - [x] Color of tabs on Pipeline page hard to read -> made them brighter
 - [x] Header switches into hamburger under 1230px (which is pretty big) -> switches at 962px now
 - [x] Header looks crazy at exactly 1230px -> no more crazy

Also in this PR:
- [x] Made Search icon centered in button
- [x] Hovering over a Pipeline page tab will make the background change color so it's more clear that it's clickable and is supposed to act like a tab

Before:
<img width="1432" alt="screen shot 2017-06-07 at 5 04 03 pm" src="https://user-images.githubusercontent.com/3230529/26906631-5fd515ba-4ba3-11e7-893f-e616f1fd3791.png">

After:
<img width="1366" alt="screen shot 2017-06-07 at 5 01 10 pm" src="https://user-images.githubusercontent.com/3230529/26906595-21c5a82a-4ba3-11e7-9c35-2af569f79289.png">

New Start button position:
<img width="1440" alt="screen shot 2017-06-07 at 6 24 59 pm" src="https://user-images.githubusercontent.com/3230529/26908303-b00c192e-4bae-11e7-9238-fc2e35f473a9.png">
