### PR TITLE
fix: Revert detached build change since it still needs other data to start

### DIFF
--- a/app/pipeline/index/controller.js
+++ b/app/pipeline/index/controller.js
@@ -95,13 +95,28 @@ export default Controller.extend(ModelReloaderMixin, {
     },
     startDetachedBuild(job) {
       const buildId = get(job, 'buildId');
+      let parentBuildId = null;
+
+      if (buildId) {
+        const build = this.store.peekRecord('build', buildId);
+
+        parentBuildId = get(build, 'parentBuildId');
+      }
+
       const event = get(this, 'selectedEventObj');
+      const parentEventId = get(event, 'id');
+      const startFrom = get(job, 'name');
+      const pipelineId = get(this, 'pipeline.id');
       const token = get(this, 'session.data.authenticated.token');
       const user = get(decoder(token), 'username');
       const causeMessage =
         `${user} clicked restart for job "${job.name}" for sha ${get(event, 'sha')}`;
       const newEvent = this.store.createRecord('event', {
         buildId,
+        pipelineId,
+        startFrom,
+        parentBuildId,
+        parentEventId,
         causeMessage
       });
 

--- a/tests/unit/pipeline/index/controller-test.js
+++ b/tests/unit/pipeline/index/controller-test.js
@@ -90,14 +90,22 @@ test('it restarts a build', function (assert) {
     201,
     { 'Content-Type': 'application/json' },
     JSON.stringify({
-      id: '2',
-      pipelineId: '1234'
+      id: '2'
     })
   ]);
 
   let controller = this.subject();
 
   run(() => {
+    controller.store.push({
+      data: {
+        id: '123',
+        type: 'build',
+        attributes: {
+          parentBuildId: '345'
+        }
+      }
+    });
     controller.set('selectedEventObj', {
       id: '1',
       sha: 'sha'
@@ -132,7 +140,11 @@ test('it restarts a build', function (assert) {
 
     assert.notOk(controller.get('isShowingModal'));
     assert.deepEqual(payload, {
+      pipelineId: '1234',
+      startFrom: 'deploy',
       buildId: 123,
+      parentBuildId: 345,
+      parentEventId: 1,
       causeMessage: 'apple clicked restart for job "deploy" for sha sha'
     });
   });


### PR DESCRIPTION
## Context
When you run a detached job for the first time, there is no `buildId`, so we still need to pass in a bunch of information.

We're getting errors when trying to start a detached build for the first time right now: `Cannot read property 'match' of undefined`

## Objective
This PR reverts the change to pass in only `buildId` and `causeMessage` so the build start can go through the other workflow: https://github.com/screwdriver-cd/screwdriver/blob/5aedfec539f4da600a1ee109b092a9a56a8b73f8/plugins/events/create.js#L36-L51

## Related links
Related to https://github.com/screwdriver-cd/ui/pull/283