### PR TITLE
fix: new workflow graph breaks validator ui

### DIFF
--- a/app/components/validator-pipeline/template.hbs
+++ b/app/components/validator-pipeline/template.hbs
@@ -13,14 +13,6 @@
 </div>
 <div class="workflow" title="This is the order that the jobs will run in.">
   <span class="label">Workflow:</span>
-  <span class="value">
-    <ul>
-      {{#each workflow as |name|}}
-      <li>{{name}}</li>
-      {{else}}
-      <li>Main</li>
-      {{/each}}
-    </ul>
-  </span>
+  {{workflow-graph-vis workflowGraph=workflowGraph}}
 </div>
 {{yield}}

--- a/app/components/validator-results/component.js
+++ b/app/components/validator-results/component.js
@@ -1,31 +1,24 @@
-import { computed } from '@ember/object';
+import { computed, get, getWithDefault } from '@ember/object';
 import Component from '@ember/component';
+const { reads, map } = computed;
 
 export default Component.extend({
   results: null,
-  errors: computed('results', {
+  jobs: reads('results.jobs'),
+  errors: map('results.errors', e => (typeof e === 'string' ? e : e.message)),
+  workflowGraph: computed('results.workflowGraph', {
     get() {
-      return (this.get('results.errors') || []).map(e => (typeof e === 'string' ? e : e.message));
+      return getWithDefault(this, 'results.workflowGraph', { nodes: [], edges: [] });
     }
   }),
-  workflow: computed('results', {
+  annotations: computed('results.annotations', {
     get() {
-      return this.get('results.workflow') || [];
-    }
-  }),
-  annotations: computed('results', {
-    get() {
-      return this.get('results.annotations') || [];
-    }
-  }),
-  jobs: computed('results', {
-    get() {
-      return this.get('results.jobs');
+      return getWithDefault(this, 'results.annotations', []);
     }
   }),
   templateName: computed('results.template.{name,version}', {
     get() {
-      return `${this.get('results.template.name')}@${this.get('results.template.version')}`;
+      return `${get(this, 'results.template.name')}@${get(this, 'results.template.version')}`;
     }
   })
 });

--- a/app/components/validator-results/template.hbs
+++ b/app/components/validator-results/template.hbs
@@ -4,15 +4,16 @@
 </div>
 {{/each}}
 {{#if isTemplate}}
-{{validator-job name=templateName job=results.template.config}}
+  {{validator-job name=templateName job=results.template.config}}
 {{else}}
-{{validator-pipeline name=pipelineName workflow=workflow annotations=annotations}}
-{{#each workflow as |jobName|}}
-  {{#if (get jobs jobName)}}
-    {{#each (get jobs jobName) as |jobConfig index|}}
-      {{validator-job name=jobName job=jobConfig index=index}}
-    {{/each}}
-  {{/if}}
-{{/each}}
+  {{validator-pipeline name=pipelineName workflowGraph=workflowGraph annotations=annotations}}
+
+  {{#each workflowGraph.nodes as |node|}}
+    {{#if (get jobs node.name)}}
+      {{#each (get jobs node.name) as |jobConfig index|}}
+        {{validator-job name=node.name job=jobConfig index=index}}
+      {{/each}}
+    {{/if}}
+  {{/each}}
 {{/if}}
 {{yield}}

--- a/app/components/workflow-graph-vis/component.js
+++ b/app/components/workflow-graph-vis/component.js
@@ -6,7 +6,7 @@ import DS from 'ember-data';
 
 export default Component.extend({
   router: service(),
-  nodes: computed({
+  nodes: computed('workflowGraph.nodes.[]', {
     get() {
       const nodes = getWithDefault(this, 'workflowGraph.nodes', []);
       const startFrom = get(this, 'startFrom');
@@ -69,7 +69,7 @@ export default Component.extend({
     }
   }),
 
-  edges: computed({
+  edges: computed('workflowGraph.edges.[]', {
     get() {
       const edges = getWithDefault(this, 'workflowGraph.edges', []);
 
@@ -87,7 +87,13 @@ export default Component.extend({
     this.createNetwork();
   },
 
-  // TODO: Listen for changes to nodes/edges and update graph accordingly.
+  // Listen for changes to nodes/edges and update graph accordingly.
+  didUpdateAttrs() {
+    this._super(...arguments);
+
+    set(this, 'network', null);
+    this.createNetwork();
+  },
 
   createNetwork() {
     const options = {

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,8 +1,3 @@
-workflow:
-  - publish
-  - beta
-  - prod
-
 shared:
   image: node:6
 
@@ -13,6 +8,9 @@ jobs:
       - bower: npm install bower && ./node_modules/.bin/bower install --allow-root
       - install-browsers: ./bin/setup_chrome.sh
       - test: npm test
+    requires:
+      - ~pr
+      - ~commit
 
   # Publish the package to GitHub and build docker image
   publish:
@@ -37,6 +35,8 @@ jobs:
       - GITHUB_TOKEN
       # Trigger a Docker Hub build
       - DOCKER_TRIGGER
+    requires:
+      - main
 
   # Deploy to our beta environment and run tests
   beta:
@@ -56,6 +56,8 @@ jobs:
     secrets:
       # Talking to Kubernetes
       - K8S_TOKEN
+    requires:
+      - publish
 
   # Deploy to our prod environment and run tests
   prod:
@@ -75,3 +77,5 @@ jobs:
     secrets:
       # Talking to Kubernetes
       - K8S_TOKEN
+    requires:
+      - beta

--- a/tests/integration/components/validator-pipeline/component-test.js
+++ b/tests/integration/components/validator-pipeline/component-test.js
@@ -14,7 +14,7 @@ test('it renders default empty settings', function (assert) {
   assert.equal(this.$('.annotations ul li').text().trim(), 'None defined');
 
   assert.equal(this.$('.workflow .label').text().trim(), 'Workflow:');
-  assert.equal(this.$('.workflow  ul li').text().trim(), 'Main');
+  assert.ok(this.$('.workflow canvas'), 'workflow canvas');
 });
 
 test('it renders pipeline annotations and workflow', function (assert) {
@@ -34,6 +34,5 @@ test('it renders pipeline annotations and workflow', function (assert) {
   assert.equal(this.$('.annotations ul li').text().trim(), 'hello: hi');
 
   assert.equal(this.$('.workflow .label').text().trim(), 'Workflow:');
-  assert.equal(this.$('.workflow ul li:nth-child(1)').text().trim(), 'firstjob');
-  assert.equal(this.$('.workflow ul li:nth-child(2)').text().trim(), 'secondjob');
+  assert.ok(this.$('.workflow canvas'), 'workflow canvas');
 });

--- a/tests/integration/components/validator-results/component-test.js
+++ b/tests/integration/components/validator-results/component-test.js
@@ -11,6 +11,15 @@ test('it renders jobs', function (assert) {
   this.set('validationMock', {
     errors: ['got an error'],
     workflow: ['main', 'foo'],
+    workflowGraph: {
+      nodes: [
+        { name: '~pr' },
+        { name: '~commit' },
+        { name: 'main' },
+        { name: 'foo' }
+      ],
+      edges: []
+    },
     jobs: {
       foo: [{
         image: 'int-test:1',


### PR DESCRIPTION
Context:
========
After the workflow updates, the validator failed to display jobs for projects that did not explicitly define workflow

Objective:
-----------
Use the new workflowGraph property instead of workflow to display the workflow and job information

![screen shot 2017-11-03 at 5 18 46 pm](https://user-images.githubusercontent.com/78533/32400369-4fc8bb84-c0bc-11e7-881c-afdb13f3105b.png)
