### PR TITLE
fix: force reload events model after starting a new build

### DIFF
--- a/app/components/artifact-tree/template.hbs
+++ b/app/components/artifact-tree/template.hbs
@@ -5,3 +5,6 @@
     typesOptions=typesOptions
     eventDidChange="handleJstreeEventDidChange"
 }}
+{{#unless treedata.content.length}}
+<span>No artifacts yet</span>
+{{/unless}}

--- a/app/components/pipeline-events-list/component.js
+++ b/app/components/pipeline-events-list/component.js
@@ -4,7 +4,6 @@ import Component from '@ember/component';
 import ENV from 'screwdriver-ui/config/environment';
 
 export default Component.extend({
-  modelToReload: 'events',
   showMore: computed('events.length', 'numToShow', {
     get() {
       return get(this, 'numToShow') < get(this, 'events.length');

--- a/app/components/pipeline-events-list/component.js
+++ b/app/components/pipeline-events-list/component.js
@@ -2,9 +2,8 @@ import { computed, get, set } from '@ember/object';
 import { sort } from '@ember/object/computed';
 import Component from '@ember/component';
 import ENV from 'screwdriver-ui/config/environment';
-import ModelReloaderMixin from 'screwdriver-ui/mixins/model-reloader';
 
-export default Component.extend(ModelReloaderMixin, {
+export default Component.extend({
   modelToReload: 'events',
   showMore: computed('events.length', 'numToShow', {
     get() {
@@ -31,14 +30,6 @@ export default Component.extend(ModelReloaderMixin, {
     set(this, 'numToShow', ENV.APP.NUM_EVENTS_LISTED);
   },
 
-  /**
-   * Runs when a render event is triggered, usually due to a change in attribute data (events)
-   * @method willRender
-   */
-  willRender() {
-    this.startReloading();
-  },
-
   actions: {
     moreClick() {
       set(this, 'numToShow', get(this, 'numToShow') + ENV.APP.NUM_EVENTS_LISTED);
@@ -46,16 +37,5 @@ export default Component.extend(ModelReloaderMixin, {
     eventClick(id) {
       set(this, 'selected', id);
     }
-  },
-
-  /**
-   * Executes when the component is about to be destroyed
-   * @method willDestroy
-   */
-  willDestroy() {
-    this.stopReloading();
-  },
-
-  // eslint doesn't know what this property is, so it wants it at the bottom
-  reloadTimeout: ENV.APP.EVENT_RELOAD_TIMER
+  }
 });

--- a/app/mixins/model-reloader.js
+++ b/app/mixins/model-reloader.js
@@ -69,6 +69,8 @@ export default Mixin.create({
   forceReload() {
     cancel(this.get('runLater'));
     // Push this reload out of current run loop.
-    later(this, 'reloadModel', FORCE_WAIT_TIMEOUT);
+    const forceLater = later(this, 'reloadModel', FORCE_WAIT_TIMEOUT);
+
+    this.set('runLater', forceLater);
   }
 });

--- a/app/mixins/model-reloader.js
+++ b/app/mixins/model-reloader.js
@@ -2,8 +2,6 @@ import { later, cancel } from '@ember/runloop';
 import Mixin from '@ember/object/mixin';
 import ENV from 'screwdriver-ui/config/environment';
 
-const FORCE_WAIT_TIMEOUT = 100;
-
 export default Mixin.create({
   /**
    * Overridable function to determine if a model should be reloaded

--- a/app/mixins/model-reloader.js
+++ b/app/mixins/model-reloader.js
@@ -2,6 +2,8 @@ import { later, cancel } from '@ember/runloop';
 import Mixin from '@ember/object/mixin';
 import ENV from 'screwdriver-ui/config/environment';
 
+const FORCE_WAIT_TIMEOUT = 100;
+
 export default Mixin.create({
   /**
    * Overridable function to determine if a model should be reloaded
@@ -58,5 +60,15 @@ export default Mixin.create({
       cancel(this.get('runLater'));
       this.set('runLater', null);
     }
+  },
+
+  /**
+   * Forces model reload
+   * @method forceReload
+   */
+  forceReload() {
+    cancel(this.get('runLater'));
+    // Push this reload out of current run loop.
+    later(this, 'reloadModel', FORCE_WAIT_TIMEOUT);
   }
 });

--- a/app/mixins/model-reloader.js
+++ b/app/mixins/model-reloader.js
@@ -69,7 +69,7 @@ export default Mixin.create({
   forceReload() {
     cancel(this.get('runLater'));
     // Push this reload out of current run loop.
-    const forceLater = later(this, 'reloadModel', FORCE_WAIT_TIMEOUT);
+    const forceLater = later(this, 'reloadModel', ENV.APP.FORCE_RELOAD_WAIT);
 
     this.set('runLater', forceLater);
   }

--- a/config/environment.js
+++ b/config/environment.js
@@ -52,7 +52,8 @@ module.exports = (environment) => {
       EVENT_RELOAD_TIMER: 90000, // 1.5 minutes
       LOG_RELOAD_TIMER: 1000,
       NUM_EVENTS_LISTED: 5,
-      MAX_LOG_LINES: 1000
+      MAX_LOG_LINES: 1000,
+      FORCE_RELOAD_WAIT: 100 // Wait 100ms before force reload
     },
     moment: {
       allowEmpty: true // allow empty dates

--- a/tests/unit/mixins/model-reloader-test.js
+++ b/tests/unit/mixins/model-reloader-test.js
@@ -2,6 +2,8 @@ import { resolve } from 'rsvp';
 import EmberObject from '@ember/object';
 import ModelReloaderMixin from 'screwdriver-ui/mixins/model-reloader';
 import { module, test } from 'qunit';
+import wait from 'ember-test-helpers/wait';
+
 let subject;
 
 module('Unit | Mixin | model reloader mixin', {
@@ -73,4 +75,22 @@ test('it should not reload a model if shouldReload returns false', function (ass
   subject.set('modelToReload', 'testModel');
 
   subject.reloadModel();
+});
+
+test('it force reloads a model', function (assert) {
+  assert.expect(2);
+  subject.set('testModel', {
+    reload() {
+      assert.ok(true);
+
+      return resolve({});
+    }
+  });
+  subject.set('modelToReload', 'testModel');
+
+  subject.forceReload();
+
+  return wait().then(() => {
+    assert.ok(true);
+  });
 });

--- a/tests/unit/pipeline/builds/index/controller-test.js
+++ b/tests/unit/pipeline/builds/index/controller-test.js
@@ -24,7 +24,7 @@ test('it exists', function (assert) {
 });
 
 test('it starts a build', function (assert) {
-  assert.expect(6);
+  assert.expect(7);
   server.post('http://localhost:8080/v4/events', () => [
     201,
     { 'Content-Type': 'application/json' },
@@ -40,6 +40,13 @@ test('it starts a build', function (assert) {
     controller.set('model', {
       pipeline: EmberObject.create({
         id: '1234'
+      }),
+      events: EmberObject.create({
+        reload: () => {
+          assert.ok(true);
+
+          return Promise.resolve({});
+        }
       })
     });
 


### PR DESCRIPTION
## Context

Reload timeout for events is configured to be 1.5 mins in production. This does not take into account user's clicking Start button to start a new event which results in users not seeing the new event unless they manually reload the page

## Objective

Reload events model after new event is started.
