### PR TITLE
add modal popup for restart of job

### DIFF
--- a/app/pipeline/build/controller.js
+++ b/app/pipeline/build/controller.js
@@ -17,6 +17,7 @@ export default Controller.extend({
   event: reads('model.event'),
   pipeline: reads('model.pipeline'),
   stepList: mapBy('build.steps', 'name'),
+  isShowingModal: false,
 
   actions: {
     stopBuild() {
@@ -27,6 +28,7 @@ export default Controller.extend({
     },
 
     startBuild() {
+      this.set('isShowingModal', true);
       const buildId = get(this, 'build.id');
       const jobName = get(this, 'job.name');
       const token = get(this, 'session.data.authenticated.token');
@@ -40,9 +42,11 @@ export default Controller.extend({
 
       return newEvent.save().then(() =>
         newEvent.get('builds')
-          .then(builds =>
-            this.transitionToRoute('pipeline.build',
-              builds.get('lastObject.id'))
+          .then((builds) => {
+            this.set('isShowingModal', false);
+            return this.transitionToRoute('pipeline.build',
+              builds.get('lastObject.id'));
+          }
           ));
     },
 

--- a/app/pipeline/build/controller.js
+++ b/app/pipeline/build/controller.js
@@ -44,6 +44,7 @@ export default Controller.extend({
         newEvent.get('builds')
           .then((builds) => {
             this.set('isShowingModal', false);
+
             return this.transitionToRoute('pipeline.build',
               builds.get('lastObject.id'));
           }

--- a/app/pipeline/build/template.hbs
+++ b/app/pipeline/build/template.hbs
@@ -14,6 +14,15 @@
   reloadBuild=(action "reload")
 }}
 
+{{#if isShowingModal}}
+  {{#modal-dialog clickOutsideToClose=false
+    targetAttachment="center"
+    translucentOverlay=true
+  }}
+    {{loading-view}}
+  {{/modal-dialog}}
+{{/if}}
+
 {{#if build.statusMessage}}
   {{info-message message=build.statusMessage type="warning" icon="exclamation-triangle"}}
 {{/if}}

--- a/tests/unit/pipeline/build/controller-test.js
+++ b/tests/unit/pipeline/build/controller-test.js
@@ -37,7 +37,7 @@ test('it exists', function (assert) {
 });
 
 test('it restarts a build', function (assert) {
-  assert.expect(3);
+  assert.expect(5);
 
   server.post('http://localhost:8080/v4/events', () => [
     201,
@@ -67,12 +67,14 @@ test('it restarts a build', function (assert) {
         sha: 'sha'
       })
     });
+
+    assert.notOk(controller.get('isShowingModal'));
     controller.transitionToRoute = (path, id) => {
       assert.equal(path, 'pipeline.build');
       assert.equal(id, 9999);
     };
-
     controller.send('startBuild');
+    assert.ok(controller.get('isShowingModal'));
   });
 
   return wait().then(() => {


### PR DESCRIPTION
When user restarts a job, modal pops up to alert user their job is restarting.

![screen shot 2018-05-17 at 3 37 12 pm](https://user-images.githubusercontent.com/9649910/40207196-31727484-59e8-11e8-871a-2b31f1d69ff9.png)

related pr: https://github.com/screwdriver-cd/screwdriver/issues/971