### PR TITLE
fix: Preserve line breaks in template step commands

### DIFF
--- a/app/components/validator-job/styles.scss
+++ b/app/components/validator-job/styles.scss
@@ -33,6 +33,7 @@
 
   ul .value {
     color: $sd-text-med;
+    white-space: pre-wrap;
   }
 
   .steps ul .value {

--- a/app/components/validator-job/template.hbs
+++ b/app/components/validator-job/template.hbs
@@ -34,7 +34,7 @@
   <span class="value">
     <ul>
       {{#each steps as |command|}}
-      <li><span class="name">{{command.name}}: </span><span class="value">{{command.command}}</span></li>
+      <li><div class="name">{{command.name}}: </div><div class="value">{{command.command}}</div></li>
       {{/each}}
     </ul>
   </span>


### PR DESCRIPTION
# Context

https://github.com/screwdriver-cd/screwdriver/issues/973

Step commands in template pages show as a single block instead of preserving line wraps.

# Objective

Preserve line breaks and formatting of a step command as specified in `sd-template.yaml`

### Demo

![image](https://user-images.githubusercontent.com/691950/38268841-ee21b6bc-3733-11e8-9b1e-579116fed7ad.png)

# Related links

Issue: https://github.com/screwdriver-cd/screwdriver/issues/973