### PR TITLE
fix(911): Fix PR icon for non-running PR

### DIFF
--- a/app/components/pipeline-pr-view/component.js
+++ b/app/components/pipeline-pr-view/component.js
@@ -21,11 +21,12 @@ export default Component.extend({
       case 'SUCCESS':
         icon = 'check';
         break;
-      case 'CREATED':
-        icon = 'fa-ban';
+      case 'ABORTED':
+      case 'FAILURE':
+        icon = 'times';
         break;
       default:
-        icon = 'times';
+        icon = 'fa-ban';
         break;
       }
 

--- a/tests/integration/components/pipeline-pr-view/component-test.js
+++ b/tests/integration/components/pipeline-pr-view/component-test.js
@@ -34,10 +34,7 @@ test('it renders a created (but not running) PR', function (assert) {
   const job = EmberObject.create({
     id: 'abcd',
     name: 'PR-1234',
-    builds: [{
-      id: '1234',
-      status: null
-    }]
+    builds: []
   });
 
   this.set('jobMock', job);

--- a/tests/integration/components/pipeline-pr-view/component-test.js
+++ b/tests/integration/components/pipeline-pr-view/component-test.js
@@ -36,7 +36,7 @@ test('it renders a created (but not running) PR', function (assert) {
     name: 'PR-1234',
     builds: [{
       id: '1234',
-      status: 'CREATED'
+      status: null
     }]
   });
 


### PR DESCRIPTION
## Context
We don't set the build status to CREATED for PRs that shouldn't be run. The builds are not even created.

## Objective
This PR fixes the icon switch statement to default to the banned icon, since we'll never reach the `CREATED` case.

## Related links
Related to https://github.com/screwdriver-cd/ui/pull/272
Original issue: https://github.com/screwdriver-cd/screwdriver/issues/911