### PR TITLE
fix(1034): fix step log space issues

### DIFF
--- a/app/components/build-log/styles.scss
+++ b/app/components/build-log/styles.scss
@@ -51,29 +51,13 @@
   overflow: auto;
   height: auto;
 
-  .line {
-    display: flex;
-    flex-direction: column;
-  }
-
   .time {
     color: $sd-text-med;
+    margin-right: 10px;
   }
 
   .content {
-    display: inline;
-    white-space: pre-wrap;
-    flex-grow: 1;
-  }
-}
-
-@media screen and (min-width: 35.5em) {
-  .logs .line {
-    flex-direction: row;
-  }
-  .logs .time {
-    display: inline-flex;
-    margin-right: 10px;
+    white-space: pre;
   }
 }
 

--- a/app/components/build-log/styles.scss
+++ b/app/components/build-log/styles.scss
@@ -53,10 +53,15 @@
 
   .time {
     color: $sd-text-med;
+    display: inline-block;
+    vertical-align: top;
+    width: 70px;
   }
 
   .content {
-    white-space: pre;
+    display: inline-block;
+    white-space: pre-wrap;
+    width: calc(100% - 80px);
   }
 }
 

--- a/app/components/build-log/styles.scss
+++ b/app/components/build-log/styles.scss
@@ -43,7 +43,6 @@
 .logs {
   font-size: 1em;
   font-family: monospace;
-  white-space: pre-line;
   background-color: #333;
   color: #eee;
   display: flex;

--- a/app/components/build-log/styles.scss
+++ b/app/components/build-log/styles.scss
@@ -53,7 +53,6 @@
 
   .time {
     color: $sd-text-med;
-    margin-right: 10px;
   }
 
   .content {

--- a/app/components/build-log/template.hbs
+++ b/app/components/build-log/template.hbs
@@ -22,7 +22,7 @@
 <div class="wrap" onScroll={{action "logScroll"}}>
   <div class="logs">
     {{#each logs as |log|}}
-      <span class="line">
+      <div class="line">
         <span class="time" onClick={{action "toggleTimeDisplay"}}>
           {{#if (eq timeFormat "datetime")}}
             {{moment-format log.t 'HH:mm:ss'}}
@@ -33,7 +33,7 @@
           {{/if}}
         </span>
         <span class="content">{{ansi-colorize log.m}}</span>
-      </span>
+      </div>
     {{/each}}
   </div>
   <div class="bottom"></div>


### PR DESCRIPTION
## Context

Fixes the following space issues wrt step log rendering

 1. https://github.com/screwdriver-cd/screwdriver/issues/1034
   1.1 Before
![screen shot 2018-05-09 at 4 42 50 pm](https://user-images.githubusercontent.com/193126/39845013-232ffce8-53a8-11e8-8b5f-53cd76aec4bb.png)
   1.2 After
![screen shot 2018-05-09 at 4 43 01 pm](https://user-images.githubusercontent.com/193126/39845014-2348129c-53a8-11e8-8e2f-46abe163bfe6.png)

 1. https://github.com/screwdriver-cd/screwdriver/issues/1049
   2.1  https://cd.screwdriver.cd/pipelines/7/builds/22458 for step `test`
<img width="1280" alt="screen shot 2018-05-10 at 8 22 29 am" src="https://user-images.githubusercontent.com/193126/39877651-587f26c0-542b-11e8-8e68-96d7353f90ba.png">

