### PR TITLE
fix: new algorithm for graph rows/columns

### DIFF
--- a/app/components/workflow-graph-d3/component.js
+++ b/app/components/workflow-graph-d3/component.js
@@ -77,7 +77,6 @@ export default Component.extend({
   },
   draw() {
     const data = get(this, 'decoratedGraph');
-
     // TODO: actually scale drawing based on available space.
     const { ICON_SIZE, TITLE_SIZE, ARROWHEAD } = get(this, 'elementSizes');
     // Adjustable spacing between nodes
@@ -131,6 +130,10 @@ export default Component.extend({
         .attr('y', d => ((d.pos.y + 1) * ICON_SIZE) + (d.pos.y * Y_SPACING) + TITLE_SIZE);
     }
 
+    // Calculate the start/end point of a line
+    const calcPos = (pos, spacer) =>
+      ((pos + 1) * ICON_SIZE) + ((pos * spacer) - (ICON_SIZE / 2));
+
     // edges
     svg.selectAll('link')
       .data(data.edges)
@@ -141,8 +144,6 @@ export default Component.extend({
       .attr('stroke-width', 2)
       .attr('fill', 'transparent')
       .attr('d', (d) => {
-        const calcPos = (pos, spacer) =>
-          ((pos + 1) * ICON_SIZE) + ((pos * spacer) - (ICON_SIZE / 2));
         const path = d3.path();
         const startX = calcPos(d.from.x, X_SPACING) + ICON_SIZE;
         const startY = calcPos(d.from.y, Y_SPACING);

--- a/app/utils/graph-tools.js
+++ b/app/utils/graph-tools.js
@@ -82,18 +82,10 @@ const decorateGraph = (inputGraph, builds, start) => {
 
   nodes.forEach((n) => {
     // Set root nodes on left
-    if (n.name.startsWith('~')) {
+    if (n.name.startsWith('~') || !n.pos) {
       n.pos = { x: 0, y: y[0] };
       y[0] += 1;
-      // recursively walk the graph from root
-      walkGraph(graph, n.name, 1, y);
-    }
-
-    // Set detached nodes on left
-    if (!n.pos) {
-      n.pos = { x: 0, y: y[0] };
-      y[0] += 1;
-      // recursively walk the graph from detached node
+      // recursively walk the graph from root/ detached node
       walkGraph(graph, n.name, 1, y);
     }
 

--- a/app/utils/graph-tools.js
+++ b/app/utils/graph-tools.js
@@ -22,12 +22,45 @@ const STATUS_MAP = {
 const node = (nodes, name) => nodes.find(o => o.name === name);
 
 /**
+ * Find a build for the given job id
+ * @method build
+ * @param  {Array} builds   List of build objects
+ * @param  {String} jobId   The job id of the build
+ * @return {Object}         Reference to the build object from the list if found
+ */
+const build = (builds, jobId) => builds.find(b => b && `${get(b, 'jobId')}` === `${jobId}`);
+
+/**
  * Find the icon to set as the text for a node
  * @method icon
  * @param  {String} status Text that denotes a build status
- * @return {String}        Unicode character that maps to an icon in denali font
+ * @return {String}        Unicode character that maps to an icon in screwdriver icon font
  */
 const icon = status => (STATUS_MAP[status] ? STATUS_MAP[status].icon : STATUS_MAP.UNKNOWN.icon);
+
+/**
+ * Walks the graph to find siblings and set their positions
+ * @method walkGraph
+ * @param  {Object}  graph Raw graph definition
+ * @param  {String}  start The job name to start from for this iteration
+ * @param  {Number}  x     The column for this iteration
+ * @param  {Array}   y     Accumulator of column depth
+ */
+const walkGraph = (graph, start, x, y) => {
+  if (!y[x]) { y[x] = 0; }
+  const nodeNames = graph.edges.filter(e => e.src === start).map(e => e.dest);
+
+  nodeNames.forEach((name) => {
+    const obj = node(graph.nodes, name);
+
+    if (!obj.pos) {
+      obj.pos = { x, y: y[x] };
+      y[x] += 1;
+    }
+
+    walkGraph(graph, name, x + 1, y);
+  });
+};
 
 /**
  * Clones and decorates an input graph datastructure into something that can be used to display
@@ -42,90 +75,66 @@ const decorateGraph = (inputGraph, builds, start) => {
   // simple clone
   const graph = JSON.parse(JSON.stringify(inputGraph));
   const nodes = graph.nodes;
+  const buildsAvailable = (Array.isArray(builds) || builds instanceof DS.PromiseArray) &&
+    get(builds, 'length');
   const edges = graph.edges;
-  const pos = { x: 0, y: 0 };
-  const nextPos = { x: 1, y: 0 };
-  let maxHeight = 1;
+  const y = [0]; // accumulator for column heights
 
-  // Decorate job status, and build info
-  if ((Array.isArray(builds) || builds instanceof DS.PromiseArray) && get(builds, 'length')) {
-    nodes.forEach((n) => {
-      const build = builds.find(j => j && `${get(j, 'jobId')}` === `${n.id}`);
-
-      if (build) {
-        const status = get(build, 'status');
-
-        if (status) {
-          n.status = status;
-        }
-
-        n.buildId = get(build, 'id');
-      }
-
-      if (n.name === start) {
-        n.status = 'STARTED_FROM';
-      }
-    });
-  }
-
-  // Calculate graph rows and columns with edges
-  for (let i = 0; i < edges.length; i += 1) {
-    const edge = edges[i];
-    const nextEdge = edges[i + 1];
-    const srcName = edge.src;
-    const srcConfig = node(nodes, srcName);
-    const destName = edge.dest;
-    const destConfig = node(nodes, destName);
-
-    // Set root node position
-    if (!srcConfig.pos) {
-      srcConfig.pos = Object.assign({}, pos);
-    }
-
-    // set "next" job position
-    if (!destConfig.pos) {
-      destConfig.pos = Object.assign({}, nextPos);
-    }
-
-    if (nextEdge) {
-      // The next edge src is a sibling of this edge src
-      if (edge.src !== nextEdge.src && edge.dest === nextEdge.dest) {
-        pos.y += 1;
-      }
-      // The next edge destination is a sibling of this edge destination
-      if (edge.src === nextEdge.src && edge.dest !== nextEdge.dest) {
-        nextPos.y += 1;
-      }
-      maxHeight = Math.max(maxHeight, pos.y, nextPos.y);
-      // We've gotten to the next step in the tree (increment x)
-      if (edge.src !== nextEdge.src && edge.dest !== nextEdge.dest) {
-        pos.x += 1;
-        pos.y = 0;
-        nextPos.x += 1;
-        nextPos.y = 0;
-      }
-    }
-
-    // copy in the src and dest job positions for drawing edge
-    edge.from = srcConfig.pos;
-    edge.to = destConfig.pos;
-
-    // copy in the src job status for coloring edge
-    if (srcConfig.status && srcConfig.status !== 'RUNNING') {
-      edge.status = srcConfig.status;
-    }
-  }
-
-  // Double check all nodes have positions (handle detached jobs with no edges)
   nodes.forEach((n) => {
+    // Set root nodes on left
+    if (n.name.startsWith('~')) {
+      n.pos = { x: 0, y: y[0] };
+      y[0] += 1;
+      // recursively walk the graph from root
+      walkGraph(graph, n.name, 1, y);
+    }
+
+    // Set detached nodes on left
     if (!n.pos) {
-      maxHeight += 1;
-      n.pos = { x: 0, y: maxHeight };
+      n.pos = { x: 0, y: y[0] };
+      y[0] += 1;
+      // recursively walk the graph from detached node
+      walkGraph(graph, n.name, 1, y);
+    }
+
+    // get build information
+    const jobId = get(n, 'id');
+
+    if (buildsAvailable && jobId) {
+      const b = build(builds, jobId);
+
+      // Add build information to node
+      if (b) {
+        n.status = get(b, 'status');
+        n.buildId = get(b, 'id');
+      }
+    }
+
+    // Set a status on the trigger node
+    if (n.name === start) {
+      n.status = 'STARTED_FROM';
+    }
+  });
+
+  // Decorate edges with positions and status
+  edges.forEach((e) => {
+    const srcNode = node(nodes, e.src);
+    const destNode = node(nodes, e.dest);
+
+    e.from = srcNode.pos;
+    e.to = destNode.pos;
+
+    if (srcNode.status && srcNode.status !== 'RUNNING') {
+      e.status = srcNode.status;
     }
   });
 
   // For auto-scaling canvas size
-  graph.meta = { height: maxHeight + 1, width: nextPos.x + 1 };
+  graph.meta = {
+    // Validator starts with a graph with no nodes or edges. Should have a size of at least 1
+    height: Math.max(1, ...y),
+    width: Math.max(1, y.length - 1)
+  };
 
   return graph;
 };

--- a/app/utils/graph-tools.js
+++ b/app/utils/graph-tools.js
@@ -63,6 +63,15 @@ const walkGraph = (graph, start, x, y) => {
 };
 
 /**
+ * Determine if a node is a root node by seeing if it is listed as a destination
+ * @method isRoot
+ * @param  {Array}  edges List of graph edges
+ * @param  {String}  name The job name to check
+ * @return {Boolean}      True if the node is not a dest in edges
+ */
+const isRoot = (edges, name) => !edges.find(e => e.dest === name);
+
+/**
  * Clones and decorates an input graph datastructure into something that can be used to display
  * a custom directed graph
  * @method decorateGraph
@@ -83,7 +92,7 @@ const decorateGraph = (inputGraph, builds, start) => {
   nodes.sort((a, b) => a.name.localeCompare(b.name));
   nodes.forEach((n) => {
     // Set root nodes on left
-    if (n.name.startsWith('~') || !n.pos) {
+    if (isRoot(edges, n.name)) {
       n.pos = { x: 0, y: y[0] };
       y[0] += 1;
       // recursively walk the graph from root/ detached node

--- a/app/utils/graph-tools.js
+++ b/app/utils/graph-tools.js
@@ -80,6 +80,7 @@ const decorateGraph = (inputGraph, builds, start) => {
   const edges = graph.edges;
   const y = [0]; // accumulator for column heights
 
+  nodes.sort((a, b) => a.name.localeCompare(b.name));
   nodes.forEach((n) => {
     // Set root nodes on left
     if (n.name.startsWith('~') || !n.pos) {

--- a/tests/unit/utils/graph-tools-test.js
+++ b/tests/unit/utils/graph-tools-test.js
@@ -196,3 +196,68 @@ test('it handles detached jobs', function (assert) {
 
   assert.deepEqual(result, expectedOutput);
 });
+
+test('it handles complex misordered pipeline with multiple commit/pr/remote triggers',
+  function (assert) {
+    const inputGraph = {
+      nodes: [
+        { name: '~pr' },
+        { name: '~commit' },
+        { name: 'no_main' },
+        { name: '~sd@241:main' },
+        { name: 'publish' },
+        { name: 'other_publish' },
+        { name: 'wow_new_main' },
+        { name: 'detached_main' },
+        { name: 'after_detached_main' },
+        { name: 'detached_solo' }
+      ],
+      edges: [
+        { src: '~commit', dest: 'no_main' },
+        { src: '~pr', dest: 'no_main' },
+        { src: '~sd@241:main', dest: 'no_main' },
+        { src: 'no_main', dest: 'publish' },
+        { src: 'wow_new_main', dest: 'other_publish' },
+        { src: '~commit', dest: 'wow_new_main' },
+        { src: '~pr', dest: 'wow_new_main' },
+        { src: '~sd@241:main', dest: 'wow_new_main' },
+        { src: 'detached_main', dest: 'after_detached_main' }
+      ]
+    };
+    const expectedOutput = {
+      nodes: [
+        { name: '~pr', pos: { x: 0, y: 0 } },
+        { name: '~commit', pos: { x: 0, y: 1 } },
+        { name: 'no_main', pos: { x: 1, y: 0 } },
+        { name: '~sd@241:main', pos: { x: 0, y: 2 } },
+        { name: 'publish', pos: { x: 2, y: 0 } },
+        { name: 'other_publish', pos: { x: 2, y: 1 } },
+        { name: 'wow_new_main', pos: { x: 1, y: 1 } },
+        { name: 'detached_main', pos: { x: 0, y: 3 } },
+        { name: 'after_detached_main', pos: { x: 1, y: 2 } },
+        { name: 'detached_solo', pos: { x: 0, y: 4 } }
+      ],
+      edges: [
+        { src: '~commit', dest: 'no_main', from: { x: 0, y: 1 }, to: { x: 1, y: 0 } },
+        { src: '~pr', dest: 'no_main', from: { x: 0, y: 0 }, to: { x: 1, y: 0 } },
+        { src: '~sd@241:main', dest: 'no_main', from: { x: 0, y: 2 }, to: { x: 1, y: 0 } },
+        { src: 'no_main', dest: 'publish', from: { x: 1, y: 0 }, to: { x: 2, y: 0 } },
+        { src: 'wow_new_main', dest: 'other_publish', from: { x: 1, y: 1 }, to: { x: 2, y: 1 } },
+        { src: '~commit', dest: 'wow_new_main', from: { x: 0, y: 1 }, to: { x: 1, y: 1 } },
+        { src: '~pr', dest: 'wow_new_main', from: { x: 0, y: 0 }, to: { x: 1, y: 1 } },
+        { src: '~sd@241:main', dest: 'wow_new_main', from: { x: 0, y: 2 }, to: { x: 1, y: 1 } },
+        { src: 'detached_main',
+          dest: 'after_detached_main',
+          from: { x: 0, y: 3 },
+          to: { x: 1, y: 2 }
+        }
+      ],
+      meta: {
+        width: 3,
+        height: 5
+      }
+    };
+    const result = decorateGraph(inputGraph);
+
+    assert.deepEqual(result, expectedOutput);
+  });

--- a/tests/unit/utils/graph-tools-test.js
+++ b/tests/unit/utils/graph-tools-test.js
@@ -30,13 +30,13 @@ test('it processes a simple graph without builds', function (assert) {
   };
   const expectedOutput = {
     nodes: [
-      { name: '~pr', pos: { x: 0, y: 0 } },
-      { name: '~commit', pos: { x: 0, y: 1 } },
+      { name: '~commit', pos: { x: 0, y: 0 } },
+      { name: '~pr', pos: { x: 0, y: 1 } },
       { name: 'main', pos: { x: 1, y: 0 } }
     ],
     edges: [
-      { src: '~pr', dest: 'main', from: { x: 0, y: 0 }, to: { x: 1, y: 0 } },
-      { src: '~commit', dest: 'main', from: { x: 0, y: 1 }, to: { x: 1, y: 0 } }
+      { src: '~pr', dest: 'main', from: { x: 0, y: 1 }, to: { x: 1, y: 0 } },
+      { src: '~commit', dest: 'main', from: { x: 0, y: 0 }, to: { x: 1, y: 0 } }
     ],
     meta: {
       height: 2,
@@ -71,17 +71,17 @@ test('it processes a more complex graph without builds', function (assert) {
   };
   const expectedOutput = {
     nodes: [
-      { name: '~pr', pos: { x: 0, y: 0 } },
-      { name: '~commit', pos: { x: 0, y: 1 } },
-      { name: 'main', pos: { x: 1, y: 0 } },
+      { name: '~commit', pos: { x: 0, y: 0 } },
+      { name: '~pr', pos: { x: 0, y: 1 } },
       { name: 'A', pos: { x: 2, y: 0 } },
       { name: 'B', pos: { x: 2, y: 1 } },
       { name: 'C', pos: { x: 3, y: 0 } },
-      { name: 'D', pos: { x: 4, y: 0 } }
+      { name: 'D', pos: { x: 4, y: 0 } },
+      { name: 'main', pos: { x: 1, y: 0 } }
     ],
     edges: [
-      { src: '~pr', dest: 'main', from: { x: 0, y: 0 }, to: { x: 1, y: 0 } },
-      { src: '~commit', dest: 'main', from: { x: 0, y: 1 }, to: { x: 1, y: 0 } },
+      { src: '~pr', dest: 'main', from: { x: 0, y: 1 }, to: { x: 1, y: 0 } },
+      { src: '~commit', dest: 'main', from: { x: 0, y: 0 }, to: { x: 1, y: 0 } },
       { src: 'main', dest: 'A', from: { x: 1, y: 0 }, to: { x: 2, y: 0 } },
       { src: 'main', dest: 'B', from: { x: 1, y: 0 }, to: { x: 2, y: 1 } },
       { src: 'A', dest: 'C', from: { x: 2, y: 0 }, to: { x: 3, y: 0 } },
@@ -128,20 +128,20 @@ test('it processes a complex graph with builds', function (assert) {
   ];
   const expectedOutput = {
     nodes: [
-      { name: '~pr', pos: { x: 0, y: 0 } },
-      { name: '~commit', status: 'STARTED_FROM', pos: { x: 0, y: 1 } },
-      { name: 'main', id: 1, buildId: 6, status: 'SUCCESS', pos: { x: 1, y: 0 } },
+      { name: '~commit', status: 'STARTED_FROM', pos: { x: 0, y: 0 } },
+      { name: '~pr', pos: { x: 0, y: 1 } },
       { name: 'A', id: 2, buildId: 7, status: 'SUCCESS', pos: { x: 2, y: 0 } },
       { name: 'B', id: 3, buildId: 8, status: 'SUCCESS', pos: { x: 2, y: 1 } },
       { name: 'C', id: 4, buildId: 9, status: 'SUCCESS', pos: { x: 3, y: 0 } },
-      { name: 'D', id: 5, buildId: 10, status: 'FAILURE', pos: { x: 4, y: 0 } }
+      { name: 'D', id: 5, buildId: 10, status: 'FAILURE', pos: { x: 4, y: 0 } },
+      { name: 'main', id: 1, buildId: 6, status: 'SUCCESS', pos: { x: 1, y: 0 } }
     ],
     edges: [
-      { src: '~pr', dest: 'main', from: { x: 0, y: 0 }, to: { x: 1, y: 0 } },
+      { src: '~pr', dest: 'main', from: { x: 0, y: 1 }, to: { x: 1, y: 0 } },
       {
         src: '~commit',
         dest: 'main',
-        from: { x: 0, y: 1 },
+        from: { x: 0, y: 0 },
         to: { x: 1, y: 0 },
         status: 'STARTED_FROM'
       },
@@ -177,15 +177,15 @@ test('it handles detached jobs', function (assert) {
   };
   const expectedOutput = {
     nodes: [
-      { name: '~pr', pos: { x: 0, y: 0 } },
-      { name: '~commit', pos: { x: 0, y: 1 } },
-      { name: 'main', pos: { x: 1, y: 0 } },
-      { name: 'foo', pos: { x: 0, y: 2 } },
-      { name: 'bar', pos: { x: 0, y: 3 } }
+      { name: '~commit', pos: { x: 0, y: 0 } },
+      { name: '~pr', pos: { x: 0, y: 1 } },
+      { name: 'bar', pos: { x: 0, y: 2 } },
+      { name: 'foo', pos: { x: 0, y: 3 } },
+      { name: 'main', pos: { x: 1, y: 0 } }
     ],
     edges: [
-      { src: '~pr', dest: 'main', from: { x: 0, y: 0 }, to: { x: 1, y: 0 } },
-      { src: '~commit', dest: 'main', from: { x: 0, y: 1 }, to: { x: 1, y: 0 } }
+      { src: '~pr', dest: 'main', from: { x: 0, y: 1 }, to: { x: 1, y: 0 } },
+      { src: '~commit', dest: 'main', from: { x: 0, y: 0 }, to: { x: 1, y: 0 } }
     ],
     meta: {
       height: 4,
@@ -226,25 +226,25 @@ test('it handles complex misordered pipeline with multiple commit/pr/remote trig
     };
     const expectedOutput = {
       nodes: [
-        { name: '~pr', pos: { x: 0, y: 0 } },
-        { name: '~commit', pos: { x: 0, y: 1 } },
-        { name: 'no_main', pos: { x: 1, y: 0 } },
+        { name: '~commit', pos: { x: 0, y: 0 } },
+        { name: '~pr', pos: { x: 0, y: 1 } },
         { name: '~sd@241:main', pos: { x: 0, y: 2 } },
-        { name: 'publish', pos: { x: 2, y: 0 } },
-        { name: 'other_publish', pos: { x: 2, y: 1 } },
-        { name: 'wow_new_main', pos: { x: 1, y: 1 } },
-        { name: 'detached_main', pos: { x: 0, y: 3 } },
         { name: 'after_detached_main', pos: { x: 1, y: 2 } },
-        { name: 'detached_solo', pos: { x: 0, y: 4 } }
+        { name: 'detached_main', pos: { x: 0, y: 3 } },
+        { name: 'detached_solo', pos: { x: 0, y: 4 } },
+        { name: 'no_main', pos: { x: 1, y: 0 } },
+        { name: 'other_publish', pos: { x: 2, y: 1 } },
+        { name: 'publish', pos: { x: 2, y: 0 } },
+        { name: 'wow_new_main', pos: { x: 1, y: 1 } }
       ],
       edges: [
-        { src: '~commit', dest: 'no_main', from: { x: 0, y: 1 }, to: { x: 1, y: 0 } },
-        { src: '~pr', dest: 'no_main', from: { x: 0, y: 0 }, to: { x: 1, y: 0 } },
+        { src: '~commit', dest: 'no_main', from: { x: 0, y: 0 }, to: { x: 1, y: 0 } },
+        { src: '~pr', dest: 'no_main', from: { x: 0, y: 1 }, to: { x: 1, y: 0 } },
         { src: '~sd@241:main', dest: 'no_main', from: { x: 0, y: 2 }, to: { x: 1, y: 0 } },
         { src: 'no_main', dest: 'publish', from: { x: 1, y: 0 }, to: { x: 2, y: 0 } },
         { src: 'wow_new_main', dest: 'other_publish', from: { x: 1, y: 1 }, to: { x: 2, y: 1 } },
-        { src: '~commit', dest: 'wow_new_main', from: { x: 0, y: 1 }, to: { x: 1, y: 1 } },
-        { src: '~pr', dest: 'wow_new_main', from: { x: 0, y: 0 }, to: { x: 1, y: 1 } },
+        { src: '~commit', dest: 'wow_new_main', from: { x: 0, y: 0 }, to: { x: 1, y: 1 } },
+        { src: '~pr', dest: 'wow_new_main', from: { x: 0, y: 1 }, to: { x: 1, y: 1 } },
         { src: '~sd@241:main', dest: 'wow_new_main', from: { x: 0, y: 2 }, to: { x: 1, y: 1 } },
         { src: 'detached_main',
           dest: 'after_detached_main',


### PR DESCRIPTION
Context:
========
We determined that the algorithm for calculating rows/columns for the workflow graph would end up displaying some bubbles on top of each other, or in other ways be difficult to read.

Objective:
----------
Change the algorithm for calculating rows and columns.

Goes from this:
<img width="231" alt="screen shot 2017-11-17 at 1 55 41 pm" src="https://user-images.githubusercontent.com/78533/32971425-0c294704-cba2-11e7-8595-6957b9a4d455.png">

to this:
<img width="222" alt="screen shot 2017-11-17 at 1 55 20 pm" src="https://user-images.githubusercontent.com/78533/32971435-112beb9e-cba2-11e7-9903-a7724eb55b57.png">
