### PR TITLE
fix(1028): Parent meta exists when restarting a build from build page

### DIFF
--- a/app/pipeline/build/controller.js
+++ b/app/pipeline/build/controller.js
@@ -28,21 +28,13 @@ export default Controller.extend({
 
     startBuild() {
       const buildId = get(this, 'build.id');
-      const parentBuildId = get(this, 'build.parentBuildId');
-      const event = get(this, 'event');
-      const parentEventId = get(event, 'id');
-      const startFrom = get(this, 'job.name');
-      const pipelineId = get(this, 'pipeline.id');
+      const jobName = get(this, 'job.name');
       const token = get(this, 'session.data.authenticated.token');
       const user = get(decoder(token), 'username');
       const causeMessage =
-        `${user} clicked restart for job "${startFrom}" for sha ${get(event, 'sha')}`;
+        `${user} clicked restart for job "${jobName}" for sha ${get(this, 'event.sha')}`;
       const newEvent = this.store.createRecord('event', {
         buildId,
-        pipelineId,
-        startFrom,
-        parentBuildId,
-        parentEventId,
         causeMessage
       });
 

--- a/app/pipeline/build/controller.js
+++ b/app/pipeline/build/controller.js
@@ -1,6 +1,9 @@
 import { later, once } from '@ember/runloop';
+import { get } from '@ember/object';
 import { reads, mapBy } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
+import { jwt_decode as decoder } from 'ember-cli-jwt-decode';
+
 import Controller from '@ember/controller';
 import ENV from 'screwdriver-ui/config/environment';
 
@@ -24,20 +27,31 @@ export default Controller.extend({
     },
 
     startBuild() {
-      const pipelineId = this.get('pipeline.id');
-      const jobName = this.get('job.name');
+      const buildId = get(this, 'build.id');
+      const parentBuildId = get(this, 'build.parentBuildId');
+      const event = get(this, 'event');
+      const parentEventId = get(event, 'id');
+      const startFrom = get(this, 'job.name');
+      const pipelineId = get(this, 'pipeline.id');
+      const token = get(this, 'session.data.authenticated.token');
+      const user = get(decoder(token), 'username');
+      const causeMessage =
+        `${user} clicked restart for job "${startFrom}" for sha ${get(event, 'sha')}`;
       const newEvent = this.store.createRecord('event', {
+        buildId,
         pipelineId,
-        startFrom: jobName
+        startFrom,
+        parentBuildId,
+        parentEventId,
+        causeMessage
       });
 
-      return newEvent.save()
-        .then(() =>
-          newEvent.get('builds')
-            .then(builds =>
-              this.transitionToRoute('pipeline.build',
-                builds.get('lastObject.id'))
-            ));
+      return newEvent.save().then(() =>
+        newEvent.get('builds')
+          .then(builds =>
+            this.transitionToRoute('pipeline.build',
+              builds.get('lastObject.id'))
+          ));
     },
 
     reload() {

--- a/app/pipeline/index/controller.js
+++ b/app/pipeline/index/controller.js
@@ -95,28 +95,13 @@ export default Controller.extend(ModelReloaderMixin, {
     },
     startDetachedBuild(job) {
       const buildId = get(job, 'buildId');
-      let parentBuildId = null;
-
-      if (buildId) {
-        const build = this.store.peekRecord('build', buildId);
-
-        parentBuildId = get(build, 'parentBuildId');
-      }
-
       const event = get(this, 'selectedEventObj');
-      const parentEventId = get(event, 'id');
-      const startFrom = get(job, 'name');
-      const pipelineId = get(this, 'pipeline.id');
       const token = get(this, 'session.data.authenticated.token');
       const user = get(decoder(token), 'username');
       const causeMessage =
         `${user} clicked restart for job "${job.name}" for sha ${get(event, 'sha')}`;
       const newEvent = this.store.createRecord('event', {
         buildId,
-        pipelineId,
-        startFrom,
-        parentBuildId,
-        parentEventId,
         causeMessage
       });
 

--- a/tests/unit/pipeline/build/controller-test.js
+++ b/tests/unit/pipeline/build/controller-test.js
@@ -57,15 +57,10 @@ test('it restarts a build', function (assert) {
   run(() => {
     controller.set('model', {
       build: EmberObject.create({
-        id: '123',
-        parentBuildId: '345'
-      }),
-      pipeline: EmberObject.create({
-        id: '1234'
+        id: '123'
       }),
       job: EmberObject.create({
-        name: 'PR-1:main',
-        buildId: '123'
+        name: 'PR-1:main'
       }),
       event: EmberObject.create({
         id: '1',
@@ -85,11 +80,7 @@ test('it restarts a build', function (assert) {
     const payload = JSON.parse(request.requestBody);
 
     assert.deepEqual(payload, {
-      pipelineId: '1234',
-      startFrom: 'PR-1:main',
       buildId: 123,
-      parentBuildId: 345,
-      parentEventId: 1,
       causeMessage: 'apple clicked restart for job "PR-1:main" for sha sha'
     });
   });

--- a/tests/unit/pipeline/index/controller-test.js
+++ b/tests/unit/pipeline/index/controller-test.js
@@ -90,23 +90,14 @@ test('it restarts a build', function (assert) {
     201,
     { 'Content-Type': 'application/json' },
     JSON.stringify({
-      id: '2'
+      id: '2',
+      pipelineId: '1234'
     })
   ]);
 
   let controller = this.subject();
 
   run(() => {
-    controller.store.push({
-      data: {
-        id: '123',
-        type: 'build',
-        attributes: {
-          parentBuildId: '345'
-        }
-      }
-    });
-
     controller.set('selectedEventObj', {
       id: '1',
       sha: 'sha'
@@ -141,11 +132,7 @@ test('it restarts a build', function (assert) {
 
     assert.notOk(controller.get('isShowingModal'));
     assert.deepEqual(payload, {
-      pipelineId: '1234',
-      startFrom: 'deploy',
       buildId: 123,
-      parentBuildId: 345,
-      parentEventId: 1,
       causeMessage: 'apple clicked restart for job "deploy" for sha sha'
     });
   });


### PR DESCRIPTION
## Context
Parent meta is not used when a user tries to Restart a build from the build detail page.

## Objective
This PR uses parent meta to start a build.

## Related links
Resolves https://github.com/screwdriver-cd/screwdriver/issues/1028