### PR TITLE
fix: minor header tweak

### DIFF
--- a/app/components/app-header/styles.scss
+++ b/app/components/app-header/styles.scss
@@ -28,6 +28,7 @@
       background: rgba(242, 242, 242, 0.1);
       color: #fff;
       border: none;
+      border-bottom: solid transparent;
       box-sizing: border-box;
       display: inline-block;
       font-size: 14px;
@@ -46,6 +47,7 @@
     }
 
     input:focus {
+      border: none;
       border-bottom: solid #3570f4;
     }
 
@@ -58,7 +60,7 @@
       border-radius: 0 2px 2px 0;
       border-left: 0;
       padding-left: 0;
-      height: 36px;
+      height: 37px;
       width: 38px;
       color: rgba(255, 255, 255, 1);
       background: #3697F2; /* For browsers that do not support gradients */


### PR DESCRIPTION
Context:
========
When focus is applied to the search bar it causes the page to shift by a pixel. The search button doesn't line up with the bottom of the search input border.

Objective:
----------
The header should always be the same height. The search button should be the same size as the search input.

Before:
![screen shot 2017-07-07 at 3 11 30 pm](https://user-images.githubusercontent.com/78533/27978814-95b15c4e-6326-11e7-8a29-0942b4349e1d.png)

After:
![screen shot 2017-07-07 at 3 05 53 pm](https://user-images.githubusercontent.com/78533/27978805-75fb49b4-6326-11e7-977f-579e16b617d7.png)
