### PR TITLE
fix: pin major and minor version for ember-data to fix tests for now

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^1.2.0",
     "ember-component-css": "^0.3.3",
-    "ember-data": "^2.13.0",
+    "ember-data": "~2.13.0",
     "ember-export-application-global": "^2.0.0",
     "ember-font-awesome": "^3.0.5",
     "ember-highlight": "^1.2.5",


### PR DESCRIPTION
Unit tests are failing due to the new ember-data version `v2.14.x` published during the weekend.
https://github.com/emberjs/data/releases

Failed build: https://cd.screwdriver.cd/pipelines/7/builds/5805

Unblock  the pipeline by pinning major and minor for now. Will create a sticky and figure out how to actually resolve it.