### PR TITLE
fix(803): artifact icons not displaying

### DIFF
--- a/app/components/artifact-tree/component.js
+++ b/app/components/artifact-tree/component.js
@@ -8,10 +8,10 @@ import ObjectProxy from '@ember/object/proxy';
 const ObjectPromiseProxy = ObjectProxy.extend(PromiseProxyMixin);
 const typesOptions = {
   directory: {
-    icon: 'fa folder-o fa-lg'
+    icon: 'fa fa-folder-o fa-lg'
   },
   file: {
-    icon: 'fa file-text-o'
+    icon: 'fa fa-file-text-o'
   }
 };
 


### PR DESCRIPTION
Context:
========
Icons on the artifact tree are not displaying

Changes to the fa-icon component noted deprecations when using icon titles with the "fa-" prefix. A change to all components in a previous PR removed the prefix to remove the deprecation warnings.

Objective:
----------
The jstree component we use to display the artifact list needs the full class names, including the prefix, to display the icons. It does not use the fa-icon component internally.