### PR TITLE
fix: do not keep recomputing coverage info

### DIFF
--- a/app/components/build-banner/component.js
+++ b/app/components/build-banner/component.js
@@ -1,50 +1,26 @@
 import { computed } from '@ember/object';
-import { match, filter } from '@ember/object/computed';
+import { alias, match } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
-import PromiseProxyMixin from '@ember/object/promise-proxy-mixin';
-import ObjectProxy from '@ember/object/proxy';
-
-const ObjectPromiseProxy = ObjectProxy.extend(PromiseProxyMixin);
 
 export default Component.extend({
   classNames: ['build-banner', 'row'],
   classNameBindings: ['buildStatus'],
   coverage: service(),
   isPR: match('jobName', /^PR-/),
-  coverageStep: filter('buildSteps', item => /^sd-teardown-screwdriver-coverage/.test(item.name)),
-
-  coverageInfo: computed('coverageStep', {
+  coverageStep: computed('buildSteps', {
     get() {
-      const coverageStep = this.get('coverageStep');
+      const buildSteps = this.get('buildSteps');
+      const coverageStep = buildSteps.find(item =>
+        /^sd-teardown-screwdriver-coverage/.test(item.name));
 
-      // No coverage step, return empty object
-      if (!coverageStep || coverageStep.length <= 0) {
-        return {};
-      }
-
-      const coverageStepData = coverageStep.objectAt(0);
-
-      // Coverage step not finished yet, return place holder value
-      if (!coverageStepData.endTime) {
-        return {
-          coverage: 'N/A',
-          projectUrl: '#'
-        };
-      }
-
-      const config = {
-        buildId: this.get('buildId'),
-        jobId: this.get('jobId'),
-        startTime: coverageStepData.startTime,
-        endTime: coverageStepData.endTime
-      };
-
-      return ObjectPromiseProxy.create({
-        promise: this.get('coverage').getCoverageInfo(config)
-      });
+      return coverageStep;
     }
   }),
+
+  coverageStepEndTime: alias('coverageStep.endTime'),
+
+  coverageStepStartTime: alias('coverageStep.startTime'),
 
   buildAction: computed('buildStatus', {
     get() {
@@ -78,6 +54,41 @@ export default Component.extend({
     }
   }),
 
+  coverageInfoCompute() {
+    const coverageStepEndTime = this.get('coverageStepEndTime');
+    const coverageStepStartTime = this.get('coverageStepStartTime');
+
+    if (!coverageStepEndTime) {
+      this.set('coverageInfo', {
+        projectUrl: '#',
+        coverage: 'N/A'
+      });
+
+      return;
+    }
+
+    const config = {
+      buildId: this.get('buildId'),
+      jobId: this.get('jobId'),
+      startTime: coverageStepStartTime,
+      endTime: coverageStepEndTime
+    };
+
+    this.get('coverage').getCoverageInfo(config)
+      .then((data) => {
+        this.set('coverageInfo', data);
+        this.set('coverageInfoSet', true);
+      });
+  },
+
+  init() {
+    this._super(...arguments);
+
+    this.set('coverageInfoSet', false);
+
+    this.coverageInfoCompute();
+  },
+
   willRender() {
     this._super(...arguments);
 
@@ -85,6 +96,10 @@ export default Component.extend({
 
     if (status === 'QUEUED' || status === 'RUNNING') {
       this.get('reloadBuild')();
+    }
+
+    if (this.get('coverageStepEndTime') && !this.get('coverageInfoSet')) {
+      this.coverageInfoCompute();
     }
   },
 

--- a/tests/integration/components/build-banner/component-test.js
+++ b/tests/integration/components/build-banner/component-test.js
@@ -16,6 +16,10 @@ const coverageService = Service.extend({
   }
 });
 
+const buildStepsMock = [
+  { name: 'sd-setup-screwdriver-scm-bookend' }
+];
+
 const eventMock = EmberObject.create({
   id: 'abcd',
   causeMessage: 'Merged by batman',
@@ -63,12 +67,14 @@ test('it renders', function (assert) {
     assert.ok(true);
   });
 
+  this.set('buildStepsMock', buildStepsMock);
   this.set('eventMock', eventMock);
   this.render(hbs`{{build-banner
     buildContainer="node:6"
     duration="5 seconds"
     buildStatus="RUNNING"
     buildStart="2016-11-04T20:09:41.238Z"
+    buildSteps=buildStepsMock
     jobName="PR-671"
     isAuthenticated=false
     event=eventMock
@@ -92,6 +98,7 @@ test('it renders a restart button for completed jobs when authenticated', functi
 
   const reloadBuildSpy = this.spy();
 
+  this.set('buildStepsMock', buildStepsMock);
   this.set('reloadCb', reloadBuildSpy);
   this.set('externalStart', () => {
     assert.ok(true);
@@ -103,6 +110,7 @@ test('it renders a restart button for completed jobs when authenticated', functi
     duration="5 seconds"
     buildStatus="ABORTED"
     buildStart="2016-11-04T20:09:41.238Z"
+    buildSteps=buildStepsMock
     jobName="PR-671"
     isAuthenticated=true
     event=eventMock
@@ -124,12 +132,14 @@ test('it renders a stop button for running job when authenticated', function (as
   this.set('externalStop', () => {
     assert.ok(true);
   });
+  this.set('buildStepsMock', buildStepsMock);
   this.set('eventMock', eventMock);
   this.render(hbs`{{build-banner
     buildContainer="node:6"
     duration="5 seconds"
     buildStatus="RUNNING"
     buildStart="2016-11-04T20:09:41.238Z"
+    buildSteps=buildStepsMock
     jobName="main"
     isAuthenticated=true
     event=eventMock
@@ -143,7 +153,7 @@ test('it renders a stop button for running job when authenticated', function (as
 
 test('it renders coverage info if coverage step finished', function (assert) {
   const $ = this.$;
-  const buildStepsMock = [
+  const coverageStepsMock = [
     { name: 'sd-setup-screwdriver-scm-bookend' },
     {
       name: 'sd-teardown-screwdriver-coverage-bookend',
@@ -154,7 +164,7 @@ test('it renders coverage info if coverage step finished', function (assert) {
 
   assert.expect(2);
   this.set('eventMock', eventMock);
-  this.set('buildStepsMock', buildStepsMock);
+  this.set('buildStepsMock', coverageStepsMock);
   this.render(hbs`{{build-banner
     buildContainer="node:6"
     duration="5 seconds"
@@ -176,7 +186,7 @@ test('it renders coverage info if coverage step finished', function (assert) {
 
 test('it renders default coverage info if coverage step has not finished', function (assert) {
   const $ = this.$;
-  const buildStepsMock = [
+  const coverageStepsMock = [
     { name: 'sd-setup-screwdriver-scm-bookend' },
     { name: 'sd-teardown-screwdriver-coverage-bookend' }
   ];
@@ -187,7 +197,7 @@ test('it renders default coverage info if coverage step has not finished', funct
     assert.ok(true);
   });
   this.set('eventMock', eventMock);
-  this.set('buildStepsMock', buildStepsMock);
+  this.set('buildStepsMock', coverageStepsMock);
   this.render(hbs`{{build-banner
     buildContainer="node:6"
     duration="5 seconds"
@@ -211,9 +221,6 @@ test('it renders default coverage info if coverage step has not finished', funct
 
 test('it does not render coverage info if there is no coverage step', function (assert) {
   const $ = this.$;
-  const buildStepsMock = [
-    { name: 'sd-setup-screwdriver-scm-bookend' }
-  ];
 
   assert.expect(1);
   this.set('eventMock', eventMock);


### PR DESCRIPTION
### Context
Since we're reloading the build-banner all the time when the build is running, coverage info will be recomputed all the time and making the number flashing 

This PR will fix the problem by only computing the info only twice:
- When page first started 
- When coverage step finished and the coverage info has not been set before