### PR TITLE
fix: use targets and real browsers

### DIFF
--- a/bin/setup_chrome.sh
+++ b/bin/setup_chrome.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
+sh -c 'echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
+apt-get update -qy
+apt-get install -qy google-chrome-stable
+ln -s /usr/bin/google-chrome /usr/bin/chrome

--- a/bin/setup_firefox.sh
+++ b/bin/setup_firefox.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+cd /tmp
+wget https://download-installer.cdn.mozilla.net/pub/firefox/releases/55.0/linux-x86_64/en-US/firefox-55.0.tar.bz2
+tar xvf firefox-55.0.tar.bz2
+ln -s /tmp/firefox/firefox /usr/bin/firefox

--- a/config/targets.js
+++ b/config/targets.js
@@ -2,8 +2,8 @@
 
 module.exports = {
   browsers: [
-    // 'last 1 Chrome versions'
-    // 'last 1 Firefox versions'
-    // 'last 1 Safari versions'
+    'last 1 Chrome versions',
+    'last 1 Firefox versions',
+    'last 1 Safari versions'
   ]
 };

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -11,6 +11,7 @@ jobs:
     steps:
       - install: npm install
       - bower: npm install bower && ./node_modules/.bin/bower install --allow-root
+      - install-browsers: ./bin/setup_chrome.sh
       - test: npm test
 
   # Publish the package to GitHub and build docker image

--- a/testem.js
+++ b/testem.js
@@ -3,10 +3,21 @@ module.exports = {
   test_page: 'tests/index.html?hidepassed',
   disable_watching: true,
   launch_in_ci: [
-    'PhantomJS'
+    'Chrome'
   ],
   launch_in_dev: [
-    'PhantomJS',
-    'Chrome'
-  ]
+    'Chrome',
+    'Firefox'
+  ],
+  "browser_args": {
+    "Chrome": [
+      "--headless",
+      "--disable-gpu",
+      "--remote-debugging-port=9222",
+      "--no-sandbox"
+    ],
+    "Firefox": [
+      "-headless"
+    ]
+  }
 };


### PR DESCRIPTION
# Context:
phantomjs is no longer maintained, and has not had an update since 1/2016. phantomjs does not support any ES2105 syntax, and tests will break when the transpiled code is created for current browsers. Newer browser releases now support a headless mode, which means we can test with the actual browsers we support.

## Objective
* Utilize [ember-cli targets](http://rwjblue.com/2017/04/21/ember-cli-targets/) to produce sane transpiled code for evergreen browsers. 
* Test with `chrome` in CI mode [`ember test`] instead of `phantomjs`
* Test with `chrome` and `firefox` in dev mode [`ember test --server`]

## Caveats
* The `node:6` container does not support user namespaces, so Chrome must run with the `--no-sandbox` flag. This is normally not recommended.
* Headless Chrome was introduced in Chrome 59. This should install at least Chrome 61.
* Headless Firefox works on Firefox 55 on linux, and Firefox 56 on macOS. Firefox 56 is still the beta version and can be fetched from [here](https://www.mozilla.org/en-US/firefox/channel/desktop/#beta). 
* When testing in dev mode [`ember test --server`], in order to get a "headed" browser, you must visit a link in a browser that is provided by the test framework on startup. A "headed" browser will not be started automatically anymore.
