### PR TITLE
fix(803): update styles of toggles and graph

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,7 +10,7 @@ module.exports = {
     browser: true
   },
   globals: {
-    ansi_up: true,
+    AnsiUp: true,
     humanizeDuration: true
   },
   rules: {

--- a/app/components/pipeline-graph-nav/styles.scss
+++ b/app/components/pipeline-graph-nav/styles.scss
@@ -1,6 +1,10 @@
 & {
   padding: 15px 0 15px 10px;
 
+  strong {
+    font-size: 16px;
+  }
+
   strong,
   a {
     vertical-align: middle;
@@ -8,6 +12,28 @@
   }
 
   .btn {
-    padding: 3px 6px;
+    border-radius: 3px;
+    padding: 5px 10px;
+    color: $brand-600;
+    background-color: $sd-white;
+    border-color: $brand-600;
+    font-weight: $weight-normal;
+
+    &:hover,
+    &:focus,
+    &.active,
+    &.active:hover,
+    &.active:focus {
+      outline: none;
+      box-shadow: none;
+      color: $brand-600;
+      background-color: $button-background;
+      border-color: $brand-600;
+    }
+
+    &:hover,
+    &.active:hover {
+      color: $brand-700;
+    }
   }
 }

--- a/app/components/workflow-graph-d3/component.js
+++ b/app/components/workflow-graph-d3/component.js
@@ -83,6 +83,7 @@ export default Component.extend({
     // Adjustable spacing between nodes
     const X_SPACING = ICON_SIZE;
     const Y_SPACING = ICON_SIZE;
+    const EDGE_GAP = Math.floor(ICON_SIZE / 6);
 
     // Calculate the canvas size based on amount of content, or override with user-defined size
     const w = get(this, 'width') || ((data.meta.width * ICON_SIZE) + (data.meta.width * X_SPACING));
@@ -146,9 +147,9 @@ export default Component.extend({
       .attr('fill', 'transparent')
       .attr('d', (d) => {
         const path = d3.path();
-        const startX = calcPos(d.from.x, X_SPACING) + ICON_SIZE;
+        const startX = calcPos(d.from.x, X_SPACING) + ICON_SIZE + EDGE_GAP;
         const startY = calcPos(d.from.y, Y_SPACING);
-        const endX = calcPos(d.to.x, X_SPACING);
+        const endX = calcPos(d.to.x, X_SPACING) - EDGE_GAP;
         const endY = calcPos(d.to.y, Y_SPACING);
 
         path.moveTo(startX, startY);

--- a/app/components/workflow-graph-d3/styles.scss
+++ b/app/components/workflow-graph-d3/styles.scss
@@ -64,14 +64,4 @@ g {
   &.build-started_from { // sass-lint:disable-line class-name-format
     stroke: $sd-success;
   }
-
-  &.build-failure,
-  &.build-aborted {
-    stroke: $sd-failure;
-  }
-
-  &.build-running,
-  &.build-queued {
-    stroke: $sd-queued;
-  }
 }

--- a/app/helpers/ansi-colorize.js
+++ b/app/helpers/ansi-colorize.js
@@ -2,6 +2,11 @@ import { helper } from '@ember/component/helper';
 import { htmlSafe } from '@ember/string';
 import Ember from 'ember';
 
+const ansiUp = new AnsiUp();
+
+// Prevent double-encoding
+ansiUp.escape_for_html = false;
+
 /**
  * Transform ansi color codes to html tags
  * @method ansiColorize
@@ -9,9 +14,10 @@ import Ember from 'ember';
  * @return {String}             Html string
  */
 export function ansiColorize([message]) {
+  // encode html content
   const m = Ember.Handlebars.Utils.escapeExpression(message);
 
-  return htmlSafe(ansi_up.ansi_to_html(m));
+  return htmlSafe(ansiUp.ansi_to_html(m));
 }
 
 export default helper(ansiColorize);

--- a/app/styles/denali-colors.scss
+++ b/app/styles/denali-colors.scss
@@ -7,6 +7,7 @@ $brand-400: #5D8CF6;
 $brand-300: #9AB7F9;
 $brand-200: #D7E2FD;
 $brand-100: #F5F8FE;
+$button-background: rgba(53, 112, 244, .12);
 
 $grey-800: #303030;
 $grey-700: #606060;

--- a/bower.json
+++ b/bower.json
@@ -1,8 +1,6 @@
 {
   "name": "screwdriver-ui",
   "dependencies": {
-    "ansi_up": "^1.3.0",
-    "humanize-duration": "^3.10.0",
     "jquery-highlight": "~3.2.2",
     "jstree": "^3.3.4"
   }

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -30,8 +30,8 @@ module.exports = function (defaults) {
     }
   });
 
-  app.import('bower_components/ansi_up/ansi_up.js');
-  app.import('bower_components/humanize-duration/humanize-duration.js');
+  app.import('node_modules/ansi_up/ansi_up.js');
+  app.import('node_modules/humanize-duration/humanize-duration.js');
   app.import('node_modules/d3/build/d3.min.js');
   // Use `app.import` to add additional libraries to the generated
   // output files.

--- a/package-lock.json
+++ b/package-lock.json
@@ -270,6 +270,12 @@
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
       "dev": true
     },
+    "ansi_up": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/ansi_up/-/ansi_up-2.0.2.tgz",
+      "integrity": "sha1-m1TeUIxcV59baWjmXBuGPgaAq5I=",
+      "dev": true
+    },
     "ansicolors": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
@@ -11764,6 +11770,12 @@
         "jsprim": "1.4.1",
         "sshpk": "1.13.1"
       }
+    },
+    "humanize-duration": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/humanize-duration/-/humanize-duration-3.12.0.tgz",
+      "integrity": "sha512-Hnx+whbZRWv2SQnGolrPk+Q20khpkF4hRWTRbldcJx8F0cJQAAo3YaV7+5P6OqssBonI8zN9aZ7Fixs3kWLAhw==",
+      "dev": true
     },
     "iconv-lite": {
       "version": "0.4.19",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "Tiffany Kyi <tiffanykyi@gmail.com>"
   ],
   "devDependencies": {
+    "ansi_up": "^2.0.2",
     "bootstrap-sass": "^3.3.7",
     "broccoli-asset-rev": "^2.4.5",
     "d3": "^4.11.0",
@@ -83,6 +84,7 @@
     "eslint": "^4.7.0",
     "eslint-config-screwdriver": "^3.0.0",
     "eslint-plugin-ember": "^4.5.0",
+    "humanize-duration": "^3.12.0",
     "loader.js": "^4.2.3"
   },
   "dependencies": {}

--- a/tests/unit/helpers/ansi-colorize-test.js
+++ b/tests/unit/helpers/ansi-colorize-test.js
@@ -14,5 +14,5 @@ test('it escapes html', function (assert) {
 test('colorizes ansi codes', function (assert) {
   let result = ansiColorize(['\u001b[32m<main>\u001b[0m']);
 
-  assert.equal(result.toString(), '<span style="color:rgb(0, 187, 0)">&lt;main&gt;</span>');
+  assert.equal(result.toString(), '<span style="color:rgb(0,187,0)">&lt;main&gt;</span>');
 });


### PR DESCRIPTION
Context:
========
Minor visual tweaks

![](https://user-images.githubusercontent.com/78533/33745894-57847576-db6e-11e7-8d33-31ecbebb53f9.png)


Objective:
----------
* No longer color edges unless build is successful
* Graph now has small gaps between bubbles and arrow start/end
* Added styling closer to designer guidelines for toggles

Misc:
-----
Moved ansi_up and humanize-duration dependencies from bower to npm per ember guidelines. Bower is maintained, but they [bower] recommend using something else. Remaining bower deps require changes to the vendor ember components that bring them in.