### PR TITLE
fix: navigating to newly created collection should work

### DIFF
--- a/app/components/collections-flyout/component.js
+++ b/app/components/collections-flyout/component.js
@@ -1,24 +1,7 @@
 import Ember from 'ember';
-import DS from 'ember-data';
-
-const formatCollection = (collection, currentCollectionId) => ({
-  id: collection.get('id'),
-  name: collection.get('name'),
-  current: collection.id === currentCollectionId
-});
 
 export default Ember.Component.extend({
-  collections: Ember.computed('storeCollections.[]', 'selectedCollectionId', {
-    get() {
-      let currentCollectionId = this.get('selectedCollectionId');
-
-      return DS.PromiseArray.create({
-        promise: this.get('storeCollections').then(collections =>
-          collections.map(collection => formatCollection(collection, currentCollectionId)))
-      });
-    }
-  }),
-  storeCollections: Ember.computed('store', {
+  collections: Ember.computed('store', {
     get() {
       return this.get('store').findAll('collection');
     }

--- a/app/components/collections-flyout/template.hbs
+++ b/app/components/collections-flyout/template.hbs
@@ -12,7 +12,7 @@
     {{/if}}
   </div>
     {{#each collections as |collection|}}
-      <div class="collection-wrapper row{{if collection.current ' row--active'}}">
+      <div class="collection-wrapper row {{if (eq collection.id selectedCollectionId) ' row--active'}}">
         {{#link-to "dashboard.show" collection.id}}
           {{collection.name}}
         {{/link-to}}

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "ember-sinon-qunit": "^1.5.0",
     "ember-source": "~2.14.0",
     "ember-toggle": "^4.0.2",
+    "ember-truth-helpers": "^1.3.0",
     "eslint": "^3.19.0",
     "eslint-config-screwdriver": "^2.1.2",
     "loader.js": "^4.2.3",

--- a/tests/integration/components/collections-flyout/component-test.js
+++ b/tests/integration/components/collections-flyout/component-test.js
@@ -156,22 +156,16 @@ test('it renders an active collection', function (assert) {
   assert.expect(4);
   const $ = this.$;
 
-  const storeStub = Ember.Object.extend({
-    findAll() {
-      return new Ember.RSVP.Promise(resolve => resolve([mockCollection]));
-    }
-  });
-
-  this.register('service:store', storeStub);
-  this.inject.service('store');
+  this.set('collections', [Ember.Object.create(mockCollection)]);
 
   this.set('selectedCollectionId', 1);
 
-  this.render(hbs`{{collections-flyout selectedCollectionId=selectedCollectionId}}`);
+  this.render(hbs`{{collections-flyout collections=collections
+    selectedCollectionId=selectedCollectionId}}`);
 
   assert.equal($('.header__text').text().trim(), 'Collections');
   assert.notOk($('.header__text a i').length);
-  assert.equal($($('.collection-wrapper a').get(0)).text().trim(), 'name');
+  assert.equal($($('.collection-wrapper a').get(0)).text().trim(), 'Test');
   assert.equal($('.collection-wrapper.row--active').length, 1);
 });
 


### PR DESCRIPTION
## Context

Currently if you create a new collection and then try to navigate to it, navigation won't work. This PR fixes it.

@joelseq @r3rastogi 