### PR TITLE
fix(945): Convert build elapsed times to HH:mm:ss format

### DIFF
--- a/app/components/build-log/styles.scss
+++ b/app/components/build-log/styles.scss
@@ -12,10 +12,12 @@
 
 .row1 a:first-child {
   grid-column: 1;
+  cursor: pointer;
 }
 
 .row1 a:last-child {
   grid-column: 3;
+  cursor: pointer;
 }
 
 .row2 {
@@ -26,6 +28,7 @@
 
 .row2 .time {
   grid-column: 1;
+  cursor: pointer;
 }
 
 .row2 .content {

--- a/app/components/build-log/template.hbs
+++ b/app/components/build-log/template.hbs
@@ -7,7 +7,7 @@
   <div class="row2">
     <span class="time" onClick={{action "toggleTimeDisplay"}}>
       {{#if (eq timeFormat "datetime")}}
-        Timestamp
+        Local Timestamp
       {{else if (eq timeFormat "elapsedBuild")}}
         Since build started
       {{else if (eq timeFormat "elapsedStep")}}

--- a/app/helpers/x-duration.js
+++ b/app/helpers/x-duration.js
@@ -1,7 +1,7 @@
 import { helper } from '@ember/component/helper';
 
 /**
- * Returns the "humanized" difference between two times
+ * Returns the difference between two times in 'HH:mm:ss' format
  * @method xDuration
  * @param  {Array}  times  List of 2 timestamps or other parseable time definitions
  * @return {String}        Duration string
@@ -11,9 +11,10 @@ export function xDuration([time1, time2]) {
     return null;
   }
 
-  let [t1, t2] = [new Date(time1), new Date(time2)];
+  const [t1, t2] = [new Date(time1), new Date(time2)];
+  const diff = t2.getTime() - t1.getTime();
 
-  return humanizeDuration(t2.getTime() - t1.getTime(), { round: true, largest: 2 });
+  return new Date(diff).toISOString().substr(11, 8);
 }
 
 export default helper(xDuration);

--- a/tests/integration/helpers/x-duration-test.js
+++ b/tests/integration/helpers/x-duration-test.js
@@ -5,19 +5,18 @@ moduleForComponent('x-duration', 'helper:x-duration', {
   integration: true
 });
 
-// Replace this with your real tests.
-test('it renders a humanized duration given two parsable times', function (assert) {
+test('it renders a duration given two parsable times in HH:mm:ss format', function (assert) {
   this.set('time1', 1478912844724);
   this.set('time2', 1478912845724);
 
   this.render(hbs`{{x-duration time1 time2}}`);
 
-  assert.equal(this.$().text().trim(), '1 second');
+  assert.equal(this.$().text().trim(), '00:00:01');
 
   this.set('time1', '2016-11-04T20:09:41.238Z');
   this.set('time2', '2016-11-04T20:09:44.238Z');
 
   this.render(hbs`{{x-duration time1 time2}}`);
 
-  assert.equal(this.$().text().trim(), '3 seconds');
+  assert.equal(this.$().text().trim(), '00:00:03');
 });


### PR DESCRIPTION
## Context
It can be hard to read/clunky when switching between the different time options on the build details page, since the formatting changes from timestamp to humanized time.

## Objective
This PR converts all the build times to `HH:mm:ss` format so they're all consistent. Also changes the cursor when hovering over `Go to Top`, `Go to Bottom`, and `Timestamp`. 

<img width="1171" alt="screen shot 2018-05-02 at 11 19 29 am" src="https://user-images.githubusercontent.com/3230529/39541950-0924f3aa-4dfc-11e8-8097-7a379477bea2.png">

_Note: Firefox still adds funky newlines in between log lines._

## Related links
Related to https://github.com/screwdriver-cd/screwdriver/issues/945