### PR TITLE
fix: Fix templates bug when no template tags exist

### DIFF
--- a/app/templates/detail/route.js
+++ b/app/templates/detail/route.js
@@ -20,6 +20,6 @@ export default Route.extend({
       }
 
       return verPayload;
-    })
+    });
   }
 });

--- a/app/templates/detail/route.js
+++ b/app/templates/detail/route.js
@@ -7,17 +7,19 @@ export default Route.extend({
   model(params) {
     return RSVP.all([
       this.get('template').getOneTemplate(params.name),
-      this.get('template').getTemplateTags(params.name)
+      this.get('template').getTemplateTags(params.name).catch(err => err)
     ]).then((arr) => {
       const [verPayload, tagPayload] = arr;
 
-      tagPayload.forEach((tagObj) => {
-        const taggedVerObj = verPayload.find(verObj => verObj.version === tagObj.version);
+      if (tagPayload !== '404 Not Found') {
+        tagPayload.forEach((tagObj) => {
+          const taggedVerObj = verPayload.find(verObj => verObj.version === tagObj.version);
 
-        taggedVerObj.tag = taggedVerObj.tag ? `${taggedVerObj.tag} ${tagObj.tag}` : tagObj.tag;
-      });
+          taggedVerObj.tag = taggedVerObj.tag ? `${taggedVerObj.tag} ${tagObj.tag}` : tagObj.tag;
+        });
+      }
 
       return verPayload;
-    });
+    })
   }
 });


### PR DESCRIPTION
# Context

There is currently a bug on the templates page where templates with no template tags will not be loaded. This is because `this.get('template').getTemplateTags(params.name)` will `throw` an `404 Not Found` error, which isn't handled in the promise chain.

# Objective

Fix the bug by handling 404s.
