### PR TITLE
fix: get err message from the right place

### DIFF
--- a/app/pipeline/builds/index/controller.js
+++ b/app/pipeline/builds/index/controller.js
@@ -27,7 +27,7 @@ export default Controller.extend({
         return this.transitionToRoute('pipeline', newEvent.get('pipelineId'));
       }).catch((e) => {
         this.set('isShowingModal', false);
-        this.set('errorMessage', e.message);
+        this.set('errorMessage', e.errors[0].detail);
       });
     }
   }


### PR DESCRIPTION
Error message is actually sitting at `e.errors[0].detail`

Reference:
https://github.com/screwdriver-cd/ui/blob/master/app/pipeline/secrets/controller.js#L19