### PR TITLE
fix: auth not working on build page

### DIFF
--- a/app/pipeline/builds/build/route.js
+++ b/app/pipeline/builds/build/route.js
@@ -4,11 +4,10 @@ import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-rout
 
 export default Route.extend(AuthenticatedRouteMixin, {
   routeAfterAuthentication: 'pipeline.builds.build',
-  beforeModel() {
-    this.set('pipeline', this.modelFor('pipeline'));
-  },
 
   model(params) {
+    this.set('pipeline', this.modelFor('pipeline'));
+
     return this.store.findRecord('build', params.build_id).then(build => all([
       this.store.findRecord('job', build.get('jobId')),
       this.store.findRecord('event', build.get('eventId')),


### PR DESCRIPTION
Context
=======
ember-simple-auth uses the `beforeModel` hook to determine authentication status before allowing a transition. When a route modifies this hook without calling `this._super()` then the auth check never happens. If you do add this to `beforeModel` it will use the global setting for `routeAfterAuthentication` instead of the one defined in the route.

Objective
---------
Move the logic from the `beforeModel` hook in the builds route into `model()` and remove `beforeModel` to get the expected behavior.