### PR TITLE
fix: change artifact urls to tunnel through api

### DIFF
--- a/app/build-artifact/service.js
+++ b/app/build-artifact/service.js
@@ -84,8 +84,13 @@ export default Service.extend({
   fetchManifest(buildId) {
     let manifest = [];
 
-    const baseUrl = `${ENV.APP.SDSTORE_HOSTNAME}/${ENV.APP.SDSTORE_NAMESPACE}` +
-      `/builds/${buildId}/ARTIFACTS/`;
+    // Fetch the manifest directly from the store to prevent CORS issues
+    const manifestUrl = `${ENV.APP.SDSTORE_HOSTNAME}/${ENV.APP.SDSTORE_NAMESPACE}` +
+      `/builds/${buildId}/ARTIFACTS/manifest.txt`;
+
+    // Set artifact file links to api to get redirects to store with short-lived jwt tokens
+    const baseUrl = `${ENV.APP.SDAPI_HOSTNAME}/${ENV.APP.SDAPI_NAMESPACE}` +
+      `/builds/${buildId}/artifacts/`;
 
     return new EmberPromise((resolve, reject) => {
       if (!this.get('session.isAuthenticated')) {
@@ -93,7 +98,7 @@ export default Service.extend({
       }
 
       return $.ajax({
-        url: `${baseUrl}manifest.txt`,
+        url: manifestUrl,
         headers: { Authorization: `Bearer ${this.get('session').get('data.authenticated.token')}` }
       })
         .done((data) => {

--- a/tests/unit/build-artifact/service-test.js
+++ b/tests/unit/build-artifact/service-test.js
@@ -16,13 +16,13 @@ const parsedManifest = [{
   children: [{
     text: 'coverage.json',
     type: 'file',
-    a_attr: { href: `http://localhost:8081/v1/builds/${buildId}/ARTIFACTS/coverage/coverage.json` }
+    a_attr: { href: `http://localhost:8080/v4/builds/${buildId}/artifacts/coverage/coverage.json` }
   }]
 },
 {
   text: 'test.txt',
   type: 'file',
-  a_attr: { href: `http://localhost:8081/v1/builds/${buildId}/ARTIFACTS/test.txt` }
+  a_attr: { href: `http://localhost:8080/v4/builds/${buildId}/artifacts/test.txt` }
 }
 ];
 


### PR DESCRIPTION
Context
=======
For security reasons, we are adding a requirement that users must be authenticated to view build logs and artifacts

Objective
---------
This PR updates the artifacts list to link users to the API which will generate a short-lived JWT and redirect to the artifact with that credential. https://github.com/screwdriver-cd/screwdriver/pull/873

Fetching the manifest via ajax still requires a call directly to store (with the user's credentials) to prevent a CORS issue with mismatched Origin headers after the redirect.