### PR TITLE
fix: fix logs overlap problem in chrome

### DIFF
--- a/app/components/build-log/styles.scss
+++ b/app/components/build-log/styles.scss
@@ -40,20 +40,37 @@
 .logs {
   font-size: 1em;
   font-family: monospace;
-  height: auto;
+  white-space: pre-line;
+  background-color: #333;
+  color: #eee;
+  display: flex;
+  flex-direction: column;
+  align-content: stretch;
   overflow: auto;
-  display: grid;
-  grid-template-columns: 1fr 10fr;
+  height: auto;
+
+  .line {
+    display: flex;
+    flex-direction: column;
+  }
 
   .time {
     color: $sd-text-med;
-    grid-column: 1;
-    user-select: none;
   }
 
   .content {
-    grid-column: 2;
-    white-space: pre-wrap;
+    display: inline-flex;
+    flex-grow: 1;
+  }
+}
+
+@media screen and (min-width: 35.5em) {
+  .logs .line {
+    flex-direction: row;
+  }
+  .logs .time {
+    display: inline-flex;
+    margin-right: 10px;
   }
 }
 

--- a/app/components/build-log/template.hbs
+++ b/app/components/build-log/template.hbs
@@ -22,16 +22,18 @@
 <div class="wrap" onScroll={{action "logScroll"}}>
   <div class="logs">
     {{#each logs as |log|}}
-      <span class="time" onClick={{action "toggleTimeDisplay"}}>
-        {{#if (eq timeFormat "datetime")}}
-          {{moment-format log.t 'HH:mm:ss'}}
-        {{else if (eq timeFormat "elapsedBuild")}}
-          {{x-duration buildStartTime log.t precision="seconds"}}
-          {{else if (eq timeFormat "elapsedStep")}}
-            {{x-duration stepStartTime log.t precision="seconds"}}
-        {{/if}}
+      <span class="line">
+        <span class="time" onClick={{action "toggleTimeDisplay"}}>
+          {{#if (eq timeFormat "datetime")}}
+            {{moment-format log.t 'HH:mm:ss'}}
+          {{else if (eq timeFormat "elapsedBuild")}}
+            {{x-duration buildStartTime log.t precision="seconds"}}
+            {{else if (eq timeFormat "elapsedStep")}}
+              {{x-duration stepStartTime log.t precision="seconds"}}
+          {{/if}}
+        </span>
+        <span class="content">{{ansi-colorize log.m}}</span>
       </span>
-      <span class="content">{{ansi-colorize log.m}}</span>
     {{/each}}
   </div>
   <div class="bottom"></div>


### PR DESCRIPTION
It turned out that chrome has problem with `display: grid` which caused the log lines overlap problem.

Switched it back to `display: flex` fixed the problem.

e.g. build with more than 5000 lines of logs in a step
<img width="1324" alt="screen shot 2018-03-28 at 5 13 49 pm" src="https://user-images.githubusercontent.com/20427140/38062936-7b21146e-32ab-11e8-8747-fc89d6955049.png">

Related to: https://github.com/screwdriver-cd/screwdriver/issues/949