### PR TITLE
Fixed issue where last build status wasn't being displayed on dashboard

### DIFF
--- a/app/components/collection-view/component.js
+++ b/app/components/collection-view/component.js
@@ -50,19 +50,19 @@ export default Component.extend({
             ret.lastBuildStatus = '';
           }
 
-          ret.lastBuildIcon = (() => {
+          [ret.lastBuildIcon, ret.lastBuildStatusColor] = (() => {
             switch (ret.lastBuildStatus) {
             case 'started_from':
             case 'queued':
             case 'running':
-              return 'spinner fa-spin text-primary';
+              return ['refresh fa-spin', 'text-primary'];
             case 'success':
-              return 'check text-success';
+              return ['check-circle', 'text-success'];
             case 'failure':
             case 'aborted':
-              return 'times text-danger';
+              return ['times-circle', 'text-danger'];
             case 'disabled':
-              return 'stop-circle text-warning';
+              return ['stop-circle', 'text-warning'];
             default:
               return '';
             }

--- a/app/components/collection-view/component.js
+++ b/app/components/collection-view/component.js
@@ -35,7 +35,7 @@ export default Component.extend({
             scm: scm.displayName,
             scmIcon: scm.iconType,
             workflow: pipeline.workflow,
-            lastBuild: pipeline.lastBuilds,
+            lastBuilds: pipeline.lastBuilds,
             prs: pipeline.prs
           };
 

--- a/app/components/collection-view/component.js
+++ b/app/components/collection-view/component.js
@@ -35,7 +35,7 @@ export default Component.extend({
             scm: scm.displayName,
             scmIcon: scm.iconType,
             workflow: pipeline.workflow,
-            lastBuilds: pipeline.lastBuilds,
+            lastBuild: pipeline.lastBuilds,
             prs: pipeline.prs
           };
 
@@ -44,9 +44,29 @@ export default Component.extend({
             const lastBuildObj = pipeline.lastBuilds[lastBuildsLength - 1];
 
             ret.lastBuildTime = new Date(lastBuildObj.createTime).valueOf();
+            ret.lastBuildStatus = lastBuildObj.status.toLowerCase();
           } else {
             ret.lastBuildTime = 0;
+            ret.lastBuildStatus = '';
           }
+
+          ret.lastBuildIcon = (() => {
+            switch (ret.lastBuildStatus) {
+            case 'started_from':
+            case 'queued':
+            case 'running':
+              return 'spinner fa-spin text-primary';
+            case 'success':
+              return 'check text-success';
+            case 'failure':
+            case 'aborted':
+              return 'times text-danger';
+            case 'disabled':
+              return 'stop-circle text-warning';
+            default:
+              return '';
+            }
+          })();
 
           return ret;
         });

--- a/app/components/collection-view/template.hbs
+++ b/app/components/collection-view/template.hbs
@@ -51,7 +51,12 @@
             </td>
             <td class="branch">{{fa-icon "code-fork"}}{{pipeline.scmRepo.branch}}</td>
             <td class="account">{{fa-icon pipeline.scmIcon}} {{pipeline.scm}}</td>
-            <td class="health">{{fa-icon pipeline.lastBuildIcon }} {{ pipeline.lastBuildStatus }}</td>
+            <td class="health">
+              {{fa-icon pipeline.lastBuildIcon class=pipeline.lastBuildStatusColor}}
+              <span class="{{pipeline.lastBuildStatusColor}}">
+                {{pipeline.lastBuildStatus}}
+              </span>
+            </td>
             <td class="prs--open">
               {{#if pipeline.prs}}
                 {{pipeline.prs.open}}

--- a/app/components/collection-view/template.hbs
+++ b/app/components/collection-view/template.hbs
@@ -51,8 +51,7 @@
             </td>
             <td class="branch">{{fa-icon "code-fork"}}{{pipeline.scmRepo.branch}}</td>
             <td class="account">{{fa-icon pipeline.scmIcon}} {{pipeline.scm}}</td>
-            <td class="health">
-            </td>
+            <td class="health">{{fa-icon pipeline.lastBuildIcon }} {{ pipeline.lastBuildStatus }}</td>
             <td class="prs--open">
               {{#if pipeline.prs}}
                 {{pipeline.prs.open}}


### PR DESCRIPTION
How can it be reproduced?
  Viewing the `/dashboards/:id` page won't display last build status
What did you expect?
  To see the status of the last build
What actually occurred?
  There was no value being populated in the template