### PR TITLE
fix: worker-src protocol should not be quoted

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -46,7 +46,7 @@ http {
             "font-src 'self'; " ..
             "img-src 'self' https: data: " .. os.getenv("AVATAR_HOSTNAME") .. "; " ..
             "media-src 'self';" ..
-            "worker-src 'blob:';"
+            "worker-src blob:;"
         }
 
         add_header x-content-type-options 'nosniff';


### PR DESCRIPTION
Context:
=========
Incorrectly quoted `blob:` in worker-src CSP header

Misc
-----
This didn't seem to affect any operation of the current code, but this is triggered by the jstree code that renders our artifacts on the build page.