### PR TITLE
fix(562): Fix broken update checkout URL feature

### DIFF
--- a/app/pipeline/options/controller.js
+++ b/app/pipeline/options/controller.js
@@ -16,7 +16,7 @@ export default Ember.Controller.extend({
       });
     },
     updatePipeline(scmUrl) {
-      let pipeline = this.model;
+      let pipeline = this.model.pipeline;
 
       pipeline.set('checkoutUrl', scmUrl);
 

--- a/tests/integration/components/pipeline-options/component-test.js
+++ b/tests/integration/components/pipeline-options/component-test.js
@@ -69,7 +69,7 @@ test('it updates a pipeline', function (assert) {
   }));
 
   // eslint-disable-next-line max-len
-  this.render(hbs`{{pipeline-options pipeline=mockPipeline errorMessage="" isSaving=false onUpdatePipeline=updatePipeline}}`);
+  this.render(hbs`{{pipeline-options pipeline=mockPipeline errorMessage="" isSaving=false onUpdatePipeline=(action updatePipeline)}}`);
   assert.equal(this.$('.text-input').val(), 'git@github.com:foo/bar.git#notMaster');
   this.$('.text-input').val(scm).keyup();
   assert.equal(this.$('.text-input').val(), scm);


### PR DESCRIPTION
## Context

The PR to update Ember to version 2.14 had some other side effects. The change here
https://github.com/screwdriver-cd/ui/pull/178/files#diff-2d27d36985688e321b57fcefe558fb7eR10
broke https://github.com/screwdriver-cd/ui/blob/master/app/pipeline/options/controller.js#L21.
## Objective

This PR will fix the issue.

## Related Links
- Update Ember to version 2.14 PR: https://github.com/screwdriver-cd/ui/pull/178
- Resolves https://github.com/screwdriver-cd/screwdriver/issues/562