### PR TITLE
fix(720): add set function to isButtonDisabled

### DIFF
--- a/app/components/pipeline-secret-settings/component.js
+++ b/app/components/pipeline-secret-settings/component.js
@@ -4,8 +4,10 @@ export default Ember.Component.extend({
   newName: null,
   newValue: null,
   newAllow: false,
-  isButtonDisabled: Ember.computed('newName', 'newValue', function isButtonDisabled() {
-    return !this.get('newName') || !this.get('newValue');
+  isButtonDisabled: Ember.computed('newName', 'newValue', {
+    get() {
+      return !this.get('newName') || !this.get('newValue');
+    }
   }),
   errorMessage: '',
   secretsSorting: ['name'],
@@ -29,7 +31,6 @@ export default Ember.Component.extend({
       this.set('newName', null);
       this.set('newValue', null);
       this.set('newAllow', false);
-      this.set('isButtonDisabled', true);
 
       return true;
     }


### PR DESCRIPTION
We could not add Secrets multiple times without browser refresh. 
Because `this.set('isButtonDisabled', true)` probably overrides the value of `isButtonDisabled`  to just `true` from the function.
This PR removes `this.set('isButtonDisabled', true)` because `isButtonDisabled` will be changed automatically by above `this.set('newName', null)` and `this.set('newValue', null)`.

Document: https://emberjs.com/api/ember/2.15/namespaces/Ember.computed
Related: https://github.com/screwdriver-cd/screwdriver/issues/720