### PR TITLE
fix: Enabled job will have a green toggle

### DIFF
--- a/app/components/pipeline-options/styles.scss
+++ b/app/components/pipeline-options/styles.scss
@@ -5,6 +5,9 @@
   .x-toggle-component {
     display: inline-flex;
   }
+  .x-toggle:checked + .x-toggle-default.x-toggle-btn {
+    background-color: $sd-success;
+  }
 
   section {
     border-radius: 5px 5px 0 0;

--- a/app/components/pipeline-options/template.hbs
+++ b/app/components/pipeline-options/template.hbs
@@ -48,7 +48,7 @@
               <h4>{{job.name}}</h4>
               <p>Toggle to {{if job.isDisabled "enable" "disable"}} the {{job.name}} job.</p>
             </div>
-            <div class="col-xs-2 right">
+            <div class="col-xs-2 right" title="Toggle to {{if job.isDisabled "enable" "disable"}} the {{job.name}} job.">
               {{x-toggle value=job.isDisabled onLabel='Enabled::false' offLabel='Disabled::true' onToggle=(action "toggleJob" job.id)}}
             </div>
           </div>


### PR DESCRIPTION
## Context
It can be hard to tell when a job is disabled or enabled at a quick glance.

## Objective
Just adding a title to the toggle button on the pipeline options page and changing the enabled jobs' toggles to green so it's more obvious.

Before:
<img width="931" alt="screen shot 2018-03-30 at 3 17 14 pm" src="https://user-images.githubusercontent.com/3230529/38155588-73665d3c-342d-11e8-9a15-6a68b4392f28.png">

After:
<img width="930" alt="screen shot 2018-03-30 at 3 14 00 pm" src="https://user-images.githubusercontent.com/3230529/38155569-510be2e8-342d-11e8-9f6f-60eeb8ff8694.png">
