### PR TITLE
feat(806): Allow users to restart event jobs and detached pipelines

### DIFF
--- a/app/components/pipeline-workflow/component.js
+++ b/app/components/pipeline-workflow/component.js
@@ -1,9 +1,7 @@
 import Component from '@ember/component';
 import { get, computed, set, setProperties } from '@ember/object';
 import { all, reject } from 'rsvp';
-import graphTools from 'screwdriver-ui/utils/graph-tools';
-
-const { isRoot } = graphTools;
+import { isRoot } from 'screwdriver-ui/utils/graph-tools';
 
 export default Component.extend({
   classNames: ['pipelineWorkflow'],

--- a/app/components/pipeline-workflow/component.js
+++ b/app/components/pipeline-workflow/component.js
@@ -1,7 +1,9 @@
 import Component from '@ember/component';
 import { get, computed, set, setProperties } from '@ember/object';
 import { all, reject } from 'rsvp';
-import { isRoot } from 'screwdriver-ui/utils/graph-tools';
+import graphTools from 'screwdriver-ui/utils/graph-tools';
+
+const { isRoot } = graphTools;
 
 export default Component.extend({
   classNames: ['pipelineWorkflow'],

--- a/app/components/pipeline-workflow/template.hbs
+++ b/app/components/pipeline-workflow/template.hbs
@@ -35,8 +35,8 @@
       }}
         <h3>Are you sure?</h3>
         <p>
-          You are about to restart the job <code>{{tooltipData.job.name}}</code> in a new event with the same
-          context of event #{{selectedEventObj.id}} for sha <code>#{{selectedEventObj.truncatedSha}}</code>.
+          You are about to start the job <code>{{tooltipData.job.name}}</code> in a new event with the same
+          context of the selected event for sha <code>#{{selectedEventObj.truncatedSha}}</code>
         </p>
         <div class="row">
           <div class="col-xs-6">

--- a/app/components/pipeline-workflow/template.hbs
+++ b/app/components/pipeline-workflow/template.hbs
@@ -1,12 +1,52 @@
 {{#if (and (eq selected 'aggregate') (is-fulfilled graph))}}
-  {{workflow-graph-d3 workflowGraph=directedGraph builds=builds}}
+  {{#workflow-graph-d3
+    workflowGraph=directedGraph
+    builds=builds
+    graphClicked=(action "graphClicked")
+  }}
+  {{workflow-tooltip
+    tooltipData=tooltipData
+    displayRestartButton=false
+    showTooltip=showTooltip
+  }}
+  {{/workflow-graph-d3}}
 {{else}}
   {{#if (is-fulfilled selectedEventObj.builds)}}
-    {{workflow-graph-d3
+    {{#workflow-graph-d3
       builds=selectedEventObj.builds
       workflowGraph=selectedEventObj.workflowGraph
       startFrom=selectedEventObj.startFrom
       causeMessage=selectedEventObj.causeMessage
+      graphClicked=(action "graphClicked")
     }}
+    {{workflow-tooltip
+      tooltipData=tooltipData
+      displayRestartButton=displayRestartButton
+      showTooltip=showTooltip
+      showTooltipPosition=showTooltipPosition
+      confirmStartBuild=(action "confirmStartBuild")
+    }}
+    {{/workflow-graph-d3}}
+    {{#if isShowingModal}}
+      {{#modal-dialog
+        targetAttachment="center"
+        translucentOverlay=true
+        containerClass="detached-confirm-dialog"
+      }}
+        <h3>Are you sure?</h3>
+        <p>
+          You are about to restart the job <code>{{tooltipData.job.name}}</code> in a new event with the same
+          context of event #{{selectedEventObj.id}} for sha <code>#{{selectedEventObj.truncatedSha}}</code>.
+        </p>
+        <div class="row">
+          <div class="col-xs-6">
+            <button class="d-button is-primary" {{action "startDetachedBuild"}}>Yes</button>
+          </div>
+          <div class="col-xs-6 right">
+            <button class="d-button is-secondary" {{action "cancelStartBuild"}}>No</button>
+          </div>
+        </div>
+      {{/modal-dialog}}
+    {{/if}}
   {{/if}}
 {{/if}}

--- a/app/components/workflow-graph-d3/component.js
+++ b/app/components/workflow-graph-d3/component.js
@@ -59,14 +59,14 @@ export default Component.extend({
     const el = d3.select(get(this, 'element'));
 
     data.nodes.forEach((node) => {
-      const n = el.select(`g.job-${node.name}`);
+      const n = el.select(`g.graph-node[data-job="${node.name}"]`);
 
       if (n) {
         const txt = n.select('text');
 
         txt.text(icon(node.status));
         n.attr('class',
-          `job-${node.name} graph-node${node.status ? ` build-${node.status.toLowerCase()}` : ''}`
+          `graph-node${node.status ? ` build-${node.status.toLowerCase()}` : ''}`
         );
       }
     });
@@ -104,8 +104,9 @@ export default Component.extend({
       // create a group element to animate
       .append('g')
       .attr('class',
-        d => `job-${d.name} graph-node${d.status ? ` build-${d.status.toLowerCase()}` : ''}`
+        d => `graph-node${d.status ? ` build-${d.status.toLowerCase()}` : ''}`
       )
+      .attr('data-job', d => d.name)
       // create the icon graphic
       .insert('text')
       .text(d => icon(d.status))

--- a/app/components/workflow-graph-d3/component.js
+++ b/app/components/workflow-graph-d3/component.js
@@ -37,44 +37,39 @@ export default Component.extend({
     }
   }),
   didInsertElement() {
+    this._super(...arguments);
     this.draw();
   },
   // Listen for changes to workflow and update graph accordingly.
   didUpdateAttrs() {
     this._super(...arguments);
-
-    // TODO: is there a way to do this more gracefully?
-    // remove the existing graph element
-    this.$('svg').remove();
-    // draw a new one
-    this.draw();
+    this.redraw();
   },
   actions: {
     buildClicked(job) {
-      if (!job.buildId) {
-        return false;
+      const fn = get(this, 'graphClicked');
+
+      if (!get(this, 'minified') && typeof fn === 'function') {
+        fn(job, d3.event, get(this, 'elementSizes'));
       }
-
-      const fn = get(this, 'buildClicked');
-
-      // Properly handle job if one is passed
-      if (typeof fn === 'function') {
-        return fn(job);
-      }
-
-      const router = get(this, 'router');
-
-      // Backwards compatibilty - hack to make click route to build page
-      let url = router.urlFor('pipeline.build', job.buildId);
-
-      if (job.name.startsWith('~sd@')) {
-        const pipelineId = job.name.match(/^~sd@(\d+):([\w-]+)$/)[1];
-
-        url = router.urlFor('pipeline.build', pipelineId, job.buildId);
-      }
-
-      return router.transitionTo(url);
     }
+  },
+  redraw() {
+    const data = get(this, 'decoratedGraph');
+    const el = d3.select(get(this, 'element'));
+
+    data.nodes.forEach((node) => {
+      const n = el.select(`g.job-${node.name}`);
+
+      if (n) {
+        const txt = n.select('text');
+
+        txt.text(icon(node.status));
+        n.attr('class',
+          `job-${node.name} graph-node${node.status ? ` build-${node.status.toLowerCase()}` : ''}`
+        );
+      }
+    });
   },
   draw() {
     const data = get(this, 'decoratedGraph');
@@ -94,7 +89,12 @@ export default Component.extend({
     const svg = d3.select(get(this, 'element'))
       .append('svg')
       .attr('width', w)
-      .attr('height', h);
+      .attr('height', h)
+      .on('click.graph-node:not', (e) => {
+        this.send('buildClicked', e);
+      }, true);
+
+    this.set('graphNode', svg);
 
     // Jobs Icons
     svg.selectAll('jobs')
@@ -103,7 +103,9 @@ export default Component.extend({
       // for each element in data array - do the following
       // create a group element to animate
       .append('g')
-      .attr('class', d => `graph-node${d.status ? ` build-${d.status.toLowerCase()}` : ''}`)
+      .attr('class',
+        d => `job-${d.name} graph-node${d.status ? ` build-${d.status.toLowerCase()}` : ''}`
+      )
       // create the icon graphic
       .insert('text')
       .text(d => icon(d.status))

--- a/app/components/workflow-graph-d3/component.js
+++ b/app/components/workflow-graph-d3/component.js
@@ -1,6 +1,6 @@
 /* global d3 */
 import Component from '@ember/component';
-import { get, getWithDefault, computed } from '@ember/object';
+import { get, set, getWithDefault, computed } from '@ember/object';
 import { inject as service } from '@ember/service';
 import graphTools from 'screwdriver-ui/utils/graph-tools';
 
@@ -39,11 +39,25 @@ export default Component.extend({
   didInsertElement() {
     this._super(...arguments);
     this.draw();
+
+    set(this, 'lastGraph', get(this, 'workflowGraph'));
   },
   // Listen for changes to workflow and update graph accordingly.
   didUpdateAttrs() {
     this._super(...arguments);
-    this.redraw();
+
+    const lg = get(this, 'lastGraph');
+    const wg = get(this, 'workflowGraph');
+
+    // redraw anyways when graph changes
+    if (lg !== wg) {
+      get(this, 'graphNode').remove();
+
+      this.draw();
+      set(this, 'lastGraph', wg);
+    } else {
+      this.redraw();
+    }
   },
   actions: {
     buildClicked(job) {

--- a/app/components/workflow-graph-d3/styles.scss
+++ b/app/components/workflow-graph-d3/styles.scss
@@ -13,6 +13,10 @@
   to {transform: rotate(360deg);}
 }
 
+& {
+  position: relative;
+}
+
 g {
   transform-origin: 50% 50%;
 

--- a/app/components/workflow-tooltip/component.js
+++ b/app/components/workflow-tooltip/component.js
@@ -1,0 +1,28 @@
+import Component from '@ember/component';
+import { get } from '@ember/object';
+import { equal } from '@ember/object/computed';
+
+export default Component.extend({
+  classNames: 'workflow-tooltip',
+  classNameBindings: ['showTooltip', 'left'],
+  showTooltip: false,
+  left: equal('showTooltipPosition', 'left'),
+
+  didUpdateAttrs() {
+    this._super(...arguments);
+
+    const event = get(this, 'tooltipData.mouseevent');
+    const el = this.$();
+
+    // setting tooltip position
+    if (el && event) {
+      let top = event.layerY + get(this, 'tooltipData.sizes.ICON_SIZE');
+      let left = get(this, 'left') ? event.layerX - 20 : event.layerX - (el.outerWidth() / 2);
+
+      el.css({
+        top,
+        left
+      });
+    }
+  }
+});

--- a/app/components/workflow-tooltip/styles.scss
+++ b/app/components/workflow-tooltip/styles.scss
@@ -1,0 +1,65 @@
+& {
+  visibility: hidden;
+  position: absolute;
+  text-align: left;
+  opacity: 0;
+  transition: opacity .3s .1s;
+
+  &.show-tooltip {
+    opacity: 1;
+    visibility: visible;
+  }
+
+  .content {
+    position: relative;
+    font-size: 16px;
+    background-color: $sd-white;
+    border: 2px solid $grey-400;
+    border-radius: 2px;
+    box-shadow: 0 4px 16px 0 $box-shadow;
+    padding: 16px 18px;
+
+    a {
+      display: block;
+      margin-bottom: 10px;
+    }
+
+    a:last-of-type {
+      margin-bottom: 0;
+    }
+
+    &::before,
+    &::after {
+      bottom: 100%;
+      left: 50%;
+      border: solid transparent;
+      content: ' ';
+      height: 0;
+      width: 0;
+      position: absolute;
+      pointer-events: none;
+      box-sizing: border-box;
+    }
+
+    &::before {
+      border-color: transparent;
+      border-bottom-color: $grey-400;
+      border-width: 13px;
+      margin-left: -13px;
+    }
+
+    &::after {
+      border-color: transparent;
+      border-bottom-color: $sd-white;
+      border-width: 10px;
+      margin-left: -10px;
+    }
+  }
+
+  &.left .content {
+    &::before,
+    &::after {
+      left: 20px;
+    }
+  }
+}

--- a/app/components/workflow-tooltip/template.hbs
+++ b/app/components/workflow-tooltip/template.hbs
@@ -1,0 +1,9 @@
+<div class="content">
+  {{#if tooltipData.job.buildId}}
+    {{#link-to "pipeline.build" tooltipData.job.buildId}}Go to build details{{/link-to}}
+  {{/if}}
+  {{#if displayRestartButton}}
+    <a {{action confirmStartBuild}}>Start pipeline from here</a>
+  {{/if}}
+  {{yield}}
+</div>

--- a/app/pipeline/index/controller.js
+++ b/app/pipeline/index/controller.js
@@ -118,12 +118,6 @@ export default Controller.extend(ModelReloaderMixin, {
         causeMessage
       });
 
-      console.log('parentBuildId', parentBuildId);
-      console.log('parentEventId', parentEventId);
-      console.log('pipelineId', pipelineId);
-      console.log('startFrom', startFrom);
-      console.log('causeMessage', causeMessage);
-
       this.set('isShowingModal', true);
 
       return newEvent.save().then(() => {

--- a/app/pipeline/index/template.hbs
+++ b/app/pipeline/index/template.hbs
@@ -16,10 +16,13 @@
     }}
 
     {{pipeline-workflow
+      mostRecent=mostRecent
       workflowGraph=pipeline.workflowGraph
       jobs=jobs
       selectedEventObj=selectedEventObj
       selected=selected
+      startDetachedBuild=(action "startDetachedBuild")
+      authenticated=session.isAuthenticated
     }}
 
     {{pipeline-events-list

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -28,6 +28,7 @@ $weight-bold: 600;
 }
 
 @import 'font-awesome';
+@import 'denali-button';
 @import 'denali-colors';
 @import 'screwdriver-colors';
 @import 'screwdriver-modal-styles';
@@ -46,4 +47,21 @@ $grid-float-breakpoint: 880px;
 body {
   font-family: Helvetica, Arial, sans-serif;
   font-weight: $weight-normal;
+}
+
+.detached-confirm-dialog {
+  max-width: 320px;
+
+  h3 {
+    margin: 10px 0;
+    padding: 0 7px;
+  }
+
+  p {
+    padding: 0 7px;
+  }
+
+  .right {
+    text-align: right;
+  }
 }

--- a/app/styles/denali-button.scss
+++ b/app/styles/denali-button.scss
@@ -1,0 +1,110 @@
+@charset "utf-8";
+
+.d-button {
+  border: none;
+  border-radius: 2px;
+  box-shadow: 0 0 0 1px transparent inset, 0 0 0 0 #D5D5D5 inset;
+  cursor: pointer;
+  display: inline-block;
+  font-family: Helvetica,Arial,sans-serif;
+  font-size: 14px;
+  font-weight: normal;
+  line-height: 0px;
+  letter-spacing: .2px;
+  margin: 5px;
+  height: 36px;
+  min-width: 120px;
+  outline: 0;
+  padding: 10px 16px;
+  text-align: center;
+  text-shadow: none;
+  text-transform: none;
+  transition: all 0.2s ease;
+  vertical-align: baseline;
+
+  .d-icon {
+    vertical-align: middle;
+  }
+}
+
+a.d-button {
+  padding: 18px 16px;
+}
+
+.d-button.has-icon {
+  min-width: 0px;
+}
+a.d-button.has-icon {
+  padding: 10px 16px;
+}
+
+//PRIMARY
+
+.d-button.is-primary {
+  background: linear-gradient(to right, #3697F2, #3570F4);
+  color: #FFF;
+}
+
+.d-button.is-primary:hover,
+.d-button.is-primary.is-active,
+.d-button.is-primary.is-active:hover {
+  background: linear-gradient(to right, #3570F4, #3448F7);
+}
+
+//SECONDARY
+
+.d-button.is-secondary {
+  background: transparent;
+  box-shadow: 0 0 0 1px #3697F2 inset;
+  color: #3697F2;
+}
+.d-button.is-secondary:hover,
+.d-button.is-secondary.is-active,
+.d-button.is-secondary.is-active:hover {
+  background: rgba(53, 112, 244, 0.2);
+}
+
+//DANGER
+
+.d-button.is-danger {
+  background: #EA0000;
+  color: #FFF;
+}
+.d-button.is-danger:hover,
+.d-button.is-danger.is-active,
+.d-button.is-danger.is-active:hover {
+  background: #BB0000;
+}
+
+// Disabled
+
+.d-button.is-disabled,
+.d-button[disabled],
+.d-button.is-disabled:hover,
+.d-button:hover[disabled] {
+  background: rgba(48, 48, 48, 0.1);
+  box-shadow: none;
+  color: rgba(48, 48, 48, 0.2);
+  cursor: not-allowed;
+}
+
+// SIZES
+
+.d-button.is-medium {
+  font-size: 14px;
+  padding: 8px 28px;
+  height: 32px;
+}
+a.d-button.is-medium {
+  padding: 15px 28px;
+}
+
+.d-button.is-small {
+  font-size: 12px;
+  min-width: 90px;
+  padding: 4px 14px;
+  height: 24px;
+}
+a.d-button.is-small{
+  padding: 12px 14px;
+}

--- a/app/styles/denali-colors.scss
+++ b/app/styles/denali-colors.scss
@@ -32,3 +32,5 @@ $blue-400: #308EE7;
 $blue-300: #60ABEF;
 $blue-200: #90C7F7;
 $blue-100: #BEE0FC;
+
+$box-shadow: rgba(0, 0, 0, .1);

--- a/app/utils/graph-tools.js
+++ b/app/utils/graph-tools.js
@@ -142,8 +142,8 @@ const decorateGraph = (inputGraph, builds, start) => {
       }
     }
 
-    // Set a status on the trigger node
-    if (n.name === start) {
+    // Set a status on the trigger node (if it starts with ~)
+    if (n.name === start && /^~/.test(n.name)) {
       n.status = 'STARTED_FROM';
     }
   });
@@ -171,4 +171,4 @@ const decorateGraph = (inputGraph, builds, start) => {
   return graph;
 };
 
-export default { node, icon, decorateGraph, graphDepth };
+export default { node, icon, decorateGraph, graphDepth, isRoot };

--- a/tests/integration/components/pipeline-workflow/component-test.js
+++ b/tests/integration/components/pipeline-workflow/component-test.js
@@ -51,6 +51,7 @@ test('it renders an aggregate', function (assert) {
   this.render(hbs`{{pipeline-workflow workflowGraph=graph jobs=jobsMock selected=selected}}`);
 
   assert.equal(this.$('.graph-node').length, 5);
+  assert.equal(this.$('.workflow-tooltip').length, 1);
 });
 
 test('it renders an event', function (assert) {
@@ -65,4 +66,5 @@ test('it renders an event', function (assert) {
   this.render(hbs`{{pipeline-workflow selectedEventObj=obj selected=selected}}`);
 
   assert.equal(this.$('.graph-node').length, 5);
+  assert.equal(this.$('.workflow-tooltip').length, 1);
 });

--- a/tests/integration/components/workflow-graph-d3/component-test.js
+++ b/tests/integration/components/workflow-graph-d3/component-test.js
@@ -70,3 +70,41 @@ test('it renders statuses when build data is available', function (assert) {
   assert.equal(svg.children('path.graph-edge.build-started_from').length, 1);
   assert.equal(svg.children('path.graph-edge.build-success').length, 2);
 });
+
+test('it does not render startFrom icon when starting in the middle of the graph',
+  function (assert) {
+    this.set('workflowGraph', {
+      nodes: [
+        { name: '~pr' },
+        { name: '~commit' },
+        { id: 1, name: 'main' },
+        { id: 2, name: 'A' },
+        { id: 3, name: 'B' }
+      ],
+      edges: [
+        { src: '~pr', dest: 'main' },
+        { src: '~commit', dest: 'main' },
+        { src: 'main', dest: 'A' },
+        { src: 'A', dest: 'B' }
+      ]
+    });
+    this.set('startFrom', 'A');
+    this.set('builds', [
+      { jobId: 2, id: 5, status: 'SUCCESS' },
+      { jobId: 3, id: 6, status: 'FAILURE' }
+    ]);
+    this.render(
+      hbs`{{workflow-graph-d3 workflowGraph=workflowGraph builds=builds startFrom=startFrom}}`
+    );
+
+    const svg = this.$('svg');
+
+    assert.equal(svg.length, 1);
+    assert.equal(svg.children('g.graph-node').length, 5);
+    assert.equal(svg.children('g.graph-node.build-success').length, 1);
+    assert.equal(svg.children('g.graph-node.build-failure').length, 1);
+    assert.equal(svg.children('g.graph-node.build-started_from').length, 0);
+    assert.equal(svg.children('path.graph-edge').length, 4);
+    assert.equal(svg.children('path.graph-edge.build-started_from').length, 0);
+    assert.equal(svg.children('path.graph-edge.build-success').length, 1);
+  });

--- a/tests/integration/components/workflow-tooltip/component-test.js
+++ b/tests/integration/components/workflow-tooltip/component-test.js
@@ -1,0 +1,79 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('workflow-tooltip', 'Integration | Component | workflow tooltip', {
+  integration: true
+});
+
+test('it renders', function (assert) {
+  this.render(hbs`{{workflow-tooltip}}`);
+
+  assert.equal(this.$().text().trim(), '');
+
+  // Template block usage:
+  this.render(hbs`
+    {{#workflow-tooltip}}
+      template block text
+    {{/workflow-tooltip}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'template block text');
+});
+
+test('it renders build link', function (assert) {
+  const data = {
+    job: {
+      buildId: 1234,
+      name: 'batmobile'
+    }
+  };
+
+  this.set('data', data);
+
+  this.render(hbs`{{workflow-tooltip tooltipData=data}}`);
+
+  assert.equal(this.$('.content a').length, 1);
+  assert.equal(this.$().text().trim(), 'Go to build details');
+});
+
+test('it renders restart link', function (assert) {
+  const data = {
+    job: {
+      buildId: 1234,
+      name: 'batmobile'
+    }
+  };
+
+  this.set('data', data);
+  this.set('confirmStartBuild', () => {});
+
+  this.render(hbs`{{
+    workflow-tooltip
+    tooltipData=data
+    displayRestartButton=true
+    confirmStartBuild="confirmStartBuild"
+  }}`);
+
+  assert.equal(this.$('.content a').length, 2);
+  assert.equal(this.$('a').text().trim(), 'Go to build detailsStart pipeline from here');
+});
+
+test('it should update position and hidden status', function (assert) {
+  this.set('show', true);
+  this.set('pos', 'left');
+
+  this.render(hbs`{{
+    workflow-tooltip
+    showTooltip=show
+    showTooltipPosition=pos
+  }}`);
+
+  assert.ok(this.$('.workflow-tooltip').hasClass('show-tooltip'));
+  assert.ok(this.$('.workflow-tooltip').hasClass('left'));
+
+  this.set('show', false);
+  this.set('pos', 'center');
+
+  assert.notOk(this.$('.workflow-tooltip').hasClass('show-tooltip'));
+  assert.notOk(this.$('.workflow-tooltip').hasClass('left'));
+});

--- a/tests/unit/utils/graph-tools-test.js
+++ b/tests/unit/utils/graph-tools-test.js
@@ -1,6 +1,6 @@
 import graphTools from 'screwdriver-ui/utils/graph-tools';
 import { module, test } from 'qunit';
-const { icon, node, decorateGraph, graphDepth } = graphTools;
+const { icon, node, decorateGraph, graphDepth, isRoot } = graphTools;
 
 const SIMPLE_GRAPH = {
   nodes: [
@@ -262,4 +262,10 @@ test('it determines the depth of a graph from various starting points', function
   assert.equal(graphDepth(MORE_COMPLEX_GRAPH.edges, 'detached_solo'), 1, 'very complex detached 2');
   // more complex graph, partial pipeline
   assert.equal(graphDepth(MORE_COMPLEX_GRAPH.edges, 'publish'), 1, 'very complex partial');
+});
+
+test('it determines if a job name is a root node', function (assert) {
+  assert.ok(isRoot(MORE_COMPLEX_GRAPH.edges, 'detached_main'));
+  assert.ok(isRoot(MORE_COMPLEX_GRAPH.edges, '~commit'));
+  assert.notOk(isRoot(MORE_COMPLEX_GRAPH.edges, 'no_main'));
 });


### PR DESCRIPTION
Context:
========
We want to allow users to restart jobs in a given event and retain that event's context in the new event. For example: restart a flakey job to continue the pipeline, or redeploy an artifact after a regression. Issue https://github.com/screwdriver-cd/screwdriver/issues/806

Objective:
-----------
Provide a mechanism that ties to the graph that allows users to start jobs. This generates a dropdown that can be populated with links and other information that allows users to go to the build details page, or restart a build/detached pipeline.

Tooltip:
![](https://user-images.githubusercontent.com/78533/36703249-a0c0402c-1b0f-11e8-99da-9ab355663ca5.png)

Confirmation on restart:
![](https://user-images.githubusercontent.com/78533/36703261-ad165866-1b0f-11e8-93b9-0e900849f31a.png)


Misc:
------
Restrictions:
* Build must be in the most recent event (this is subject to change)
* Build must have previously executed -or- be the root node of a detached workflow

Additional:
------------
Sort of addresses https://github.com/screwdriver-cd/screwdriver/issues/817 and https://github.com/screwdriver-cd/screwdriver/issues/878 by providing a standard html link to build details.