### PR TITLE
fix(alerts): fix alerts on user-settings page

### DIFF
--- a/app/components/info-message/styles.scss
+++ b/app/components/info-message/styles.scss
@@ -1,4 +1,6 @@
 & {
+  margin-top: 10px;
+
   &.disabled {
     display: none;
   }

--- a/app/components/pipeline-secret-settings/styles.scss
+++ b/app/components/pipeline-secret-settings/styles.scss
@@ -2,10 +2,6 @@
   padding: 10px 15px;
 }
 
-.info-message {
-  margin-top: 10px;
-}
-
 table {
   width: 100%;
   font-weight: 300;

--- a/app/components/token-list/component.js
+++ b/app/components/token-list/component.js
@@ -5,12 +5,7 @@ export default Ember.Component.extend({
   sortedTokens: Ember.computed.sort('tokens', 'tokenSorting'),
 
   // Error for failed to create/update/remove/refresh token
-  error: null,
-  errorMessage: Ember.computed('error', function errorMessage() {
-    const error = this.get('error');
-
-    return error ? error.errors[0].detail : '';
-  }),
+  errorMessage: null,
 
   // Adding a new token
   isButtonDisabled: Ember.computed('newName', 'isSaving', function isButtonDisabled() {
@@ -30,15 +25,15 @@ export default Ember.Component.extend({
   modalText: null,
 
   // Don't show the "new token" and "error" dialogs at the same time
-  errorObserver: Ember.observer('error', function errorObserver() {
-    if (this.get('error')) {
+  errorObserver: Ember.observer('errorMessage', function errorObserver() {
+    if (this.get('errorMessage')) {
       this.set('newToken', null);
       this.set('isSaving', null);
     }
   }),
   newTokenObserver: Ember.observer('newToken', function newTokenObserver() {
     if (this.get('newToken')) {
-      this.set('error', null);
+      this.set('errorMessage', null);
       this.set('isSaving', null);
     }
   }),
@@ -58,7 +53,7 @@ export default Ember.Component.extend({
           this.set('newName', null);
           this.set('newDescription', null);
         }).catch((error) => {
-          this.set('error', error);
+          this.set('errorMessage', error.errors[0].detail);
         });
     },
     /**
@@ -70,10 +65,10 @@ export default Ember.Component.extend({
     },
     /**
      * Set the error to be displayed from child components
-     * @param {Object} error
+     * @param {String} errorMessage
      */
-    setError(error) {
-      this.set('error', error);
+    setErrorMessage(errorMessage) {
+      this.set('errorMessage', errorMessage);
     },
     /**
      * Show or hide the saving modal from child components
@@ -116,7 +111,7 @@ export default Ember.Component.extend({
           this.set('isSaving', true);
           this.get('onRefreshToken')(this.get('modalTarget.id'))
             .catch((error) => {
-              this.set('error', error);
+              this.set('errorMessage', error.errors[0].detail);
             });
         }
       }

--- a/app/components/token-list/style.scss
+++ b/app/components/token-list/style.scss
@@ -1,10 +1,6 @@
 & {
   padding: 10px 25px;
 
-  .info-message {
-    margin-top: 10px;
-  }
-
   table {
     width: 100%;
     font-weight: 300;

--- a/app/components/token-list/template.hbs
+++ b/app/components/token-list/template.hbs
@@ -26,7 +26,7 @@
       {{token-view
         token=token
         confirmAction=(action "confirmAction")
-        setError=(action "setError")
+        setErrorMessage=(action "setErrorMessage")
         setIsSaving=(action "setIsSaving")
       }}
     {{/each}}

--- a/app/components/token-view/component.js
+++ b/app/components/token-view/component.js
@@ -34,7 +34,7 @@ export default Ember.Component.extend({
             this.get('setIsSaving')(false);
           })
           .catch((error) => {
-            this.get('setError')(error);
+            this.get('setErrorMessage')(error.errors[0].detail);
           });
       }
     },

--- a/app/pipeline/builds/index/template.hbs
+++ b/app/pipeline/builds/index/template.hbs
@@ -1,4 +1,4 @@
-{{info-message message=errorMessage type="error"}}
+{{info-message message=errorMessage type="warning" icon="exclamation-triangle"}}
 
 {{#if session.isAuthenticated}}
 <div class="row">


### PR DESCRIPTION
I went through every page with alerts and made sure everything worked. Found two more issues, but this should be the last of it. Apologies for all the PRs on this, should have tested more thoroughly from the start. Won't happen again.

* fixed CSS styling issue on the pipeline overview page
* Ember.computed was breaking the ability of the error message to come back after being closed on the user-settings page, moved to setting the errorMessage as a string to be consistent with other places in the application