### PR TITLE
feat(523): Collections-flyout component

### DIFF
--- a/app/authenticators/screwdriver-api.js
+++ b/app/authenticators/screwdriver-api.js
@@ -66,7 +66,7 @@ export default Base.extend({
 
       // check to see if the window has closed
       const interval = setInterval(() => {
-        if (win == null || win.closed) {
+        if (win === null || win.closed) {
           clearInterval(interval);
 
           fetchToken().then(resolve, reject);

--- a/app/components/collections-flyout/component.js
+++ b/app/components/collections-flyout/component.js
@@ -1,0 +1,35 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  showModal: false,
+  errorMessage: null,
+  actions: {
+    /**
+     * Action to create a new collection
+     */
+    addNewCollection() {
+      const name = this.get('name');
+      const description = this.get('description');
+
+      return this.get('onCreateCollection')(name, description)
+        .then(() => {
+          this.set('showModal', false);
+        })
+        .catch((error) => {
+          this.set('errorMessage', error.errors[0].detail);
+        });
+    },
+    /**
+     * Action to open / close the create collection modal
+     * @param {boolean} open - whether modal should be open
+     */
+    setModal(open) {
+      if (!open) {
+        this.set('name', null);
+        this.set('description', null);
+        this.set('errorMessage', null);
+      }
+      this.set('showModal', open);
+    }
+  }
+});

--- a/app/components/collections-flyout/styles.scss
+++ b/app/components/collections-flyout/styles.scss
@@ -1,0 +1,31 @@
+& {
+  border-right: 1px solid $sd-text-light;
+  border-bottom: 1px solid $sd-text-light;
+
+  a {
+    cursor: pointer;
+  }
+
+  .flyout {
+    padding: 20px;
+    background-color: $sd-flyout-bg;
+    color: $sd-text;
+  }
+
+  .collection-wrapper {
+    padding: 10px 15px;
+    border-bottom: 1px solid $sd-white;
+    position: relative;
+
+    &:hover {
+      background-color: $sd-flyout-hover;
+      .name {
+        text-decoration: underline;
+      }
+    }
+  }
+
+  .no-collections-text {
+    padding: 15px;
+  }
+}

--- a/app/components/collections-flyout/template.hbs
+++ b/app/components/collections-flyout/template.hbs
@@ -1,0 +1,38 @@
+<div class="flyout row">
+  <h3 class="header-text">
+    <a class="new" {{action "setModal" true}}>{{fa-icon "plus-circle" title="Create a collection" size="md"}}</a> Collections
+  </h3>
+    {{#each collections as |collection|}}
+      <div class="collection-wrapper row">
+        {{#link-to "collection.show" collection.id}}{{collection.name}}{{/link-to}}
+      </div>
+    {{else}}
+      <p class="no-collections-text">No collections to display.</p>
+    {{/each}}
+    {{#if showModal}}
+      {{#bs-modal onHide=(action "setModal" false) as |modal|}}
+        {{#modal.header}}
+          <h4 class="modal-title">Create a new Collection</h4>
+        {{/modal.header}}
+        {{#modal.body}}
+          {{#if errorMessage}}
+            {{info-message message=errorMessage type="warning" icon="exclamation-triangle"}}
+          {{/if}}
+          {{#bs-form onSubmit=(action "addNewCollection") as |form|}}
+            {{#form.group class="name"}}
+              <label class="control-label">Name</label>
+              <input value={{name}} class="form-control" oninput={{action (mut name) value="target.value"}} type="text">
+            {{/form.group}}
+            {{#form.group class="description"}}
+              <label class="control-label">Description</label>
+              <input value={{description}} class="form-control" oninput={{action (mut description) value="target.value"}} type="text">
+            {{/form.group}}
+          {{/bs-form}}
+        {{/modal.body}}
+        {{#modal.footer as |footer|}}
+          {{#bs-button class="cancel" onClick=(action modal.close) type="danger"}}Cancel{{/bs-button}}
+          {{#bs-button class="create" onClick=(action modal.submit) type="success"}}Create{{/bs-button}}
+        {{/modal.footer}}
+      {{/bs-modal}}
+    {{/if}}
+</div>

--- a/app/styles/screwdriver-colors.scss
+++ b/app/styles/screwdriver-colors.scss
@@ -30,3 +30,6 @@ $sd-running: #0f69ff;
 $sd-queued: $sd-running;
 $sd-running-gradient-start: $sd-link;
 $sd-running-gradient-end: $sd-running;
+
+$sd-flyout-bg: #f0f4ff;
+$sd-flyout-hover: #f7faff;

--- a/tests/integration/components/collections-flyout/component-test.js
+++ b/tests/integration/components/collections-flyout/component-test.js
@@ -1,0 +1,87 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import Ember from 'ember';
+import wait from 'ember-test-helpers/wait';
+
+moduleForComponent('collections-flyout', 'Integration | Component | collections flyout', {
+  integration: true
+});
+
+test('it renders', function (assert) {
+  assert.expect(5);
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+  const $ = this.$;
+
+  this.set('collections', [
+    Ember.Object.create({
+      id: 1,
+      name: 'collection1',
+      description: 'description1',
+      pipelineIds: [1, 2, 3]
+    }),
+    Ember.Object.create({
+      id: 2,
+      name: 'collection2',
+      description: 'description2',
+      pipelineIds: [4, 5, 6]
+    }),
+    Ember.Object.create({
+      id: 3,
+      name: 'collection3',
+      description: 'description3',
+      pipelineIds: [7, 8, 9]
+    })
+  ]);
+
+  this.render(hbs`{{collections-flyout collections=collections}}`);
+
+  assert.equal($('.header-text').text().trim(), 'Collections');
+  assert.equal($('.header-text a i').attr('class'), 'fa fa-plus-circle fa-mdx ember-view');
+  assert.equal($($('.collection-wrapper a').get(0)).text().trim(), 'collection1');
+  assert.equal($($('.collection-wrapper a').get(1)).text().trim(), 'collection2');
+  assert.equal($($('.collection-wrapper a').get(2)).text().trim(), 'collection3');
+});
+
+test('it renders with no collections', function (assert) {
+  assert.expect(2);
+  const $ = this.$;
+  const noCollectionsText = 'No collections to display.';
+
+  this.set('collections', []);
+
+  this.render(hbs`{{collections-flyout collections=collections}}`);
+
+  assert.equal($('.no-collections-text').length, 1);
+  assert.equal($('.no-collections-text').text().trim(), noCollectionsText);
+});
+
+test('it opens collection create modal', function (assert) {
+  assert.expect(9);
+  const $ = this.$;
+
+  this.set('collections', []);
+  this.set('showModal', false);
+
+  this.render(hbs`{{collections-flyout collections=collections showModal=showModal}}`);
+  assert.equal(this.get('showModal'), false);
+  // Make sure there are no modals
+  assert.notOk($('.modal').length);
+
+  $('.new').click();
+
+  return wait().then(() => {
+    const modalTitle = 'Create a new Collection';
+    const cancelButton = $($('.modal-footer button').get(0));
+    const createButton = $($('.modal-footer button').get(1));
+
+    assert.equal(this.get('showModal'), true);
+    // Make sure there is only 1 modal
+    assert.equal($('.modal').length, 1);
+    assert.equal($('.modal-title').text().trim(), modalTitle);
+    assert.equal($('.name input').length, 1);
+    assert.equal($('.description input').length, 1);
+    assert.equal(cancelButton.text().trim(), 'Cancel');
+    assert.equal(createButton.text().trim(), 'Create');
+  });
+});


### PR DESCRIPTION
## Context

For the user dashboard, the user needs to be able to create / view collections.

## Objective

This PR adds a component that will act as a flyout component that can be added to the routes that require it. Right now, the component is not collapsible but in the future it will be.

Screenshots:

Flyout:
![Flyout](https://user-images.githubusercontent.com/12389411/28977609-963368b0-78f7-11e7-87a8-252027a209a5.png)


Modal:
![Create Modal](https://user-images.githubusercontent.com/12389411/28981084-16ca2c18-7905-11e7-9b1b-562474780ab7.png)



## References

Issue: [screwdriver-cd/screwdriver#523](https://github.com/screwdriver-cd/screwdriver/issues/523)