### PR TITLE
feat(collections): Add last builds health to dashboard

### DIFF
--- a/app/components/build-health/component.js
+++ b/app/components/build-health/component.js
@@ -1,0 +1,30 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  tagName: 'span',
+  className: ['build-health'],
+  icon: Ember.computed('build', 'build.status', {
+    get() {
+      const build = this.get('build');
+
+      if (!build) {
+        return '';
+      }
+
+      switch (build.status) {
+      case 'SUCCESS':
+        return 'check';
+      case 'FAILURE':
+        return 'times';
+      case 'ABORTED':
+        return 'stop';
+      case 'RUNNING':
+        return 'fa-spinner fa-spin';
+      case 'QUEUED':
+        return 'clock-o';
+      default:
+        return 'question';
+      }
+    }
+  })
+});

--- a/app/components/build-health/styles.scss
+++ b/app/components/build-health/styles.scss
@@ -1,0 +1,40 @@
+& {
+  text-align: center;
+  display: inline-block;
+  font-weight: 300;
+
+  a {
+    display: inline-block;
+    color: $sd-text-med;
+    text-decoration: none;
+    cursor: pointer;
+
+    &:hover {
+      text-decoration: none;
+    }
+  }
+
+  .status {
+    display: inline-block;
+    border-radius: 32px;
+    border: 4px solid $sd-text-light;
+    width: 24px;
+    height: 24px;
+    font-size: 11px;
+
+    &--SUCCESS {
+      color: $sd-success;
+      border-color: $sd-success;
+    }
+
+    &--FAILURE, &--ABORTED {
+      color: $sd-failure;
+      border-color: $sd-failure;
+    }
+
+    &--RUNNING, &--QUEUED {
+      color: $sd-running;
+      border-color: $sd-running;
+    }
+  }
+}

--- a/app/components/build-health/template.hbs
+++ b/app/components/build-health/template.hbs
@@ -1,0 +1,3 @@
+{{#link-to "pipeline.builds.build" pipelineId build.id title=jobName}}
+  <span class="status status--{{build.status}}">{{fa-icon icon}}</span>
+{{/link-to}}

--- a/app/components/collection-view/template.hbs
+++ b/app/components/collection-view/template.hbs
@@ -14,6 +14,7 @@
         <tr>
           <th class="app-id">Name</th>
           <th class="branch">Branch</th>
+          <th class="health">Last Build</th>
           {{#if session.isAuthenticated}}
             <th></th>
           {{/if}}
@@ -26,6 +27,15 @@
               {{#highlight-terms query}}{{#link-to "pipeline" pipeline.id}}{{pipeline.scmRepo.name}}{{/link-to}}{{/highlight-terms}}
             </td>
             <td class="branch">{{fa-icon "fa-code-fork"}}{{pipeline.scmRepo.branch}}</td>
+            <td class="health">
+              {{#each pipeline.workflow as |job index|}}
+                {{#if pipeline.lastBuilds}}
+                  {{build-health pipelineId=pipeline.id build=(index-of pipeline.lastBuilds index) jobName=job}}
+                {{else}}
+                  {{build-health}}
+                {{/if}}
+              {{/each}}
+            </td>
             {{#if session.isAuthenticated}}
               <td onclick={{action "pipelineRemove" pipeline.id collection.id}} class="collection-pipeline__remove">
                 <span>

--- a/tests/acceptance/dashboards-test.js
+++ b/tests/acceptance/dashboards-test.js
@@ -112,7 +112,7 @@ test('visiting / when logged in and have collections', function (assert) {
     assert.equal(find('th.app-id').text().trim(), 'Name');
     assert.equal(find('th.branch').text().trim(), 'Branch');
     assert.equal(find('tr').length, 3);
-    assert.equal(find('td').length, 6);
+    assert.equal(find('td').length, 8);
   });
 });
 
@@ -146,7 +146,7 @@ test('visiting /dashboards/1', function (assert) {
     assert.equal(find('th.app-id').text().trim(), 'Name');
     assert.equal(find('th.branch').text().trim(), 'Branch');
     assert.equal(find('tr').length, 3);
-    assert.equal(find('td').length, 6);
+    assert.equal(find('td').length, 8);
   });
 });
 

--- a/tests/integration/components/build-health/component-test.js
+++ b/tests/integration/components/build-health/component-test.js
@@ -1,0 +1,92 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import Ember from 'ember';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('build-health', 'Integration | Component | build health', {
+  integration: true
+});
+
+test('it renders a success bubble', function (assert) {
+  const buildMock = Ember.Object.create({
+    id: 1,
+    status: 'SUCCESS'
+  });
+
+  this.set('buildMock', buildMock);
+
+  this.render(hbs`{{build-bubble build=buildMock pipelineId=1}}`);
+
+  assert.ok(this.$('a i').hasClass('fa-check'));
+});
+
+test('it renders a failure bubble', function (assert) {
+  const buildMock = Ember.Object.create({
+    id: 1,
+    status: 'FAILURE'
+  });
+
+  this.set('buildMock', buildMock);
+
+  this.render(hbs`{{build-bubble build=buildMock pipelineId=1}}`);
+
+  assert.ok(this.$('a i').hasClass('fa-times'));
+});
+
+test('it renders a running bubble', function (assert) {
+  const buildMock = Ember.Object.create({
+    id: 1,
+    status: 'RUNNING'
+  });
+
+  this.set('buildMock', buildMock);
+
+  this.render(hbs`{{build-bubble build=buildMock piplineId=1}}`);
+
+  assert.ok(this.$('a i').hasClass('fa-spinner'));
+  assert.ok(this.$('a i').hasClass('fa-spin'));
+});
+
+test('it renders a queued bubble', function (assert) {
+  const buildMock = Ember.Object.create({
+    id: 1,
+    status: 'QUEUED'
+  });
+
+  this.set('buildMock', buildMock);
+
+  this.render(hbs`{{build-bubble build=buildMock pipelineId=1}}`);
+
+  assert.ok(this.$('a i').hasClass('fa-clock-o'));
+});
+
+test('it renders an aborted bubble', function (assert) {
+  const buildMock = Ember.Object.create({
+    id: 1,
+    status: 'ABORTED'
+  });
+
+  this.set('buildMock', buildMock);
+
+  this.render(hbs`{{build-bubble build=buildMock pipelineId=1}}`);
+
+  assert.ok(this.$('a i').hasClass('fa-stop'));
+});
+
+test('it renders an unknown bubble', function (assert) {
+  const buildMock = Ember.Object.create({
+    id: 1,
+    status: 'banana'
+  });
+
+  this.set('buildMock', buildMock);
+
+  this.render(hbs`{{build-bubble build=buildMock pipelineId=1}}`);
+
+  assert.ok(this.$('a i').hasClass('fa-question'));
+});
+
+test('it renders an empty bubble', function (assert) {
+  this.render(hbs`{{build-bubble}}`);
+
+  assert.ok(this.$('a i').length);
+});

--- a/tests/integration/components/collection-view/component-test.js
+++ b/tests/integration/components/collection-view/component-test.js
@@ -27,7 +27,18 @@ moduleForComponent('collection-view', 'Integration | Component | collection view
             branch: 'master',
             url: 'https://github.com/screwdriver-cd/screwdriver/tree/master'
           },
-          annotations: {}
+          annotations: {},
+          lastEventId: 12,
+          lastBuilds: [
+            {
+              id: 123,
+              status: 'SUCCESS'
+            },
+            {
+              id: 124,
+              status: 'FAILURE'
+            }
+          ]
         },
         {
           id: 2,
@@ -65,9 +76,18 @@ test('it renders', function (assert) {
   assert.equal($('table').length, 1);
   assert.equal($('th.app-id').text().trim(), 'Name');
   assert.equal($('th.branch').text().trim(), 'Branch');
+  assert.equal($('th.health').text().trim(), 'Last Build');
   assert.equal($('tr').length, 3);
   assert.equal($($('td.app-id').get(0)).text().trim(), 'screwdriver-cd/screwdriver');
   assert.equal($($('td.app-id').get(1)).text().trim(), 'screwdriver-cd/ui');
+  // Since both pipelines have two jobs, there will be 4 build icons in total
+  assert.equal($('td.health i').length, 4);
+  assert.equal($($('td.health i').get(0)).attr('class'), 'fa fa-check ember-view');
+  assert.equal($($('td.health i').get(1)).attr('class'), 'fa fa-times ember-view');
+  // The build icons for the second pipeline should be empty circles since
+  // there are no builds
+  assert.equal($($('td.health i').get(2)).attr('class'), 'fa ember-view');
+  assert.equal($($('td.health i').get(3)).attr('class'), 'fa ember-view');
 });
 
 test('it removes a pipeline from a collection', function (assert) {


### PR DESCRIPTION
## Context

Users want to see the last builds health for each of the pipelines in their collection on the dashboard

## Objective

This PR adds last builds health to the dashboard

Screenshot:
![image](https://user-images.githubusercontent.com/12389411/29677650-9c281388-88b0-11e7-89ab-4bd3beb47516.png)

## References

Issue: [screwdriver-cd/screwdriver#523](https://github.com/screwdriver-cd/screwdriver/issues/523)
