### PR TITLE
feat(1024): Add pages request query for logs

### DIFF
--- a/app/build-logs/service.js
+++ b/app/build-logs/service.js
@@ -8,12 +8,13 @@ export default Service.extend({
   /**
    * Calls the logs api service to fetch logs
    * @method fetchLogs
-   * @param  {String}  buildId       sha representing a build id
-   * @param  {String}  stepName      name of a step
-   * @param  {Number}  [logNumber=0] The line number to start from
-   * @return {Promise}               Resolves to { lines, done }
+   * @param  {String}  buildId              sha representing a build id
+   * @param  {String}  stepName             name of a step
+   * @param  {Number}  [logNumber=0]        The line number to start from
+   * @param  {Number}  [pagesToLoad=10]     The number of pages to load
+   * @return {Promise}                      Resolves to { lines, done }
    */
-  fetchLogs(buildId, stepName, logNumber = 0) {
+  fetchLogs(buildId, stepName, logNumber = 0, pagesToLoad = 10) {
     let lines = [];
     let done = false;
 
@@ -28,7 +29,7 @@ export default Service.extend({
       // convert jquery's ajax promises to a real promise
       return $.ajax({
         url,
-        data: { from: logNumber },
+        data: { from: logNumber, pages: pagesToLoad },
         headers: {
           Authorization: `Bearer ${this.get('session').get('data.authenticated.token')}`
         }

--- a/app/components/build-log/component.js
+++ b/app/components/build-log/component.js
@@ -11,6 +11,7 @@ export default Component.extend({
   autoscroll: true,
   isFetching: false,
   timeFormat: 'datetime',
+  rawLogs: true,
 
   logs: computed('isFetching', 'stepName', {
     get() {
@@ -103,7 +104,7 @@ export default Component.extend({
         done: false
       });
       const buildId = get(this, 'buildId');
-      const pagesToLoad = this.get('buildStatus') === 'RUNNING' ? 10 : 1000;
+        const pagesToLoad = this.get('buildStatus') === 'RUNNING' ? 10 : 1000;
 
       set(this, 'isFetching', true);
       this.get('logger').fetchLogs(

--- a/app/components/build-log/component.js
+++ b/app/components/build-log/component.js
@@ -103,12 +103,14 @@ export default Component.extend({
         done: false
       });
       const buildId = get(this, 'buildId');
+      const pagesToLoad = this.get('buildStatus') === 'RUNNING' ? 10 : 1000;
 
       set(this, 'isFetching', true);
       this.get('logger').fetchLogs(
         buildId,
         stepName,
-        logData.lastLine
+        logData.lastLine,
+        pagesToLoad
       ).then(({ lines, done }) => {
         // prevent updating logs when component is being destroyed
         if (!this.get('isDestroyed') && !this.get('isDestroying')) {

--- a/app/components/build-log/component.js
+++ b/app/components/build-log/component.js
@@ -11,7 +11,6 @@ export default Component.extend({
   autoscroll: true,
   isFetching: false,
   timeFormat: 'datetime',
-  rawLogs: true,
 
   logs: computed('isFetching', 'stepName', {
     get() {
@@ -104,7 +103,7 @@ export default Component.extend({
         done: false
       });
       const buildId = get(this, 'buildId');
-        const pagesToLoad = this.get('buildStatus') === 'RUNNING' ? 10 : 1000;
+      const pagesToLoad = this.get('buildStatus') === 'RUNNING' ? 10 : 1000;
 
       set(this, 'isFetching', true);
       this.get('logger').fetchLogs(

--- a/app/components/build-log/template.hbs
+++ b/app/components/build-log/template.hbs
@@ -21,20 +21,28 @@
 {{yield}}
 <div class="wrap" onScroll={{action "logScroll"}}>
   <div class="logs">
-    {{#each logs as |log|}}
-      <span class="line">
-        <span class="time" onClick={{action "toggleTimeDisplay"}}>
-          {{#if (eq timeFormat "datetime")}}
-            {{moment-format log.t 'HH:mm:ss'}}
-          {{else if (eq timeFormat "elapsedBuild")}}
-            {{x-duration buildStartTime log.t precision="seconds"}}
+    {{#if rawLogs}}
+      <pre>
+        {{#each logs as |log|}}
+{{moment-format log.t 'HH:mm:ss'}} {{log.m}}
+        {{/each}}
+      </pre>
+    {{else}}
+      {{#each logs as |log|}}
+        <span class="line">
+          <span class="time" onClick={{action "toggleTimeDisplay"}}>
+            {{#if (eq timeFormat "datetime")}}
+              {{moment-format log.t 'HH:mm:ss'}}
+            {{else if (eq timeFormat "elapsedBuild")}}
+              {{x-duration buildStartTime log.t precision="seconds"}}
             {{else if (eq timeFormat "elapsedStep")}}
               {{x-duration stepStartTime log.t precision="seconds"}}
-          {{/if}}
+            {{/if}}
+          </span>
+          <span class="content">{{ansi-colorize log.m}}</span>
         </span>
-        <span class="content">{{ansi-colorize log.m}}</span>
-      </span>
-    {{/each}}
+      {{/each}}
+    {{/if}}
   </div>
   <div class="bottom"></div>
 </div>

--- a/app/components/build-log/template.hbs
+++ b/app/components/build-log/template.hbs
@@ -21,28 +21,20 @@
 {{yield}}
 <div class="wrap" onScroll={{action "logScroll"}}>
   <div class="logs">
-    {{#if rawLogs}}
-      <pre>
-        {{#each logs as |log|}}
-{{moment-format log.t 'HH:mm:ss'}} {{log.m}}
-        {{/each}}
-      </pre>
-    {{else}}
-      {{#each logs as |log|}}
-        <span class="line">
-          <span class="time" onClick={{action "toggleTimeDisplay"}}>
-            {{#if (eq timeFormat "datetime")}}
-              {{moment-format log.t 'HH:mm:ss'}}
-            {{else if (eq timeFormat "elapsedBuild")}}
-              {{x-duration buildStartTime log.t precision="seconds"}}
-            {{else if (eq timeFormat "elapsedStep")}}
-              {{x-duration stepStartTime log.t precision="seconds"}}
-            {{/if}}
-          </span>
-          <span class="content">{{ansi-colorize log.m}}</span>
+    {{#each logs as |log|}}
+      <span class="line">
+        <span class="time" onClick={{action "toggleTimeDisplay"}}>
+          {{#if (eq timeFormat "datetime")}}
+            {{moment-format log.t 'HH:mm:ss'}}
+          {{else if (eq timeFormat "elapsedBuild")}}
+            {{x-duration buildStartTime log.t precision="seconds"}}
+          {{else if (eq timeFormat "elapsedStep")}}
+            {{x-duration stepStartTime log.t precision="seconds"}}
+          {{/if}}
         </span>
-      {{/each}}
-    {{/if}}
+        <span class="content">{{ansi-colorize log.m}}</span>
+      </span>
+    {{/each}}
   </div>
   <div class="bottom"></div>
 </div>

--- a/tests/unit/build-logs/service-test.js
+++ b/tests/unit/build-logs/service-test.js
@@ -113,7 +113,8 @@ test('it makes a call to logs api and logs return with no remaining', function (
 
     const [request] = server.handledRequests;
 
-    assert.equal(request.url, 'http://localhost:8080/v4/builds/1/steps/banana/logs?from=0');
+    assert.equal(request.url,
+      'http://localhost:8080/v4/builds/1/steps/banana/logs?from=0&pages=10');
   });
 });
 
@@ -130,7 +131,8 @@ test('it makes a call to logs api and logs return with more remaining', function
 
     const [request] = server.handledRequests;
 
-    assert.equal(request.url, 'http://localhost:8080/v4/builds/1/steps/banana/logs?from=50');
+    assert.equal(request.url,
+      'http://localhost:8080/v4/builds/1/steps/banana/logs?from=50&pages=10');
   });
 });
 
@@ -146,7 +148,8 @@ test('it makes a call to logs api and no logs return with no more remaining', fu
 
     const [request] = server.handledRequests;
 
-    assert.equal(request.url, 'http://localhost:8080/v4/builds/1/steps/banana/logs?from=0');
+    assert.equal(request.url,
+      'http://localhost:8080/v4/builds/1/steps/banana/logs?from=0&pages=10');
   });
 });
 
@@ -162,6 +165,24 @@ test('it handles log api failure by treating it as there are more logs', functio
 
     const [request] = server.handledRequests;
 
-    assert.equal(request.url, 'http://localhost:8080/v4/builds/1/steps/banana/logs?from=0');
+    assert.equal(request.url,
+      'http://localhost:8080/v4/builds/1/steps/banana/logs?from=0&pages=10');
+  });
+});
+
+test('it handles fetching multiple pages', function (assert) {
+  assert.expect(3);
+  noNewLogs();
+  const service = this.subject();
+  const p = service.fetchLogs('1', 'banana', 0, 100);
+
+  p.then(({ lines, done }) => {
+    assert.notOk(done);
+    assert.equal(lines.length, 0);
+
+    const [request] = server.handledRequests;
+
+    assert.equal(request.url,
+      'http://localhost:8080/v4/builds/1/steps/banana/logs?from=0&pages=100');
   });
 });


### PR DESCRIPTION
## Context

Build logs are stored in the store as pages; each "page" is 100 lines long. Currently, the API log retrieval endpoint, `GET /builds/{id}/steps/{name}/logs`, sends a maximum of 10 pages (ie. 1000 lines) each request.

While this behavior is ideal for retrieving build updates in real-time, it's unnecessary for finished builds. Adding a `pages` query provides additional flexibility; for example, it can be set to a small value for more accurate real-time updates, or a large value to avoid additional HTTP overhead when fetching long logs from finished builds.

## Objective

* Set the `pages` argument when fetching logs
  * `pages=10` when the build's status is `RUNNING`
  * `pages=1000` when the build is finished

## References

* Issue: https://github.com/screwdriver-cd/screwdriver/issues/1024
* data-schema PR: https://github.com/screwdriver-cd/data-schema/pull/229/
* API PR: https://github.com/screwdriver-cd/screwdriver/pull/1035/