### PR TITLE
feat(collections): Add remove pipeline functionality

### DIFF
--- a/app/components/collection-view/component.js
+++ b/app/components/collection-view/component.js
@@ -1,4 +1,24 @@
 import Ember from 'ember';
 
 export default Ember.Component.extend({
+  session: Ember.inject.service(),
+  removePipelineError: null,
+  actions: {
+    /**
+     * Action to remove a pipeline from a collection
+     *
+     * @param {Number} pipelineId - id of pipeline to remove
+     * @param {Number} collectionId - id of collection to remove from
+     * @returns {Promise}
+     */
+    pipelineRemove(pipelineId, collectionId) {
+      return this.get('onPipelineRemove')(+pipelineId, collectionId)
+        .then(() => {
+          this.set('removePipelineError', null);
+        })
+        .catch((error) => {
+          this.set('removePipelineError', error.errors[0].detail);
+        });
+    }
+  }
 });

--- a/app/components/collection-view/styles.scss
+++ b/app/components/collection-view/styles.scss
@@ -42,6 +42,17 @@
   .collection-table {
     padding: 25px;
   }
+
+  .collection-pipeline__remove {
+    opacity: 0;
+    cursor: pointer;
+    font-size: 1.5em;
+  }
+
+  // When collection-pipeline is hovered on, show remove button
+  .collection-pipeline:hover .collection-pipeline__remove {
+    opacity: 1;
+  }
 }
 
 @media (max-width: 47.999em) {

--- a/app/components/collection-view/template.hbs
+++ b/app/components/collection-view/template.hbs
@@ -1,4 +1,7 @@
 <div>
+  {{#if removePipelineError}}
+    {{info-message message=removePipelineError type="warning" icon="exclamation-triangle"}}
+  {{/if}}
   <div class="header">
     <h2>{{collection.name}}</h2>
     {{#if collection.description}}
@@ -11,15 +14,25 @@
         <tr>
           <th class="app-id">Name</th>
           <th class="branch">Branch</th>
+          {{#if session.isAuthenticated}}
+            <th></th>
+          {{/if}}
         </tr>
       </thead>
       <tbody>
         {{#each collection.pipelines as |pipeline|}}
-          <tr>
+          <tr class="collection-pipeline">
             <td class="app-id">
               {{#highlight-terms query}}{{#link-to "pipeline" pipeline.id}}{{pipeline.scmRepo.name}}{{/link-to}}{{/highlight-terms}}
             </td>
             <td class="branch">{{fa-icon "fa-code-fork"}}{{pipeline.scmRepo.branch}}</td>
+            {{#if session.isAuthenticated}}
+              <td onclick={{action "pipelineRemove" pipeline.id collection.id}} class="collection-pipeline__remove">
+                <span>
+                  &times;
+                </span>
+              </td>
+            {{/if}}
           </tr>
         {{/each}}
       </tbody>

--- a/app/components/collections-flyout/styles.scss
+++ b/app/components/collections-flyout/styles.scss
@@ -1,6 +1,5 @@
 & {
-  border-right: 1px solid $sd-text-light;
-  border-bottom: 1px solid $sd-text-light;
+  max-width: 275px;
 
   a {
     cursor: pointer;

--- a/app/dashboard/show/controller.js
+++ b/app/dashboard/show/controller.js
@@ -1,0 +1,16 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  actions: {
+    removePipeline(pipelineId, collectionId) {
+      return this.store.findRecord('collection', collectionId)
+        .then((collection) => {
+          const pipelineIds = collection.get('pipelineIds') || [];
+
+          collection.set('pipelineIds', pipelineIds.filter(id => id !== pipelineId));
+
+          return collection.save();
+        });
+    }
+  }
+});

--- a/app/dashboard/show/template.hbs
+++ b/app/dashboard/show/template.hbs
@@ -1,6 +1,10 @@
 <div class="row">
-  {{collections-flyout class="col-md-2" selectedCollectionId=model.id}}
-  {{collection-view collection=model class="col-md-10"}}
+  {{collections-flyout class="col-md-3" selectedCollectionId=model.id}}
+  {{collection-view
+      onPipelineRemove=(action "removePipeline")
+      collection=model
+      class="col-md-9"
+  }}
 </div>
 
 {{outlet}}

--- a/tests/acceptance/dashboards-test.js
+++ b/tests/acceptance/dashboards-test.js
@@ -112,7 +112,7 @@ test('visiting / when logged in and have collections', function (assert) {
     assert.equal(find('th.app-id').text().trim(), 'Name');
     assert.equal(find('th.branch').text().trim(), 'Branch');
     assert.equal(find('tr').length, 3);
-    assert.equal(find('td').length, 4);
+    assert.equal(find('td').length, 6);
   });
 });
 
@@ -146,7 +146,7 @@ test('visiting /dashboards/1', function (assert) {
     assert.equal(find('th.app-id').text().trim(), 'Name');
     assert.equal(find('th.branch').text().trim(), 'Branch');
     assert.equal(find('tr').length, 3);
-    assert.equal(find('td').length, 4);
+    assert.equal(find('td').length, 6);
   });
 });
 

--- a/tests/integration/components/collection-view/component-test.js
+++ b/tests/integration/components/collection-view/component-test.js
@@ -2,51 +2,57 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
 
+import injectSessionStub from '../../../helpers/inject-session';
+
+let testCollection;
+
 moduleForComponent('collection-view', 'Integration | Component | collection view', {
-  integration: true
+  integration: true,
+  beforeEach() {
+    testCollection = Ember.Object.create({
+      id: 1,
+      name: 'Test',
+      description: 'Test Collection',
+      pipelines: [
+        {
+          id: 1,
+          scmUri: 'github.com:12345678:master',
+          createTime: '2017-01-05T00:55:46.775Z',
+          admins: {
+            username: true
+          },
+          workflow: ['main', 'publish'],
+          scmRepo: {
+            name: 'screwdriver-cd/screwdriver',
+            branch: 'master',
+            url: 'https://github.com/screwdriver-cd/screwdriver/tree/master'
+          },
+          annotations: {}
+        },
+        {
+          id: 2,
+          scmUri: 'github.com:87654321:master',
+          createTime: '2017-01-05T00:55:46.775Z',
+          admins: {
+            username: true
+          },
+          workflow: ['main', 'publish'],
+          scmRepo: {
+            name: 'screwdriver-cd/ui',
+            branch: 'master',
+            url: 'https://github.com/screwdriver-cd/ui/tree/master'
+          },
+          annotations: {}
+        }
+      ]
+    });
+  }
 });
 
 test('it renders', function (assert) {
   // Set any properties with this.set('myProperty', 'value');
   // Handle any actions with this.on('myAction', function(val) { ... });
   const $ = this.$;
-  const testCollection = Ember.Object.create({
-    id: 1,
-    name: 'Test',
-    description: 'Test Collection',
-    pipelines: [
-      {
-        id: 12742,
-        scmUri: 'github.com:12345678:master',
-        createTime: '2017-01-05T00:55:46.775Z',
-        admins: {
-          username: true
-        },
-        workflow: ['main', 'publish'],
-        scmRepo: {
-          name: 'screwdriver-cd/screwdriver',
-          branch: 'master',
-          url: 'https://github.com/screwdriver-cd/screwdriver/tree/master'
-        },
-        annotations: {}
-      },
-      {
-        id: 12743,
-        scmUri: 'github.com:87654321:master',
-        createTime: '2017-01-05T00:55:46.775Z',
-        admins: {
-          username: true
-        },
-        workflow: ['main', 'publish'],
-        scmRepo: {
-          name: 'screwdriver-cd/ui',
-          branch: 'master',
-          url: 'https://github.com/screwdriver-cd/ui/tree/master'
-        },
-        annotations: {}
-      }
-    ]
-  });
 
   this.set('mockCollection', testCollection);
 
@@ -62,4 +68,89 @@ test('it renders', function (assert) {
   assert.equal($('tr').length, 3);
   assert.equal($($('td.app-id').get(0)).text().trim(), 'screwdriver-cd/screwdriver');
   assert.equal($($('td.app-id').get(1)).text().trim(), 'screwdriver-cd/ui');
+});
+
+test('it removes a pipeline from a collection', function (assert) {
+  assert.expect(2);
+
+  injectSessionStub(this);
+  const $ = this.$;
+  const pipelineRemoveMock = (pipelineId, collectionId) => {
+    assert.strictEqual(pipelineId, 1);
+    assert.strictEqual(collectionId, 1);
+
+    return Ember.RSVP.resolve({
+      id: 1,
+      name: 'collection1',
+      description: 'description1',
+      pipelineIds: [1],
+      pipelines: [
+        {
+          id: 1,
+          scmUri: 'github.com:12345678:master',
+          createTime: '2017-01-05T00:55:46.775Z',
+          admins: {
+            username: true
+          },
+          workflow: ['main', 'publish'],
+          scmRepo: {
+            name: 'screwdriver-cd/screwdriver',
+            branch: 'master',
+            url: 'https://github.com/screwdriver-cd/screwdriver/tree/master'
+          },
+          annotations: {}
+        }
+      ]
+    });
+  };
+
+  this.set('mockCollection', testCollection);
+  this.set('onPipelineRemoveMock', pipelineRemoveMock);
+
+  this.render(hbs`
+    {{collection-view
+        collection=mockCollection
+        onPipelineRemove=onPipelineRemoveMock
+    }}
+  `);
+
+  $($('.collection-pipeline__remove').get(0)).click();
+});
+
+test('it fails to remove a pipeline', function (assert) {
+  assert.expect(1);
+
+  injectSessionStub(this);
+  const $ = this.$;
+  const pipelineRemoveMock = () => Ember.RSVP.reject({
+    errors: [{
+      detail: 'User does not have permission'
+    }]
+  });
+
+  this.set('mockCollection', testCollection);
+  this.set('onPipelineRemoveMock', pipelineRemoveMock);
+
+  this.render(hbs`
+    {{collection-view
+        collection=mockCollection
+        onPipelineRemove=onPipelineRemoveMock
+    }}
+  `);
+
+  $($('.collection-pipeline__remove').get(0)).click();
+
+  assert.strictEqual($('.alert-warning > span').text().trim(),
+    'User does not have permission');
+});
+
+test('it does not show remove button if user is not logged in', function (assert) {
+  assert.expect(1);
+
+  const $ = this.$;
+
+  this.set('mockCollection', testCollection);
+  this.render(hbs`{{collection-view collection=mockCollection}}`);
+
+  assert.strictEqual($('.collection-pipeline__remove').length, 0);
 });

--- a/tests/unit/dashboard/show/controller-test.js
+++ b/tests/unit/dashboard/show/controller-test.js
@@ -1,12 +1,13 @@
 import { moduleFor, test } from 'ember-qunit';
 import Ember from 'ember';
-import injectSessionStub from '../../helpers/inject-session';
+import injectSessionStub from '../../../helpers/inject-session';
 
-moduleFor('controller:search', 'Unit | Controller | search', {
+moduleFor('controller:dashboard/show', 'Unit | Controller | dashboard/show', {
   // Specify the other units that are required for this test.
   // needs: ['controller:foo']
 });
 
+// Replace this with your real tests.
 test('it exists', function (assert) {
   injectSessionStub(this);
   const controller = this.subject();
@@ -14,10 +15,10 @@ test('it exists', function (assert) {
   assert.ok(controller);
 });
 
-test('it calls addToCollection', function (assert) {
+test('it calls removePipeline', function (assert) {
   injectSessionStub(this);
   const controller = this.subject();
-  let pipelineIds = [1, 2];
+  let pipelineIds = [1, 2, 3];
 
   const collectionModelMock = {
     id: 1,
@@ -27,23 +28,23 @@ test('it calls addToCollection', function (assert) {
     get(field) {
       assert.strictEqual(field, 'pipelineIds');
 
-      // The collection currently has pipelineIds 1 and 2
+      // The collections currently has pipelineIds 1, 2 and 3
       return pipelineIds;
     },
     set(field, value) {
       assert.strictEqual(field, 'pipelineIds');
-      assert.deepEqual(value, [1, 2, 3]);
+      assert.deepEqual(value, [1, 2]);
 
       pipelineIds = value;
     },
     save() {
-      assert.deepEqual(pipelineIds, [1, 2, 3]);
+      assert.deepEqual(pipelineIds, [1, 2]);
 
       return Ember.RSVP.resolve({
         id: 1,
         name: 'collection1',
         description: 'description1',
-        pipelineIds: [1, 2, 3]
+        pipelineIds: [1, 2]
       });
     }
   };
@@ -57,6 +58,6 @@ test('it calls addToCollection', function (assert) {
     }
   });
 
-  // Add pipeline with id 3 to collection with id 1
-  controller.send('addToCollection', 3, 1);
+  // Remove pipeline with id 3 from collection with id 1
+  controller.send('removePipeline', 3, 1);
 });


### PR DESCRIPTION
## Context

Users need to be able to remove pipelines from a collection (if they own it).

## Objective

This PR adds functionality to allow users to remove pipelines that they don't want to have in a collection

Example:

![Screen](https://media.giphy.com/media/3oEhn2LKlre0LBhAqY/giphy.gif)

## Reference

Issue: [screwdriver-cd/screwdriver#523](https://github.com/screwdriver-cd/screwdriver/issues/523)