### PR TITLE
feat(911): Show sourcePaths in validator [6]

### DIFF
--- a/app/components/validator-job/template.hbs
+++ b/app/components/validator-job/template.hbs
@@ -39,7 +39,7 @@
     </ul>
   </span>
 </div>
-<div class="sourcePaths" title="These are the source paths that will trigger a job upon modification.">
+<div class="sourcePaths" title="These are the source paths that will trigger a job upon modification. If you want to specify a directory, make sure it has a trailing slash (/).">
   <span class="label">Source Paths:</span>
   <span class="value">
     <ul>

--- a/app/components/validator-job/template.hbs
+++ b/app/components/validator-job/template.hbs
@@ -39,6 +39,18 @@
     </ul>
   </span>
 </div>
+<div class="sourcePaths" title="These are the source paths that will trigger a job upon modification.">
+  <span class="label">Source Paths:</span>
+  <span class="value">
+    <ul>
+      {{#each job.sourcePaths as |path|}}
+      <li>{{path}}</li>
+      {{else}}
+      <li>None defined</li>
+      {{/each}}
+    </ul>
+  </span>
+</div>
 <div class="secrets" title="These are the keys for secrets that will be available in this job.">
   <span class="label">Secrets:</span>
   <span class="value">

--- a/tests/integration/components/validator-job/component-test.js
+++ b/tests/integration/components/validator-job/component-test.js
@@ -112,6 +112,9 @@ test('it renders template steps', function (assert) {
 
   assert.equal(this.$('.annotations .label').text().trim(), 'Annotations:');
   assert.equal(this.$('.annotations .value').text().trim(), 'None defined');
+
+  assert.equal(this.$('.sourcePaths .label').text().trim(), 'Source Paths:');
+  assert.equal(this.$('.sourcePaths ul li').text().trim(), 'None defined');
 });
 
 test('it renders when there are no steps or commands', function (assert) {
@@ -178,6 +181,24 @@ test('it renders a description', function (assert) {
   assert.equal(this.$('h4').text().trim(), 'int-test');
   assert.equal(this.$('.description .label').text().trim(), 'Description:');
   assert.equal(this.$('.description .value ul li').text().trim(), 'This is a description');
+});
+
+test('it renders sourcePaths', function (assert) {
+  this.set('jobMock', {
+    image: 'int-test:1',
+    description: 'This is a description',
+    secrets: [],
+    environment: {},
+    settings: {},
+    annotations: {},
+    sourcePaths: ['README.md', 'src/folder']
+  });
+
+  this.render(hbs`{{validator-job name="int-test" index=0 job=jobMock}}`);
+
+  assert.equal(this.$('h4').text().trim(), 'int-test');
+  assert.equal(this.$('.sourcePaths .label').text().trim(), 'Source Paths:');
+  assert.equal(this.$('.sourcePaths .value ul li').text().trim(), 'README.mdsrc/folder');
 });
 
 test('it renders without a collapsible heading', function (assert) {

--- a/tests/integration/components/validator-job/component-test.js
+++ b/tests/integration/components/validator-job/component-test.js
@@ -191,14 +191,14 @@ test('it renders sourcePaths', function (assert) {
     environment: {},
     settings: {},
     annotations: {},
-    sourcePaths: ['README.md', 'src/folder']
+    sourcePaths: ['README.md', 'src/folder/']
   });
 
   this.render(hbs`{{validator-job name="int-test" index=0 job=jobMock}}`);
 
   assert.equal(this.$('h4').text().trim(), 'int-test');
   assert.equal(this.$('.sourcePaths .label').text().trim(), 'Source Paths:');
-  assert.equal(this.$('.sourcePaths .value ul li').text().trim(), 'README.mdsrc/folder');
+  assert.equal(this.$('.sourcePaths .value ul li').text().trim(), 'README.mdsrc/folder/');
 });
 
 test('it renders without a collapsible heading', function (assert) {


### PR DESCRIPTION
## Context
Now that users can configure `sourcePaths` in their `screwdriver.yaml` files, we should reflect those paths in the validator.

## Objective
This PR adds `sourcePaths` in the validator UI.

Array of strings example:
<img width="1382" alt="screen shot 2018-03-29 at 1 26 01 pm" src="https://user-images.githubusercontent.com/3230529/38111763-c58db94a-3354-11e8-93a6-db924392388c.png">
String example:
<img width="1422" alt="screen shot 2018-03-29 at 1 26 46 pm" src="https://user-images.githubusercontent.com/3230529/38111793-e0cc75ac-3354-11e8-8bf0-a6dadd483df2.png">


## Related links
Blocked by https://github.com/screwdriver-cd/screwdriver/pull/940 (still needs to be tested and pulled into prod)
Related to https://github.com/screwdriver-cd/screwdriver/issues/911