### PR TITLE
feat(562): Allow users to update checkout URL for pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ Make use of the many generators for code, try `ember help generate` for more det
 * `ember test`
 * `ember test --server`
 
+To run a single ember test:
+* `ember t -s -m '<TEST_NAME>'`   // e.g. ember t -s -m 'Integration | Component | pipeline options'
+
 ### Building
 
 * `ember build` (development)

--- a/app/components/pipeline-create-form/component.js
+++ b/app/components/pipeline-create-form/component.js
@@ -1,15 +1,14 @@
 /* global localStorage*/
 import Ember from 'ember';
-import git from '../../utils/git';
+import { parse } from '../../utils/git';
 
 export default Ember.Component.extend({
   scmUrl: '',
-  isSaving: false,
   isValid: Ember.computed('scmUrl', {
     get() {
       const val = this.get('scmUrl');
 
-      return val.length !== 0 && git.parse(val).valid;
+      return val.length !== 0 && parse(val).valid;
     }
   }),
   isInvalid: Ember.computed.not('isValid'),

--- a/app/components/pipeline-options/component.js
+++ b/app/components/pipeline-options/component.js
@@ -1,13 +1,50 @@
 import Ember from 'ember';
+import { parse, getCheckoutUrl } from '../../utils/git';
 
 export default Ember.Component.extend({
-  showDangerButton: true,
-  showRemoveButtons: false,
+  // Updating a pipeline
+  init() {
+    this._super(...arguments);
+    this.set('scmUrl', getCheckoutUrl({
+      appId: this.get('pipeline.appId'),
+      scmUri: this.get('pipeline.scmUri')
+    }));
+  },
+  errorMessage: '',
+  scmUrl: '',
+  isValid: Ember.computed('scmUrl', {
+    get() {
+      const val = this.get('scmUrl');
+
+      return val.length !== 0 && parse(val).valid;
+    }
+  }),
+  isInvalid: Ember.computed.not('isValid'),
+  isDisabled: Ember.computed.or('isSaving', 'isInvalid'),
+  // Removing a pipeline
   isRemoving: false,
   isShowingModal: false,
-  errorMessage: '',
+  showDangerButton: true,
+  showRemoveButtons: false,
+  // Syncing a pipeline
   sync: Ember.inject.service('sync'),
   actions: {
+    // Checks if scm URL is valid or not
+    scmChange(val) {
+      this.set('scmUrl', val.trim());
+      const input = Ember.$('.text-input');
+
+      input.removeClass('bad-text-input good-text-input');
+
+      if (this.get('isValid')) {
+        input.addClass('good-text-input');
+      } else if (val.trim().length > 0) {
+        input.addClass('bad-text-input');
+      }
+    },
+    updatePipeline() {
+      this.get('onUpdatePipeline')(this.get('scmUrl'));
+    },
     toggleJob(jobId, event) {
       this.get('setJobStatus')(jobId, event.newValue ? 'DISABLED' : 'ENABLED');
     },

--- a/app/components/pipeline-options/styles.scss
+++ b/app/components/pipeline-options/styles.scss
@@ -120,3 +120,88 @@
     text-align: right;
   }
 }
+
+.text-input {
+  box-sizing: border-box;
+  margin-top: 10px;
+  outline: 0;
+  height: 45px;
+  width: 90%;
+  border-radius: 2px;
+  border: 2px solid $sd-separator;
+  font-size: 16px;
+  padding-left: 10px;
+  color: $sd-text;
+
+  &:focus {
+    border-color: $sd-running;
+  }
+
+  &::-webkit-input-placeholder {
+    color: $sd-text-med;
+  }
+
+  &:-moz-placeholder {
+    color: $sd-text-med;
+  }
+
+  &::-moz-placeholder {
+    color: $sd-text-med;
+  }
+
+  &:-ms-input-placeholder {
+    color: $sd-text-med;
+  }
+
+  &.bad-text-input {
+    border-color: $sd-failure;
+  }
+
+  &.good-text-input {
+    border-color: $sd-success;
+  }
+}
+
+.blue-button {
+  border: none;
+  border-radius: 3px;
+  height: 45px;
+  padding: 0 30px;
+  color: #fff;
+  font-size: 16px;
+  margin-top: 10px;
+  background: $sd-running;
+  @include transition(all, 50ms);
+
+  &:focus {
+    outline: none;
+  }
+
+  &:hover {
+    background: $sd-link;
+  }
+
+  &:disabled {
+    background: $sd-text-med;
+  }
+
+  .saving-loading {
+    display: none;
+  }
+
+  &.saving {
+    .saving-loading {
+      display: block;
+    }
+
+    .button-label {
+      display: none;
+    }
+  }
+
+  &:active {
+    &:not(:disabled) {
+      @include scale(0.97);
+    }
+  }
+}

--- a/app/components/pipeline-options/template.hbs
+++ b/app/components/pipeline-options/template.hbs
@@ -1,6 +1,42 @@
-{{info-message message=errorMessage type="error"}}
+{{info-message message=errorMessage type="error" icon="exclamation-triangle"}}
 
 <div class="row">
+  <div class="col-xs-12 col-md-8">
+    <section class="pipeline">
+      <h3>Pipeline</h3>
+      <ul>
+        <li>
+          <div class="row">
+            <div class="col-xs-10">
+              <h4>Checkout URL</h4>
+              <p>Update your checkout URL.</p>
+            </div>
+          </div>
+          <div class="row">
+            <div class="col-xs-10">
+              <div>
+                {{input
+                  class="text-input"
+                  key-up="scmChange"
+                  value=scmUrl
+                }}
+              </div>
+            </div>
+            <div class="col-xs-2 right">
+              <button {{action "updatePipeline"}} disabled={{isDisabled}} class="blue-button{{if isSaving ' saving'}}">
+                <div class="saving-loading">
+                  Updating pipeline
+                </div>
+                <div class="button-label">Update</div>
+              </button>
+              {{#if isSaving}}{{fa-icon "spinner" spin=true}}{{/if}}
+            </div>
+          </div>
+        </li>
+      </ul>
+    </section>
+  </div>
+
   <div class="col-xs-12 col-md-8">
     <section class="jobs">
       <h3>Jobs</h3>
@@ -22,47 +58,46 @@
     </section>
   </div>
 
-
-    <div class="col-xs-12 col-md-8">
-      <section class="sync">
-        <h3>Sync</h3>
-        <ul>
-          <li>
-            <div class="row">
-              <div class="col-xs-10">
-                <h4>SCM webhooks</h4>
-                <p>Update the webhooks if they are not working correctly.</p>
-              </div>
-              <div class="col-xs-2 right">
-                <a href="#" {{action "sync" "webhooks"}} >{{fa-icon "fa-refresh"}}</a>
-              </div>
+  <div class="col-xs-12 col-md-8">
+    <section class="sync">
+      <h3>Sync</h3>
+      <ul>
+        <li>
+          <div class="row">
+            <div class="col-xs-10">
+              <h4>SCM webhooks</h4>
+              <p>Update the webhooks if they are not working correctly.</p>
             </div>
-          </li>
-          <li>
-            <div class="row">
-              <div class="col-xs-10">
-                <h4>Pull requests</h4>
-                <p>Create or update pull-request jobs if they are not displaying properly.</p>
-              </div>
-              <div class="col-xs-2 right">
-                <a href="#" {{action "sync" "pullrequests"}}>{{fa-icon "fa-refresh"}}</a>
-              </div>
+            <div class="col-xs-2 right">
+              <a href="#" {{action "sync" "webhooks"}} >{{fa-icon "fa-refresh"}}</a>
             </div>
-          </li>
-          <li>
-            <div class="row">
-              <div class="col-xs-10">
-                <h4>Pipeline</h4>
-                <p>Update jobs if they are not displaying properly.</p>
-              </div>
-              <div class="col-xs-2 right">
-                <a href="#" {{action "sync"}}>{{fa-icon "fa-refresh"}}</a>
-              </div>
+          </div>
+        </li>
+        <li>
+          <div class="row">
+            <div class="col-xs-10">
+              <h4>Pull requests</h4>
+              <p>Create or update pull-request jobs if they are not displaying properly.</p>
             </div>
-          </li>
-        </ul>
-      </section>
-    </div>
+            <div class="col-xs-2 right">
+              <a href="#" {{action "sync" "pullrequests"}}>{{fa-icon "fa-refresh"}}</a>
+            </div>
+          </div>
+        </li>
+        <li>
+          <div class="row">
+            <div class="col-xs-10">
+              <h4>Pipeline</h4>
+              <p>Update jobs if they are not displaying properly.</p>
+            </div>
+            <div class="col-xs-2 right">
+              <a href="#" {{action "sync"}}>{{fa-icon "fa-refresh"}}</a>
+            </div>
+          </div>
+        </li>
+      </ul>
+    </section>
+  </div>
 
   <div class="col-xs-12 col-md-8">
     <section class="danger">

--- a/app/pipeline/options/controller.js
+++ b/app/pipeline/options/controller.js
@@ -1,6 +1,8 @@
 import Ember from 'ember';
 
 export default Ember.Controller.extend({
+  errorMessage: '',
+  isSaving: false,
   actions: {
     setJobStatus(id, state) {
       const job = this.store.peekRecord('job', id);
@@ -12,6 +14,22 @@ export default Ember.Controller.extend({
       this.model.destroyRecord().then(() => {
         this.transitionToRoute('home');
       });
+    },
+    updatePipeline(scmUrl) {
+      let pipeline = this.model;
+
+      pipeline.set('checkoutUrl', scmUrl);
+
+      this.set('isSaving', true);
+
+      pipeline.save()
+        .then(() => this.set('errorMessage', ''))
+        .catch((err) => {
+          this.set('errorMessage', err.errors[0].detail);
+        })
+        .finally(() => {
+          this.set('isSaving', false);
+        });
     }
   }
 });

--- a/app/pipeline/options/template.hbs
+++ b/app/pipeline/options/template.hbs
@@ -1,6 +1,9 @@
 {{pipeline-options
   pipeline=model
+  errorMessage=errorMessage
   setJobStatus=(action "setJobStatus")
   onRemovePipeline=(action "removePipeline")
+  isSaving=isSaving
+  onUpdatePipeline=(action "updatePipeline")
 }}
 {{outlet}}

--- a/app/utils/git.js
+++ b/app/utils/git.js
@@ -4,25 +4,43 @@
  * @param  {String}  scmUrl Url to parse
  * @return {Object}         Data about the url
  */
-export default {
-  parse(scmUrl) {
-    // eslint-disable-next-line max-len
-    const match = scmUrl.match(/^(?:(?:https?|git):\/\/)?(?:[^@]+@)?([^/:]+)(?:\/|:)([^/]+)\/([^.#]+)(?:\.git)?(#.+)?$/);
+function parse(scmUrl) {
+  // eslint-disable-next-line max-len
+  const match = scmUrl.match(/^(?:(?:https?|git):\/\/)?(?:[^@]+@)?([^/:]+)(?:\/|:)([^/]+)\/([^.#]+)(?:\.git)?(#.+)?$/);
 
-    if (!match) {
-      return {
-        valid: false
-      };
-    }
-
-    const result = {
-      server: match[1],
-      owner: match[2],
-      repo: match[3],
-      branch: match[4] ? match[4].slice(1) : 'master',
-      valid: true
+  if (!match) {
+    return {
+      valid: false
     };
-
-    return result;
   }
+
+  const result = {
+    server: match[1],
+    owner: match[2],
+    repo: match[3],
+    branch: match[4] ? match[4].slice(1) : 'master',
+    valid: true
+  };
+
+  return result;
+}
+
+/**
+ * Generate the checkout URL based on pipeline values
+ * @method getCheckoutUrl
+ * @param  {Object}       config
+ * @param  {String}       config.appId    App ID in the form of <organization>/<repo>
+ * @param  {String}       config.scmUri   Scm URI with <server>:<URI>:<branch>
+ * @return {String}                       Returns the checkout URL
+ */
+function getCheckoutUrl(config) {
+  const scmUri = (config.scmUri).split(':');
+  const checkoutUrl = `git@${scmUri[0]}:${config.appId}.git#${scmUri[2]}`;
+
+  return checkoutUrl;
+}
+
+export {
+  parse,
+  getCheckoutUrl
 };

--- a/tests/acceptance/pipeline-options-test.js
+++ b/tests/acceptance/pipeline-options-test.js
@@ -14,6 +14,12 @@ moduleForAcceptance('Acceptance | pipeline/options', {
       JSON.stringify({
         id: '1',
         scmUrl: 'git@github.com:foo/bar.git#master',
+        scmUri: 'github.com:84604643:master',
+        scmRepo: {
+          branch: 'master',
+          name: 'foo/bar',
+          url: 'https://github.com/foo/bar/tree/master'
+        },
         createTime: '2016-09-15T23:12:23.760Z',
         admins: { batman: true },
         workflow: ['main', 'publish']
@@ -41,6 +47,7 @@ test('visiting /pipelines/:id/options', function (assert) {
 
   andThen(() => {
     assert.equal(currentURL(), '/pipelines/1/options');
+    assert.equal(find('section.pipeline li').length, 1);
     assert.equal(find('section.jobs li').length, 2);
     assert.equal(find('section.danger li').length, 1);
   });

--- a/tests/integration/components/pipeline-options/component-test.js
+++ b/tests/integration/components/pipeline-options/component-test.js
@@ -12,6 +12,8 @@ moduleForComponent('pipeline-options', 'Integration | Component | pipeline optio
 
 test('it renders', function (assert) {
   this.set('mockPipeline', Ember.Object.create({
+    appId: 'foo/bar',
+    scmUri: 'github.com:84604643:master',
     id: 'abc1234',
     jobs: Ember.A([
       Ember.Object.create({
@@ -23,6 +25,13 @@ test('it renders', function (assert) {
   }));
 
   this.render(hbs`{{pipeline-options pipeline=mockPipeline}}`);
+
+  // Pipeline
+  assert.equal(this.$('section.pipeline h3').text().trim(), 'Pipeline');
+  assert.equal(this.$('section.pipeline li').length, 1);
+  assert.equal(this.$('section.pipeline h4').text().trim(), 'Checkout URL');
+  assert.equal(this.$('section.pipeline p').text().trim(), 'Update your checkout URL.');
+  assert.equal(this.$('section.pipeline .button-label').text().trim(), 'Update');
 
   // Jobs
   assert.equal(this.$('section.jobs h3').text().trim(), 'Jobs');
@@ -45,6 +54,27 @@ test('it renders', function (assert) {
   assert.ok(this.$('section.danger a i').hasClass('fa-trash'));
 });
 
+test('it updates a pipeline', function (assert) {
+  const scm = 'git@github.com:foo/bar.git';
+
+  this.set('updatePipeline', (scmUrl) => {
+    assert.equal(scmUrl, scm);
+  });
+
+  this.set('mockPipeline', Ember.Object.create({
+    appId: 'foo/bar',
+    scmUri: 'github.com:84604643:notMaster',
+    id: 'abc1234'
+  }));
+
+  // eslint-disable-next-line max-len
+  this.render(hbs`{{pipeline-options pipeline=mockPipeline errorMessage="" isSaving=false onUpdatePipeline=updatePipeline}}`);
+  assert.equal(this.$('.text-input').val(), 'git@github.com:foo/bar.git#notMaster');
+  this.$('.text-input').val(scm).keyup();
+  assert.equal(this.$('.text-input').val(), scm);
+  this.$('button.blue-button').click();
+});
+
 test('it handles job disabling', function (assert) {
   const main = Ember.Object.create({
     id: '1234',
@@ -53,6 +83,8 @@ test('it handles job disabling', function (assert) {
   });
 
   this.set('mockPipeline', Ember.Object.create({
+    appId: 'foo/bar',
+    scmUri: 'github.com:84604643:master',
     id: 'abc1234',
     jobs: Ember.A([main])
   }));
@@ -81,6 +113,8 @@ test('it handles job enabling', function (assert) {
   });
 
   this.set('mockPipeline', Ember.Object.create({
+    appId: 'foo/bar',
+    scmUri: 'github.com:84604643:master',
     id: 'abc1234',
     jobs: Ember.A([main])
   }));
@@ -107,6 +141,8 @@ test('it handles pipeline remove flow', function (assert) {
   const $ = this.$;
 
   this.set('mockPipeline', Ember.Object.create({
+    appId: 'foo/bar',
+    scmUri: 'github.com:84604643:master',
     id: 'abc1234'
   }));
 
@@ -142,6 +178,8 @@ test('it syncs the webhooks', function (assert) {
   const $ = this.$;
 
   this.set('mockPipeline', Ember.Object.create({
+    appId: 'foo/bar',
+    scmUri: 'github.com:84604643:master',
     id: '1'
   }));
 
@@ -164,6 +202,8 @@ test('it syncs the pullrequests', function (assert) {
   const $ = this.$;
 
   this.set('mockPipeline', Ember.Object.create({
+    appId: 'foo/bar',
+    scmUri: 'github.com:84604643:master',
     id: '1'
   }));
 
@@ -186,6 +226,8 @@ test('it syncs the pipeline', function (assert) {
   const $ = this.$;
 
   this.set('mockPipeline', Ember.Object.create({
+    appId: 'foo/bar',
+    scmUri: 'github.com:84604643:master',
     id: '1'
   }));
 
@@ -205,6 +247,8 @@ test('it fails to sync the pipeline', function (assert) {
   const $ = this.$;
 
   this.set('mockPipeline', Ember.Object.create({
+    appId: 'foo/bar',
+    scmUri: 'github.com:84604643:master',
     id: '1'
   }));
 

--- a/tests/unit/utils/git-test.js
+++ b/tests/unit/utils/git-test.js
@@ -3,8 +3,7 @@ import { module, test } from 'qunit';
 
 module('Unit | Utility | git');
 
-// Replace this with your real tests.
-test('it works', (assert) => {
+test('it parses the checkout URL correctly', (assert) => {
   let result = git.parse('bananas');
 
   assert.notOk(result.valid);
@@ -28,4 +27,13 @@ test('it works', (assert) => {
     branch: 'tree',
     valid: true
   });
+});
+
+test('it generates the checkout URL correctly', (assert) => {
+  let result = git.getCheckoutUrl({
+    appId: 'bananas/peel',
+    scmUri: 'github.com:12345:master'
+  });
+
+  assert.strictEqual(result, 'git@github.com:bananas/peel.git#master');
 });


### PR DESCRIPTION
## Context

Users would like to be able to update their pipeline repo and branch from the Screwdriver UI.

## Objective

This PR will add a pipeline section to Options tab and allow users to update checkout URL. There will also be validation to pipeline checkout URL update. There is also a one-liner added to README instructions for running a single test with ember.

**Invalid checkoutURL:**
![screen shot 2017-06-30 at 12 51 21 pm](https://user-images.githubusercontent.com/3230529/27752918-30ab775a-5d98-11e7-985f-7574f8091162.png)

**Valid checkoutURL:**
![screen shot 2017-06-30 at 12 51 09 pm](https://user-images.githubusercontent.com/3230529/27752908-2ab13902-5d98-11e7-95a4-2a70466d493c.png)


**Note:** The entire Pipeline options page definitely needs a redesign. Leaving those changes for another PR/time.

## Relevant Links

- Original issue: https://github.com/screwdriver-cd/screwdriver/issues/562
- API PR: https://github.com/screwdriver-cd/screwdriver/pull/627