### PR TITLE
feat(collections): Add pipelines to a collection from search route

### DIFF
--- a/app/components/search-list/component.js
+++ b/app/components/search-list/component.js
@@ -39,5 +39,21 @@ export default Ember.Component.extend({
       return filtered;
     }
   }),
-  isEmpty: Ember.computed.empty('filteredPipelines')
+  isEmpty: Ember.computed.empty('filteredPipelines'),
+  addCollectionError: null,
+  addCollectionSuccess: null,
+  actions: {
+    addToCollection(pipelineId, collection) {
+      return this.get('onAddToCollection')(+pipelineId, collection.id)
+        .then(() => {
+          this.set('addCollectionError', null);
+          this.set('addCollectionSuccess',
+            `Successfully added Pipeline to ${collection.get('name')}`);
+        })
+        .catch(() => {
+          this.set('addCollectionError', `Could not add Pipeline to ${collection.get('name')}`);
+          this.set('addCollectionSuccess', null);
+        });
+    }
+  }
 });

--- a/app/components/search-list/styles.scss
+++ b/app/components/search-list/styles.scss
@@ -46,6 +46,23 @@
     padding: 10px;
     border-bottom: 1px solid $sd-text-light;
   }
+
+  .add-to-collection {
+    border: none;
+  }
+
+  .dropdown-menu > li > span {
+    cursor: pointer;
+    display: inline-block;
+    padding: 5px;
+    width: 100%;
+
+    &:hover {
+      background-color: $sd-highlight;
+      color: $sd-text;
+      opacity: 1;
+    }
+  }
 }
 
 @media (max-width: 47.999em) {

--- a/app/components/search-list/template.hbs
+++ b/app/components/search-list/template.hbs
@@ -1,3 +1,9 @@
+{{#if addCollectionError}}
+  {{info-message message=addCollectionError type="warning" icon="exclamation-triangle"}}
+{{/if}}
+{{#if addCollectionSuccess}}
+  {{info-message message=addCollectionSuccess type="success" icon="check"}}
+{{/if}}
 <div class="num-results">
   {{if isEmpty "No Results" (concat "Found " filteredPipelines.length " result(s)")}}
 </div>
@@ -6,6 +12,7 @@
     <tr>
       <th class="appId">Name</th>
       <th class="branch">Branch</th>
+      <th class="add">Add to Collection</th>
     </tr>
   </thead>
   <tbody>
@@ -13,6 +20,22 @@
     <tr>
       <td class="appId">{{#highlight-terms query}}{{#link-to "pipeline" pipeline.id}}{{pipeline.appId}}{{/link-to}}{{/highlight-terms}}</td>
       <td class="branch">{{fa-icon "fa-code-fork"}}{{pipeline.branch}}</td>
+      <td class="add">
+        {{#bs-dropdown as |dd|}}
+          {{#dd.button class="add-to-collection"}}
+            {{fa-icon "plus" title="Add to collection" size="sm"}}
+          {{/dd.button}}
+          {{#dd.menu align="right" as |menu|}}
+            {{#each collections as |collection|}}
+              {{#menu.item}}
+                <span onclick={{action "addToCollection" pipeline.id collection}}>
+                  {{collection.name}}
+                </span>
+              {{/menu.item}}
+            {{/each}}
+          {{/dd.menu}}
+        {{/bs-dropdown}}
+      </td>
     </tr>
     {{/each}}
   </tbody>

--- a/app/search/controller.js
+++ b/app/search/controller.js
@@ -1,0 +1,23 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  actions: {
+    /**
+     * Adding a pipeline to a collection
+     * @param {Number} pipelineId - id of pipeline to add to collection
+     * @param {Object} collection - collection object
+     */
+    addToCollection(pipelineId, collectionId) {
+      return this.store.findRecord('collection', collectionId)
+        .then((collection) => {
+          const pipelineIds = collection.get('pipelineIds');
+
+          if (!pipelineIds.includes(pipelineId)) {
+            collection.set('pipelineIds', [...pipelineIds, pipelineId]);
+          }
+
+          return collection.save();
+        });
+    }
+  }
+});

--- a/app/search/route.js
+++ b/app/search/route.js
@@ -12,6 +12,7 @@ export default Ember.Route.extend({
   model(params) {
     return {
       pipelines: this.store.findAll('pipeline'),
+      collections: this.store.findAll('collection'),
       query: params.query
     };
   }

--- a/app/search/template.hbs
+++ b/app/search/template.hbs
@@ -1,3 +1,12 @@
-{{search-list pipelines=model.pipelines query=model.query}}
+<div class="row">
+  {{collections-flyout class="col-md-2"}}
+  {{search-list
+    pipelines=model.pipelines
+    collections=model.collections
+    onAddToCollection=(action "addToCollection")
+    query=model.query
+    class="col-md-10"
+  }}
+</div>
 
 {{outlet}}

--- a/tests/acceptance/search-test.js
+++ b/tests/acceptance/search-test.js
@@ -48,6 +48,19 @@ moduleForAcceptance('Acceptance | search', {
         }
       ])
     ]);
+
+    server.get('http://localhost:8080/v4/collections', () => [
+      200,
+      { 'Content-Type': 'application/json' },
+      JSON.stringify([
+        {
+          id: '1',
+          name: 'collection1',
+          description: 'description1',
+          pipelineIds: [1, 2, 3]
+        }
+      ])
+    ]);
   },
   afterEach() {
     server.shutdown();

--- a/tests/integration/components/search-list/component-test.js
+++ b/tests/integration/components/search-list/component-test.js
@@ -22,15 +22,35 @@ test('it renders', function (assert) {
       branch: 'waynecorp'
     })
   ];
+  const collections = [
+    Ember.Object.create({
+      id: 1,
+      name: 'collection1',
+      description: 'description1',
+      pipelineIds: [1, 2, 3]
+    }),
+    Ember.Object.create({
+      id: 2,
+      name: 'collection2',
+      description: 'description2',
+      pipelineIds: [4, 5, 6]
+    })
+  ];
 
   this.set('pipelineList', pipelines);
+  this.set('collections', collections);
 
-  this.render(hbs`{{search-list pipelines=pipelineList}}`);
+  this.render(hbs`{{search-list pipelines=pipelineList collections=collections}}`);
 
   assert.equal($($('td.appId').get(0)).text().trim(), 'batman/tumbler');
   assert.equal($($('td.branch').get(0)).text().trim(), 'waynecorp');
   assert.equal($($('td.appId').get(1)).text().trim(), 'foo/bar');
   assert.equal($($('td.branch').get(1)).text().trim(), 'master');
+  assert.equal($('.add-to-collection').length, 2);
+  assert.equal($($('td.add .dropdown-menu span').get(0)).text().trim(), 'collection1');
+  assert.equal($($('td.add .dropdown-menu span').get(1)).text().trim(), 'collection2');
+  assert.equal($($('td.add .dropdown-menu span').get(2)).text().trim(), 'collection1');
+  assert.equal($($('td.add .dropdown-menu span').get(3)).text().trim(), 'collection2');
 });
 
 test('it filters the list', function (assert) {
@@ -112,4 +132,103 @@ test('it filters the list by multiple advanced search queries', function (assert
   assert.ok($('tr').length, 2);
   assert.equal($('td.appId').text().trim(), 'batman/tumbler');
   assert.equal($('td.branch').text().trim(), 'waynecorp');
+});
+
+test('it adds a pipeline to a collection', function (assert) {
+  assert.expect(3);
+
+  const $ = this.$;
+  const pipelines = [
+    Ember.Object.create({
+      id: 1,
+      appId: 'foo/bar',
+      branch: 'master'
+    }),
+    Ember.Object.create({
+      id: 2,
+      appId: 'batman/tumbler',
+      branch: 'waynecorp'
+    })
+  ];
+  const collections = [
+    Ember.Object.create({
+      id: 1,
+      name: 'collection1',
+      description: 'description1',
+      pipelineIds: [2, 3]
+    }),
+    Ember.Object.create({
+      id: 2,
+      name: 'collection2',
+      description: 'description2',
+      pipelineIds: []
+    })
+  ];
+  const addToCollectionMock = (pipelineId, collectionId) => {
+    assert.strictEqual(pipelineId, 2);
+    assert.strictEqual(collectionId, 1);
+
+    return Ember.RSVP.resolve({
+      id: 1,
+      name: 'collection1',
+      description: 'description1',
+      pipelineIds: [1, 2, 3]
+    });
+  };
+
+  this.set('pipelineList', pipelines);
+  this.set('collections', collections);
+  this.set('onAddToCollection', addToCollectionMock);
+
+  this.render(hbs`
+    {{search-list
+      pipelines=pipelineList
+      collections=collections
+      onAddToCollection=onAddToCollection
+    }}
+  `);
+
+  $($('td.add .dropdown-menu span').get(0)).click();
+
+  assert.strictEqual($('.alert-success > span').text().trim(),
+    'Successfully added Pipeline to collection1');
+});
+
+test('it fails to add a pipeline to a collection', function (assert) {
+  assert.expect(1);
+
+  const $ = this.$;
+  const pipelines = [
+    Ember.Object.create({
+      id: 1,
+      appId: 'foo/bar',
+      branch: 'master'
+    })
+  ];
+  const collections = [
+    Ember.Object.create({
+      id: 1,
+      name: 'collection1',
+      description: 'description1',
+      pipelineIds: [2, 3]
+    })
+  ];
+  const addToCollectionMock = () => Ember.RSVP.reject();
+
+  this.set('pipelineList', pipelines);
+  this.set('collections', collections);
+  this.set('onAddToCollection', addToCollectionMock);
+
+  this.render(hbs`
+    {{search-list
+      pipelines=pipelineList
+      collections=collections
+      onAddToCollection=onAddToCollection
+    }}
+  `);
+
+  $($('td.add .dropdown-menu span').get(0)).click();
+
+  assert.strictEqual($('.alert-warning > span').text().trim(),
+    'Could not add Pipeline to collection1');
 });

--- a/tests/unit/search/controller-test.js
+++ b/tests/unit/search/controller-test.js
@@ -1,0 +1,59 @@
+import { moduleFor, test } from 'ember-qunit';
+import Ember from 'ember';
+
+moduleFor('controller:search', 'Unit | Controller | search', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+test('it exists', function (assert) {
+  const controller = this.subject();
+
+  assert.ok(controller);
+});
+
+test('it calls addToCollection', function (assert) {
+  const controller = this.subject();
+  let pipelineIds = [1, 2];
+
+  const collectionModelMock = {
+    id: 1,
+    name: 'collection1',
+    description: 'description1',
+    pipelineIds,
+    get(field) {
+      assert.strictEqual(field, 'pipelineIds');
+
+      // The collection currently has pipelineIds 1 and 2
+      return pipelineIds;
+    },
+    set(field, value) {
+      assert.strictEqual(field, 'pipelineIds');
+      assert.deepEqual(value, [1, 2, 3]);
+
+      pipelineIds = value;
+    },
+    save() {
+      assert.deepEqual(pipelineIds, [1, 2, 3]);
+
+      return Ember.RSVP.resolve({
+        id: 1,
+        name: 'collection1',
+        description: 'description1',
+        pipelineIds: [1, 2, 3]
+      });
+    }
+  };
+
+  controller.set('store', {
+    findRecord(modelName, pipelineId) {
+      assert.strictEqual(modelName, 'collection');
+      assert.strictEqual(pipelineId, 1);
+
+      return Ember.RSVP.resolve(collectionModelMock);
+    }
+  });
+
+  // Add pipeline with id 3 to collection with id 1
+  controller.send('addToCollection', 3, 1);
+});


### PR DESCRIPTION
## Context

For the dashboards feature, users need to be able to add pipelines to their collections

## Objective

This PR adds functionality to allow users to add pipelines to their collections from the search results page.

**Screenshots**

Search page:
![search page](https://user-images.githubusercontent.com/12389411/29233611-dfad0582-7ea6-11e7-86d7-52afc4125d1c.png)

Dropdown:
![dropdown](https://user-images.githubusercontent.com/12389411/29233620-eeac2d56-7ea6-11e7-8ec4-1a9cc3a979fd.png)

Successful add:
![image](https://user-images.githubusercontent.com/12389411/29233658-24d7bc42-7ea7-11e7-832a-cf9fe8a9c450.png)

## References

Issue: [screwdriver-cd/screwdriver#523](https://github.com/screwdriver-cd/screwdriver/issues/523)