### PR TITLE
feat(580): Add annotations to validator

### DIFF
--- a/app/components/validator-job/template.hbs
+++ b/app/components/validator-job/template.hbs
@@ -1,4 +1,16 @@
-<h4 {{action 'nameClick'}}>{{fa-icon (if isOpen "minus-square" "plus-square")}} {{name}}{{#if index }}.{{index}}{{/if}}</h4>
+<h4 class="job" {{action 'nameClick'}}>{{fa-icon (if isOpen "minus-square" "plus-square")}} {{name}}{{#if index }}.{{index}}{{/if}}</h4>
+<div class="annotations" title="These are the job-level annotations that the user has defined.">
+  <span class="label">Annotations:</span>
+  <span class="value">
+    <ul>
+      {{#each-in job.annotations as |name value|}}
+      <li><span class="name">{{name}}: </span><span class="value">{{value}}</span></li>
+      {{else}}
+      <li>None defined</li>
+      {{/each-in}}
+    </ul>
+  </span>
+</div>
 <div class="image" title="This is the docker image that acts as the base container for the job.">
   <span class="label">Image:</span>
   <span class="value">{{job.image}}</span>
@@ -38,7 +50,7 @@
   </span>
 </div>
 <div class="settings" title="These settings are used to configure the way a build executes and how build results are processed.">
-  <span class="label">Job Settings:</span>
+  <span class="label">Settings:</span>
   <span class="value">
     <ul>
       {{!TODO handle settings properly}}

--- a/app/components/validator-pipeline/component.js
+++ b/app/components/validator-pipeline/component.js
@@ -1,0 +1,11 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  isOpen: true,
+  actions: {
+    nameClick() {
+      this.toggleProperty('isOpen');
+      this.$('div').toggle('hidden');
+    }
+  }
+});

--- a/app/components/validator-pipeline/styles.scss
+++ b/app/components/validator-pipeline/styles.scss
@@ -1,0 +1,47 @@
+& {
+  margin: 10px 10px 0 0;
+  border-radius: 3px;
+  border: 1px solid $sd-separator;
+  padding: 10px;
+  font-weight: 300;
+  color: $sd-text;
+
+  > div {
+    padding: 3px;
+    border-radius: 3px;
+  }
+
+  > div:hover {
+    background-color: $sd-highlight;
+  }
+
+  ul {
+    margin: 0;
+  }
+
+  h4 {
+    padding: 0;
+    margin: 0 0 10px 0;
+  }
+
+  .label {
+    color: $sd-text;
+    font-weight: 600;
+  }
+
+  ul .value {
+    color: $sd-text-med;
+  }
+
+  .steps ul .value {
+    font-family: monospace;
+    display: inline-block;
+  }
+
+  &.has-parse-error .steps ul {
+    .name, .value {
+      font-weight: 600;
+      color: $sd-failure;
+    }
+  }
+}

--- a/app/components/validator-pipeline/template.hbs
+++ b/app/components/validator-pipeline/template.hbs
@@ -1,0 +1,26 @@
+<h4 class="pipeline" {{action 'nameClick'}}>{{fa-icon (if isOpen "minus-square" "plus-square")}} Pipeline Settings</h4>
+<div class="annotations" title="These are the pipeline-level annotations that the user has defined.">
+  <span class="label">Annotations:</span>
+  <span class="value">
+    <ul>
+      {{#each-in annotations as |name value|}}
+      <li><span class="name">{{name}}: </span><span class="value">{{value}}</span></li>
+      {{else}}
+      <li>None defined</li>
+      {{/each-in}}
+    </ul>
+  </span>
+</div>
+<div class="workflow" title="This is the order that the jobs will run in.">
+  <span class="label">Workflow:</span>
+  <span class="value">
+    <ul>
+      {{#each workflow as |name|}}
+      <li>{{name}}</li>
+      {{else}}
+      <li>Main</li>
+      {{/each}}
+    </ul>
+  </span>
+</div>
+{{yield}}

--- a/app/components/validator-results/component.js
+++ b/app/components/validator-results/component.js
@@ -12,6 +12,11 @@ export default Ember.Component.extend({
       return this.get('results.workflow') || [];
     }
   }),
+  annotations: Ember.computed('results', {
+    get() {
+      return this.get('results.annotations') || [];
+    }
+  }),
   jobs: Ember.computed('results', {
     get() {
       return this.get('results.jobs');

--- a/app/components/validator-results/template.hbs
+++ b/app/components/validator-results/template.hbs
@@ -6,6 +6,7 @@
 {{#if isTemplate}}
 {{validator-job name=templateName job=results.template.config}}
 {{else}}
+{{validator-pipeline name=pipelineName workflow=workflow annotations=annotations}}
 {{#each workflow as |jobName|}}
   {{#if (get jobs jobName)}}
     {{#each (get jobs jobName) as |jobConfig index|}}

--- a/tests/integration/components/validator-job/component-test.js
+++ b/tests/integration/components/validator-job/component-test.js
@@ -36,11 +36,14 @@ test('it renders', function (assert) {
   assert.equal(this.$('.env .label').text().trim(), 'Environment Variables:');
   assert.equal(this.$('.env ul li').text().trim(), 'None defined');
 
-  assert.equal(this.$('.settings .label').text().trim(), 'Job Settings:');
+  assert.equal(this.$('.settings .label').text().trim(), 'Settings:');
   assert.equal(this.$('.settings ul li').text().trim(), 'None defined');
+
+  assert.equal(this.$('.annotations .label').text().trim(), 'Annotations:');
+  assert.equal(this.$('.annotations .value').text().trim(), 'None defined');
 });
 
-test('it renders settings, env, secrets', function (assert) {
+test('it renders settings, env, secrets, annotations', function (assert) {
   this.set('jobMock', {
     image: 'int-test:1',
     commands: [
@@ -52,6 +55,9 @@ test('it renders settings, env, secrets', function (assert) {
       FOO: 'bar'
     },
     settings: {
+      FOO: 'bar'
+    },
+    annotations: {
       FOO: 'bar'
     }
   });
@@ -65,8 +71,11 @@ test('it renders settings, env, secrets', function (assert) {
   assert.equal(this.$('.env .label').text().trim(), 'Environment Variables:');
   assert.equal(this.$('.env ul li').text().trim(), 'FOO: bar');
 
-  assert.equal(this.$('.settings .label').text().trim(), 'Job Settings:');
+  assert.equal(this.$('.settings .label').text().trim(), 'Settings:');
   assert.equal(this.$('.settings ul li').text().trim(), 'FOO: bar');
+
+  assert.equal(this.$('.annotations .label').text().trim(), 'Annotations:');
+  assert.equal(this.$('.annotations ul li').text().trim(), 'FOO: bar');
 });
 
 test('it renders template steps', function (assert) {
@@ -78,7 +87,8 @@ test('it renders template steps', function (assert) {
     ],
     secrets: [],
     environment: {},
-    settings: {}
+    settings: {},
+    annotations: {}
   });
 
   this.render(hbs`{{validator-job name="int-test" index=0 job=jobMock}}`);
@@ -97,8 +107,11 @@ test('it renders template steps', function (assert) {
   assert.equal(this.$('.env .label').text().trim(), 'Environment Variables:');
   assert.equal(this.$('.env ul li').text().trim(), 'None defined');
 
-  assert.equal(this.$('.settings .label').text().trim(), 'Job Settings:');
+  assert.equal(this.$('.settings .label').text().trim(), 'Settings:');
   assert.equal(this.$('.settings ul li').text().trim(), 'None defined');
+
+  assert.equal(this.$('.annotations .label').text().trim(), 'Annotations:');
+  assert.equal(this.$('.annotations .value').text().trim(), 'None defined');
 });
 
 test('it renders when there are no steps or commands', function (assert) {
@@ -106,7 +119,8 @@ test('it renders when there are no steps or commands', function (assert) {
     image: 'int-test:1',
     secrets: [],
     environment: {},
-    settings: {}
+    settings: {},
+    annotations: {}
   });
 
   this.render(hbs`{{validator-job name="int-test" index=1 job=jobMock}}`);
@@ -129,7 +143,8 @@ test('it handles clicks on header', function (assert) {
     },
     settings: {
       FOO: 'bar'
-    }
+    },
+    annotations: {}
   });
 
   this.set('openMock', true);

--- a/tests/integration/components/validator-pipeline/component-test.js
+++ b/tests/integration/components/validator-pipeline/component-test.js
@@ -1,0 +1,39 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('validator-pipeline', 'Integration | Component | validator pipeline', {
+  integration: true
+});
+
+test('it renders default empty settings', function (assert) {
+  this.render(hbs`{{validator-pipeline}}`);
+
+  assert.equal(this.$('h4.pipeline').text().trim(), 'Pipeline Settings');
+
+  assert.equal(this.$('.annotations .label').text().trim(), 'Annotations:');
+  assert.equal(this.$('.annotations ul li').text().trim(), 'None defined');
+
+  assert.equal(this.$('.workflow .label').text().trim(), 'Workflow:');
+  assert.equal(this.$('.workflow  ul li').text().trim(), 'Main');
+});
+
+test('it renders pipeline annotations and workflow', function (assert) {
+  this.set('plMock', {
+    annotations: {
+      hello: 'hi'
+    },
+    workflow: [
+      'firstjob',
+      'secondjob'
+    ]
+  });
+
+  this.render(hbs`{{validator-pipeline annotations=plMock.annotations workflow=plMock.workflow}}`);
+
+  assert.equal(this.$('.annotations .label').text().trim(), 'Annotations:');
+  assert.equal(this.$('.annotations ul li').text().trim(), 'hello: hi');
+
+  assert.equal(this.$('.workflow .label').text().trim(), 'Workflow:');
+  assert.equal(this.$('.workflow ul li:nth-child(1)').text().trim(), 'firstjob');
+  assert.equal(this.$('.workflow ul li:nth-child(2)').text().trim(), 'secondjob');
+});

--- a/tests/integration/components/validator-results/component-test.js
+++ b/tests/integration/components/validator-results/component-test.js
@@ -48,7 +48,8 @@ test('it renders jobs', function (assert) {
   this.render(hbs`{{validator-results results=validationMock}}`);
 
   assert.equal(this.$('.error').text().trim(), 'got an error');
-  assert.equal(this.$('h4').text().trim(), 'main main.1 foo');
+  assert.equal(this.$('h4.pipeline').text().trim(), 'Pipeline Settings');
+  assert.equal(this.$('h4.job').text().trim(), 'main main.1 foo');
 });
 
 test('it renders templates', function (assert) {


### PR DESCRIPTION
Validator now displays job-level annotations similar to image, steps,
etc.

In addition, this PR adds "Pipeline-Level Settings", which includes
Workflow and pipeline-level Annotations.

Related to https://github.com/screwdriver-cd/screwdriver/issues/580

![image](https://user-images.githubusercontent.com/3217917/27246338-c1f297f0-52a5-11e7-9672-e7af75425cdd.png)
