### PR TITLE
fix(438): display loading message when build is in queued state

### DIFF
--- a/app/components/build-banner/component.js
+++ b/app/components/build-banner/component.js
@@ -20,6 +20,12 @@ export default Component.extend({
     }
   }),
 
+  isWaiting: computed('buildStatus', {
+    get() {
+      return this.get('buildStatus') === 'QUEUED';
+    }
+  }),
+
   hasButton: computed('buildAction', 'jobName', {
     get() {
       if (this.get('buildAction') === 'Stop') {

--- a/app/components/build-banner/styles.scss
+++ b/app/components/build-banner/styles.scss
@@ -30,6 +30,10 @@
       font-size: 20px;
     }
 
+    .build-waiting {
+      padding: 5px 0;
+    }
+
     .col-xs-4:nth-child(2) {
       text-align: center;
     }

--- a/app/components/build-banner/template.hbs
+++ b/app/components/build-banner/template.hbs
@@ -6,7 +6,11 @@
 </div>
 <div class="headerbar">
   <div class="row">
-    <div class="col-xs-4"></div>
+    <div class="col-xs-4">
+      {{#if isWaiting}}
+      <div class="build-waiting">{{fa-icon "spinner fa-spin fa-fw"}} Setting up build...</div>
+      {{/if}}
+    </div>
     <div class="col-xs-4"><h1>{{jobName}}</h1></div>
     <div class="col-xs-4">{{#if isAuthenticated}}{{#if hasButton}}<button {{action "toggleBuild"}}>{{buildAction}}</button>{{/if}}{{/if}}</div>
   </div>

--- a/tests/integration/components/build-banner/component-test.js
+++ b/tests/integration/components/build-banner/component-test.js
@@ -187,3 +187,41 @@ test('it renders a stop button for job when authenticated', function (assert) {
   assert.equal(this.$('button').text().trim(), 'Stop');
   this.$('button').click();
 });
+
+test('it shows waiting message when queued', function (assert) {
+  assert.expect(10);
+  const $ = this.$;
+
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+  this.set('reloadCb', () => {
+    assert.ok(true);
+  });
+
+  this.set('eventMock', eventMock);
+  this.set('jobMock', jobMock);
+  this.render(hbs`{{build-banner
+    buildContainer="node:6"
+    buildStatus="QUEUED"
+    duration="5 seconds"
+    event=eventMock
+    isAuthenticated=false
+    jobName="main"
+    reloadBuild=(action reloadCb)
+    jobs=jobMock
+    eventBuilds=eventMock.builds
+  }}`);
+
+  assert.equal($('h1').text().trim(), 'main');
+  assert.equal($('.build-waiting').text().trim(), 'Setting up build...');
+  assert.equal($('.commit a').prop('href'),
+    'http://example.com/batcave/batmobile/commit/abcdef1029384');
+  assert.equal($('.commit a').text().trim(), '#abcdef');
+  assert.equal($('.message').text().trim(),
+    'Merge it');
+  assert.equal($('.message').prop('title'),
+    'Merge pull request #2 from batcave/batmobile');
+  assert.equal($('.event .col-xs-4:nth-child(2)').text().trim(), 'node:6');
+  assert.equal($('.event .col-xs-4:nth-child(3)').text().trim(), '5 seconds');
+  assert.equal($('button').length, 0);
+});


### PR DESCRIPTION
# Context 

Addresses https://github.com/screwdriver-cd/screwdriver/issues/438

# Objective

Display a message with spinner when build is in queued state

![screen shot 2018-01-26 at 12 25 59 pm](https://user-images.githubusercontent.com/193126/35459714-2a2d576a-0296-11e8-9156-8af3f49da04f.png)

