### PR TITLE
fix(719): Sort artifacts alphabetically

### DIFF
--- a/app/build-artifact/service.js
+++ b/app/build-artifact/service.js
@@ -102,7 +102,7 @@ export default Service.extend({
         headers: { Authorization: `Bearer ${this.get('session').get('data.authenticated.token')}` }
       })
         .done((data) => {
-          const paths = data.split('\n');
+          const paths = data.split('\n').sort(); // sort in alphabetical order
 
           manifest = arrangeIntoTree(paths, baseUrl);
         })

--- a/tests/unit/build-artifact/service-test.js
+++ b/tests/unit/build-artifact/service-test.js
@@ -4,9 +4,9 @@ import Service from '@ember/service';
 let server;
 
 const manifest = `.
+./test.txt
 ./coverage
-./coverage/coverage.json
-./test.txt`;
+./coverage/coverage.json`;
 
 const buildId = 1;
 


### PR DESCRIPTION
## Context
It can be hard to find the artifact you're looking for when they are displayed in a weird order.

## Objective
This PR sorts them alphabetically so they are easier to find.

**Before:**
<img width="252" alt="screen shot 2018-04-06 at 3 47 11 pm" src="https://user-images.githubusercontent.com/3230529/38447377-cd89b97e-39b1-11e8-8dc9-243a9ba4e5db.png">
**After:**
<img width="234" alt="screen shot 2018-04-06 at 3 43 32 pm" src="https://user-images.githubusercontent.com/3230529/38447381-cfd01c8c-39b1-11e8-8915-9ea26815e8a2.png">

## Related links
Fixes https://github.com/screwdriver-cd/screwdriver/issues/719