### PR TITLE
feat(907): detached workflows graph start on their own row

### DIFF
--- a/tests/unit/utils/graph-tools-test.js
+++ b/tests/unit/utils/graph-tools-test.js
@@ -217,7 +217,7 @@ test('it handles complex misordered pipeline with multiple commit/pr/remote trig
         { name: 'other_publish', pos: { x: 2, y: 1 } },
         { name: 'wow_new_main', pos: { x: 1, y: 1 } },
         { name: 'detached_main', pos: { x: 0, y: 3 } },
-        { name: 'after_detached_main', pos: { x: 1, y: 2 } },
+        { name: 'after_detached_main', pos: { x: 1, y: 3 } },
         { name: 'detached_solo', pos: { x: 0, y: 4 } }
       ],
       edges: [
@@ -232,7 +232,7 @@ test('it handles complex misordered pipeline with multiple commit/pr/remote trig
         { src: 'detached_main',
           dest: 'after_detached_main',
           from: { x: 0, y: 3 },
-          to: { x: 1, y: 2 }
+          to: { x: 1, y: 3 }
         }
       ],
       meta: {


### PR DESCRIPTION
Context:
=======
https://github.com/screwdriver-cd/screwdriver/issues/907

Detached workflows can get confusing when the jobs merge together in their respective columns

![](https://user-images.githubusercontent.com/78533/36869368-6c3ab740-1d50-11e8-87da-e5c7617db737.png)

Objective:
-----------
Make a fully detached pipeline workflow start on its own "clean" row, and bind the height of each of its jobs to start from that row.

![](https://user-images.githubusercontent.com/78533/36869422-9ceddf0c-1d50-11e8-88b8-85436cacda35.png)

