### PR TITLE
fix: enable more eslint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -41,7 +41,7 @@ module.exports = {
     "ember/no-old-shims": "off",
     "ember/no-on-calls-in-components": "error",
     "ember/no-side-effects": "error",
-    "ember/order-in-components": "off",
+    "ember/order-in-components": "error",
     "ember/order-in-controllers": "off",
     "ember/order-in-models": "off",
     "ember/order-in-routes": "off",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -34,7 +34,7 @@ module.exports = {
     "ember/no-capital-letters-in-routes": "error",
     "ember/no-duplicate-dependent-keys": "off",
     "ember/no-empty-attrs": "off",
-    "ember/no-function-prototype-extensions": "off",
+    "ember/no-function-prototype-extensions": "error",
     "ember/no-global-jquery": "off",
     "ember/no-jquery": "off",
     "ember/no-observers": "off",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -43,7 +43,7 @@ module.exports = {
     "ember/no-side-effects": "error",
     "ember/order-in-components": "error",
     "ember/order-in-controllers": "error",
-    "ember/order-in-models": "off",
+    "ember/order-in-models": "error",
     "ember/order-in-routes": "off",
     "ember/require-super-in-init": "off",
     "ember/routes-segments-snake-case": "error",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -42,7 +42,7 @@ module.exports = {
     "ember/no-on-calls-in-components": "error",
     "ember/no-side-effects": "error",
     "ember/order-in-components": "error",
-    "ember/order-in-controllers": "off",
+    "ember/order-in-controllers": "error",
     "ember/order-in-models": "off",
     "ember/order-in-routes": "off",
     "ember/require-super-in-init": "off",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,7 +23,7 @@ module.exports = {
     'import/no-mutable-exports': 'off',
     'import/newline-after-import': 'off',
     "ember/alias-model-in-controller": "off",
-    "ember/avoid-leaking-state-in-components": "off",
+    "ember/avoid-leaking-state-in-components": "error",
     "ember/closure-actions": "error",
     "ember/jquery-ember-run": "off",
     "ember/local-modules": "off",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -44,7 +44,7 @@ module.exports = {
     "ember/order-in-components": "error",
     "ember/order-in-controllers": "error",
     "ember/order-in-models": "error",
-    "ember/order-in-routes": "off",
+    "ember/order-in-routes": "error",
     "ember/require-super-in-init": "off",
     "ember/routes-segments-snake-case": "error",
     "ember/use-brace-expansion": "error",

--- a/app/application/controller.js
+++ b/app/application/controller.js
@@ -3,9 +3,9 @@ import { inject as service } from '@ember/service';
 import Controller from '@ember/controller';
 
 export default Controller.extend({
+  session: service('session'),
   queryParams: ['fromUrl'],
   fromUrl: null,
-  session: service('session'),
   currentUrl: computed('currentPath', () => window.location.pathname),
   actions: {
     invalidateSession() {

--- a/app/application/route.js
+++ b/app/application/route.js
@@ -5,6 +5,9 @@ import ApplicationRouteMixin from 'ember-simple-auth/mixins/application-route-mi
 export default Route.extend(ApplicationRouteMixin, {
   scmService: service('scm'),
   routeAfterAuthentication: 'home',
+  model() {
+    return this.get('scmService').createScms();
+  },
   sessionInvalidated: () => window.location.replace(window.location.href),
   sessionAuthenticated: function sessionAuthenticated() {
     const previousUrl = this.controllerFor('application').get('fromUrl');
@@ -21,8 +24,5 @@ export default Route.extend(ApplicationRouteMixin, {
     arr.push('screwdriver.cd');
 
     return arr.join(' > ');
-  },
-  model() {
-    return this.get('scmService').createScms();
   }
 });

--- a/app/build/model.js
+++ b/app/build/model.js
@@ -39,21 +39,9 @@ function durationText(start, end) {
 export default DS.Model.extend({
   // ember-data has some reservations with the "container" attribute name
   buildContainer: DS.attr('string'),
-  buildDuration: computed('startTime', 'endTime', {
-    get() {
-      return durationText.call(this, 'startTime', 'endTime');
-    }
-  }),
   cause: DS.attr('string'),
   commit: DS.attr(),
   createTime: DS.attr('date'),
-  createTimeWords: computed('createTime', {
-    get() {
-      const dt = durationText.call(this, 'createTime', 'now');
-
-      return `${dt} ago`;
-    }
-  }),
   endTime: DS.attr('date'),
   eventId: DS.attr('string'),
   jobId: DS.attr('string'),
@@ -61,15 +49,28 @@ export default DS.Model.extend({
   number: DS.attr('number'),
   parameters: DS.attr(),
   parentBuildId: DS.attr('string'),
+  sha: DS.attr('string'),
+  startTime: DS.attr('date'),
+  status: DS.attr('string'),
+  steps: DS.attr(),
+
+  createTimeWords: computed('createTime', {
+    get() {
+      const dt = durationText.call(this, 'createTime', 'now');
+
+      return `${dt} ago`;
+    }
+  }),
   queuedDuration: computed('createTime', 'startTime', {
     get() {
       return durationText.call(this, 'createTime', 'startTime');
     }
   }),
-  sha: DS.attr('string'),
-  startTime: DS.attr('date'),
-  status: DS.attr('string'),
-  steps: DS.attr(),
+  buildDuration: computed('startTime', 'endTime', {
+    get() {
+      return durationText.call(this, 'startTime', 'endTime');
+    }
+  }),
   totalDurationMS: computed('createTime', 'endTime', {
     get() {
       return calcDuration.call(this, 'createTime', 'endTime');

--- a/app/build/route.js
+++ b/app/build/route.js
@@ -2,9 +2,6 @@ import Route from '@ember/routing/route';
 const RELOAD_TIMER = 5000;
 
 export default Route.extend({
-  redirect(model) {
-    this.transitionTo('pipeline.builds.build', model.pipeline.id, model.build.id);
-  },
   model(params) {
     return this.store.findRecord('build', params.build_id).then((build) => {
       // reload again in a little bit if queued
@@ -21,5 +18,8 @@ export default Route.extend({
           build, job, pipeline
         })));
     });
+  },
+  redirect(model) {
+    this.transitionTo('pipeline.builds.build', model.pipeline.id, model.build.id);
   }
 });

--- a/app/components/artifact-tree/component.js
+++ b/app/components/artifact-tree/component.js
@@ -16,9 +16,9 @@ const typesOptions = {
 };
 
 export default Component.extend({
+  artifact: service('build-artifact'),
   classNames: ['artifact-tree'],
   classNameBindings: ['buildStatus'],
-  artifact: service('build-artifact'),
   typesOptions,
   plugins: 'types',
   treedata: computed('buildStatus', 'buildId', {

--- a/app/components/build-bubble/component.js
+++ b/app/components/build-bubble/component.js
@@ -9,16 +9,6 @@ export default Component.extend(ModelReloaderMixin, {
   classNames: ['build-bubble'],
   classNameBindings: ['build.id', 'small'],
   modelToReload: 'build',
-  reloadTimeout: ENV.APP.BUILD_RELOAD_TIMER,
-  shouldReload(build) {
-    if (build) {
-      const s = build.get('status');
-
-      return s === 'RUNNING' || s === 'QUEUED';
-    }
-
-    return false;
-  },
 
   icon: computed('jobIsDisabled', 'build', 'build.status', {
     get() {
@@ -59,16 +49,30 @@ export default Component.extend(ModelReloaderMixin, {
     }
   }),
 
-  mouseEnter() {
-    $(`.${this.get('build.id')}`).addClass('highlight');
-  },
-  mouseLeave() {
-    $('.build-bubble').removeClass('highlight');
-  },
   willRender() {
     this.startReloading();
   },
+
+  mouseEnter() {
+    $(`.${this.get('build.id')}`).addClass('highlight');
+  },
+
+  mouseLeave() {
+    $('.build-bubble').removeClass('highlight');
+  },
+
   willDestroy() {
     this.stopReloading();
-  }
+  },
+
+  shouldReload(build) {
+    if (build) {
+      const s = build.get('status');
+
+      return s === 'RUNNING' || s === 'QUEUED';
+    }
+
+    return false;
+  },
+  reloadTimeout: ENV.APP.BUILD_RELOAD_TIMER
 });

--- a/app/components/build-health/component.js
+++ b/app/components/build-health/component.js
@@ -1,3 +1,4 @@
+/* eslint ember/avoid-leaking-state-in-components: [2, ["className"]] */
 import { computed } from '@ember/object';
 import Component from '@ember/component';
 

--- a/app/components/build-log/component.js
+++ b/app/components/build-log/component.js
@@ -19,19 +19,36 @@ export default Component.extend({
   lastLine: 0,
   // store of logs to display, so we only have to recalculate new logs
   logContent: '',
+  autoscroll: true,
+
+  /**
+   * Determines if log loading should occur
+   * - step must have a defined start time (it is, or has executed)
+   * - the log panel must be open
+   * - the step must have logs left to load
+   * @property {Boolean} shouldLoad
+   */
+  shouldLoad: computed('isOpen', 'finishedLoading', {
+    get() {
+      return this.get('isOpen') &&
+        !this.get('finishedLoading');
+    }
+  }),
+
+  /**
+   * Listens to 'isOpen' to determine if the value has changed
+   * @method isOpenChanged
+   * @private
+   */
+  isOpenChanged: observer('isOpen', function isOpenChanged() {
+    if (this.get('isOpen')) {
+      this.getLogs();
+    }
+  }),
 
   init() {
     this._super(...arguments);
     this.set('logs', A());
-  },
-
-  /**
-   * Listen to the user clicking on logs to turn off autoClose
-   * This listener is really only necessary when the step is still running
-   * @method click
-   */
-  click() {
-    this.get('onClick')();
   },
 
   // Start loading logs immediately upon inserting the element if the panel is open
@@ -42,8 +59,6 @@ export default Component.extend({
       this.getLogs();
     }
   },
-
-  autoscroll: true,
 
   /**
    * Set up scroll listener when component has been rendered
@@ -76,29 +91,13 @@ export default Component.extend({
   },
 
   /**
-   * Listens to 'isOpen' to determine if the value has changed
-   * @method isOpenChanged
-   * @private
+   * Listen to the user clicking on logs to turn off autoClose
+   * This listener is really only necessary when the step is still running
+   * @method click
    */
-  isOpenChanged: observer('isOpen', function isOpenChanged() {
-    if (this.get('isOpen')) {
-      this.getLogs();
-    }
-  }),
-
-  /**
-   * Determines if log loading should occur
-   * - step must have a defined start time (it is, or has executed)
-   * - the log panel must be open
-   * - the step must have logs left to load
-   * @property {Boolean} shouldLoad
-   */
-  shouldLoad: computed('isOpen', 'finishedLoading', {
-    get() {
-      return this.get('isOpen') &&
-        !this.get('finishedLoading');
-    }
-  }),
+  click() {
+    this.get('onClick')();
+  },
 
   /**
    * Scroll to the bottom of the page

--- a/app/components/build-step-view/component.js
+++ b/app/components/build-step-view/component.js
@@ -98,19 +98,19 @@ export default Component.extend({
     }
   }),
 
-  /**
-   * Update the property now every second
-   * @method timer
-   */
-  timer: function timer() {
-    const interval = 1000;
+  init(...args) {
+    this._super(...args);
 
-    setInterval(() => {
-      run(() => {
-        this.notifyPropertyChange('now');
-      });
-    }, interval);
-  }.on('init'),
+    this.set('timer', () => {
+      const interval = 1000;
+
+      setInterval(() => {
+        run(() => {
+          this.notifyPropertyChange('now');
+        });
+      }, interval);
+    });
+  },
 
   /**
    * Allow user to click on a step to open the logs

--- a/app/components/build-step/component.js
+++ b/app/components/build-step/component.js
@@ -7,6 +7,26 @@ export default Component.extend({
   autoClose: true,
   autoOpen: true,
 
+  // Called when component will render again
+  willRender() {
+    this._super(...arguments);
+    this.setOpen();
+  },
+
+  actions: {
+    // Opens display of logs, turn off auto close of logs when step is done
+    toggleOpen() {
+      this.set('isOpen', !this.get('isOpen'));
+      this.set('autoClose', false);
+      this.set('autoOpen', false);
+    },
+    // turn off auto close of logs when step is done when user clicks on logs
+    cancelAutoClose() {
+      this.set('autoClose', false);
+      this.set('autoOpen', false);
+    }
+  },
+
   /**
    * Determine if logs should displayed or not, when component is re-rendered
    * @method shouldOpen
@@ -28,26 +48,6 @@ export default Component.extend({
     // and the user hasn't stopped logs from closing
     } else if (!shouldOpen && isOpen && autoClose) {
       this.set('isOpen', false);
-    }
-  },
-
-  // Called when component will render again
-  willRender() {
-    this._super(...arguments);
-    this.setOpen();
-  },
-
-  actions: {
-    // Opens display of logs, turn off auto close of logs when step is done
-    toggleOpen() {
-      this.set('isOpen', !this.get('isOpen'));
-      this.set('autoClose', false);
-      this.set('autoOpen', false);
-    },
-    // turn off auto close of logs when step is done when user clicks on logs
-    cancelAutoClose() {
-      this.set('autoClose', false);
-      this.set('autoOpen', false);
     }
   }
 });

--- a/app/components/collection-view/component.js
+++ b/app/components/collection-view/component.js
@@ -1,3 +1,4 @@
+/* eslint ember/avoid-leaking-state-in-components: [2, ["sortBy"]] */
 import { sort } from '@ember/object/computed';
 import { computed } from '@ember/object';
 import { inject as service } from '@ember/service';

--- a/app/components/collection-view/component.js
+++ b/app/components/collection-view/component.js
@@ -7,6 +7,8 @@ export default Component.extend({
   session: service(),
   scmService: service('scm'),
   sortBy: ['scmRepo.name'],
+  removePipelineError: null,
+  sortedPipelines: sort('collectionPipelines', 'sortBy'),
   sortByText: computed('sortBy', {
     get() {
       switch (this.get('sortBy').get(0)) {
@@ -52,8 +54,7 @@ export default Component.extend({
       return [];
     }
   }),
-  sortedPipelines: sort('collectionPipelines', 'sortBy'),
-  removePipelineError: null,
+
   actions: {
     /**
      * Action to remove a pipeline from a collection

--- a/app/components/collections-flyout/component.js
+++ b/app/components/collections-flyout/component.js
@@ -4,18 +4,20 @@ import { computed } from '@ember/object';
 import Component from '@ember/component';
 
 export default Component.extend({
-  collections: computed('store', {
-    get() {
-      return this.get('store').findAll('collection');
-    }
-  }),
+  session: service(),
+  store: service(),
   collectionToDelete: null,
   errorMessage: null,
   showConfirmation: false,
   showDeleteButtons: false,
   showModal: false,
-  session: service(),
-  store: service(),
+
+  collections: computed('store', {
+    get() {
+      return this.get('store').findAll('collection');
+    }
+  }),
+
   actions: {
     /**
      * Action to create a new collection

--- a/app/components/loading-view/component.js
+++ b/app/components/loading-view/component.js
@@ -1,3 +1,4 @@
+/* eslint ember/avoid-leaking-state-in-components: [2, ["funnies"]] */
 import { computed } from '@ember/object';
 import Component from '@ember/component';
 

--- a/app/components/pipeline-create-form/component.js
+++ b/app/components/pipeline-create-form/component.js
@@ -8,6 +8,9 @@ import { parse } from '../../utils/git';
 
 export default Component.extend({
   scmUrl: '',
+  isInvalid: not('isValid'),
+  isDisabled: or('isSaving', 'isInvalid'),
+
   isValid: computed('scmUrl', {
     get() {
       const val = this.get('scmUrl');
@@ -15,8 +18,6 @@ export default Component.extend({
       return val.length !== 0 && parse(val).valid;
     }
   }),
-  isInvalid: not('isValid'),
-  isDisabled: or('isSaving', 'isInvalid'),
 
   actions: {
     /**

--- a/app/components/pipeline-event-view/component.js
+++ b/app/components/pipeline-event-view/component.js
@@ -4,7 +4,11 @@ import ENV from 'screwdriver-ui/config/environment';
 
 export default Component.extend(ModelReloaderMixin, {
   modelToReload: 'event.builds',
-  reloadTimeout: ENV.APP.EVENT_RELOAD_TIMER,
+
+  willRender() {
+    this.startReloading();
+  },
+
   shouldReload() {
     const event = this.get('event');
 
@@ -14,10 +18,11 @@ export default Component.extend(ModelReloaderMixin, {
 
     return false;
   },
-  willRender() {
-    this.startReloading();
-  },
+
   willDestroy() {
     this.stopReloading();
-  }
+  },
+
+  // eslint doesn't know what this property is, so it wants it on the bottom
+  reloadTimeout: ENV.APP.EVENT_RELOAD_TIMER
 });

--- a/app/components/pipeline-events-list/component.js
+++ b/app/components/pipeline-events-list/component.js
@@ -6,26 +6,9 @@ import ModelReloaderMixin from 'screwdriver-ui/mixins/model-reloader';
 
 export default Component.extend(ModelReloaderMixin, {
   modelToReload: 'events',
-  reloadTimeout: ENV.APP.EVENT_RELOAD_TIMER,
   showAll: false,
   eventsSorted: sort('events.[]',
     (a, b) => parseInt(b.id, 10) - parseInt(a.id, 10)),
-
-  /**
-   * Runs when a render event is triggered, usually due to a change in attribute data (events)
-   * @method willRender
-   */
-  willRender() {
-    this.startReloading();
-  },
-
-  /**
-   * Executes when the component is about to be destroyed
-   * @method willDestroy
-   */
-  willDestroy() {
-    this.stopReloading();
-  },
 
   eventsToView: computed('events.[]', 'showAll', {
     get() {
@@ -37,9 +20,28 @@ export default Component.extend(ModelReloaderMixin, {
     }
   }),
 
+  /**
+   * Runs when a render event is triggered, usually due to a change in attribute data (events)
+   * @method willRender
+   */
+  willRender() {
+    this.startReloading();
+  },
+
   actions: {
     showAllEvents() {
       this.set('showAll', true);
     }
-  }
+  },
+
+  /**
+   * Executes when the component is about to be destroyed
+   * @method willDestroy
+   */
+  willDestroy() {
+    this.stopReloading();
+  },
+
+  // eslint doesn't know what this property is, so it wants it at the bottom
+  reloadTimeout: ENV.APP.EVENT_RELOAD_TIMER
 });

--- a/app/components/pipeline-header/component.js
+++ b/app/components/pipeline-header/component.js
@@ -3,8 +3,8 @@ import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 
 export default Component.extend({
-  classNames: ['row'],
   scmService: service('scm'),
+  classNames: ['row'],
   scmContext: computed({
     get() {
       const pipeline = this.get('pipeline');

--- a/app/components/pipeline-options/component.js
+++ b/app/components/pipeline-options/component.js
@@ -6,6 +6,24 @@ import Component from '@ember/component';
 import { parse, getCheckoutUrl } from '../../utils/git';
 
 export default Component.extend({
+  // Syncing a pipeline
+  sync: service('sync'),
+  errorMessage: '',
+  scmUrl: '',
+  // Removing a pipeline
+  isRemoving: false,
+  isShowingModal: false,
+  showDangerButton: true,
+  showRemoveButtons: false,
+  isInvalid: not('isValid'),
+  isDisabled: or('isSaving', 'isInvalid'),
+  isValid: computed('scmUrl', {
+    get() {
+      const val = this.get('scmUrl');
+
+      return val.length !== 0 && parse(val).valid;
+    }
+  }),
   // Updating a pipeline
   init() {
     this._super(...arguments);
@@ -14,24 +32,6 @@ export default Component.extend({
       scmUri: this.get('pipeline.scmUri')
     }));
   },
-  errorMessage: '',
-  scmUrl: '',
-  isValid: computed('scmUrl', {
-    get() {
-      const val = this.get('scmUrl');
-
-      return val.length !== 0 && parse(val).valid;
-    }
-  }),
-  isInvalid: not('isValid'),
-  isDisabled: or('isSaving', 'isInvalid'),
-  // Removing a pipeline
-  isRemoving: false,
-  isShowingModal: false,
-  showDangerButton: true,
-  showRemoveButtons: false,
-  // Syncing a pipeline
-  sync: service('sync'),
   actions: {
     // Checks if scm URL is valid or not
     scmChange(val) {

--- a/app/components/pipeline-secret-settings/component.js
+++ b/app/components/pipeline-secret-settings/component.js
@@ -1,3 +1,4 @@
+/* eslint ember/avoid-leaking-state-in-components: [2, ["secretsSorting"]] */
 import { sort } from '@ember/object/computed';
 import { computed } from '@ember/object';
 import Component from '@ember/component';

--- a/app/components/pipeline-secret-settings/component.js
+++ b/app/components/pipeline-secret-settings/component.js
@@ -6,14 +6,14 @@ export default Component.extend({
   newName: null,
   newValue: null,
   newAllow: false,
+  errorMessage: '',
+  secretsSorting: ['name'],
+  sortedSecrets: sort('secrets', 'secretsSorting'),
   isButtonDisabled: computed('newName', 'newValue', {
     get() {
       return !this.get('newName') || !this.get('newValue');
     }
   }),
-  errorMessage: '',
-  secretsSorting: ['name'],
-  sortedSecrets: sort('secrets', 'secretsSorting'),
   actions: {
     /**
      * Kicks off create secret flow

--- a/app/components/search-list/component.js
+++ b/app/components/search-list/component.js
@@ -8,7 +8,10 @@ export default Component.extend({
   session: service(),
   scmService: service('scm'),
   pipelineSorting: ['appId', 'branch'],
+  addCollectionError: null,
+  addCollectionSuccess: null,
   sortedPipelines: sort('pipelines', 'pipelineSorting'),
+  isEmpty: empty('filteredPipelines'),
   filterSet: computed('query', {
     get() {
       const q = this.get('query') || '';
@@ -54,9 +57,6 @@ export default Component.extend({
       });
     }
   }),
-  isEmpty: empty('filteredPipelines'),
-  addCollectionError: null,
-  addCollectionSuccess: null,
   actions: {
     addToCollection(pipelineId, collection) {
       return this.get('onAddToCollection')(+pipelineId, collection.id)

--- a/app/components/search-list/component.js
+++ b/app/components/search-list/component.js
@@ -1,3 +1,4 @@
+/* eslint ember/avoid-leaking-state-in-components: [2, ["pipelineSorting"]] */
 import { inspect } from '@ember/debug';
 import { computed } from '@ember/object';
 import { sort, empty } from '@ember/object/computed';

--- a/app/components/secret-view/component.js
+++ b/app/components/secret-view/component.js
@@ -3,6 +3,8 @@ import Component from '@ember/component';
 
 export default Component.extend({
   tagName: 'tr',
+  newValue: null,
+  originalAllowInPR: null,
   buttonAction: computed('newValue', 'secret.allowInPR', 'originalAllowInPR', {
     get() {
       return (this.get('newValue')
@@ -10,8 +12,6 @@ export default Component.extend({
         'Update' : 'Delete';
     }
   }),
-  newValue: null,
-  originalAllowInPR: null,
   init() {
     this._super(...arguments);
     this.set('originalAllowInPR', this.get('secret.allowInPR'));

--- a/app/components/token-list/component.js
+++ b/app/components/token-list/component.js
@@ -1,3 +1,4 @@
+/* eslint ember/avoid-leaking-state-in-components: [2, ["tokenSorting"]] */
 import { capitalize } from '@ember/string';
 import { computed, observer } from '@ember/object';
 import { sort } from '@ember/object/computed';

--- a/app/components/token-list/component.js
+++ b/app/components/token-list/component.js
@@ -5,15 +5,11 @@ import Component from '@ember/component';
 
 export default Component.extend({
   tokenSorting: ['name', 'description', 'lastUsed'],
-  sortedTokens: sort('tokens', 'tokenSorting'),
 
   // Error for failed to create/update/remove/refresh token
   errorMessage: null,
 
   // Adding a new token
-  isButtonDisabled: computed('newName', 'isSaving', function isButtonDisabled() {
-    return !this.get('newName') || this.get('isSaving');
-  }),
   isSaving: false,
   newDescription: null,
   newName: null,
@@ -21,11 +17,18 @@ export default Component.extend({
   // Confirmation dialog
   isShowingModal: false,
   modalAction: null,
+  modalTarget: null,
+  modalText: null,
+
+  sortedTokens: sort('tokens', 'tokenSorting'),
+
+  isButtonDisabled: computed('newName', 'isSaving', function isButtonDisabled() {
+    return !this.get('newName') || this.get('isSaving');
+  }),
+
   modalButtonText: computed('modalAction', function modalButtonText() {
     return capitalize(this.get('modalAction'));
   }),
-  modalTarget: null,
-  modalText: null,
 
   // Don't show the "new token" and "error" dialogs at the same time
   errorObserver: observer('errorMessage', function errorObserver() {

--- a/app/components/token-view/component.js
+++ b/app/components/token-view/component.js
@@ -2,6 +2,8 @@ import { computed } from '@ember/object';
 import Component from '@ember/component';
 
 export default Component.extend({
+  newDescription: null,
+  newName: null,
   tagName: 'tr',
   buttonAction: computed('token.{name,description}', 'newName', 'newDescription', {
     get() {
@@ -12,8 +14,6 @@ export default Component.extend({
         'Update' : 'Delete';
     }
   }),
-  newName: null,
-  newDescription: null,
   init() {
     this._super(...arguments);
     this.set('newName', this.get('token.name'));

--- a/app/dashboard/index/route.js
+++ b/app/dashboard/index/route.js
@@ -2,6 +2,9 @@ import Route from '@ember/routing/route';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
 export default Route.extend(AuthenticatedRouteMixin, {
+  titleToken: 'Dashboard',
+  authenticationRoute: 'login',
+
   activate() {
     return this.get('store').findAll('collection')
       .then((collections) => {
@@ -21,7 +24,5 @@ export default Route.extend(AuthenticatedRouteMixin, {
       .catch(() => {
         this.replaceWith('home');
       });
-  },
-  titleToken: 'Dashboard',
-  authenticationRoute: 'login'
+  }
 });

--- a/app/event/model.js
+++ b/app/event/model.js
@@ -3,11 +3,19 @@ import { sort, not } from '@ember/object/computed';
 import DS from 'ember-data';
 
 export default DS.Model.extend({
-  builds: DS.hasMany('build'),
-  buildsSorted: sort('builds', (a, b) => parseInt(a.id, 10) - parseInt(b.id, 10)),
   causeMessage: DS.attr('string'),
   commit: DS.attr(),
   createTime: DS.attr('date'),
+  creator: DS.attr(),
+  pipelineId: DS.attr('string'),
+  sha: DS.attr('string'),
+  type: DS.attr('string'),
+  workflow: DS.attr(),
+
+  builds: DS.hasMany('build'),
+
+  isRunning: not('isComplete'),
+  buildsSorted: sort('builds', (a, b) => parseInt(a.id, 10) - parseInt(b.id, 10)),
   createTimeWords: computed('createTime', {
     get() {
       const duration = Date.now() - this.get('createTime').getTime();
@@ -15,7 +23,6 @@ export default DS.Model.extend({
       return `${humanizeDuration(duration, { round: true, largest: 1 })} ago`;
     }
   }),
-  creator: DS.attr(),
   duration: computed('builds.[]', 'isComplete', {
     get() {
       return this.get('builds').reduce((val = 0, item) => val + item.get('totalDurationMS'));
@@ -54,9 +61,6 @@ export default DS.Model.extend({
       return true;
     }
   }),
-  isRunning: not('isComplete'),
-  pipelineId: DS.attr('string'),
-  sha: DS.attr('string'),
   truncatedMessage: computed('commit.message', {
     get() {
       return this.get('commit.message').split('\n')[0];
@@ -66,7 +70,5 @@ export default DS.Model.extend({
     get() {
       return this.get('sha').substr(0, 6);
     }
-  }),
-  type: DS.attr('string'),
-  workflow: DS.attr()
+  })
 });

--- a/app/login/route.js
+++ b/app/login/route.js
@@ -3,9 +3,9 @@ import Route from '@ember/routing/route';
 import UnauthenticatedRouteMixin from 'ember-simple-auth/mixins/unauthenticated-route-mixin';
 
 export default Route.extend(UnauthenticatedRouteMixin, {
+  scmService: service('scm'),
   titleToken: 'Login',
   routeIfAlreadyAuthenticated: 'home',
-  scmService: service('scm'),
   model() {
     return this.get('scmService').getScms();
   }

--- a/app/pipeline/builds/build/controller.js
+++ b/app/pipeline/builds/build/controller.js
@@ -10,6 +10,29 @@ export default Controller.extend({
   counter: 0,
   stepList: mapBy('model.build.steps', 'name'),
 
+  actions: {
+    stopBuild() {
+      const build = this.get('model.build');
+
+      build.set('status', 'ABORTED');
+      build.save();
+    },
+
+    startBuild() {
+      const jobId = this.get('model.build.jobId');
+      const build = this.store.createRecord('build', { jobId });
+
+      return build.save()
+        .then(() => this.transitionToRoute('pipeline.builds.build', build.get('id')));
+    },
+
+    reload() {
+      // If there is already a reload scheduled in the runloop,
+      // this replaces it with one with no timeout
+      once(this, 'reloadBuild', 0);
+    }
+  },
+
   /**
    * Schedules a build to reload after a certain amount of time
    * @method reloadBuild
@@ -36,29 +59,6 @@ export default Controller.extend({
         // refetch builds which are part of current event
         this.get('model.event').hasMany('builds').reload();
       }
-    }
-  },
-
-  actions: {
-    stopBuild() {
-      const build = this.get('model.build');
-
-      build.set('status', 'ABORTED');
-      build.save();
-    },
-
-    startBuild() {
-      const jobId = this.get('model.build.jobId');
-      const build = this.store.createRecord('build', { jobId });
-
-      return build.save()
-        .then(() => this.transitionToRoute('pipeline.builds.build', build.get('id')));
-    },
-
-    reload() {
-      // If there is already a reload scheduled in the runloop,
-      // this replaces it with one with no timeout
-      once(this, 'reloadBuild', 0);
     }
   }
 });

--- a/app/pipeline/builds/build/route.js
+++ b/app/pipeline/builds/build/route.js
@@ -6,9 +6,7 @@ export default Route.extend({
   beforeModel() {
     this.set('pipeline', this.modelFor('pipeline'));
   },
-  titleToken(model) {
-    return `${model.job.get('name')} > #${model.build.get('sha').substr(0, 6)}`;
-  },
+
   model(params) {
     return this.store.findRecord('build', params.build_id).then(build => all([
       this.store.findRecord('job', build.get('jobId')),
@@ -22,6 +20,7 @@ export default Route.extend({
       jobs: jobs.filter(j => !/^PR-/.test(j.get('name')))
     })));
   },
+
   afterModel(model) {
     const pipelineId = model.pipeline.get('id');
 
@@ -29,5 +28,9 @@ export default Route.extend({
     if (pipelineId !== model.job.get('pipelineId')) {
       this.transitionTo('pipeline', pipelineId);
     }
+  },
+
+  titleToken(model) {
+    return `${model.job.get('name')} > #${model.build.get('sha').substr(0, 6)}`;
   }
 });

--- a/app/pipeline/builds/index/controller.js
+++ b/app/pipeline/builds/index/controller.js
@@ -2,9 +2,9 @@ import { inject as service } from '@ember/service';
 import Controller from '@ember/controller';
 
 export default Controller.extend({
+  session: service('session'),
   isShowingModal: false,
   errorMessage: '',
-  session: service('session'),
 
   actions: {
     startMainBuild() {

--- a/app/pipeline/model.js
+++ b/app/pipeline/model.js
@@ -3,15 +3,17 @@ import DS from 'ember-data';
 
 export default DS.Model.extend({
   admins: DS.attr(),
-  appId: alias('scmRepo.name'),
-  branch: alias('scmRepo.branch'),
   checkoutUrl: DS.attr('string'),
   scmContext: DS.attr('string'),
   createTime: DS.attr('date'),
-  events: DS.hasMany('event', { async: true }),
-  hubUrl: alias('scmRepo.url'),
-  jobs: DS.hasMany('job', { async: true }),
   scmRepo: DS.attr(),
   scmUri: DS.attr('string'),
-  secrets: DS.hasMany('secret', { async: true })
+
+  events: DS.hasMany('event', { async: true }),
+  jobs: DS.hasMany('job', { async: true }),
+  secrets: DS.hasMany('secret', { async: true }),
+
+  appId: alias('scmRepo.name'),
+  branch: alias('scmRepo.branch'),
+  hubUrl: alias('scmRepo.url')
 });

--- a/app/pipeline/route.js
+++ b/app/pipeline/route.js
@@ -2,9 +2,6 @@ import Route from '@ember/routing/route';
 
 export default Route.extend({
   routeAfterAuthentication: 'pipeline',
-  titleToken(model) {
-    return model.get('appId');
-  },
   model(params) {
     this.set('pipelineId', params.pipeline_id);
 
@@ -15,5 +12,9 @@ export default Route.extend({
     error(reason) {
       this.transitionTo('page-not-found', { path: `pipelines/${this.get('pipelineId')}`, reason });
     }
+  },
+
+  titleToken(model) {
+    return model.get('appId');
   }
 });

--- a/app/search/route.js
+++ b/app/search/route.js
@@ -1,14 +1,14 @@
 import Route from '@ember/routing/route';
 
 export default Route.extend({
-  routeAfterAuthentication: 'search',
-  titleToken: 'Search',
   queryParams: {
     query: {
       refreshModel: true,
       replace: true
     }
   },
+  routeAfterAuthentication: 'search',
+  titleToken: 'Search',
   model(params) {
     return {
       pipelines: this.store.findAll('pipeline'),

--- a/app/templates/detail/controller.js
+++ b/app/templates/detail/controller.js
@@ -8,16 +8,16 @@ export default Controller.extend({
       return this.get('model')[0];
     }
   }),
-  // Set selected version to null whenever the list of templates changes
-  modelObserver: observer('model.[]', function modelObserver() {
-    this.set('selectedVersion', null);
-  }),
   template: computed('selectedVersion', 'model.[]', {
     get() {
       const version = this.get('selectedVersion') || this.get('latest.version');
 
       return this.get('model').findBy('version', version);
     }
+  }),
+  // Set selected version to null whenever the list of templates changes
+  modelObserver: observer('model.[]', function modelObserver() {
+    this.set('selectedVersion', null);
   }),
   actions: {
     changeVersion(version) {


### PR DESCRIPTION
Context:
========
Utilize the ember best-practices defined in their eslint rules

Objective:
-----------
Enable more of the default eslint rules from the ember plugin, and fix the issues that were raised.

* https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/order-in-components.md
* https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/order-in-controllers.md
* https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/order-in-models.md
* https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/order-in-models.md
* https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/avoid-leaking-state-in-components.md