### PR TITLE
refactor(secrets): set isButtonDisabled with Ember.computed

### DIFF
--- a/app/components/pipeline-secret-settings/component.js
+++ b/app/components/pipeline-secret-settings/component.js
@@ -4,20 +4,13 @@ export default Ember.Component.extend({
   newName: null,
   newValue: null,
   newAllow: false,
-  isButtonDisabled: true,
+  isButtonDisabled: Ember.computed('newName', 'newValue', function isButtonDisabled() {
+    return !this.get('newName') || !this.get('newValue');
+  }),
   errorMessage: '',
   secretsSorting: ['name'],
   sortedSecrets: Ember.computed.sort('secrets', 'secretsSorting'),
   actions: {
-    /**
-     * Sets disabled state of "add" button
-     * @method enableButton
-     */
-    enableButton() {
-      const isDisabled = !this.get('newName') || !this.get('newValue');
-
-      this.set('isButtonDisabled', isDisabled);
-    },
     /**
      * Kicks off create secret flow
      * @method addNewSecret

--- a/app/components/pipeline-secret-settings/styles.scss
+++ b/app/components/pipeline-secret-settings/styles.scss
@@ -31,7 +31,7 @@ th {
 tfoot button {
   border-width: 0;
   width: 100px;
-  background-color: #0078ff;
+  background-color: $sd-primary;
   color: #fff;
   border-radius: 3px;
 }

--- a/app/components/pipeline-secret-settings/template.hbs
+++ b/app/components/pipeline-secret-settings/template.hbs
@@ -23,8 +23,8 @@
   </tbody>
   <tfoot>
     <tr class="new">
-      <td class="key">{{input placeholder="SECRET_KEY" size="40" value=newName key-up="enableButton" title="Secret keys can only consist of numbers, uppercase letters and underscores, and cannot begin with a number."}}</td>
-      <td class="pass">{{input type="password" placeholder="SECRET_VALUE" size="40" value=newValue key-up="enableButton"}}</td>
+      <td class="key">{{input placeholder="SECRET_KEY" size="40" value=newName title="Secret keys can only consist of numbers, uppercase letters and underscores, and cannot begin with a number."}}</td>
+      <td class="pass">{{input type="password" placeholder="SECRET_VALUE" size="40" value=newValue}}</td>
       <td class="allow"><div title="Check to allow this secret to be used in pull-requests">{{input type="checkbox" checked=newAllow}}</div></td>
       <td><button disabled={{isButtonDisabled}} {{action "addNewSecret"}}>Add</button></td>
     </tr>

--- a/tests/integration/components/build-step-collection/component-test.js
+++ b/tests/integration/components/build-step-collection/component-test.js
@@ -1,11 +1,9 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
-moduleForComponent('build-step-collection',
-  'Integration | Component | sd build step collection', {
-    integration: true
-  }
-);
+moduleForComponent('build-step-collection', 'Integration | Component | sd build step collection', {
+  integration: true
+});
 
 test('it renders', function (assert) {
   const $ = this.$;

--- a/tests/integration/components/pipeline-secret-settings/component-test.js
+++ b/tests/integration/components/pipeline-secret-settings/component-test.js
@@ -2,11 +2,10 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
 
-moduleForComponent('pipeline-secret-settings',
-  'Integration | Component | pipeline secret settings', {
-    integration: true
-  }
-);
+// eslint-disable-next-line max-len
+moduleForComponent('pipeline-secret-settings', 'Integration | Component | pipeline secret settings', {
+  integration: true
+});
 
 test('it renders', function (assert) {
   // Set any properties with this.set('myProperty', 'value');

--- a/tests/integration/components/secret-view/component-test.js
+++ b/tests/integration/components/secret-view/component-test.js
@@ -2,8 +2,7 @@ import { moduleForComponent, test } from 'ember-qunit';
 import Ember from 'ember';
 import hbs from 'htmlbars-inline-precompile';
 
-moduleForComponent('secret-view',
-'Integration | Component | secret view', {
+moduleForComponent('secret-view', 'Integration | Component | secret view', {
   integration: true
 });
 


### PR DESCRIPTION
Some of the feedback from https://github.com/screwdriver-cd/ui/pull/176 was also applicable to other places in the code.

* Changed pipeline-secret-settings to use `Ember.computed` instead of a function called on `key-up` events
* Changed indentation on some test headers to be consistent with the rest of the tests