### PR TITLE
feat(builds): only show pipeline options when logged in

### DIFF
--- a/app/pipeline/controller.js
+++ b/app/pipeline/controller.js
@@ -1,0 +1,5 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  session: Ember.inject.service('session')
+});

--- a/app/pipeline/template.hbs
+++ b/app/pipeline/template.hbs
@@ -1,4 +1,6 @@
 {{pipeline-header pipeline=model}}
-{{pipeline-nav pipeline=model}}
+{{#if session.isAuthenticated}}
+  {{pipeline-nav pipeline=model}}
+{{/if}}
 
 {{outlet}}

--- a/tests/acceptance/pipeline-builds-test.js
+++ b/tests/acceptance/pipeline-builds-test.js
@@ -214,6 +214,7 @@ test('visiting /pipelines/4', function (assert) {
     assert.equal(find('a h1').text().trim(), 'foo/bar', 'incorrect pipeline name');
     assert.equal(find('.pipelineWorkflow .build-bubble').length, 2, 'not enough workflow');
     assert.equal(find('button.start-button').length, 0, 'should not have a start button');
+    assert.equal(find('ul.nav-pills').length, 0, 'should not show options or secrets tabs');
     assert.equal(find('.col-md-9 h2').text().trim(), 'Builds');
     assert.equal(find('.col-md-3 h2').text().trim(), 'Pull Requests');
     assert.equal(find('.col-md-9 > div > div.ember-view').length, 2);


### PR DESCRIPTION
## Background
Some users have pointed out that it's hard to tell when they're logged in, and additionally it was mentioned in the security training the other day that it's generally better not to show users options for things they aren't authorized to do.

## Objective
This PR makes it such that if you're logged out you don't get to see the menu that would give you the "options" and "secrets" tabs when viewing a pipeline.

## Screenshots
Logged in:
<img width="1909" alt="screen shot 2017-07-20 at 1 51 12 pm" src="https://user-images.githubusercontent.com/7689953/28438320-9f75b564-6d52-11e7-9906-8cebf9fa70ed.png">

Logged out:
<img width="1899" alt="screen shot 2017-07-20 at 1 51 25 pm" src="https://user-images.githubusercontent.com/7689953/28438319-9f73b048-6d52-11e7-9534-d0bd6e4b8124.png">
