### PR TITLE
feat(collections): Add pr info to dashboard

### DIFF
--- a/app/components/collection-view/styles.scss
+++ b/app/components/collection-view/styles.scss
@@ -20,6 +20,14 @@
     text-align: right;
   }
 
+  .prs {
+    border-bottom: none;
+
+    &--failing {
+      color: $sd-failure;
+    }
+  }
+
   tbody tr:hover {
     background-color: $sd-separator;
     .name {

--- a/app/components/collection-view/template.hbs
+++ b/app/components/collection-view/template.hbs
@@ -12,12 +12,17 @@
     <table class="col-md-10">
       <thead>
         <tr>
-          <th class="app-id">Name</th>
-          <th class="branch">Branch</th>
-          <th class="health">Last Build</th>
+          <th class="app-id" rowspan=2>Name</th>
+          <th class="branch" rowspan=2>Branch</th>
+          <th class="health" rowspan=2>Last Build</th>
+          <th class="prs" colspan=2>Pull Requests</th>
           {{#if session.isAuthenticated}}
-            <th></th>
+            <th rowspan=2></th>
           {{/if}}
+        </tr>
+        <tr>
+          <th>Open</th>
+          <th>Failing</th>
         </tr>
       </thead>
       <tbody>
@@ -35,6 +40,16 @@
                   {{build-health}}
                 {{/if}}
               {{/each}}
+            </td>
+            <td class="prs--open">
+              {{#if pipeline.prs}}
+                {{pipeline.prs.open}}
+              {{/if}}
+            </td>
+            <td class="prs--failing">
+              {{#if pipeline.prs}}
+                {{pipeline.prs.failing}}
+              {{/if}}
             </td>
             {{#if session.isAuthenticated}}
               <td onclick={{action "pipelineRemove" pipeline.id collection.id}} class="collection-pipeline__remove">

--- a/tests/acceptance/dashboards-test.js
+++ b/tests/acceptance/dashboards-test.js
@@ -37,7 +37,18 @@ moduleForAcceptance('Acceptance | dashboards', {
                 branch: 'master',
                 url: 'https://github.com/screwdriver-cd/screwdriver/tree/master'
               },
-              annotations: {}
+              annotations: {},
+              lastEventId: 12,
+              lastBuilds: [
+                {
+                  id: 123,
+                  status: 'SUCCESS'
+                },
+                {
+                  id: 124,
+                  status: 'FAILURE'
+                }
+              ]
             },
             {
               id: 12743,
@@ -52,7 +63,11 @@ moduleForAcceptance('Acceptance | dashboards', {
                 branch: 'master',
                 url: 'https://github.com/screwdriver-cd/ui/tree/master'
               },
-              annotations: {}
+              annotations: {},
+              prs: {
+                open: 2,
+                failing: 1
+              }
             }
           ]
         }
@@ -111,8 +126,8 @@ test('visiting / when logged in and have collections', function (assert) {
     assert.equal(find('table').length, 1);
     assert.equal(find('th.app-id').text().trim(), 'Name');
     assert.equal(find('th.branch').text().trim(), 'Branch');
-    assert.equal(find('tr').length, 3);
-    assert.equal(find('td').length, 8);
+    assert.equal(find('tr').length, 4);
+    assert.equal(find('td').length, 12);
   });
 });
 
@@ -145,8 +160,8 @@ test('visiting /dashboards/1', function (assert) {
     assert.equal(find('table').length, 1);
     assert.equal(find('th.app-id').text().trim(), 'Name');
     assert.equal(find('th.branch').text().trim(), 'Branch');
-    assert.equal(find('tr').length, 3);
-    assert.equal(find('td').length, 8);
+    assert.equal(find('tr').length, 4);
+    assert.equal(find('td').length, 12);
   });
 });
 

--- a/tests/integration/components/collection-view/component-test.js
+++ b/tests/integration/components/collection-view/component-test.js
@@ -53,7 +53,11 @@ moduleForComponent('collection-view', 'Integration | Component | collection view
             branch: 'master',
             url: 'https://github.com/screwdriver-cd/ui/tree/master'
           },
-          annotations: {}
+          annotations: {},
+          prs: {
+            open: 2,
+            failing: 1
+          }
         }
       ]
     });
@@ -77,7 +81,8 @@ test('it renders', function (assert) {
   assert.equal($('th.app-id').text().trim(), 'Name');
   assert.equal($('th.branch').text().trim(), 'Branch');
   assert.equal($('th.health').text().trim(), 'Last Build');
-  assert.equal($('tr').length, 3);
+  assert.equal($('th.prs').text().trim(), 'Pull Requests');
+  assert.equal($('tr').length, 4);
   assert.equal($($('td.app-id').get(0)).text().trim(), 'screwdriver-cd/screwdriver');
   assert.equal($($('td.app-id').get(1)).text().trim(), 'screwdriver-cd/ui');
   // Since both pipelines have two jobs, there will be 4 build icons in total
@@ -88,6 +93,12 @@ test('it renders', function (assert) {
   // there are no builds
   assert.equal($($('td.health i').get(2)).attr('class'), 'fa ember-view');
   assert.equal($($('td.health i').get(3)).attr('class'), 'fa ember-view');
+  // The first pipeline should not have any info for prs open and failing
+  assert.equal($($('td.prs--open').get(0)).text().trim(), '');
+  assert.equal($($('td.prs--failing').get(0)).text().trim(), '');
+  // The second pipeline should have 2 prs open and 1 failing
+  assert.equal($($('td.prs--open').get(1)).text().trim(), '2');
+  assert.equal($($('td.prs--failing').get(1)).text().trim(), '1');
 });
 
 test('it removes a pipeline from a collection', function (assert) {


### PR DESCRIPTION
## Context

For the dashboard, users want information about the number of pull requests that are open and failing for each of the pipelines in the collection

## Objective

This PR displays the pr info for each pipeline in the collection

Screenshot:
![image](https://user-images.githubusercontent.com/12389411/29793617-5e155492-8bf9-11e7-8e57-2ac952c2a26f.png)

## References

Issue: [screwdriver-cd/screwdriver#523](https://github.com/screwdriver-cd/screwdriver/issues/523)

Blocked by: [screwdriver-cd/screwdriver#724](https://github.com/screwdriver-cd/screwdriver/pull/724)