### PR TITLE
fix: Show loading view when build is loading on a restart

### DIFF
--- a/app/pipeline/build/controller.js
+++ b/app/pipeline/build/controller.js
@@ -17,6 +17,7 @@ export default Controller.extend({
   event: reads('model.event'),
   pipeline: reads('model.pipeline'),
   stepList: mapBy('build.steps', 'name'),
+  buildLoading: false,
 
   actions: {
     stopBuild() {
@@ -27,6 +28,7 @@ export default Controller.extend({
     },
 
     startBuild() {
+      this.set('buildLoading', true);
       const buildId = get(this, 'build.id');
       const jobName = get(this, 'job.name');
       const token = get(this, 'session.data.authenticated.token');
@@ -40,15 +42,18 @@ export default Controller.extend({
 
       return newEvent.save().then(() =>
         newEvent.get('builds')
-          .then(builds =>
-            this.transitionToRoute('pipeline.build',
-              builds.get('lastObject.id'))
-          ));
+          .then((builds) => {
+            this.set('buildLoading', false);
+
+            return this.transitionToRoute('pipeline.build',
+              builds.get('lastObject.id'));
+          }));
     },
 
     reload() {
       // If there is already a reload scheduled in the runloop,
       // this replaces it with one with no timeout
+      this.set('buildLoading', false);
       once(this, 'reloadBuild', 0);
     }
   },

--- a/app/pipeline/build/template.hbs
+++ b/app/pipeline/build/template.hbs
@@ -14,17 +14,26 @@
   reloadBuild=(action "reload")
 }}
 
+{{#if buildLoading}}
+  {{#modal-dialog clickOutsideToClose=false
+    targetAttachment="center"
+    translucentOverlay=true
+  }}
+    {{loading-view}}
+  {{/modal-dialog}}
+{{/if}}
+
 {{#if build.statusMessage}}
   {{info-message message=build.statusMessage type="warning" icon="exclamation-triangle"}}
 {{/if}}
 
 {{#if stepList}}
-{{build-step-collection
-  buildStatus=build.status
-  buildId=build.id
-  buildSteps=build.steps
-  buildStart=build.startTime
-}}
+  {{build-step-collection
+    buildStatus=build.status
+    buildId=build.id
+    buildSteps=build.steps
+    buildStart=build.startTime
+  }}
 {{/if}}
 
 {{outlet}}

--- a/tests/unit/pipeline/build/controller-test.js
+++ b/tests/unit/pipeline/build/controller-test.js
@@ -72,13 +72,16 @@ test('it restarts a build', function (assert) {
       assert.equal(id, 9999);
     };
 
+    assert.notOk(controller.get('buildLoading'));
     controller.send('startBuild');
+    assert.ok(controller.get('buildLoading'));
   });
 
   return wait().then(() => {
     const [request] = server.handledRequests;
     const payload = JSON.parse(request.requestBody);
 
+    assert.notOk(controller.get('buildLoading'));
     assert.deepEqual(payload, {
       buildId: 123,
       causeMessage: 'apple clicked restart for job "PR-1:main" for sha sha'


### PR DESCRIPTION
Currently, clicking the 'Restart' button on a build shows no visual feedback that the build is restarting. It just sits there until the event fires and the page transitions to the new build. This PR adds the loading dialog until the new build loads.

![image](https://user-images.githubusercontent.com/691950/40207351-ed22cf4e-59e8-11e8-96be-5cd9ad678b22.png)
