### PR TITLE
fix(694): display statusMessage if there is one

### DIFF
--- a/app/build/model.js
+++ b/app/build/model.js
@@ -52,6 +52,7 @@ export default DS.Model.extend({
   sha: DS.attr('string'),
   startTime: DS.attr('date'),
   status: DS.attr('string'),
+  statusMessage: DS.attr('string'),
   steps: DS.attr(),
 
   createTimeWords: computed('createTime', {

--- a/app/pipeline/builds/build/template.hbs
+++ b/app/pipeline/builds/build/template.hbs
@@ -12,6 +12,10 @@
   eventBuilds=event.buildsSorted
 }}
 
+{{#if build.statusMessage}}
+  {{info-message message=build.statusMessage type="warning" icon="exclamation-triangle"}}
+{{/if}}
+
 {{#if stepList}}
 {{#build-step-collection}}
   {{#each stepList as |name index|}}

--- a/tests/acceptance/build-test.js
+++ b/tests/acceptance/build-test.js
@@ -78,6 +78,7 @@ moduleForAcceptance('Acceptance | build', {
         name: 'test'
       }],
       status: 'FAILURE',
+      statusMessage: 'Build failed to start due to infrastructure err',
       commit: {
         url: 'https://github.com/commit',
         message: 'merge this'
@@ -180,6 +181,8 @@ test('visiting /pipelines/:id/builds/:id', function (assert) {
     assert.equal(currentURL(), '/pipelines/1/builds/1234');
     assert.equal(find('a h1').text().trim(), 'foo/bar', 'incorrect pipeline name');
     assert.equal(find('.headerbar h1').text().trim(), 'PR-50', 'incorrect job name');
+    assert.equal($('.alert-warning > span').text().trim(),
+      'Build failed to start due to infrastructure err', 'incorrect statusMessage');
     assert.equal(find('span.sha').text().trim(), '#abcdef', 'incorrect sha');
     assert.ok(find('.is-open .logs').text().trim().match(first), 'incorrect logs open');
 


### PR DESCRIPTION
Display `statusMessage` on the build page if there is one.

I know this is ugly, but let's get the functionality out and let Chas makes it prettier.

example: I aborted my build with the following `statusMessage`
<img width="1394" alt="screen shot 2017-11-16 at 2 37 48 pm" src="https://user-images.githubusercontent.com/20427140/32919958-6fd34eba-cadc-11e7-894c-24dcf7739ecd.png">

Related to https://github.com/screwdriver-cd/screwdriver/issues/694

