### PR TITLE
feat(365): Add login buttons for each scm

### DIFF
--- a/app/authenticators/screwdriver-api.js
+++ b/app/authenticators/screwdriver-api.js
@@ -3,7 +3,7 @@ import Base from 'ember-simple-auth/authenticators/base';
 // eslint-disable-next-line camelcase
 import { jwt_decode } from 'ember-cli-jwt-decode';
 import ENV from 'screwdriver-ui/config/environment';
-const loginUrl = `${ENV.APP.SDAPI_HOSTNAME}/${ENV.APP.SDAPI_NAMESPACE}/auth/login/web`;
+const loginUrlBase = `${ENV.APP.SDAPI_HOSTNAME}/${ENV.APP.SDAPI_NAMESPACE}/auth/login`;
 const tokenUrl = `${ENV.APP.SDAPI_HOSTNAME}/${ENV.APP.SDAPI_NAMESPACE}/auth/token`;
 const logoutUrl = `${ENV.APP.SDAPI_HOSTNAME}/${ENV.APP.SDAPI_NAMESPACE}/auth/logout`;
 
@@ -58,10 +58,17 @@ export default Base.extend({
    * @method authenticate
    * @return {Promise}
    */
-  authenticate() {
+  authenticate(scmContext) {
     return new Ember.RSVP.Promise((resolve, reject) => {
+      let url = [loginUrlBase];
+
+      if (scmContext) {
+        url.push(scmContext);
+      }
+      url.push('web');
+
       // Open a window for github auth flow
-      const win = window.open(loginUrl, 'SDAuth',
+      const win = window.open(url.join('/'), 'SDAuth',
         'width=1024,height=768,resizable,alwaysRaised');
 
       // check to see if the window has closed

--- a/app/authenticators/screwdriver-api.js
+++ b/app/authenticators/screwdriver-api.js
@@ -56,6 +56,7 @@ export default Base.extend({
   /**
    * Authenticates with resource
    * @method authenticate
+   * @param  {String}  [scmContext]    scmContext of the user
    * @return {Promise}
    */
   authenticate(scmContext) {

--- a/app/components/login-button/component.js
+++ b/app/components/login-button/component.js
@@ -2,8 +2,8 @@ import Ember from 'ember';
 
 export default Ember.Component.extend({
   actions: {
-    authenticate() {
-      this.get('authenticate')();
+    authenticate(context) {
+      this.get('authenticate')(context);
     }
   }
 });

--- a/app/components/login-button/template.hbs
+++ b/app/components/login-button/template.hbs
@@ -7,6 +7,11 @@
 <p>
   Clicking this button will open a new window with your SCM provider.
 </p>
+
+{{#each contexts as |context|}}
+<a href="#authenticate"{{action "authenticate" context.context}}>{{fa-icon "fa-sign-in"}} Login with {{context.displayName}}</a>
+{{else}}
 <a href="#authenticate"{{action "authenticate"}}>{{fa-icon "fa-sign-in"}} Login with SCM Provider</a>
+{{/each}}
 
 {{yield}}

--- a/app/login/controller.js
+++ b/app/login/controller.js
@@ -2,10 +2,9 @@ import Ember from 'ember';
 
 export default Ember.Controller.extend({
   session: Ember.inject.service('session'),
-
   actions: {
-    authenticate() {
-      this.get('session').authenticate('authenticator:screwdriver-api');
+    authenticate(context) {
+      this.get('session').authenticate('authenticator:screwdriver-api', context);
     }
   }
 });

--- a/app/login/route.js
+++ b/app/login/route.js
@@ -1,6 +1,13 @@
 import Ember from 'ember';
 import UnauthenticatedRouteMixin from 'ember-simple-auth/mixins/unauthenticated-route-mixin';
+import ENV from 'screwdriver-ui/config/environment';
+
 export default Ember.Route.extend(UnauthenticatedRouteMixin, {
   titleToken: 'Login',
-  routeIfAlreadyAuthenticated: 'home'
+  routeIfAlreadyAuthenticated: 'home',
+  model() {
+    return Ember.$.getJSON(
+      `${ENV.APP.SDAPI_HOSTNAME}/${ENV.APP.SDAPI_NAMESPACE}/auth/contexts`
+    ).catch(() => []);
+  }
 });

--- a/app/login/template.hbs
+++ b/app/login/template.hbs
@@ -1,3 +1,3 @@
-{{login-button authenticate=(action "authenticate")}}
+{{login-button authenticate=(action "authenticate") contexts=model}}
 
 {{outlet}}

--- a/tests/integration/components/login-button/component-test.js
+++ b/tests/integration/components/login-button/component-test.js
@@ -17,3 +17,23 @@ test('it renders', function (assert) {
   assert.equal(this.$('h2').text().trim(), 'Login to Screwdriver');
   this.$('a').click();
 });
+
+test('it renders multiple buttons', function (assert) {
+  const contexts = [
+    { context: 'github:github.com', displayName: 'github' },
+    { context: 'github:mygit.org', displayName: 'mygit' }
+  ];
+
+  assert.expect(5);
+  this.set('externalAction', (context) => {
+    assert.ok(context);
+  });
+  this.set('model', contexts);
+  this.render(hbs`{{login-button authenticate=(action externalAction) contexts=model}}`);
+
+  assert.equal(this.$('a').length, 2);
+  contexts.forEach((context, index) => {
+    assert.equal(this.$(`a:eq(${index})`).text(), ` Login with ${context.displayName}`);
+    this.$(`a:eq(${index})`).click();
+  });
+});


### PR DESCRIPTION
## Context

Multiple SCM feature API has been implemented to API(#365).
There is no multiple scm support for UI yet, so we can't test it.

## Objective

I added the support for multiple scms feature to the UI so that we can test the feature on cd.screwdriver.cd.
New login page uses `/v4/auth/contexts` API to show buttons for each scm. It shows the same button as current one if the API returns an error, for backward compatibility.

When the contexts API returns data as below,
```
[
  {
    "context": "github:github.com",
    "displayName": "github"
  },
  {
    "context": "github:mygithubinstance.mycompany.com",
    "displayName": "mygithub_instance"
  }
]
```
UI shows buttons as below.
![image](https://user-images.githubusercontent.com/1608595/29249312-f0c9ac9a-8067-11e7-8408-6ac82de36472.png)


## References

Multiple SCMs feature: screwdriver-cd/screwdriver#365

TODO:
- [x] API change for UI: screwdriver-cd/screwdriver#692 