### PR TITLE
fix: display username if logged in

### DIFF
--- a/app/components/app-header/template.hbs
+++ b/app/components/app-header/template.hbs
@@ -82,7 +82,7 @@
           {{#nav.dropdown as |dd|}}
             {{#dd.toggle class="icon profile-outline"}}
               {{inline-svg "profile-outline" class="img"}}
-              <span class='icontitle'>Account</span>
+              <span class='icontitle'>{{session.data.authenticated.username}}</span>
               <span class="caret"></span>
             {{/dd.toggle}}
             {{#dd.menu as |ddm|}}

--- a/tests/integration/components/app-header/component-test.js
+++ b/tests/integration/components/app-header/component-test.js
@@ -30,6 +30,25 @@ test('it renders when search flag is off', function (assert) {
   assert.equal(this.$('.icon.profile-outline').prop('title'), 'Sign in to Screwdriver');
 });
 
+test('it shows user github username', function (assert) {
+  assert.expect(2);
+  this.set('sessionMock', {
+    isAuthenticated: true,
+    data: {
+      authenticated: {
+        username: 'foofoo'
+      }
+    }
+  });
+  this.set('invalidateSession', () => {
+    assert.ok(true);
+  });
+
+  this.render(hbs`{{app-header session=sessionMock onInvalidate=(action invalidateSession)}}`);
+  assert.equal(this.$('.profile-outline > .icontitle').text(), 'foofoo');
+  this.$('.logout').click();
+});
+
 test('it calls the logout method on logout', function (assert) {
   assert.expect(2);
   this.set('sessionMock', {


### PR DESCRIPTION
<img width="1405" alt="screen shot 2018-04-06 at 3 14 55 pm" src="https://user-images.githubusercontent.com/20427140/38447686-c8855a1c-39b3-11e8-8f30-a00d061fb1a8.png">

Display username if user logged in.

Related to: https://github.com/screwdriver-cd/screwdriver/issues/670