### PR TITLE
refactor(collections): Move store interactions to component

### DIFF
--- a/app/components/collections-flyout/component.js
+++ b/app/components/collections-flyout/component.js
@@ -17,19 +17,21 @@ export default Ember.Component.extend({
       const name = this.get('name');
       const description = this.get('description');
 
-      const newCollection = this.get('store').createRecord('collection', {
-        name,
-        description
-      });
-
-      return newCollection.save()
-        .then(() => {
-          this.set('showModal', false);
-        })
-        .catch((error) => {
-          newCollection.destroyRecord();
-          this.set('errorMessage', error.errors[0].detail);
+      Ember.run.schedule('actions', () => {
+        const newCollection = this.get('store').createRecord('collection', {
+          name,
+          description
         });
+
+        return newCollection.save()
+          .then(() => {
+            this.set('showModal', false);
+          })
+          .catch((error) => {
+            newCollection.destroyRecord();
+            this.set('errorMessage', error.errors[0].detail);
+          });
+      });
     },
     /**
      * Action to open / close the create collection modal

--- a/app/components/collections-flyout/component.js
+++ b/app/components/collections-flyout/component.js
@@ -1,8 +1,14 @@
 import Ember from 'ember';
 
 export default Ember.Component.extend({
-  showModal: false,
+  collections: Ember.computed('store', {
+    get() {
+      return this.get('store').findAll('collection');
+    }
+  }),
   errorMessage: null,
+  showModal: false,
+  store: Ember.inject.service(),
   actions: {
     /**
      * Action to create a new collection
@@ -11,11 +17,17 @@ export default Ember.Component.extend({
       const name = this.get('name');
       const description = this.get('description');
 
-      return this.get('onCreateCollection')(name, description)
+      const newCollection = this.get('store').createRecord('collection', {
+        name,
+        description
+      });
+
+      return newCollection.save()
         .then(() => {
           this.set('showModal', false);
         })
         .catch((error) => {
+          newCollection.destroyRecord();
           this.set('errorMessage', error.errors[0].detail);
         });
     },

--- a/app/components/collections-flyout/template.hbs
+++ b/app/components/collections-flyout/template.hbs
@@ -4,7 +4,7 @@
   </h3>
     {{#each collections as |collection|}}
       <div class="collection-wrapper row">
-        {{#link-to "collection.show" collection.id}}{{collection.name}}{{/link-to}}
+        {{collection.name}}
       </div>
     {{else}}
       <p class="no-collections-text">No collections to display.</p>
@@ -27,12 +27,12 @@
               <label class="control-label">Description</label>
               <input value={{description}} class="form-control" oninput={{action (mut description) value="target.value"}} type="text">
             {{/form.group}}
+            {{#form.group class="footer"}}
+            {{#bs-button class="cancel" onClick=(action modal.close) type="danger"}}Cancel{{/bs-button}}
+            {{#bs-button buttonType="submit" class="create" type="success"}}Create{{/bs-button}}
+            {{/form.group}}
           {{/bs-form}}
         {{/modal.body}}
-        {{#modal.footer as |footer|}}
-          {{#bs-button class="cancel" onClick=(action modal.close) type="danger"}}Cancel{{/bs-button}}
-          {{#bs-button class="create" onClick=(action modal.submit) type="success"}}Create{{/bs-button}}
-        {{/modal.footer}}
       {{/bs-modal}}
     {{/if}}
 </div>

--- a/app/components/collections-flyout/template.hbs
+++ b/app/components/collections-flyout/template.hbs
@@ -4,7 +4,7 @@
   </h3>
     {{#each collections as |collection|}}
       <div class="collection-wrapper row">
-        {{collection.name}}
+        {{#link-to "dashboard.show" collection.id}}{{collection.name}}{{/link-to}}
       </div>
     {{else}}
       <p class="no-collections-text">No collections to display.</p>

--- a/tests/integration/components/collections-flyout/component-test.js
+++ b/tests/integration/components/collections-flyout/component-test.js
@@ -131,14 +131,14 @@ test('it creates a collection', function (assert) {
     description=description
   }}`);
 
-  Ember.run(() => $('.new').click());
+  $('.new').click();
 
   this.set('name', 'Test');
   this.set('description', 'Test description');
 
   assert.ok(this.get('showModal'));
 
-  Ember.run(() => $('.create').click());
+  $('.create').click();
 
   assert.notOk(this.get('showModal'));
 });

--- a/tests/integration/components/collections-flyout/component-test.js
+++ b/tests/integration/components/collections-flyout/component-test.js
@@ -83,8 +83,8 @@ test('it opens collection create modal', function (assert) {
 
   return wait().then(() => {
     const modalTitle = 'Create a new Collection';
-    const cancelButton = $($('.modal-footer button').get(0));
-    const createButton = $($('.modal-footer button').get(1));
+    const cancelButton = $('.cancel');
+    const createButton = $('.create');
 
     assert.equal(this.get('showModal'), true);
     // Make sure there is only 1 modal

--- a/tests/integration/components/collections-flyout/component-test.js
+++ b/tests/integration/components/collections-flyout/component-test.js
@@ -98,7 +98,8 @@ test('it opens collection create modal', function (assert) {
 });
 
 test('it creates a collection', function (assert) {
-  assert.expect(3);
+  assert.expect(4);
+
   const $ = this.$;
   const storeStub = Ember.Object.extend({
     createRecord(model, data) {
@@ -125,23 +126,25 @@ test('it creates a collection', function (assert) {
   this.set('showModal', false);
   this.set('name', null);
   this.set('description', null);
-  this.set('storeStub', storeStub);
+
+  this.register('service:store', storeStub);
+  this.inject.service('store');
 
   this.render(hbs`{{collections-flyout
     collections=collections
     showModal=showModal
     name=name
     description=description
-    store=storeStub
   }}`);
 
-  $('.new').click();
+  Ember.run(() => $('.new').click());
 
   return wait().then(() => {
     this.set('name', 'Test');
     this.set('description', 'Test description');
 
-    $('form').get(0).submit();
+    assert.ok(this.get('showModal'));
+    Ember.run(() => $('.create').click());
 
     return wait().then(() => {
       assert.notOk(this.get('showModal'));

--- a/tests/integration/components/collections-flyout/component-test.js
+++ b/tests/integration/components/collections-flyout/component-test.js
@@ -3,15 +3,15 @@ import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
 import wait from 'ember-test-helpers/wait';
 
+const mockCollection = {
+  id: 1,
+  name: 'Test',
+  description: 'Test description'
+};
+
 const collectionModel = {
   save() {
-    return new Ember.RSVP.Promise((resolve) => {
-      resolve({
-        id: 1,
-        name: 'Test',
-        description: 'Test description'
-      });
-    });
+    return new Ember.RSVP.Promise((resolve) => resolve(mockCollection));
   },
   destroyRecord() {}
 };
@@ -112,13 +112,7 @@ test('it creates a collection', function (assert) {
       return collectionModel;
     },
     findAll() {
-      return new Ember.RSVP.Promise((resolve) => {
-        resolve([{
-          id: 1,
-          name: 'Test',
-          description: 'Test description'
-        }]);
-      });
+      return new Ember.RSVP.Promise((resolve) => resolve([mockCollection]));
     }
   });
 
@@ -139,15 +133,12 @@ test('it creates a collection', function (assert) {
 
   Ember.run(() => $('.new').click());
 
-  return wait().then(() => {
-    this.set('name', 'Test');
-    this.set('description', 'Test description');
+  this.set('name', 'Test');
+  this.set('description', 'Test description');
 
-    assert.ok(this.get('showModal'));
-    Ember.run(() => $('.create').click());
+  assert.ok(this.get('showModal'));
 
-    return wait().then(() => {
-      assert.notOk(this.get('showModal'));
-    });
-  });
+  Ember.run(() => $('.create').click());
+
+  assert.notOk(this.get('showModal'));
 });

--- a/tests/integration/components/collections-flyout/component-test.js
+++ b/tests/integration/components/collections-flyout/component-test.js
@@ -11,7 +11,7 @@ const mockCollection = {
 
 const collectionModel = {
   save() {
-    return new Ember.RSVP.Promise((resolve) => resolve(mockCollection));
+    return new Ember.RSVP.Promise(resolve => resolve(mockCollection));
   },
   destroyRecord() {}
 };
@@ -112,7 +112,7 @@ test('it creates a collection', function (assert) {
       return collectionModel;
     },
     findAll() {
-      return new Ember.RSVP.Promise((resolve) => resolve([mockCollection]));
+      return new Ember.RSVP.Promise(resolve => resolve([mockCollection]));
     }
   });
 


### PR DESCRIPTION
## Context

Currently, all the interactions with the store that the collections-flyout component needs to do are done through the controllers of the routes that require the collections-flyout component. This is not very DRY.

## Objective

This PR moves all the store interactions into the collections-flyout component itself so that it can be a self-sustained component. So now, any route that needs the collections-flyout component can simply just add it to the template like so `{{collections-flyout}}`.

## Reference

Issue: [screwdriver-cd/screwdriver#523](https://github.com/screwdriver-cd/screwdriver/issues/523)
