### PR TITLE
feat(tokens): Add user-settings page to menu bar

### DIFF
--- a/app/components/app-header/template.hbs
+++ b/app/components/app-header/template.hbs
@@ -53,17 +53,28 @@
           {{/dd.menu}}
         {{/nav.dropdown}}
       {{/nav.item}}
-
       {{#nav.item}}
         {{#if session.isAuthenticated}}
-          <a {{action 'invalidateSession'}} title="Log out of Screwdriver" class="icon auth">
-            {{inline-svg "login" class="img"}}
-            <span class='icontitle'>Log out</span>
-          </a>
+          {{#nav.dropdown as |dd|}}
+            {{#dd.toggle class="icon profile-outline"}}
+              {{inline-svg "profile-outline" class="img"}}
+              <span class='icontitle'>Account</span>
+              <span class="caret"></span>
+            {{/dd.toggle}}
+            {{#dd.menu as |ddm|}}
+              {{#if session.isAuthenticated}}
+                {{#ddm.item}}{{#link-to "user-settings" title="User Settings"}}User Settings{{/link-to}}{{/ddm.item}}
+                {{ddm.divider}}
+              {{/if}}
+              {{#ddm.item}}
+                <a {{action 'invalidateSession'}} class="logout" title="Log out of Screwdriver">Log out</a>
+              {{/ddm.item}}
+            {{/dd.menu}}
+          {{/nav.dropdown}}
         {{else}}
-          {{#link-to "login" title="Login to Screwdriver" class="icon auth"}}
-          {{inline-svg "login" class="img"}}
-          <span class='icontitle'>Log in</span>
+          {{#link-to "login" title="Login to Screwdriver" class="icon profile-outline"}}
+            {{inline-svg "profile-outline" class="img"}}
+            <span class='icontitle'>Log in</span>
           {{/link-to}}
         {{/if}}
       {{/nav.item}}
@@ -73,7 +84,7 @@
 <div class="tooltips">
   {{#bs-tooltip placement="bottom" triggerElement=".icon.create" renderInPlace=true}}Create a new Pipeline{{/bs-tooltip}}
   {{#bs-tooltip placement="bottom" triggerElement=".icon.docs" renderInPlace=true}}Screwdriver Documentation{{/bs-tooltip}}
-  {{#bs-tooltip placement="bottom" triggerElement=".icon.auth" renderInPlace=true}}
-    {{#if session.isAuthenticated}}Log out of Screwdriver{{else}}Login to Screwdriver{{/if}}
-  {{/bs-tooltip}}
+  {{#unless session.isAuthenticated}}
+    {{#bs-tooltip placement="bottom" triggerElement=".icon.profile-outline" renderInPlace=true}}Login to Screwdriver{{/bs-tooltip}}
+  {{/unless}}
 </div>

--- a/public/assets/svg/login.svg
+++ b/public/assets/svg/login.svg
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 20.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 48 48" style="enable-background:new 0 0 48 48;" xml:space="preserve">
-<path d="M38.8,9.1c-0.7-0.7-2-0.7-2.7,0c-0.7,0.7-0.7,2,0,2.7c3.3,3.3,5.1,7.6,5.1,12.2c0,9.5-7.7,17.2-17.2,17.2S6.8,33.5,6.8,24
-	c0-4.6,1.8-9,5.1-12.2c0.7-0.7,0.8-2,0-2.7c-0.7-0.8-2-0.8-2.7,0C5.2,13,3,18.3,3,24c0,11.6,9.4,21,21,21s21-9.4,21-21
-	C45,18.3,42.8,13,38.8,9.1L38.8,9.1z M24,24c1.1,0,1.9-0.9,1.9-1.9V4.9C25.9,3.9,25.1,3,24,3c-1.1,0-1.9,0.9-1.9,1.9v17.2
-	C22.1,23.1,22.9,24,24,24z"/>
-</svg>

--- a/public/assets/svg/profile-outline.svg
+++ b/public/assets/svg/profile-outline.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 21.0.2, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 48 48" style="enable-background:new 0 0 48 48;" xml:space="preserve">
+<title>profile-outline</title>
+<g id="Layer_3">
+	<path class="st0" d="M24,34c4.3,0.1,8.5,1.2,12.3,3.2c-6.9,6.4-17.6,6.4-24.5,0C15.5,35.2,19.7,34.1,24,34 M24,2
+		C11.8,2,2,11.8,2,24s9.8,22,22,22s22-9.8,22-22S36.2,2,24,2z M9.1,34.1c-5.6-8.2-3.4-19.4,4.8-25s19.4-3.4,25,4.8
+		C43,20,43,28,38.9,34.1l0,0l0,0.1l0-0.1c-4.5-2.6-9.7-4-14.9-4.1C18.8,30.1,13.6,31.5,9.1,34.1L9.1,34.1L9.1,34.1z"/>
+	<path class="st0" d="M24,14c2.2,0,4,1.8,4,4s-1.8,4-4,4s-4-1.8-4-4S21.8,14,24,14 M24,10c-4.4,0-8,3.6-8,8s3.6,8,8,8s8-3.6,8-8
+		S28.4,10,24,10z"/>
+</g>
+</svg>

--- a/tests/integration/components/app-header/component-test.js
+++ b/tests/integration/components/app-header/component-test.js
@@ -21,11 +21,11 @@ test('it renders when search flag is off', function (assert) {
   assert.equal(this.$('.icon.blog').length, 1);
   assert.equal(this.$('.icon.community').length, 1);
   assert.equal(this.$('.icon.github').length, 1);
-  assert.equal(this.$('.icon.auth').length, 1);
+  assert.equal(this.$('.icon.profile-outline').length, 1);
   assert.equal(this.$('.search-input').length, 0);
 
   // check that user has not logged in yet
-  assert.equal(this.$('.icon.auth').prop('title'), 'Login to Screwdriver');
+  assert.equal(this.$('.icon.profile-outline').prop('title'), 'Login to Screwdriver');
 });
 
 test('it calls the logout method on logout', function (assert) {
@@ -38,8 +38,8 @@ test('it calls the logout method on logout', function (assert) {
   });
 
   this.render(hbs`{{app-header session=sessionMock onInvalidate=(action invalidateSession)}}`);
-  assert.equal(this.$('.icon.auth').prop('title'), 'Log out of Screwdriver');
-  this.$('.auth').click();
+  assert.equal(this.$('.logout').prop('title'), 'Log out of Screwdriver');
+  this.$('.logout').click();
 });
 
 test('it shows the search bar', function (assert) {


### PR DESCRIPTION
The user-settings page now exists, but is not part of the menu bar! (Because it made for a smaller PR)

This PR changes the "log in" button to use an updated icon, and when the user is logged in it will be a dropdown featuring an option for "log out" and an option for "user settings."

Logged out:
<img width="380" alt="screen shot 2017-07-11 at 2 39 50 pm" src="https://user-images.githubusercontent.com/7689953/28092055-f3832d0c-6646-11e7-8984-d34429057aa2.png">
<img width="293" alt="screen shot 2017-07-11 at 2 39 59 pm" src="https://user-images.githubusercontent.com/7689953/28092056-f386e8fc-6646-11e7-935c-2cebd8045afc.png">

Logged in:
<img width="275" alt="screen shot 2017-07-11 at 2 40 10 pm" src="https://user-images.githubusercontent.com/7689953/28092087-05c5bb2e-6647-11e7-8921-34e1f7d8ce4f.png">
<img width="272" alt="screen shot 2017-07-11 at 2 40 17 pm" src="https://user-images.githubusercontent.com/7689953/28092086-05c47804-6647-11e7-822d-efa0eb8cb31f.png">

Related to https://github.com/screwdriver-cd/screwdriver/issues/532