### PR TITLE
fix: pass buildId when recreating build

### DIFF
--- a/app/event/model.js
+++ b/app/event/model.js
@@ -8,6 +8,7 @@ import ModelReloaderMixin from 'screwdriver-ui/mixins/model-reloader';
 const { graphDepth } = graphTools;
 
 export default DS.Model.extend(ModelReloaderMixin, {
+  buildId: DS.attr('number'),
   causeMessage: DS.attr('string'),
   commit: DS.attr(),
   createTime: DS.attr('date'),

--- a/app/event/serializer.js
+++ b/app/event/serializer.js
@@ -25,6 +25,10 @@ export default DS.RESTSerializer.extend({
       data.parentEventId = parseInt(snapshot.attr('parentEventId'), 10);
     }
 
+    if (snapshot.attr('buildId')) {
+      data.buildId = parseInt(snapshot.attr('buildId'), 10);
+    }
+
     return merge(hash, data);
   }
 });

--- a/app/pipeline/index/controller.js
+++ b/app/pipeline/index/controller.js
@@ -102,6 +102,7 @@ export default Controller.extend(ModelReloaderMixin, {
 
         parentBuildId = get(build, 'parentBuildId');
       }
+
       const event = get(this, 'selectedEventObj');
       const parentEventId = get(event, 'id');
       const startFrom = get(job, 'name');
@@ -111,6 +112,7 @@ export default Controller.extend(ModelReloaderMixin, {
       const causeMessage =
         `${user} clicked restart for job "${job.name}" for sha ${get(event, 'sha')}`;
       const newEvent = this.store.createRecord('event', {
+        buildId,
         pipelineId,
         startFrom,
         parentBuildId,

--- a/tests/unit/pipeline/index/controller-test.js
+++ b/tests/unit/pipeline/index/controller-test.js
@@ -2,7 +2,18 @@ import EmberObject from '@ember/object';
 import { run } from '@ember/runloop';
 import { moduleFor, test } from 'ember-qunit';
 import Pretender from 'pretender';
+import Service from '@ember/service';
 import wait from 'ember-test-helpers/wait';
+const sessionServiceMock = Service.extend({
+  isAuthenticated: true,
+  data: {
+    authenticated: {
+      // fake token for test, it has { username: apple } inside
+      // eslint-disable-next-line max-len
+      token: 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImFwcGxlIiwianRpIjoiNTA1NTQzYTUtNDhjZi00OTAyLWE3YTktZGY0NTI1ODFjYWM0IiwiaWF0IjoxNTIxNTcyMDE5LCJleHAiOjE1MjE1NzU2MTl9.ImS1ajOnksl1X74uL85jOjzdUXmBW3HfMdPfP1vjrmc'
+    }
+  }
+});
 let server;
 
 moduleFor('controller:pipeline/index', 'Unit | Controller | pipeline/index', {
@@ -11,6 +22,7 @@ moduleFor('controller:pipeline/index', 'Unit | Controller | pipeline/index', {
   needs: ['model:build', 'model:event', 'adapter:application', 'service:session', 'serializer:build', 'serializer:event'],
   beforeEach() {
     server = new Pretender();
+    this.register('service:session', sessionServiceMock);
   },
   afterEach() {
     server.shutdown();
@@ -68,6 +80,73 @@ test('it starts a build', function (assert) {
     assert.deepEqual(payload, {
       pipelineId: '1234',
       startFrom: '~commit'
+    });
+  });
+});
+
+test('it restarts a build', function (assert) {
+  assert.expect(7);
+  server.post('http://localhost:8080/v4/events', () => [
+    201,
+    { 'Content-Type': 'application/json' },
+    JSON.stringify({
+      id: '2'
+    })
+  ]);
+
+  let controller = this.subject();
+
+  run(() => {
+    controller.store.push({
+      data: {
+        id: '123',
+        type: 'build',
+        attributes: {
+          parentBuildId: '345'
+        }
+      }
+    });
+
+    controller.set('selectedEventObj', {
+      id: '1',
+      sha: 'sha'
+    });
+
+    controller.set('model', {
+      pipeline: EmberObject.create({
+        id: '1234'
+      }),
+      events: EmberObject.create({
+        reload: () => {
+          assert.ok(true);
+
+          return Promise.resolve({});
+        }
+      })
+    });
+
+    controller.transitionToRoute = (path, id) => {
+      assert.equal(path, 'pipeline');
+      assert.equal(id, 1234);
+    };
+
+    assert.notOk(controller.get('isShowingModal'));
+    controller.send('startDetachedBuild', { buildId: '123', name: 'deploy' });
+    assert.ok(controller.get('isShowingModal'));
+  });
+
+  return wait().then(() => {
+    const [request] = server.handledRequests;
+    const payload = JSON.parse(request.requestBody);
+
+    assert.notOk(controller.get('isShowingModal'));
+    assert.deepEqual(payload, {
+      pipelineId: '1234',
+      startFrom: 'deploy',
+      buildId: 123,
+      parentBuildId: 345,
+      parentEventId: 1,
+      causeMessage: 'apple clicked restart for job "deploy" for sha sha'
     });
   });
 });


### PR DESCRIPTION
- pass an extra field `buildId` when recreating build/event
- after the API change is done, we can remove extra unnecessary params we pass in now, e.g. `parentBuildId`. API will fetch all the info it need with the `buildId`

Related: https://github.com/screwdriver-cd/screwdriver/issues/904