### PR TITLE
fix(803): event model does not properly compute when it is finished

### DIFF
--- a/app/utils/graph-tools.js
+++ b/app/utils/graph-tools.js
@@ -39,6 +39,33 @@ const build = (builds, jobId) => builds.find(b => b && `${get(b, 'jobId')}` === 
 const icon = status => (STATUS_MAP[status] ? STATUS_MAP[status].icon : STATUS_MAP.UNKNOWN.icon);
 
 /**
+ * Calculate how many nodes are visited in the graph from the given starting point
+ * @method graphDepth
+ * @param  {Array}   edges    List of graph edges
+ * @param  {String}  start    Node name for starting point
+ * @param  {Set}     visited  List of visited nodes
+ * @return {Number}           Number of visited nodes
+ */
+const graphDepth = (edges, start, visited = new Set()) => {
+  const dests = edges.filter(e => e.src === start);
+
+  // For partials/detached jobs
+  if (!start.startsWith('~')) {
+    visited.add(start);
+  }
+
+  // walk the graph
+  if (dests.length) {
+    dests.forEach((e) => {
+      visited.add(e.dest);
+      graphDepth(edges, e.dest, visited);
+    });
+  }
+
+  return visited.size;
+};
+
+/**
  * Walks the graph to find siblings and set their positions
  * @method walkGraph
  * @param  {Object}  graph Raw graph definition
@@ -89,7 +116,6 @@ const decorateGraph = (inputGraph, builds, start) => {
   const edges = graph.edges;
   const y = [0]; // accumulator for column heights
 
-  nodes.sort((a, b) => a.name.localeCompare(b.name));
   nodes.forEach((n) => {
     // Set root nodes on left
     if (isRoot(edges, n.name)) {
@@ -141,4 +167,4 @@ const decorateGraph = (inputGraph, builds, start) => {
   return graph;
 };
 
-export default { node, icon, decorateGraph };
+export default { node, icon, decorateGraph, graphDepth };

--- a/tests/unit/event/model-test.js
+++ b/tests/unit/event/model-test.js
@@ -1,7 +1,27 @@
 import { run } from '@ember/runloop';
+import { get } from '@ember/object';
 import { moduleForModel, test } from 'ember-qunit';
 
-const workflow = ['one', 'two', 'three', 'four'];
+const workflowGraph = {
+  nodes: [
+    { name: '~pr' },
+    { name: '~commit' },
+    { name: 'main', id: 1 },
+    { name: 'A', id: 2 },
+    { name: 'B', id: 3 },
+    { name: 'C', id: 4 },
+    { name: 'D', id: 5 }
+  ],
+  edges: [
+    { src: '~pr', dest: 'main' },
+    { src: '~commit', dest: 'main' },
+    { src: 'main', dest: 'A' },
+    { src: 'main', dest: 'B' },
+    { src: 'A', dest: 'C' },
+    { src: 'B', dest: 'D' },
+    { src: 'C', dest: 'D' }
+  ]
+};
 
 moduleForModel('event', 'Unit | Model | event', {
   // Specify the other units that are required for this test.
@@ -15,46 +35,86 @@ test('it exists', function (assert) {
 });
 
 test('it is not completed when there are no builds', function (assert) {
-  const model = this.subject({ builds: [], workflow });
+  const model = this.subject({ builds: [], workflowGraph, startFrom: '~commit' });
 
-  assert.notOk(model.get('isComplete'));
+  return get(model, 'isComplete').then(isComplete => assert.notOk(isComplete));
 });
 
-test('it is not completed when the most recent build is not complete', function (assert) {
+test('it is not completed when the a build is not complete', function (assert) {
   run(() => {
-    const build = this.store().createRecord('build', { status: 'RUNNING' });
-    const model = this.subject({ builds: [build], workflow });
+    const build = this.store().createRecord('build', { jobId: 1, status: 'RUNNING' });
+    const model = this.subject({ builds: [build], workflowGraph, startFrom: '~commit' });
 
-    assert.notOk(model.get('isComplete'));
+    return get(model, 'isComplete').then(isComplete => assert.notOk(isComplete));
   });
 });
 
-test('it is completed when the most recent build is unsuccessful', function (assert) {
+test('it is completed when any build is unsuccessful', function (assert) {
   run(() => {
     const build = this.store().createRecord('build', { status: 'ABORTED' });
-    const model = this.subject({ builds: [build], workflow });
+    const model = this.subject({ builds: [build], workflowGraph, startFrom: '~commit' });
 
-    assert.ok(model.get('isComplete'));
+    return get(model, 'isComplete').then(isComplete => assert.ok(isComplete));
   });
 });
 
-test('it is not completed when all not all builds have run', function (assert) {
+test('it is not completed when all not all expected builds have run', function (assert) {
   run(() => {
     const build = this.store().createRecord('build', { status: 'SUCCESS' });
-    const model = this.subject({ builds: [build], workflow });
+    const model = this.subject({ builds: [build], workflowGraph, startFrom: '~commit' });
 
-    assert.notOk(model.get('isComplete'));
+    return get(model, 'isComplete').then(isComplete => assert.notOk(isComplete));
   });
 });
 
-test('it is complete when all builds have run', function (assert) {
+test('it is complete when all expected builds have run', function (assert) {
   run(() => {
-    const build1 = this.store().createRecord('build', { status: 'SUCCESS' });
-    const build2 = this.store().createRecord('build', { status: 'SUCCESS' });
-    const build3 = this.store().createRecord('build', { status: 'SUCCESS' });
-    const build4 = this.store().createRecord('build', { status: 'SUCCESS' });
-    const model = this.subject({ builds: [build4, build3, build2, build1], workflow });
+    const build1 = this.store().createRecord('build', { jobId: 1, status: 'SUCCESS' });
+    const build2 = this.store().createRecord('build', { jobId: 2, status: 'SUCCESS' });
+    const build3 = this.store().createRecord('build', { jobId: 3, status: 'SUCCESS' });
+    const build4 = this.store().createRecord('build', { jobId: 4, status: 'SUCCESS' });
+    const build5 = this.store().createRecord('build', { jobId: 5, status: 'SUCCESS' });
+    const model = this.subject({
+      builds: [build5, build4, build3, build2, build1],
+      workflowGraph,
+      startFrom: '~commit'
+    });
 
-    assert.ok(model.get('isComplete'));
+    return get(model, 'isComplete').then(isComplete => assert.ok(isComplete));
+  });
+});
+
+test('it is RUNNING when there are no builds', function (assert) {
+  run(() => {
+    const model = this.subject({ builds: [], workflowGraph, startFrom: '~commit' });
+
+    get(model, 'status').then(status => assert.equal('RUNNING', status));
+  });
+});
+
+test('it returns build status when a build is not SUCCESS', function (assert) {
+  run(() => {
+    const build1 = this.store().createRecord('build', { jobId: 1, status: 'ABORTED' });
+    const build2 = this.store().createRecord('build', { jobId: 2, status: 'SUCCESS' });
+    const model = this.subject({ builds: [build2, build1], workflowGraph, startFrom: '~commit' });
+
+    get(model, 'status').then(status => assert.equal('ABORTED', status));
+  });
+});
+
+test('it is SUCCESS when all expected builds have run successfully', function (assert) {
+  run(() => {
+    const build1 = this.store().createRecord('build', { jobId: 1, status: 'SUCCESS' });
+    const build2 = this.store().createRecord('build', { jobId: 2, status: 'SUCCESS' });
+    const build3 = this.store().createRecord('build', { jobId: 3, status: 'SUCCESS' });
+    const build4 = this.store().createRecord('build', { jobId: 4, status: 'SUCCESS' });
+    const build5 = this.store().createRecord('build', { jobId: 5, status: 'SUCCESS' });
+    const model = this.subject({
+      builds: [build5, build4, build3, build2, build1],
+      workflowGraph,
+      startFrom: '~commit'
+    });
+
+    return get(model, 'status').then(status => assert.equal('SUCCESS', status));
   });
 });

--- a/tests/unit/utils/graph-tools-test.js
+++ b/tests/unit/utils/graph-tools-test.js
@@ -1,6 +1,65 @@
 import graphTools from 'screwdriver-ui/utils/graph-tools';
 import { module, test } from 'qunit';
-const { icon, node, decorateGraph } = graphTools;
+const { icon, node, decorateGraph, graphDepth } = graphTools;
+
+const SIMPLE_GRAPH = {
+  nodes: [
+    { name: '~pr' },
+    { name: '~commit' },
+    { name: 'main' }
+  ],
+  edges: [
+    { src: '~pr', dest: 'main' },
+    { src: '~commit', dest: 'main' }
+  ]
+};
+
+const COMPLEX_GRAPH = {
+  nodes: [
+    { name: '~pr' },
+    { name: '~commit' },
+    { name: 'main', id: 1 },
+    { name: 'A', id: 2 },
+    { name: 'B', id: 3 },
+    { name: 'C', id: 4 },
+    { name: 'D', id: 5 }
+  ],
+  edges: [
+    { src: '~pr', dest: 'main' },
+    { src: '~commit', dest: 'main' },
+    { src: 'main', dest: 'A' },
+    { src: 'main', dest: 'B' },
+    { src: 'A', dest: 'C' },
+    { src: 'B', dest: 'D' },
+    { src: 'C', dest: 'D' }
+  ]
+};
+
+const MORE_COMPLEX_GRAPH = {
+  nodes: [
+    { name: '~pr' },
+    { name: '~commit' },
+    { name: 'no_main' },
+    { name: '~sd@241:main' },
+    { name: 'publish' },
+    { name: 'other_publish' },
+    { name: 'wow_new_main' },
+    { name: 'detached_main' },
+    { name: 'after_detached_main' },
+    { name: 'detached_solo' }
+  ],
+  edges: [
+    { src: '~commit', dest: 'no_main' },
+    { src: '~pr', dest: 'no_main' },
+    { src: '~sd@241:main', dest: 'no_main' },
+    { src: 'no_main', dest: 'publish' },
+    { src: 'wow_new_main', dest: 'other_publish' },
+    { src: '~commit', dest: 'wow_new_main' },
+    { src: '~pr', dest: 'wow_new_main' },
+    { src: '~sd@241:main', dest: 'wow_new_main' },
+    { src: 'detached_main', dest: 'after_detached_main' }
+  ]
+};
 
 module('Unit | Utility | graph tools');
 
@@ -17,71 +76,40 @@ test('it gets an element from a list', function (assert) {
 });
 
 test('it processes a simple graph without builds', function (assert) {
-  const inputGraph = {
-    nodes: [
-      { name: '~pr' },
-      { name: '~commit' },
-      { name: 'main' }
-    ],
-    edges: [
-      { src: '~pr', dest: 'main' },
-      { src: '~commit', dest: 'main' }
-    ]
-  };
   const expectedOutput = {
     nodes: [
-      { name: '~commit', pos: { x: 0, y: 0 } },
-      { name: '~pr', pos: { x: 0, y: 1 } },
+      { name: '~pr', pos: { x: 0, y: 0 } },
+      { name: '~commit', pos: { x: 0, y: 1 } },
       { name: 'main', pos: { x: 1, y: 0 } }
     ],
     edges: [
-      { src: '~pr', dest: 'main', from: { x: 0, y: 1 }, to: { x: 1, y: 0 } },
-      { src: '~commit', dest: 'main', from: { x: 0, y: 0 }, to: { x: 1, y: 0 } }
+      { src: '~pr', dest: 'main', from: { x: 0, y: 0 }, to: { x: 1, y: 0 } },
+      { src: '~commit', dest: 'main', from: { x: 0, y: 1 }, to: { x: 1, y: 0 } }
     ],
     meta: {
       height: 2,
       width: 2
     }
   };
-  const result = decorateGraph(inputGraph);
+  const result = decorateGraph(SIMPLE_GRAPH);
 
   assert.deepEqual(result, expectedOutput);
 });
 
 test('it processes a more complex graph without builds', function (assert) {
-  const inputGraph = {
-    nodes: [
-      { name: '~pr' },
-      { name: '~commit' },
-      { name: 'main' },
-      { name: 'A' },
-      { name: 'B' },
-      { name: 'C' },
-      { name: 'D' }
-    ],
-    edges: [
-      { src: '~pr', dest: 'main' },
-      { src: '~commit', dest: 'main' },
-      { src: 'main', dest: 'A' },
-      { src: 'main', dest: 'B' },
-      { src: 'A', dest: 'C' },
-      { src: 'B', dest: 'D' },
-      { src: 'C', dest: 'D' }
-    ]
-  };
   const expectedOutput = {
     nodes: [
-      { name: '~commit', pos: { x: 0, y: 0 } },
-      { name: '~pr', pos: { x: 0, y: 1 } },
-      { name: 'A', pos: { x: 2, y: 0 } },
-      { name: 'B', pos: { x: 2, y: 1 } },
-      { name: 'C', pos: { x: 3, y: 0 } },
-      { name: 'D', pos: { x: 4, y: 0 } },
-      { name: 'main', pos: { x: 1, y: 0 } }
+      { name: '~pr', pos: { x: 0, y: 0 } },
+      { name: '~commit', pos: { x: 0, y: 1 } },
+      { name: 'main', id: 1, pos: { x: 1, y: 0 } },
+      { name: 'A', id: 2, pos: { x: 2, y: 0 } },
+      { name: 'B', id: 3, pos: { x: 2, y: 1 } },
+      { name: 'C', id: 4, pos: { x: 3, y: 0 } },
+      { name: 'D', id: 5, pos: { x: 4, y: 0 } }
     ],
     edges: [
-      { src: '~pr', dest: 'main', from: { x: 0, y: 1 }, to: { x: 1, y: 0 } },
-      { src: '~commit', dest: 'main', from: { x: 0, y: 0 }, to: { x: 1, y: 0 } },
+      { src: '~pr', dest: 'main', from: { x: 0, y: 0 }, to: { x: 1, y: 0 } },
+      { src: '~commit', dest: 'main', from: { x: 0, y: 1 }, to: { x: 1, y: 0 } },
       { src: 'main', dest: 'A', from: { x: 1, y: 0 }, to: { x: 2, y: 0 } },
       { src: 'main', dest: 'B', from: { x: 1, y: 0 }, to: { x: 2, y: 1 } },
       { src: 'A', dest: 'C', from: { x: 2, y: 0 }, to: { x: 3, y: 0 } },
@@ -93,32 +121,12 @@ test('it processes a more complex graph without builds', function (assert) {
       width: 5
     }
   };
-  const result = decorateGraph(inputGraph);
+  const result = decorateGraph(COMPLEX_GRAPH);
 
   assert.deepEqual(result, expectedOutput);
 });
 
 test('it processes a complex graph with builds', function (assert) {
-  const inputGraph = {
-    nodes: [
-      { name: '~pr' },
-      { name: '~commit' },
-      { name: 'main', id: 1 },
-      { name: 'A', id: 2 },
-      { name: 'B', id: 3 },
-      { name: 'C', id: 4 },
-      { name: 'D', id: 5 }
-    ],
-    edges: [
-      { src: '~pr', dest: 'main' },
-      { src: '~commit', dest: 'main' },
-      { src: 'main', dest: 'A' },
-      { src: 'main', dest: 'B' },
-      { src: 'A', dest: 'C' },
-      { src: 'B', dest: 'D' },
-      { src: 'C', dest: 'D' }
-    ]
-  };
   const builds = [
     { jobId: 1, status: 'SUCCESS', id: 6 },
     { jobId: 2, status: 'SUCCESS', id: 7 },
@@ -128,20 +136,20 @@ test('it processes a complex graph with builds', function (assert) {
   ];
   const expectedOutput = {
     nodes: [
-      { name: '~commit', status: 'STARTED_FROM', pos: { x: 0, y: 0 } },
-      { name: '~pr', pos: { x: 0, y: 1 } },
+      { name: '~pr', pos: { x: 0, y: 0 } },
+      { name: '~commit', status: 'STARTED_FROM', pos: { x: 0, y: 1 } },
+      { name: 'main', id: 1, buildId: 6, status: 'SUCCESS', pos: { x: 1, y: 0 } },
       { name: 'A', id: 2, buildId: 7, status: 'SUCCESS', pos: { x: 2, y: 0 } },
       { name: 'B', id: 3, buildId: 8, status: 'SUCCESS', pos: { x: 2, y: 1 } },
       { name: 'C', id: 4, buildId: 9, status: 'SUCCESS', pos: { x: 3, y: 0 } },
-      { name: 'D', id: 5, buildId: 10, status: 'FAILURE', pos: { x: 4, y: 0 } },
-      { name: 'main', id: 1, buildId: 6, status: 'SUCCESS', pos: { x: 1, y: 0 } }
+      { name: 'D', id: 5, buildId: 10, status: 'FAILURE', pos: { x: 4, y: 0 } }
     ],
     edges: [
-      { src: '~pr', dest: 'main', from: { x: 0, y: 1 }, to: { x: 1, y: 0 } },
+      { src: '~pr', dest: 'main', from: { x: 0, y: 0 }, to: { x: 1, y: 0 } },
       {
         src: '~commit',
         dest: 'main',
-        from: { x: 0, y: 0 },
+        from: { x: 0, y: 1 },
         to: { x: 1, y: 0 },
         status: 'STARTED_FROM'
       },
@@ -156,7 +164,7 @@ test('it processes a complex graph with builds', function (assert) {
       width: 5
     }
   };
-  const result = decorateGraph(inputGraph, builds, '~commit');
+  const result = decorateGraph(COMPLEX_GRAPH, builds, '~commit');
 
   assert.deepEqual(result, expectedOutput);
 });
@@ -177,15 +185,15 @@ test('it handles detached jobs', function (assert) {
   };
   const expectedOutput = {
     nodes: [
-      { name: '~commit', pos: { x: 0, y: 0 } },
-      { name: '~pr', pos: { x: 0, y: 1 } },
-      { name: 'bar', pos: { x: 0, y: 2 } },
-      { name: 'foo', pos: { x: 0, y: 3 } },
-      { name: 'main', pos: { x: 1, y: 0 } }
+      { name: '~pr', pos: { x: 0, y: 0 } },
+      { name: '~commit', pos: { x: 0, y: 1 } },
+      { name: 'main', pos: { x: 1, y: 0 } },
+      { name: 'foo', pos: { x: 0, y: 2 } },
+      { name: 'bar', pos: { x: 0, y: 3 } }
     ],
     edges: [
-      { src: '~pr', dest: 'main', from: { x: 0, y: 1 }, to: { x: 1, y: 0 } },
-      { src: '~commit', dest: 'main', from: { x: 0, y: 0 }, to: { x: 1, y: 0 } }
+      { src: '~pr', dest: 'main', from: { x: 0, y: 0 }, to: { x: 1, y: 0 } },
+      { src: '~commit', dest: 'main', from: { x: 0, y: 1 }, to: { x: 1, y: 0 } }
     ],
     meta: {
       height: 4,
@@ -199,52 +207,27 @@ test('it handles detached jobs', function (assert) {
 
 test('it handles complex misordered pipeline with multiple commit/pr/remote triggers',
   function (assert) {
-    const inputGraph = {
-      nodes: [
-        { name: '~pr' },
-        { name: '~commit' },
-        { name: 'no_main' },
-        { name: '~sd@241:main' },
-        { name: 'publish' },
-        { name: 'other_publish' },
-        { name: 'wow_new_main' },
-        { name: 'detached_main' },
-        { name: 'after_detached_main' },
-        { name: 'detached_solo' }
-      ],
-      edges: [
-        { src: '~commit', dest: 'no_main' },
-        { src: '~pr', dest: 'no_main' },
-        { src: '~sd@241:main', dest: 'no_main' },
-        { src: 'no_main', dest: 'publish' },
-        { src: 'wow_new_main', dest: 'other_publish' },
-        { src: '~commit', dest: 'wow_new_main' },
-        { src: '~pr', dest: 'wow_new_main' },
-        { src: '~sd@241:main', dest: 'wow_new_main' },
-        { src: 'detached_main', dest: 'after_detached_main' }
-      ]
-    };
     const expectedOutput = {
       nodes: [
-        { name: '~commit', pos: { x: 0, y: 0 } },
-        { name: '~pr', pos: { x: 0, y: 1 } },
-        { name: '~sd@241:main', pos: { x: 0, y: 2 } },
-        { name: 'after_detached_main', pos: { x: 1, y: 2 } },
-        { name: 'detached_main', pos: { x: 0, y: 3 } },
-        { name: 'detached_solo', pos: { x: 0, y: 4 } },
+        { name: '~pr', pos: { x: 0, y: 0 } },
+        { name: '~commit', pos: { x: 0, y: 1 } },
         { name: 'no_main', pos: { x: 1, y: 0 } },
-        { name: 'other_publish', pos: { x: 2, y: 1 } },
+        { name: '~sd@241:main', pos: { x: 0, y: 2 } },
         { name: 'publish', pos: { x: 2, y: 0 } },
-        { name: 'wow_new_main', pos: { x: 1, y: 1 } }
+        { name: 'other_publish', pos: { x: 2, y: 1 } },
+        { name: 'wow_new_main', pos: { x: 1, y: 1 } },
+        { name: 'detached_main', pos: { x: 0, y: 3 } },
+        { name: 'after_detached_main', pos: { x: 1, y: 2 } },
+        { name: 'detached_solo', pos: { x: 0, y: 4 } }
       ],
       edges: [
-        { src: '~commit', dest: 'no_main', from: { x: 0, y: 0 }, to: { x: 1, y: 0 } },
-        { src: '~pr', dest: 'no_main', from: { x: 0, y: 1 }, to: { x: 1, y: 0 } },
+        { src: '~commit', dest: 'no_main', from: { x: 0, y: 1 }, to: { x: 1, y: 0 } },
+        { src: '~pr', dest: 'no_main', from: { x: 0, y: 0 }, to: { x: 1, y: 0 } },
         { src: '~sd@241:main', dest: 'no_main', from: { x: 0, y: 2 }, to: { x: 1, y: 0 } },
         { src: 'no_main', dest: 'publish', from: { x: 1, y: 0 }, to: { x: 2, y: 0 } },
         { src: 'wow_new_main', dest: 'other_publish', from: { x: 1, y: 1 }, to: { x: 2, y: 1 } },
-        { src: '~commit', dest: 'wow_new_main', from: { x: 0, y: 0 }, to: { x: 1, y: 1 } },
-        { src: '~pr', dest: 'wow_new_main', from: { x: 0, y: 1 }, to: { x: 1, y: 1 } },
+        { src: '~commit', dest: 'wow_new_main', from: { x: 0, y: 1 }, to: { x: 1, y: 1 } },
+        { src: '~pr', dest: 'wow_new_main', from: { x: 0, y: 0 }, to: { x: 1, y: 1 } },
         { src: '~sd@241:main', dest: 'wow_new_main', from: { x: 0, y: 2 }, to: { x: 1, y: 1 } },
         { src: 'detached_main',
           dest: 'after_detached_main',
@@ -257,7 +240,26 @@ test('it handles complex misordered pipeline with multiple commit/pr/remote trig
         height: 5
       }
     };
-    const result = decorateGraph(inputGraph);
+    const result = decorateGraph(MORE_COMPLEX_GRAPH);
 
     assert.deepEqual(result, expectedOutput);
   });
+
+test('it determines the depth of a graph from various starting points', function (assert) {
+  // simple graph, commit
+  assert.equal(graphDepth(SIMPLE_GRAPH.edges, '~commit'), 1, 'simple commit');
+  // simple graph, pr
+  assert.equal(graphDepth(SIMPLE_GRAPH.edges, '~pr'), 1, 'simple pr');
+  // complex graph, commit
+  assert.equal(graphDepth(COMPLEX_GRAPH.edges, '~commit'), 5, 'complex commit');
+  // more complex graph, commit
+  assert.equal(graphDepth(MORE_COMPLEX_GRAPH.edges, '~commit'), 4, 'very complex commit');
+  // more complex graph, reverse trigger
+  assert.equal(graphDepth(MORE_COMPLEX_GRAPH.edges, '~sd@241:main'), 4, 'very complex trigger');
+  // more complex graph, detached workflow
+  assert.equal(graphDepth(MORE_COMPLEX_GRAPH.edges, 'detached_main'), 2, 'very complex detached');
+  // more complex graph, detached job
+  assert.equal(graphDepth(MORE_COMPLEX_GRAPH.edges, 'detached_solo'), 1, 'very complex detached 2');
+  // more complex graph, partial pipeline
+  assert.equal(graphDepth(MORE_COMPLEX_GRAPH.edges, 'publish'), 1, 'very complex partial');
+});


### PR DESCRIPTION
Context:
========
The event model is using the old workflow list instead of the new workflowGraph to compute whether it has completed all expected builds. This results in events with the new workflow from never having the isComplete flag true. This may result in unexpected api traffic for completed events.

Objective:
-----------
Use the new workflow graph to compute the number of expected jobs for an event. Pipelines configuring the old workflow will still have a new workflowGraph, so this change is backwards compatible.

Misc:
-----
* Removed the node sort in decorateGraph, as it is no longer necessary, and leads to confusion when comparing output and input.
* Added a event.status to tell the aggregate status of the event
* Wrapped status and isComplete in ObjectPromiseProxy since they depend on build information that comes as a PromiseArray.