### PR TITLE
Workflow graphed with vis

### DIFF
--- a/app/components/pipeline-event-view/template.hbs
+++ b/app/components/pipeline-event-view/template.hbs
@@ -5,9 +5,13 @@
   <div class="col-xs-8 col-lg-6 message">
     <div class="cause" title="{{event.commit.message}}">{{event.truncatedMessage}}</div>
     <div>
-      {{#each event.workflow as |name index|}}
-      {{build-bubble jobName=name build=(index-of event.buildsSorted index) small=true}}
-      {{/each}}
+      {{#if (and (is-fulfilled event.builds) event.workflowGraph)}}
+        {{workflow-graph-vis builds=event.builds workflowGraph=event.workflowGraph}}
+      {{else}}
+        {{#each event.workflow as |name index|}}
+        {{build-bubble jobName=name build=(index-of event.buildsSorted index) small=true}}
+        {{/each}}
+      {{/if}}
     </div>
   </div>
   <div class="col-xs-6 col-lg-2 user">

--- a/app/components/pipeline-workflow/component.js
+++ b/app/components/pipeline-workflow/component.js
@@ -1,5 +1,50 @@
 import Component from '@ember/component';
+import { get, computed, set } from '@ember/object';
+import { all, reject } from 'rsvp';
 
 export default Component.extend({
-  classNames: ['pipelineWorkflow']
+  classNames: ['pipelineWorkflow'],
+  graph: computed('workflowGraph', {
+    get() {
+      const jobs = get(this, 'jobs');
+      const fetchBuilds = [];
+      const graph = get(this, 'workflowGraph');
+
+      // Hack to make page display stuff when a workflow is not provided
+      if (!graph) {
+        return reject(new Error('No workflow graph provided'));
+      }
+
+      // Preload the builds for the jobs
+      jobs.forEach((j) => {
+        const jobName = get(j, 'name');
+
+        const node = graph.nodes.find(n => n.name === jobName);
+
+        // push the job id into the graph
+        if (node) {
+          node.id = get(j, 'id');
+          fetchBuilds.push(get(j, 'builds'));
+        }
+      });
+
+      return all(fetchBuilds).then(() => {
+        const builds = [];
+
+        // preload the "last build" data for each job for the graph to consume
+        jobs.forEach(j => builds.push(get(j, 'lastBuild')));
+
+        // set values to consume from templates
+        set(this, 'builds', builds);
+        set(this, 'visGraph', graph);
+
+        return graph;
+      });
+    }
+  }),
+
+  init() {
+    this._super(...arguments);
+    set(this, 'builds', []);
+  }
 });

--- a/app/components/pipeline-workflow/template.hbs
+++ b/app/components/pipeline-workflow/template.hbs
@@ -1,3 +1,7 @@
-{{#each jobs as |job|}}
-{{build-bubble jobName=job.name jobIsDisabled=job.isDisabled build=job.lastBuild}}
-{{/each}}
+{{#if (is-fulfilled graph)}}
+  {{workflow-graph-vis workflowGraph=visGraph builds=builds}}
+{{else}}
+  {{#each jobs as |job|}}
+    {{build-bubble jobName=job.name jobIsDisabled=job.isDisabled build=job.lastBuild}}
+  {{/each}}
+{{/if}}

--- a/app/components/workflow-graph-vis/component.js
+++ b/app/components/workflow-graph-vis/component.js
@@ -8,12 +8,12 @@ export default Component.extend({
   nodes: computed({
     get() {
       const nodes = getWithDefault(this, 'workflowGraph.nodes', []);
-      let list = nodes.map(n => ({ id: `${n.name}`, label: n.name }));
+      let list = nodes.map(n => ({ id: n.name, label: n.name }));
       const builds = get(this, 'builds');
 
       if (Array.isArray(builds) && builds.length) {
         list = nodes.map((n) => {
-          const obj = { id: `${n.name}`, label: n.name };
+          const obj = { id: n.name, label: n.name };
           const build = builds.find(j => `${j.get('jobId')}` === `${n.id}`);
 
           if (build) {

--- a/app/components/workflow-graph-vis/component.js
+++ b/app/components/workflow-graph-vis/component.js
@@ -11,7 +11,7 @@ export default Component.extend({
       let list = nodes.map(n => ({ id: `${n.name}`, label: n.name }));
       const builds = get(this, 'builds');
 
-      if (builds) {
+      if (Array.isArray(builds) && builds.length) {
         list = nodes.map((n) => {
           const obj = { id: `${n.name}`, label: n.name };
           const build = builds.find(j => `${j.get('jobId')}` === `${n.id}`);

--- a/app/components/workflow-graph-vis/component.js
+++ b/app/components/workflow-graph-vis/component.js
@@ -1,0 +1,138 @@
+/* global vis */
+import { get, getWithDefault, computed, set } from '@ember/object';
+import { inject as service } from '@ember/service';
+import Component from '@ember/component';
+
+export default Component.extend({
+  router: service(),
+  nodes: computed({
+    get() {
+      const nodes = getWithDefault(this, 'workflowGraph.nodes', []);
+      let list = nodes.map(n => ({ id: `${n.name}`, label: n.name }));
+      const builds = get(this, 'builds');
+
+      if (builds) {
+        list = nodes.map((n) => {
+          const obj = { id: `${n.name}`, label: n.name };
+          const build = builds.find(j => `${j.get('jobId')}` === `${n.id}`);
+
+          if (build) {
+            obj.status = get(build, 'status');
+            obj.buildId = get(build, 'id');
+            obj.sha = get(build, 'sha');
+            obj.title = obj.status;
+
+            // TODO: graph icons work, but look terrible
+            switch (obj.status) {
+            case 'SUCCESS':
+              obj.color = '#1ac567';
+              obj.icon = { code: '\uf05d', color: '#1ac567' };
+              break;
+            case 'RUNNING':
+              obj.color = '#0f69ff';
+              obj.icon = { code: '\uf110', color: '#dc142d' };
+              break;
+            case 'QUEUED':
+              obj.color = '#0f69ff';
+              obj.icon = { code: '\uf017', color: '#dc142d' };
+              break;
+            case 'FAILURE':
+              obj.color = '#dc142d';
+              obj.icon = { code: '\uf05c', color: '#dc142d' };
+              break;
+            case 'ABORTED':
+              obj.color = '#dc142d';
+              obj.icon = { code: '\uf28e', color: '#dc142d' };
+              break;
+            default:
+            }
+          }
+
+          return obj;
+        });
+      }
+
+      return list;
+    }
+  }),
+
+  edges: computed({
+    get() {
+      const edges = getWithDefault(this, 'workflowGraph.edges', []);
+
+      // TODO: Probably should only color edges from a successful build
+      return edges.map(e => ({
+        from: `${e.src}`,
+        to: `${e.dest}`
+      }));
+    }
+  }),
+
+  didInsertElement() {
+    this._super(...arguments);
+
+    this.createNetwork();
+  },
+
+  // TODO: Listen for changes to nodes/edges and update graph accordingly.
+
+  createNetwork() {
+    const options = {
+      width: '400px',
+      height: '150px',
+      manipulation: { enabled: false },
+      layout: {
+        hierarchical: {
+          enabled: true,
+          direction: 'LR',
+          sortMethod: 'directed'
+        }
+      },
+      interaction: {
+        dragView: false,
+        zoomView: false,
+        dragNodes: false,
+        hover: true
+      },
+      nodes: {
+        color: '#eeeeee',
+        shape: 'dot'
+      },
+      edges: {
+        arrows: {
+          to: {
+            enabled: true
+          }
+        },
+        smooth: {
+          type: 'discrete',
+          forceDirection: 'none'
+        }
+      },
+      physics: {
+        enabled: false
+      }
+    };
+
+    const nodeSet = get(this, 'nodes');
+    const edgeSet = get(this, 'edges');
+    const el = this.$('.vis-network-graph')[0];
+    const nodes = new vis.DataSet(nodeSet);
+    const edges = new vis.DataSet(edgeSet);
+    const network = new vis.Network(el, { nodes, edges }, options);
+
+    network.on('selectNode', (e) => {
+      const node = nodeSet.find(n => e.nodes[0] === n.id);
+
+      if (node.buildId) {
+        const router = get(this, 'router');
+        // Hack to make click route to build page
+        const url = router.urlFor('pipeline.builds.build', node.buildId);
+
+        router.transitionTo(url);
+      }
+    });
+
+    set(this, 'network', network);
+  }
+});

--- a/app/components/workflow-graph-vis/template.hbs
+++ b/app/components/workflow-graph-vis/template.hbs
@@ -1,0 +1,2 @@
+<div class="vis-network-graph"></div>
+{{yield}}

--- a/app/event/model.js
+++ b/app/event/model.js
@@ -12,6 +12,7 @@ export default DS.Model.extend({
   startFrom: DS.attr('string'),
   type: DS.attr('string'),
   workflow: DS.attr(),
+  workflowGraph: DS.attr(),
 
   builds: DS.hasMany('build'),
 

--- a/app/pipeline/builds/index/controller.js
+++ b/app/pipeline/builds/index/controller.js
@@ -1,16 +1,21 @@
 import { inject as service } from '@ember/service';
 import Controller from '@ember/controller';
+import { reads } from '@ember/object/computed';
 
 export default Controller.extend({
   session: service('session'),
   isShowingModal: false,
   errorMessage: '',
+  pipeline: reads('model.pipeline'),
+  jobs: reads('model.jobs'),
+  events: reads('model.events'),
+  pullRequests: reads('model.pullRequests'),
 
   actions: {
     startMainBuild() {
       this.set('isShowingModal', true);
 
-      const pipelineId = this.get('model.pipeline.id');
+      const pipelineId = this.get('pipeline.id');
       const newEvent = this.store.createRecord('event', {
         pipelineId,
         startFrom: '~commit'

--- a/app/pipeline/builds/index/template.hbs
+++ b/app/pipeline/builds/index/template.hbs
@@ -8,22 +8,21 @@
         {{pipeline-start startBuild=(action "startMainBuild")}}
       </div>
       <div class="col-xs-12 col-lg-6">
-        {{pipeline-workflow jobs=model.jobs}}
+        {{pipeline-workflow workflowGraph=pipeline.workflowGraph jobs=jobs}}
       </div>
     </div>
   </div>
 </div>
 {{else}}
-{{pipeline-workflow jobs=model.jobs}}
+{{pipeline-workflow workflowGraph=pipeline.workflowGraph jobs=jobs}}
 {{/if}}
-
 
 <div class="row">
   <div class="col-xs-12 col-md-9">
-    {{pipeline-events-list events=model.events}}
+    {{pipeline-events-list events=events}}
   </div>
   <div class="col-xs-12 col-md-3">
-    {{pipeline-pr-list pullRequests=model.pullRequests}}
+    {{pipeline-pr-list pullRequests=pullRequests}}
   </div>
 </div>
 

--- a/app/pipeline/model.js
+++ b/app/pipeline/model.js
@@ -8,6 +8,7 @@ export default DS.Model.extend({
   createTime: DS.attr('date'),
   scmRepo: DS.attr(),
   scmUri: DS.attr('string'),
+  workflowGraph: DS.attr(),
 
   events: DS.hasMany('event', { async: true }),
   jobs: DS.hasMany('job', { async: true }),

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -32,6 +32,8 @@ module.exports = function (defaults) {
 
   app.import('bower_components/ansi_up/ansi_up.js');
   app.import('bower_components/humanize-duration/humanize-duration.js');
+  app.import('node_modules/vis/dist/vis-network.min.js');
+  app.import('node_modules/vis/dist/vis-network.min.css');
   // Use `app.import` to add additional libraries to the generated
   // output files.
   //

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "ember-load-initializers": "^1.0.0",
     "ember-modal-dialog": "^2.3.0",
     "ember-moment": "^7.3.0",
+    "ember-promise-helpers": "^1.0.3",
     "ember-resolver": "^4.0.0",
     "ember-simple-auth": "^1.3.0",
     "ember-sinon": "^1.0.1",
@@ -81,6 +82,8 @@
     "eslint": "^4.7.0",
     "eslint-config-screwdriver": "^3.0.0",
     "eslint-plugin-ember": "^4.5.0",
-    "loader.js": "^4.2.3"
-  }
+    "loader.js": "^4.2.3",
+    "vis": "^4.21.0"
+  },
+  "dependencies": {}
 }

--- a/tests/integration/components/workflow-graph-vis/component-test.js
+++ b/tests/integration/components/workflow-graph-vis/component-test.js
@@ -1,0 +1,24 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('workflow-graph-vis', 'Integration | Component | workflow graph vis', {
+  integration: true
+});
+
+test('it renders', function (assert) {
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{workflow-graph-vis}}`);
+
+  assert.equal(this.$().text().trim(), '');
+
+  // Template block usage:
+  this.render(hbs`
+    {{#workflow-graph-vis}}
+      template block text
+    {{/workflow-graph-vis}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'template block text');
+});


### PR DESCRIPTION
Context:
========
With the updates to the workflow backend, we need a better way to display a workflow than a linear set of builds

Objective:
-----------
Display a directed graph of the workflow for pipelines and events.

Misc:
------
This PR is meant as a stop-gap to display a graph of the workflow, but the intention is to replace this graph with something much better ASAP. 

This is still missing the following features:
* Automatically update the graph when builds for an event/pipeline update. WORKAROUND: refresh page
* Display meaningful icons for the colorblind. WORKAROUND: Status on hover
* Display a more minified graph for events
* Mobile-friendly view

There are probably a number of other things that should be cleaned up, too.

<img width="829" alt="screen shot 2017-10-23 at 3 26 21 pm" src="https://user-images.githubusercontent.com/78533/31916482-c51a0b8a-b807-11e7-899e-ceef20660115.png">
