### PR TITLE
Show repo url beside template name in template page

### DIFF
--- a/app/components/template-header/component.js
+++ b/app/components/template-header/component.js
@@ -1,10 +1,18 @@
 import Component from '@ember/component';
+import { inject as service } from '@ember/service';
 
 export default Component.extend({
   templateToRemove: null,
+  scmUrl: null,
   isRemoving: false,
+  store: service(),
   init() {
     this._super(...arguments);
+    this.get('store').findRecord('pipeline', this.template.pipelineId).then((pipeline) => {
+      this.set('scmUrl', pipeline.get('scmRepo.url'));
+    }).catch(() => {
+      this.set('scmUrl', null);
+    });
   },
   actions: {
     setTemplateToRemove(template) {

--- a/app/components/template-header/template.hbs
+++ b/app/components/template-header/template.hbs
@@ -1,5 +1,5 @@
 {{#link-to "templates" class="back"}}Back to Templates{{/link-to}}
-<h1>{{template.name}} <a href="#" {{action "setTemplateToRemove" template}} class="remove">{{fa-icon "trash"}}</a></h1>
+<h1>{{template.name}} {{#if scmUrl}}<a href="{{scmUrl}}">{{fa-icon "code-fork"}}</a>{{/if}} <a href="#" {{action "setTemplateToRemove" template}} class="remove">{{fa-icon "trash"}}</a></h1>
 <h2>{{template.version}}</h2>
 <p>{{template.description}}</p>
 <ul>

--- a/tests/integration/components/template-header/component-test.js
+++ b/tests/integration/components/template-header/component-test.js
@@ -1,5 +1,7 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import EmberObject from '@ember/object';
+import { Promise as EmberPromise } from 'rsvp';
 
 const TEMPLATE = {
   id: 2,
@@ -9,8 +11,19 @@ const TEMPLATE = {
   description: 'A test example',
   labels: ['car', 'armored'],
   maintainer: 'bruce@wayne.com',
+  pipelineId: 1,
   name: 'foo/bar',
   version: '2.0.0'
+};
+
+const mockPipeline = {
+  id: 1,
+  scmRepo: {
+    url: 'github.com/screwdriver-cd'
+  },
+  get(key) {
+    return this[key];
+  }
 };
 
 moduleForComponent('template-header', 'Integration | Component | template header', {
@@ -19,6 +32,15 @@ moduleForComponent('template-header', 'Integration | Component | template header
 
 test('it renders', function (assert) {
   const $ = this.$;
+
+  const storeStub = EmberObject.extend({
+    findRecord() {
+      return new EmberPromise(resolve => resolve(mockPipeline));
+    }
+  });
+
+  this.register('service:store', storeStub);
+  this.inject.service('store');
 
   this.set('mock', TEMPLATE);
   this.render(hbs`{{template-header template=mock}}`);


### PR DESCRIPTION
# Context

Currently, there's no way to find out a template's source repo without using the search function.

# Objective
 
- [x] Show link to source repo beside template name on the template page

![image](https://user-images.githubusercontent.com/691950/38157365-1c8c71fa-343b-11e8-96ce-e432dfc436d5.png)

# Related links

Issue that tracks this - https://github.com/screwdriver-cd/screwdriver/issues/522