### PR TITLE
fix: use environment variable to badge url

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -47,7 +47,8 @@ http {
                ngx.say("window.SUPPLEMENTARY_CONFIG = { SDAPI_HOSTNAME: '", os.getenv("ECOSYSTEM_API"), "', SDSTORE_HOSTNAME: '", os.getenv("ECOSYSTEM_STORE"), "'  };")
            }
         }
-
-        rewrite ^/pipelines/([^/]*)/badge$ https://api.screwdriver.cd/v4/pipelines/$1/badge redirect;
+        
+        set_by_lua $ecosystem_api 'return os.getenv("ECOSYSTEM_API")';
+        rewrite ^/pipelines/([^/]*)/badge$ $ecosystem_api/v4/pipelines/$1/badge redirect;
     }
 }


### PR DESCRIPTION
We should change a redirect url of badge api but it is hard coded.
This PR provides to use ECOSYSTEM_API to determine the url of API.