### PR TITLE
fix(tokens): Can create tokens with empty description

### DIFF
--- a/app/components/secret-view/component.js
+++ b/app/components/secret-view/component.js
@@ -2,22 +2,20 @@ import Ember from 'ember';
 
 export default Ember.Component.extend({
   tagName: 'tr',
-  buttonAction: 'Delete',
+  buttonAction: Ember.computed('newValue', 'secret.allowInPR', 'originalAllowInPR', {
+    get() {
+      return (this.get('newValue')
+        || this.get('originalAllowInPR') !== this.get('secret.allowInPR')) ?
+        'Update' : 'Delete';
+    }
+  }),
   newValue: null,
   originalAllowInPR: null,
   init() {
     this._super(...arguments);
-    this.set('originalAllowInPR', this.get('secret').get('allowInPR'));
+    this.set('originalAllowInPR', this.get('secret.allowInPR'));
   },
   actions: {
-    secretDidChange() {
-      if (this.get('newValue')
-        || this.get('originalAllowInPR') !== this.$('.allow input').prop('checked')) {
-        this.set('buttonAction', 'Update');
-      } else {
-        this.set('buttonAction', 'Delete');
-      }
-    },
     modifySecret() {
       const secret = this.get('secret');
 
@@ -27,12 +25,9 @@ export default Ember.Component.extend({
         if (this.get('newValue')) {
           secret.set('value', this.get('newValue'));
         }
-        if (this.get('originalAllowInPR') !== this.$('.allow input').prop('checked')) {
-          secret.set('allowInPR', this.$('.allow input').prop('checked'));
-        }
         secret.save();
         this.set('newValue', null);
-        this.set('buttonAction', 'Delete');
+        this.set('originalAllowInPR', secret.get('allowInPR'));
       }
     }
   }

--- a/app/components/secret-view/template.hbs
+++ b/app/components/secret-view/template.hbs
@@ -1,4 +1,4 @@
 <td class="name">{{secret.name}}</td>
-<td class="pass">{{input type="password" placeholder="Protected" size="40" value=newValue key-up="secretDidChange"}}</td>
-<td class="allow">{{input type="checkbox" checked=secret.allowInPR click=(action "secretDidChange" )}}</td>
+<td class="pass">{{input type="password" placeholder="Protected" size="40" value=newValue}}</td>
+<td class="allow">{{input type="checkbox" checked=secret.allowInPR}}</td>
 <td><button {{action "modifySecret"}}>{{buttonAction}}</button></td>

--- a/app/components/token-view/component.js
+++ b/app/components/token-view/component.js
@@ -2,12 +2,14 @@ import Ember from 'ember';
 
 export default Ember.Component.extend({
   tagName: 'tr',
-  buttonAction: Ember.computed('newName', 'newDescription', function buttonAction() {
-    const token = this.get('token');
+  buttonAction: Ember.computed('token.name', 'token.description', 'newName', 'newDescription', {
+    get() {
+      const token = this.get('token');
 
-    return (this.get('newName') !== token.get('name')
-         || this.get('newDescription') !== token.get('description')) ?
-      'Update' : 'Delete';
+      return (this.get('newName') !== token.get('name')
+           || this.get('newDescription') !== token.get('description')) ?
+        'Update' : 'Delete';
+    }
   }),
   newName: null,
   newDescription: null,
@@ -29,7 +31,6 @@ export default Ember.Component.extend({
 
         token.save()
           .then(() => {
-            this.set('buttonAction', 'Delete');
             this.get('setIsSaving')(false);
           })
           .catch((error) => {

--- a/app/user-settings/controller.js
+++ b/app/user-settings/controller.js
@@ -7,7 +7,7 @@ export default Ember.Controller.extend({
     createToken(name, description) {
       const newToken = this.store.createRecord('token', {
         name,
-        description,
+        description: description || '',
         action: 'created'
       });
 

--- a/app/user-settings/service.js
+++ b/app/user-settings/service.js
@@ -18,7 +18,7 @@ export default Ember.Service.extend({
           withCredentials: true
         }
       })
-      .done(content => resolve(content))
+      .done(content => resolve(Object.assign(content, { action: 'refreshed' })))
       .fail((response) => {
         let message = `${response.status} Request Failed`;
 


### PR DESCRIPTION
## Context
There was a bug where "refreshed" was not being displayed on the alert when a token had its value refreshed, and one where creating a token with an empty description failed.

There is also a bug where if you refresh a token and then try to modify the same token without refreshing the page the button won't change from "delete" to "update." This seems to be because the `Ember.computed` block changing the button text stops caring about changes to the values after the line that sets it to `Delete` following an update.

This is fixed by modifying the setter for `buttonAction`.

Related to https://github.com/screwdriver-cd/screwdriver/issues/532