### PR TITLE
feat(851): Add template tags to template detail page

### DIFF
--- a/app/components/template-versions/template.hbs
+++ b/app/components/template-versions/template.hbs
@@ -1,11 +1,10 @@
 <h4>Versions:</h4>
 <ul>
   {{#each templates as |t|}}
-    {{!-- <li {{action changeVersion t.version on="click"}}><span class="version">{{t.version}}{{#if t.tag}} - {{t.tag}}{{/if}}</span></li> --}}
-  {{#if t.tag}}
-    <li {{action changeVersion t.version on="click"}}><span class="version">{{t.version}} - {{t.tag}}</span></li>
-  {{else}}
-    <li {{action changeVersion t.version on="click"}}><span class="version">{{t.version}}</span></li>
-   {{/if}}
+    {{#if t.tag}}
+      <li {{action changeVersion t.version on="click"}}><span class="version">{{t.version}} - {{t.tag}}</span></li>
+    {{else}}
+      <li {{action changeVersion t.version on="click"}}><span class="version">{{t.version}}</span></li>
+    {{/if}}
   {{/each}}
 </ul>

--- a/app/components/template-versions/template.hbs
+++ b/app/components/template-versions/template.hbs
@@ -1,6 +1,11 @@
 <h4>Versions:</h4>
 <ul>
   {{#each templates as |t|}}
-  <li {{action changeVersion t.version on="click"}}><span class="version">{{t.version}}</span></li>
+    {{!-- <li {{action changeVersion t.version on="click"}}><span class="version">{{t.version}}{{#if t.tag}} - {{t.tag}}{{/if}}</span></li> --}}
+  {{#if t.tag}}
+    <li {{action changeVersion t.version on="click"}}><span class="version">{{t.version}} - {{t.tag}}<span></li>
+  {{else}}
+    <li {{action changeVersion t.version on="click"}}><span class="version">{{t.version}}</span></li>
+   {{/if}}
   {{/each}}
 </ul>

--- a/app/components/template-versions/template.hbs
+++ b/app/components/template-versions/template.hbs
@@ -3,7 +3,7 @@
   {{#each templates as |t|}}
     {{!-- <li {{action changeVersion t.version on="click"}}><span class="version">{{t.version}}{{#if t.tag}} - {{t.tag}}{{/if}}</span></li> --}}
   {{#if t.tag}}
-    <li {{action changeVersion t.version on="click"}}><span class="version">{{t.version}} - {{t.tag}}<span></li>
+    <li {{action changeVersion t.version on="click"}}><span class="version">{{t.version}} - {{t.tag}}</span></li>
   {{else}}
     <li {{action changeVersion t.version on="click"}}><span class="version">{{t.version}}</span></li>
    {{/if}}

--- a/app/template/service.js
+++ b/app/template/service.js
@@ -10,6 +10,12 @@ export default Service.extend({
 
     return this.fetchData(url);
   },
+  getTemplateTags(name) {
+    const url = 
+      `${ENV.APP.SDAPI_HOSTNAME}/${ENV.APP.SDAPI_NAMESPACE}/templates/${encodeURIComponent(name)}/tags`;
+
+    return this.fetchData(url);
+  },
   getAllTemplates() {
     const url = `${ENV.APP.SDAPI_HOSTNAME}/${ENV.APP.SDAPI_NAMESPACE}/templates`;
 

--- a/app/template/service.js
+++ b/app/template/service.js
@@ -11,7 +11,8 @@ export default Service.extend({
     return this.fetchData(url);
   },
   getTemplateTags(name) {
-    const url = 
+    const url =
+      // eslint-disable-next-line max-len
       `${ENV.APP.SDAPI_HOSTNAME}/${ENV.APP.SDAPI_NAMESPACE}/templates/${encodeURIComponent(name)}/tags`;
 
     return this.fetchData(url);

--- a/app/templates/detail/route.js
+++ b/app/templates/detail/route.js
@@ -12,15 +12,16 @@ export default Route.extend({
       const [verPayload, tagPayload] = arr;
 
       tagPayload.forEach((tagObj) => {
-        const verObj = verPayload.find(version => verPayload.version === tagPayload.version);
-        if (verObj.tag !== undefined) {
-          verObj.tag += ` ${tagObj.tag}`;
+        const taggedVerObj = verPayload.find(verObj => verObj.version === tagObj.version);
+
+        if (taggedVerObj.tag !== undefined) {
+          taggedVerObj.tag += ` ${tagObj.tag}`;
         } else {
-          verObj.tag = tagObj.tag;
+          taggedVerObj.tag = tagObj.tag;
         }
       });
 
-      return versions;
-    })
+      return verPayload;
+    });
   }
 });

--- a/app/templates/detail/route.js
+++ b/app/templates/detail/route.js
@@ -5,10 +5,10 @@ import Route from '@ember/routing/route';
 export default Route.extend({
   template: service(),
   model(params) {
-    return RSVP.all(
+    return RSVP.all([
       this.get('template').getOneTemplate(params.name),
       this.get('template').getTemplateTags(params.name)
-    ).then((arr) => {
+    ]).then((arr) => {
       const [verPayload, tagPayload] = arr;
 
       tagPayload.forEach((tagObj) => {

--- a/app/templates/detail/route.js
+++ b/app/templates/detail/route.js
@@ -1,9 +1,26 @@
 import { inject as service } from '@ember/service';
+import RSVP from 'rsvp';
 import Route from '@ember/routing/route';
 
 export default Route.extend({
   template: service(),
   model(params) {
-    return this.get('template').getOneTemplate(params.name);
+    return RSVP.all(
+      this.get('template').getOneTemplate(params.name),
+      this.get('template').getTemplateTags(params.name)
+    ).then((arr) => {
+      const [verPayload, tagPayload] = arr;
+
+      tagPayload.forEach((tagObj) => {
+        const verObj = verPayload.find(version => verPayload.version === tagPayload.version);
+        if (verObj.tag !== undefined) {
+          verObj.tag += ` ${tagObj.tag}`;
+        } else {
+          verObj.tag = tagObj.tag;
+        }
+      });
+
+      return versions;
+    })
   }
 });

--- a/app/templates/detail/route.js
+++ b/app/templates/detail/route.js
@@ -14,11 +14,7 @@ export default Route.extend({
       tagPayload.forEach((tagObj) => {
         const taggedVerObj = verPayload.find(verObj => verObj.version === tagObj.version);
 
-        if (taggedVerObj.tag !== undefined) {
-          taggedVerObj.tag += ` ${tagObj.tag}`;
-        } else {
-          taggedVerObj.tag = tagObj.tag;
-        }
+        taggedVerObj.tag = taggedVerObj.tag ? `${taggedVerObj.tag} ${tagObj.tag}` : tagObj.tag;
       });
 
       return verPayload;

--- a/tests/integration/components/template-versions/component-test.js
+++ b/tests/integration/components/template-versions/component-test.js
@@ -2,8 +2,8 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
 const TEMPLATES = [
-  { version: '3.0.0' },
-  { version: '2.0.0' },
+  { version: '3.0.0', tag: 'latest stable' },
+  { version: '2.0.0', tag: 'meeseeks' },
   { version: '1.0.0' }
 ];
 
@@ -18,7 +18,7 @@ test('it renders', function (assert) {
   this.render(hbs`{{template-versions templates=mock changeVersion=(action "mockAction")}}`);
 
   assert.equal(this.$('h4').text().trim(), 'Versions:');
-  assert.equal(this.$('ul li').text().trim(), '3.0.02.0.01.0.0');
+  assert.equal(this.$('ul li').text().trim(), '3.0.0 - latest stable2.0.0 - meeseeks1.0.0');
 });
 
 test('it handles clicks on versions', function (assert) {
@@ -32,6 +32,6 @@ test('it handles clicks on versions', function (assert) {
   this.render(hbs`{{template-versions templates=mock changeVersion=(action "mockAction")}}`);
 
   assert.equal(this.$('h4').text().trim(), 'Versions:');
-  assert.equal(this.$('ul li').text().trim(), '3.0.02.0.01.0.0');
+  assert.equal(this.$('ul li').text().trim(), '3.0.0 - latest stable2.0.0 - meeseeks1.0.0');
   this.$('ul li:last-child').click();
 });

--- a/tests/unit/templates/detail/route-test.js
+++ b/tests/unit/templates/detail/route-test.js
@@ -9,6 +9,13 @@ const templateServiceStub = Service.extend({
       { id: 2, name, version: '2.0.0' },
       { id: 1, name, version: '1.0.0' }
     ]);
+  },
+  getTemplateTags(name) {
+    return resolve([
+      { id: 5, name, version: '3.0.0', tag: 'latest' },
+      { id: 6, name, version: '3.0.0', tag: 'stable' },
+      { id: 7, name, version: '2.0.0', tag: 'meeseeks' }
+    ]);
   }
 });
 


### PR DESCRIPTION
# Context

It's hard for users to figure out what tags are available for each template and what versions they correspond to. It would be ideal if the template tags were listed beside their respective versions on the UI.

# Objective

List the template tags beside their respective versions on the UI. If a version has multiple tags, then all tags will be listed and delimited by a space. For example:

### Versions

* 2.0.0 - latest stable
* 1.9.9 - deprecated
* 1.0.0

# Related links

Issue: https://github.com/screwdriver-cd/screwdriver/issues/851