### PR TITLE
feat(584): hide app-header tooltips when menu is collapsed

### DIFF
--- a/app/components/app-header/styles.scss
+++ b/app/components/app-header/styles.scss
@@ -100,6 +100,9 @@
       }
     }
   }
+  .tooltips {
+    display: none;
+  }
 }
 
 @media screen and (min-width: 962px) {
@@ -107,7 +110,7 @@
     display: none;
   }
 
-  .navbar-form input {
-    width: 326px;
+  .tooltips {
+    display: block;
   }
 }

--- a/app/components/app-header/template.hbs
+++ b/app/components/app-header/template.hbs
@@ -19,35 +19,31 @@
         {{#link-to "create" class="icon create"}}
         {{inline-svg "write" class="img"}}
         <span class='icontitle'>Create Pipeline</span>
-        {{#bs-tooltip placement="bottom"}}Create a new Pipeline{{/bs-tooltip}}
         {{/link-to}}
       {{/nav.item}}
       {{#nav.item}}
         <a href="http://docs.screwdriver.cd" class="icon docs">
           {{inline-svg "documentation" class="img"}}
           <span class='icontitle'>Documentation</span>
-          {{#bs-tooltip placement="bottom"}}Screwdriver Documentation{{/bs-tooltip}}
         </a>
       {{/nav.item}}
       {{#nav.item}}
         <a href="http://blog.screwdriver.cd" class="icon blog">
           {{inline-svg "blog" class="img"}}
           <span class='icontitle'>Screwdriver Blog</span>
-          {{#bs-tooltip placement="bottom"}}Screwdriver Blog{{/bs-tooltip}}
         </a>
       {{/nav.item}}
       {{#nav.item}}
         <a href="http://slack.screwdriver.cd" class="icon community">
           {{inline-svg "community" class="img"}}
           <span class='icontitle'>Slack Channel</span>
-          {{#bs-tooltip placement="bottom"}}Screwdriver Slack Channel{{/bs-tooltip}}
         </a>
       {{/nav.item}}
       {{#nav.item}}
         <a href="https://github.com/screwdriver-cd" class="icon github">
           {{inline-svg "github" class="img"}}
           <span class='icontitle'>Github</span>
-          {{#bs-tooltip placement="bottom"}}Screwdriver Github Repo{{/bs-tooltip}}
+
         </a>
       {{/nav.item}}
       {{#nav.item}}
@@ -55,16 +51,24 @@
           <a {{action 'invalidateSession'}} title="Log out of Screwdriver" class="icon auth">
             {{inline-svg "login" class="img"}}
             <span class='icontitle'>Log out</span>
-            {{#bs-tooltip placement="bottom"}}Log out of Screwdriver{{/bs-tooltip}}
           </a>
         {{else}}
           {{#link-to "login" title="Login to Screwdriver" class="icon auth"}}
           {{inline-svg "login" class="img"}}
           <span class='icontitle'>Log in</span>
-          {{#bs-tooltip placement="bottom"}}Login to Screwdriver{{/bs-tooltip}}
           {{/link-to}}
         {{/if}}
       {{/nav.item}}
     {{/navbar.nav}}
   {{/navbar.content}}
 {{/bs-navbar}}
+<div class="tooltips">
+  {{#bs-tooltip placement="bottom" triggerElement=".icon.create" renderInPlace=true}}Create a new Pipeline{{/bs-tooltip}}
+  {{#bs-tooltip placement="bottom" triggerElement=".icon.docs" renderInPlace=true}}Screwdriver Documentation{{/bs-tooltip}}
+  {{#bs-tooltip placement="bottom" triggerElement=".icon.blog" renderInPlace=true}}Screwdriver Blog{{/bs-tooltip}}
+  {{#bs-tooltip placement="bottom" triggerElement=".icon.community" renderInPlace=true}}Screwdriver Slack Channel{{/bs-tooltip}}
+  {{#bs-tooltip placement="bottom" triggerElement=".icon.github" renderInPlace=true}}Screwdriver Github Repo{{/bs-tooltip}}
+  {{#bs-tooltip placement="bottom" triggerElement=".icon.auth" renderInPlace=true}}
+    {{#if session.isAuthenticated}}Log out of Screwdriver{{else}}Login to Screwdriver{{/if}}
+  {{/bs-tooltip}}
+</div>

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "broccoli-asset-rev": "^2.4.5",
     "ember-ace": "^0.1.2",
     "ember-ajax": "^3.0.0",
-    "ember-bootstrap": "^1.0.0-alpha.12",
+    "ember-bootstrap": "^1.0.0-beta.1",
     "ember-cli": "2.13.1",
     "ember-cli-app-version": "^3.0.0",
     "ember-cli-babel": "^6.0.0",


### PR DESCRIPTION
Context:
========
When the header menu is collapsed, tooltips display on the menu center screen which can be confusing.

Objective:
----------
Hide tooltips when the menu is collapsed

Misc:
------
Fixes last verifiable issue in https://github.com/screwdriver-cd/screwdriver/issues/584