### PR TITLE
fix(alerts): new alerts show after old ones are hidden

### DIFF
--- a/app/components/info-message/component.js
+++ b/app/components/info-message/component.js
@@ -3,7 +3,7 @@ import Ember from 'ember';
 export default Ember.Component.extend({
   type: 'info',
   actions: {
-    clearMessage: () => {
+    clearMessage: function clearMessage() {
       this.set('message', null);
     }
   }


### PR DESCRIPTION
I tested that the new token alert came back after you dismissed it, but not that the info-message behaved the same way.

Related to https://github.com/screwdriver-cd/ui/pull/189