### PR TITLE
DNM: feat: require auth for build page views

### DIFF
--- a/app/pipeline/builds/build/route.js
+++ b/app/pipeline/builds/build/route.js
@@ -1,7 +1,8 @@
 import { all } from 'rsvp';
 import Route from '@ember/routing/route';
+import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
-export default Route.extend({
+export default Route.extend(AuthenticatedRouteMixin, {
   routeAfterAuthentication: 'pipeline.builds.build',
   beforeModel() {
     this.set('pipeline', this.modelFor('pipeline'));

--- a/tests/unit/build-artifact/service-test.js
+++ b/tests/unit/build-artifact/service-test.js
@@ -1,5 +1,6 @@
 import { moduleFor, test } from 'ember-qunit';
 import Pretender from 'pretender';
+import Service from '@ember/service';
 let server;
 
 const manifest = `.
@@ -35,12 +36,24 @@ const getManifest = () => {
   ]);
 };
 
+const sessionServiceMock = Service.extend({
+  isAuthenticated: false,
+  data: {
+    authenticated: {
+      token: 'banana'
+    }
+  }
+});
+
 moduleFor('service:build-artifact', 'Unit | Service | build artifact', {
   // Specify the other units that are required for this test.
-  // needs: ['service:foo']
+  // needs: ['service:session'],
 
   beforeEach() {
     server = new Pretender();
+    this.register('service:session', sessionServiceMock);
+    this.inject.service('session', { as: 'session' });
+    this.session.set('isAuthenticated', false);
   },
 
   afterEach() {
@@ -54,8 +67,21 @@ test('it exists', function (assert) {
   assert.ok(service);
 });
 
+test('it rejects if the user is not authenticated', function (assert) {
+  assert.expect(2);
+
+  const service = this.subject();
+  const p = service.fetchManifest(buildId);
+
+  p.catch((e) => {
+    assert.ok(e instanceof Error, e);
+    assert.equal('User is not authenticated', e.message);
+  });
+});
+
 test('it makes a call to get artifact manifest successfully', function (assert) {
   assert.expect(2);
+  this.session.set('isAuthenticated', true);
   getManifest();
   const service = this.subject();
   const p = service.fetchManifest(buildId);

--- a/tests/unit/pipeline/builds/build/route-test.js
+++ b/tests/unit/pipeline/builds/build/route-test.js
@@ -4,7 +4,7 @@ import sinonTest from 'ember-sinon-qunit/test-support/test';
 
 moduleFor('route:pipeline/builds/build', 'Unit | Route | pipeline/builds/build', {
   // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:session']
 });
 
 test('it exists', function (assert) {


### PR DESCRIPTION
Context
=======
Security requirements have been set requiring users to be authenticated to view logs and artifacts

Objective
----------
Add auth requirement to view the build page. Send Authentication headers to api calls to get logs and artifacts.