### PR TITLE
fix(608): Visual difference for screwdriver-provided steps

### DIFF
--- a/app/components/build-step-view/component.js
+++ b/app/components/build-step-view/component.js
@@ -4,6 +4,11 @@ export default Ember.Component.extend({
   classNames: ['step-view'],
   classNameBindings: ['status'],
   isOpen: false,
+  isSdStep: Ember.computed('stepName', {
+    get() {
+      return this.get('stepName').match(/^sd-/);
+    }
+  }),
 
   /**
    * Maps step exit code with status.

--- a/app/components/build-step-view/styles.scss
+++ b/app/components/build-step-view/styles.scss
@@ -17,6 +17,10 @@
     text-align: right;
   }
 
+  .sd-step {
+    color: $sd-text-med;
+  }
+
   .status-icon {
     padding-left: 15px;
   }

--- a/app/components/build-step-view/template.hbs
+++ b/app/components/build-step-view/template.hbs
@@ -3,7 +3,7 @@
     <span class="status-icon">{{#if icon}}{{fa-icon icon}}{{/if}}</span>
   </div>
   <div class='col-xs-8'>
-    <span class="name">{{stepName}}</span>
+    <span class="name{{if isSdStep ' sd-step'}}">{{stepName}}</span>
   </div>
   <div class='col-xs-2'>
     <span class="duration">

--- a/tests/integration/components/build-step-view/component-test.js
+++ b/tests/integration/components/build-step-view/component-test.js
@@ -78,3 +78,15 @@ test('it has an "x" when failed', function (assert) {
 
   assert.ok(this.$(this.$('.status-icon i').get(0)).hasClass('fa-times'));
 });
+
+test('it is a different color for sd-steps', function (assert) {
+  this.render(hbs`{{build-step-view
+    code=0
+    endTime='2017-06-30T14:13:52.531Z'
+    isOpen=false
+    startTime='2017-06-30T14:07:42.531Z'
+    stepName='sd-foo'
+  }}`);
+
+  assert.equal(this.$('.sd-step').length, 1);
+});


### PR DESCRIPTION
Make screwdriver provided steps a grey-ish color to easily distinguish between user-defined steps. Related to [screwdriver-cd/screwdriver#608](https://github.com/screwdriver-cd/screwdriver/issues/608)

Screenshot of what it looks like:
![image](https://user-images.githubusercontent.com/12389411/27667053-d609b800-5c2c-11e7-9662-ae0e86bd6eb8.png)
