### PR TITLE
fix(423): Add job descriptions to validator in UI

### DIFF
--- a/app/components/validator-job/template.hbs
+++ b/app/components/validator-job/template.hbs
@@ -11,6 +11,18 @@
     </ul>
   </span>
 </div>
+<div class="description" title="This is the description of the job">
+  <span class="label">Description:</span>
+  <span class="value">
+    <ul>
+      {{#if job.description}}
+      <li>{{job.description}}</li>
+      {{else}}
+      <li>None defined</li>
+      {{/if}}
+    </ul>
+  </span>
+</div>
 <div class="image" title="This is the docker image that acts as the base container for the job.">
   <span class="label">Image:</span>
   <span class="value">{{job.image}}</span>

--- a/tests/integration/components/validator-job/component-test.js
+++ b/tests/integration/components/validator-job/component-test.js
@@ -162,3 +162,20 @@ test('it handles clicks on header', function (assert) {
     });
   });
 });
+
+test('it renders a description', function (assert) {
+  this.set('jobMock', {
+    image: 'int-test:1',
+    description: 'This is a description',
+    secrets: [],
+    environment: {},
+    settings: {},
+    annotations: {}
+  });
+
+  this.render(hbs`{{validator-job name="int-test" index=0 job=jobMock}}`);
+
+  assert.equal(this.$('h4').text().trim(), 'int-test');
+  assert.equal(this.$('.description .label').text().trim(), 'Description:');
+  assert.equal(this.$('.description .value ul li').text().trim(), 'This is a description');
+});


### PR DESCRIPTION
Validator now displays the job description in the UI.

Related to [screwdriver-cd/screwdriver#423](https://github.com/screwdriver-cd/screwdriver/issues/423)

![image](https://user-images.githubusercontent.com/12389411/27665310-49049e58-5c21-11e7-8db6-b981da40f1ca.png)
