### PR TITLE
fix: event doesn't serialize parentBuildId or parentEventId

### DIFF
--- a/app/event/model.js
+++ b/app/event/model.js
@@ -13,6 +13,8 @@ export default DS.Model.extend(ModelReloaderMixin, {
   createTime: DS.attr('date'),
   creator: DS.attr(),
   isComplete: DS.attr('boolean', { defaultValue: false }),
+  parentBuildId: DS.attr('number'),
+  parentEventId: DS.attr('number'),
   pipelineId: DS.attr('string'),
   sha: DS.attr('string'),
   startFrom: DS.attr('string'),

--- a/app/event/serializer.js
+++ b/app/event/serializer.js
@@ -8,9 +8,23 @@ export default DS.RESTSerializer.extend({
    * @method serializeIntoHash
    */
   serializeIntoHash(hash, typeClass, snapshot) {
-    return merge(hash, {
+    const data = {
       pipelineId: snapshot.attr('pipelineId'),
       startFrom: snapshot.attr('startFrom')
-    });
+    };
+
+    if (snapshot.attr('causeMessage')) {
+      data.causeMessage = snapshot.attr('causeMessage');
+    }
+
+    if (snapshot.attr('parentBuildId')) {
+      data.parentBuildId = parseInt(snapshot.attr('parentBuildId'), 10);
+    }
+
+    if (snapshot.attr('parentEventId')) {
+      data.parentEventId = parseInt(snapshot.attr('parentEventId'), 10);
+    }
+
+    return merge(hash, data);
   }
 });


### PR DESCRIPTION
Context:
========
payload sent to api for (re)start event job didn't include necessary data

Objective:
-----------
Add required data to serializer so it will be sent to API