### PR TITLE
fix: dereference errors from joi when validating templates

### DIFF
--- a/app/components/validator-results/component.js
+++ b/app/components/validator-results/component.js
@@ -4,7 +4,7 @@ export default Ember.Component.extend({
   results: null,
   errors: Ember.computed('results', {
     get() {
-      return this.get('results.errors') || [];
+      return (this.get('results.errors') || []).map(e => (typeof e === 'string' ? e : e.message));
     }
   }),
   workflow: Ember.computed('results', {

--- a/tests/integration/components/validator-results/component-test.js
+++ b/tests/integration/components/validator-results/component-test.js
@@ -70,3 +70,22 @@ test('it renders templates', function (assert) {
   assert.equal(this.$('.error').text().trim(), '');
   assert.equal(this.$('h4').text().trim(), 'batman/batmobile@1.0.0');
 });
+
+test('it renders joi error results', function (assert) {
+  this.set('validationMock', {
+    errors: [{ message: 'there is an error' }],
+    template: {
+      name: 'batman/batmobile',
+      version: '1.0.0',
+      config: {
+        image: 'int-test:1',
+        steps: [{ forgreatjustice: 'ba.sh' }]
+      }
+    }
+  });
+
+  this.render(hbs`{{validator-results results=validationMock isTemplate=true}}`);
+
+  assert.equal(this.$('.error').text().trim(), 'there is an error');
+  assert.equal(this.$('h4').text().trim(), 'batman/batmobile@1.0.0');
+});


### PR DESCRIPTION
Context:
========
If there is a template validation error, the UI displays [Object object]

Objective:
----------
Template validation spits out the raw Joi validation error results, but screwdriver.yaml validation has an array of strings. This PR normalizes the errors array to an array of strings.