### PR TITLE
fix(911): Display special icon for created PRs

### DIFF
--- a/app/components/pipeline-pr-view/component.js
+++ b/app/components/pipeline-pr-view/component.js
@@ -21,6 +21,9 @@ export default Component.extend({
       case 'SUCCESS':
         icon = 'check';
         break;
+      case 'CREATED':
+        icon = 'fa-ban';
+        break;
       default:
         icon = 'times';
         break;

--- a/tests/integration/components/pipeline-pr-view/component-test.js
+++ b/tests/integration/components/pipeline-pr-view/component-test.js
@@ -26,6 +26,28 @@ test('it renders a successful PR', function (assert) {
   assert.equal(this.$('.fa-check').length, 1);
 });
 
+// When a user changes files in the PR that do not match sourcePaths, the
+// PR will be created but not started
+test('it renders a created (but not running) PR', function (assert) {
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+  const job = EmberObject.create({
+    id: 'abcd',
+    name: 'PR-1234',
+    builds: [{
+      id: '1234',
+      status: 'CREATED'
+    }]
+  });
+
+  this.set('jobMock', job);
+
+  this.render(hbs`{{pipeline-pr-view job=jobMock}}`);
+
+  assert.equal(this.$().text().trim(), 'PR-1234');
+  assert.equal(this.$('.fa-ban').length, 1);
+});
+
 test('it renders a failed PR', function (assert) {
   // Set any properties with this.set('myProperty', 'value');
   // Handle any actions with this.on('myAction', function(val) { ... });


### PR DESCRIPTION
## Context
When a user changes files in a PR that do not fall under `sourcePaths`, the PR will be created but not started. The PR should still show up in the UI, but we need a different icon to indicate it will not be run. The current default for any job that is failed or aborted is a blue X.

## Objective
This PR adds a special icon for created (but not running) PRs.

<img width="239" alt="screen shot 2018-03-30 at 1 28 36 pm" src="https://user-images.githubusercontent.com/3230529/38152892-be0a193c-341e-11e8-80a4-c2e973a788ed.png">

## Related links
Original issue: https://github.com/screwdriver-cd/screwdriver/issues/911
Created status: https://github.com/screwdriver-cd/data-schema/blob/master/models/build.js#L112