### PR TITLE
fix: Change Builds title to Events on pipeline page

### DIFF
--- a/app/components/pipeline-events-list/template.hbs
+++ b/app/components/pipeline-events-list/template.hbs
@@ -1,4 +1,4 @@
-<h2>Builds</h2>
+<h2>Events</h2>
 {{#each eventsToView as |event|}}
 {{pipeline-event-view event=event}}
 {{/each}}

--- a/tests/acceptance/pipeline-builds-test.js
+++ b/tests/acceptance/pipeline-builds-test.js
@@ -215,7 +215,7 @@ test('visiting /pipelines/4', function (assert) {
     assert.equal(find('.pipelineWorkflow .build-bubble').length, 2, 'not enough workflow');
     assert.equal(find('button.start-button').length, 0, 'should not have a start button');
     assert.equal(find('ul.nav-pills').length, 0, 'should not show options or secrets tabs');
-    assert.equal(find('.col-md-9 h2').text().trim(), 'Builds');
+    assert.equal(find('.col-md-9 h2').text().trim(), 'Events');
     assert.equal(find('.col-md-3 h2').text().trim(), 'Pull Requests');
     assert.equal(find('.col-md-9 > div > div.ember-view').length, 2);
   });

--- a/tests/integration/components/pipeline-events-list/component-test.js
+++ b/tests/integration/components/pipeline-events-list/component-test.js
@@ -68,6 +68,6 @@ test('it renders', function (assert) {
   this.set('eventsMock', events);
   this.render(hbs`{{pipeline-events-list events=eventsMock}}`);
 
-  assert.equal(this.$('h2').text().trim(), 'Builds');
+  assert.equal(this.$('h2').text().trim(), 'Events');
   assert.equal(this.$('> div').length, 1);
 });


### PR DESCRIPTION
It was confusing for users to have the title "Builds" on the Pipeline page. Changing it to "Events" to be more accurate.

<img width="1289" alt="screen shot 2017-09-19 at 5 36 06 pm" src="https://user-images.githubusercontent.com/3230529/30621635-10ce404e-9d61-11e7-9068-2fea3ea54c3a.png">
