### PR TITLE
fix: fix link of token api guide

### DIFF
--- a/app/components/token-list/template.hbs
+++ b/app/components/token-list/template.hbs
@@ -10,7 +10,7 @@
   {{/bs-alert}}
 {{/if}}
 <p>
-  User access tokens provide access to the <a href="http://docs.screwdriver.cd/user-guide/api/">Screwdriver API</a>. They are scoped to your account.
+  User access tokens provide access to the <a href="http://docs.screwdriver.cd/user-guide/api">Screwdriver API</a>. They are scoped to your account.
 </p>
 <table class="token-list">
   <thead>


### PR DESCRIPTION
This PR fix link of the document on the access tokens page.
Same as https://github.com/screwdriver-cd/ui/pull/209