### PR TITLE
fix(799): Sort job names alphabetically in options tab

### DIFF
--- a/app/components/pipeline-options/component.js
+++ b/app/components/pipeline-options/component.js
@@ -1,6 +1,7 @@
+/* eslint ember/avoid-leaking-state-in-components: [2, ["jobSorting"]] */
 import $ from 'jquery';
 import { inject as service } from '@ember/service';
-import { not, or } from '@ember/object/computed';
+import { not, or, sort } from '@ember/object/computed';
 import { computed } from '@ember/object';
 import Component from '@ember/component';
 import { parse, getCheckoutUrl } from '../../utils/git';
@@ -15,6 +16,8 @@ export default Component.extend({
   isShowingModal: false,
   showDangerButton: true,
   showRemoveButtons: false,
+  jobSorting: ['name'],
+  sortedJobs: sort('jobs', 'jobSorting'),
   isInvalid: not('isValid'),
   isDisabled: or('isSaving', 'isInvalid'),
   isValid: computed('scmUrl', {

--- a/app/components/pipeline-options/template.hbs
+++ b/app/components/pipeline-options/template.hbs
@@ -41,7 +41,7 @@
     <section class="jobs">
       <h3>Jobs</h3>
       <ul>
-        {{#each jobs as |job|}}
+        {{#each sortedJobs as |job|}}
         <li>
           <div class="row">
             <div class="col-xs-10">

--- a/tests/integration/components/pipeline-options/component-test.js
+++ b/tests/integration/components/pipeline-options/component-test.js
@@ -22,8 +22,18 @@ test('it renders', function (assert) {
 
   this.set('mockJobs', A([
     EmberObject.create({
+      id: '3456',
+      name: 'B',
+      isDisabled: false
+    }),
+    EmberObject.create({
       id: '1234',
       name: 'main',
+      isDisabled: false
+    }),
+    EmberObject.create({
+      id: '2345',
+      name: 'A',
       isDisabled: false
     })
   ]));
@@ -39,9 +49,10 @@ test('it renders', function (assert) {
 
   // Jobs
   assert.equal(this.$('section.jobs h3').text().trim(), 'Jobs');
-  assert.equal(this.$('section.jobs li').length, 1);
-  assert.equal(this.$('section.jobs h4').text().trim(), 'main');
-  assert.equal(this.$('section.jobs p').text().trim(), 'Toggle to disable the main job.');
+  assert.equal(this.$('section.jobs li').length, 3);
+  assert.equal(this.$('section.jobs h4').text().trim(), 'ABmain');
+  // eslint-disable-next-line max-len
+  assert.equal(this.$('section.jobs p').text().trim(), 'Toggle to disable the A job.Toggle to disable the B job.Toggle to disable the main job.');
   assert.ok(this.$('.x-toggle-container').hasClass('x-toggle-container-checked'));
 
   // Sync


### PR DESCRIPTION
## Context
Jobs listed in options tab are not sorted, so it is hard to find a particular job to disable.

## Objective
This PR sorts the jobs alphabetically on the options tab so it is easier to find them.

*Previous*

<img width="348" alt="screen shot 2018-01-23 at 4 03 50 pm" src="https://user-images.githubusercontent.com/3230529/35307316-1a3fa344-0057-11e8-86fe-d5d5b4953699.png">

*Now*

<img width="470" alt="screen shot 2018-01-23 at 4 05 34 pm" src="https://user-images.githubusercontent.com/3230529/35307355-4549045e-0057-11e8-84c6-1749f1c4f24b.png">



## Related links
Original issue: https://github.com/screwdriver-cd/screwdriver/issues/799