### PR TITLE
fix(783): Make valid pipeline more obvious

### DIFF
--- a/app/components/build-step-collection/styles.scss
+++ b/app/components/build-step-collection/styles.scss
@@ -26,4 +26,9 @@
   .step-list {
     overflow-y: auto;
   }
+
+  .step-toggle {
+    cursor: pointer;
+    text-decoration: none;
+  }
 }

--- a/app/components/build-step-collection/template.hbs
+++ b/app/components/build-step-collection/template.hbs
@@ -8,9 +8,9 @@
     </h3>
     <a class="step-toggle" onClick={{action "toggleSetup"}}>
       {{#if setupCollapsed}}
-      {{fa-icon "chevron-down"}}
+      {{fa-icon "chevron-right"}}
       {{else}}
-      {{fa-icon "chevron-up"}}
+      {{fa-icon "chevron-down"}}
       {{/if}}
       Setup
     </a>
@@ -48,9 +48,9 @@
     </div>
     <a class="step-toggle" onClick={{action "toggleTeardown"}}>
       {{#if teardownCollapsed}}
-      {{fa-icon "chevron-down"}}
+      {{fa-icon "chevron-right"}}
       {{else}}
-      {{fa-icon "chevron-up"}}
+      {{fa-icon "chevron-down"}}
       {{/if}}
       Teardown
     </a>

--- a/app/components/pipeline-create-form/styles.scss
+++ b/app/components/pipeline-create-form/styles.scss
@@ -50,6 +50,13 @@
   }
 }
 
+.success i {
+  color: $sd-success;
+  padding: 8px 8px 2px 8px;
+  vertical-align: bottom;
+  font-size: 36px;
+}
+
 .blue-button {
   @include transition(all, 50ms);
   border: none;

--- a/app/components/pipeline-create-form/template.hbs
+++ b/app/components/pipeline-create-form/template.hbs
@@ -10,6 +10,9 @@
   placeholder="Enter your repository url (eg: git@github.com:screwdriver-cd/ui.git#master)"
   value=scmUrl
 }}
+{{#if isValid}}
+  <i class="success">{{fa-icon "check"}}</i>
+{{/if}}
 </div>
 <div>
 <button {{action "saveData"}} disabled={{isDisabled}} class="blue-button{{if isSaving ' saving'}}">

--- a/app/components/pipeline-pr-view/component.js
+++ b/app/components/pipeline-pr-view/component.js
@@ -26,7 +26,7 @@ export default Component.extend({
         icon = 'times';
         break;
       default:
-        icon = 'fa-ban';
+        icon = 'ban';
         break;
       }
 

--- a/tests/integration/components/pipeline-create-form/component-test.js
+++ b/tests/integration/components/pipeline-create-form/component-test.js
@@ -17,7 +17,7 @@ test('it renders', function (assert) {
 });
 
 test('it handles the entire ui flow', function (assert) {
-  assert.expect(1);
+  assert.expect(2);
   const scm = 'git@github.com:foo/bar.git';
 
   this.set('createPipeline', (scmUrl) => {
@@ -27,5 +27,6 @@ test('it handles the entire ui flow', function (assert) {
   // eslint-disable-next-line max-len
   this.render(hbs`{{pipeline-create-form errorMessage="" isSaving=false onCreatePipeline=(action createPipeline)}}`);
   this.$('.text-input').val(scm).keyup();
+  assert.ok(this.$('i.fa').hasClass('fa-check'), 'success icon');
   this.$('button.blue-button').click();
 });


### PR DESCRIPTION
## Context
It's hard to tell when the git URL you're using is valid or not (the green border is hard to see sometimes).

## Objective
This PR adds a checkmark next to the input form when the input is valid.

<img width="765" alt="screen shot 2018-04-06 at 4 50 52 pm" src="https://user-images.githubusercontent.com/3230529/38448997-704b24fc-39be-11e8-8165-2c5e791af022.png">

This PR also:
- changes `fa-ban` to `ban` since [ember-font-awesome](https://github.com/martndemus/ember-font-awesome) is deprecating using `fa-`
- changes the chevron directions for setup and teardown steps on the build page to `>`(for collapsed) and `v`(for not collapsed) instead of `v`(for collapsed) and `^`(for not collapsed)

<img width="343" alt="screen shot 2018-04-06 at 5 02 55 pm" src="https://user-images.githubusercontent.com/3230529/38448998-744ba4d2-39be-11e8-8a3b-a1cede637a68.png">

## Related links
- https://github.com/screwdriver-cd/screwdriver/issues/783
