### PR TITLE
fix: Show Next job link once current job finishes

### DIFF
--- a/app/components/build-banner/component.js
+++ b/app/components/build-banner/component.js
@@ -58,7 +58,11 @@ export default Ember.Component.extend({
   willRender() {
     this._super(...arguments);
 
-    this.get('reloadBuild')();
+    const status = this.get('buildStatus');
+
+    if (status === 'QUEUED' || status === 'RUNNING') {
+      this.get('reloadBuild')();
+    }
   },
 
   actions: {

--- a/app/components/pipeline-events-list/styles.scss
+++ b/app/components/pipeline-events-list/styles.scss
@@ -1,5 +1,5 @@
 & {
-  padding: 0 60px 0 15px;
+  padding: 0 30px 0 10px;
   margin-bottom: 2em;
 
   h2 {

--- a/app/pipeline/builds/build/controller.js
+++ b/app/pipeline/builds/build/controller.js
@@ -17,17 +17,22 @@ export default Ember.Controller.extend({
     const status = build.get('status');
 
     // reload again in a little bit if queued
-    if ((status === 'QUEUED' || status === 'RUNNING') && !this.get('loading')) {
-      Ember.run.later(this, () => {
-        if (!build.get('isDeleted') && !this.get('loading')) {
-          this.set('loading', true);
+    if (!this.get('loading')) {
+      if ((status === 'QUEUED' || status === 'RUNNING')) {
+        Ember.run.later(this, () => {
+          if (!build.get('isDeleted') && !this.get('loading')) {
+            this.set('loading', true);
 
-          build.reload().then(() => {
-            this.set('loading', false);
-            Ember.run.once(this, 'reloadBuild');
-          });
-        }
-      }, timeout);
+            build.reload().then(() => {
+              this.set('loading', false);
+              Ember.run.once(this, 'reloadBuild');
+            });
+          }
+        }, timeout);
+      } else {
+        // refetch builds which are part of current event
+        this.get('model.event').hasMany('builds').reload();
+      }
     }
   },
 

--- a/tests/integration/components/build-banner/component-test.js
+++ b/tests/integration/components/build-banner/component-test.js
@@ -59,7 +59,7 @@ test('it renders', function (assert) {
   this.set('jobMock', jobMock);
   this.render(hbs`{{build-banner
     buildContainer="node:6"
-    buildStatus="SUCCESS"
+    buildStatus="RUNNING"
     duration="5 seconds"
     event=eventMock
     isAuthenticated=false
@@ -83,7 +83,7 @@ test('it renders', function (assert) {
 });
 
 test('it does not render a restart button for main job when authenticated', function (assert) {
-  assert.expect(2);
+  assert.expect(1);
   this.set('willRender', () => {
     assert.ok(true);
   });
@@ -105,7 +105,7 @@ test('it does not render a restart button for main job when authenticated', func
 });
 
 test('it does not render a restart button for publish job when authenticated', function (assert) {
-  assert.expect(2);
+  assert.expect(1);
   this.set('willRender', () => {
     assert.ok(true);
   });
@@ -127,7 +127,7 @@ test('it does not render a restart button for publish job when authenticated', f
 });
 
 test('it renders a restart button for PR jobs when authenticated', function (assert) {
-  assert.expect(3);
+  assert.expect(2);
   this.set('willRender', () => {
     assert.ok(true);
   });

--- a/tests/integration/components/build-banner/component-test.js
+++ b/tests/integration/components/build-banner/component-test.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
-import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import { moduleForComponent } from 'ember-qunit';
+import test from 'ember-sinon-qunit/test-support/test';
 
 const eventMock = Ember.Object.create({
   id: 'abcd',
@@ -51,7 +52,7 @@ test('it renders', function (assert) {
 
   // Set any properties with this.set('myProperty', 'value');
   // Handle any actions with this.on('myAction', function(val) { ... });
-  this.set('willRender', () => {
+  this.set('reloadCb', () => {
     assert.ok(true);
   });
 
@@ -64,7 +65,7 @@ test('it renders', function (assert) {
     event=eventMock
     isAuthenticated=false
     jobName="PR-671"
-    reloadBuild=(action willRender)
+    reloadBuild=(action reloadCb)
     jobs=jobMock
     eventBuilds=eventMock.builds
   }}`);
@@ -83,10 +84,10 @@ test('it renders', function (assert) {
 });
 
 test('it does not render a restart button for main job when authenticated', function (assert) {
-  assert.expect(1);
-  this.set('willRender', () => {
-    assert.ok(true);
-  });
+  assert.expect(2);
+  const reloadBuildSpy = this.spy();
+
+  this.set('reloadCb', reloadBuildSpy);
   this.set('eventMock', eventMock);
   this.set('jobMock', jobMock);
   this.render(hbs`{{build-banner
@@ -96,19 +97,21 @@ test('it does not render a restart button for main job when authenticated', func
     event=eventMock
     isAuthenticated=true
     jobName="main"
-    reloadBuild=(action willRender)
+    reloadBuild=(action reloadCb)
     jobs=jobMock
     eventBuilds=eventMock.builds
   }}`);
 
   assert.equal(this.$('button').length, 0);
+  assert.notOk(reloadBuildSpy.called);
 });
 
 test('it does not render a restart button for publish job when authenticated', function (assert) {
-  assert.expect(1);
-  this.set('willRender', () => {
-    assert.ok(true);
-  });
+  assert.expect(2);
+
+  const reloadBuildSpy = this.spy();
+
+  this.set('reloadCb', reloadBuildSpy);
   this.set('eventMock', eventMock);
   this.set('jobMock', jobMock);
   this.render(hbs`{{build-banner
@@ -118,26 +121,27 @@ test('it does not render a restart button for publish job when authenticated', f
     event=eventMock
     isAuthenticated=true
     jobName="publish"
-    reloadBuild=(action willRender)
+    reloadBuild=(action reloadCb)
     jobs=jobMock
     eventBuilds=eventMock.builds
   }}`);
 
   assert.equal(this.$('button').length, 0);
+  assert.notOk(reloadBuildSpy.called);
 });
 
 test('it renders a restart button for PR jobs when authenticated', function (assert) {
-  assert.expect(2);
-  this.set('willRender', () => {
-    assert.ok(true);
-  });
+  assert.expect(3);
 
+  const reloadBuildSpy = this.spy();
+
+  this.set('reloadCb', reloadBuildSpy);
   this.set('externalStart', () => {
     assert.ok(true);
   });
-
   this.set('eventMock', eventMock);
   this.set('jobMock', jobMock);
+
   this.render(hbs`{{build-banner
     buildContainer="node:6"
     buildStatus="ABORTED"
@@ -145,13 +149,14 @@ test('it renders a restart button for PR jobs when authenticated', function (ass
     event=eventMock
     isAuthenticated=true
     jobName="PR-671"
-    reloadBuild=(action willRender)
+    reloadBuild=(action reloadCb)
     onStart=(action externalStart)
     jobs=jobMock
     eventBuilds=eventMock.builds
   }}`);
 
   assert.equal(this.$('button').text().trim(), 'Restart');
+  assert.notOk(reloadBuildSpy.called);
   this.$('button').click();
 });
 

--- a/tests/unit/pipeline/builds/build/controller-test.js
+++ b/tests/unit/pipeline/builds/build/controller-test.js
@@ -86,7 +86,7 @@ test('it stops a build', function (assert) {
 });
 
 test('it reloads a build', function (assert) {
-  assert.expect(2);
+  assert.expect(4);
   let controller = this.subject();
   const build = Ember.Object.create({
     id: '5678',
@@ -104,9 +104,20 @@ test('it reloads a build', function (assert) {
     }
   });
 
+  const event = Ember.Object.create({
+    hasMany: (key) => {
+      assert.equal(key, 'builds');
+
+      return {
+        reload: () => assert.ok(true)
+      };
+    }
+  });
+
   Ember.run(() => {
     controller.set('model', {
-      build
+      build,
+      event
     });
 
     controller.reloadBuild();


### PR DESCRIPTION
Currently when an ongoing job finishes, it does not display link to the next job which should be part of the same workflow. This PR fixes it by refetching builds tied to the same event.