### PR TITLE
fix(alerts): fix sizing of icon in alerts

### DIFF
--- a/app/components/info-message/styles.scss
+++ b/app/components/info-message/styles.scss
@@ -1,8 +1,4 @@
 & {
-  i.fa {
-    font-size: 1.1rem;
-  }
-
   &.disabled {
     display: none;
   }

--- a/app/components/info-message/template.hbs
+++ b/app/components/info-message/template.hbs
@@ -1,5 +1,5 @@
 {{#if message}}
   {{#bs-alert onDismissed=(action "clearMessage") type=type}}
-    {{fa-icon icon}}&nbsp;&nbsp;<span>{{message}}</span>
+    {{fa-icon icon}} <span>{{message}}</span>
   {{/bs-alert}}
 {{/if}}

--- a/app/components/token-list/style.scss
+++ b/app/components/token-list/style.scss
@@ -5,11 +5,6 @@
     margin-top: 10px;
   }
 
-  i.fa {
-    vertical-align: top;
-    font-size: 1.1rem;
-  }
-
   table {
     width: 100%;
     font-weight: 300;

--- a/app/components/token-list/template.hbs
+++ b/app/components/token-list/template.hbs
@@ -2,9 +2,8 @@
 {{info-message message=errorMessage type="warning" icon="exclamation-triangle"}}
 {{#if newToken}}
   {{#bs-alert type="success" onDismissed=(action "clearNewToken")}}
-    {{fa-icon "check"}}
     <div class="new-token">
-      <p>Token {{newToken.action}}. You can only see this value once, so remember to copy it!</p>
+      <p>{{fa-icon "check"}} Token {{newToken.action}}. You can only see this value once, so remember to copy it!</p>
       <span class="new-name">{{newToken.name}}:</span>
       <span class="new-value">{{newToken.value}}</span>
     </div>


### PR DESCRIPTION
1.1rem didn't come out to be the same pixel value as expected, and I neglected to verify that things looked the same after the change. Updated to just have the icons use regular font size.

Before:
<img width="439" alt="screen shot 2017-07-26 at 1 36 11 pm" src="https://user-images.githubusercontent.com/7689953/28642614-df01aa30-7207-11e7-8476-f97a58ac81c4.png">
<img width="528" alt="screen shot 2017-07-26 at 1 29 01 pm" src="https://user-images.githubusercontent.com/7689953/28642613-df01826c-7207-11e7-8e82-b9a65c7c90fb.png">
After:
<img width="296" alt="screen shot 2017-07-26 at 1 35 59 pm" src="https://user-images.githubusercontent.com/7689953/28642612-df00381c-7207-11e7-9d2c-04b5f2a16d09.png">
<img width="568" alt="screen shot 2017-07-26 at 1 35 20 pm" src="https://user-images.githubusercontent.com/7689953/28642615-df0195a4-7207-11e7-935a-261d2d91e5b4.png">

Related to https://github.com/screwdriver-cd/ui/pull/189