### PR TITLE
feat(523): Add collection model and serializer

### DIFF
--- a/app/collection/model.js
+++ b/app/collection/model.js
@@ -1,0 +1,8 @@
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  name: DS.attr('string'),
+  description: DS.attr('string'),
+  pipelineIds: DS.attr(),
+  pipelines: DS.attr()
+});

--- a/app/collection/serializer.js
+++ b/app/collection/serializer.js
@@ -1,0 +1,21 @@
+import DS from 'ember-data';
+import Ember from 'ember';
+
+export default DS.RESTSerializer.extend({
+  /**
+   * Override the serializeIntoHash method
+   * See http://emberjs.com/api/data/classes/DS.RESTSerializer.html#method_serializeIntoHash
+   * @method serializeIntoHash
+   */
+  serializeIntoHash(hash, typeClass, snapshot) {
+    const dirty = snapshot.changedAttributes();
+
+    Object.keys(dirty).forEach((key) => {
+      dirty[key] = dirty[key][1];
+    });
+
+    const h = Ember.merge(hash, dirty);
+
+    return h;
+  }
+});

--- a/tests/unit/collection/model-test.js
+++ b/tests/unit/collection/model-test.js
@@ -1,0 +1,12 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('collection', 'Unit | Model | collection', {
+  // Specify the other units that are required for this test.
+  needs: []
+});
+
+test('it exists', function (assert) {
+  let model = this.subject();
+
+  assert.ok(!!model);
+});

--- a/tests/unit/collection/serializer-test.js
+++ b/tests/unit/collection/serializer-test.js
@@ -1,0 +1,86 @@
+import { moduleForModel, test } from 'ember-qunit';
+import Pretender from 'pretender';
+import Ember from 'ember';
+import wait from 'ember-test-helpers/wait';
+let server;
+
+moduleForModel('collection', 'Unit | Serializer | collection', {
+  // Specify the other units that are required for this test.
+  needs: ['serializer:collection'],
+  beforeEach() {
+    server = new Pretender();
+  },
+  afterEach() {
+    server.shutdown();
+  }
+});
+
+test('it serializes records', function (assert) {
+  let record = this.subject();
+  let serializedRecord = record.serialize();
+
+  assert.ok(serializedRecord);
+});
+
+test('it does not post with model name as key', function (assert) {
+  assert.expect(2);
+  server.post('/collections', function () {
+    return [200, {}, JSON.stringify({ collection: { id: 123 } })];
+  });
+
+  Ember.run(() => {
+    const collection = this.store().createRecord('collection', {
+      name: 'Screwdriver',
+      description: 'Collection of screwdriver pipelines'
+    });
+
+    collection.save()
+      .then(() => {
+        assert.equal(collection.get('id'), 123);
+      });
+  });
+
+  return wait().then(() => {
+    const [request] = server.handledRequests;
+    const payload = JSON.parse(request.requestBody);
+
+    assert.deepEqual(payload, {
+      name: 'Screwdriver',
+      description: 'Collection of screwdriver pipelines'
+    });
+  });
+});
+
+test('it serializes only dirty fields', function (assert) {
+  assert.expect(1);
+  server.patch('/collections/123', function () {
+    return [200, {}, JSON.stringify({ collection: { id: 123 } })];
+  });
+
+  Ember.run(() => {
+    this.store().push({
+      data: {
+        id: 123,
+        type: 'collection',
+        attributes: {
+          name: 'Screwdriver',
+          description: 'Collection of screwdriver pipelines'
+        }
+      }
+    });
+
+    const collection = this.store().peekRecord('collection', 123);
+
+    collection.set('description', 'newDescription');
+    collection.save();
+  });
+
+  return wait().then(() => {
+    const [request] = server.handledRequests;
+    const payload = JSON.parse(request.requestBody);
+
+    assert.deepEqual(payload, {
+      description: 'newDescription'
+    });
+  });
+});


### PR DESCRIPTION
## Objective

This PR adds a model and serializer for collections for use with `ember-data`.

## References

Blocked by PR: #195 
Issue: [screwdriver-cd/screwdriver#523](https://github.com/screwdriver-cd/screwdriver/issues/523)
