### PR TITLE
fix(tokens): display new token value in a modal

### DIFF
--- a/app/components/token-list/style.scss
+++ b/app/components/token-list/style.scss
@@ -39,25 +39,4 @@
     background-color: inherit;
     color: inherit;
   }
-
-  .new-token {
-    min-height: 20px;
-    border-radius: 3px;
-    margin-bottom: 30px;
-    padding: 10px;
-    border: 2px solid $sd-success;
-
-    & i.fa {
-      font-size: 26px;
-      color: $sd-success;
-    }
-
-    & .new-name {
-      font-weight: bold;
-    }
-
-    & .new-value {
-      color: $sd-text-med;
-    }
-  }
 }

--- a/app/components/token-list/template.hbs
+++ b/app/components/token-list/template.hbs
@@ -1,12 +1,5 @@
 <h3>Access Tokens</h3>
 {{info-message message=errorMessage type="error" icon="exclamation-triangle"}}
-{{#if newToken}}
-  <div class="new-token">
-    <p>{{fa-icon "check"}} Token {{newToken.action}}. You can only see this value once, so remember to copy it!</p>
-    <span class="new-name">{{newToken.name}}:</span>
-    <span class="new-value">{{newToken.value}}</span>
-  </div>
-{{/if}}
 <p>
   User access tokens provide access to the <a href="http://docs.screwdriver.cd/user-guide/api/">Screwdriver API</a>. They are scoped to your account.
 </p>
@@ -42,9 +35,19 @@
       translucentOverlay=true
       onClickOverlay=(action "closeModal" false)
   }}
-    <div class="token-confirm-dialog">
-      <h3>Are you sure?</h3>
-      <p>{{modalText}}</p>
+    <div class="token-modal">
+      <h3>{{modalTitle}}</h3>
+      {{#if newToken}}
+        <p>
+          You can only see this value once, so remember to copy it!
+        </p>
+        <p>
+          <span class="new-name">{{newToken.name}}:</span>
+          <span class="new-value">{{newToken.value}}</span>
+        </p>
+      {{else}}
+        <p>{{modalText}}</p>
+      {{/if}}
       <button onclick={{action "closeModal" true}} class={{modalAction}}>
         {{modalButtonText}}
       </button>

--- a/app/styles/screwdriver-modal-styles.scss
+++ b/app/styles/screwdriver-modal-styles.scss
@@ -1,4 +1,4 @@
-.token-confirm-dialog {
+.token-modal {
   padding: 0px 50px 20px;
 
   & button {
@@ -11,5 +11,13 @@
 
   & button.delete {
     background-color: $sd-failure;
+  }
+
+  & .new-name {
+    font-weight: bold;
+  }
+
+  & .new-value {
+    color: $sd-text-med;
   }
 }

--- a/app/token/serializer.js
+++ b/app/token/serializer.js
@@ -16,6 +16,10 @@ export default DS.RESTSerializer.extend({
 
     const h = Ember.merge(hash, dirty);
 
+    if (h.description === null) {
+      delete h.description;
+    }
+
     delete h.lastUsed;
     delete h.userId;
     delete h.action;

--- a/app/user-settings/controller.js
+++ b/app/user-settings/controller.js
@@ -7,7 +7,7 @@ export default Ember.Controller.extend({
     createToken(name, description) {
       const newToken = this.store.createRecord('token', {
         name,
-        description,
+        description: description || '',
         action: 'created'
       });
 

--- a/app/user-settings/service.js
+++ b/app/user-settings/service.js
@@ -18,7 +18,7 @@ export default Ember.Service.extend({
           withCredentials: true
         }
       })
-      .done(content => resolve(content))
+      .done(content => resolve(Object.assign(content, { action: 'refreshed' })))
       .fail((response) => {
         let message = `${response.status} Request Failed`;
 


### PR DESCRIPTION
Following feedback from @petey have moved new token values into a modal!

Also fixed a bug where trying to create a token with an empty description would fail.

<img width="1810" alt="screen shot 2017-07-14 at 2 09 52 pm" src="https://user-images.githubusercontent.com/7689953/28231047-48ea1450-689e-11e7-80f7-a6851ee85070.png">
