### PR TITLE
fix: set default value when failed to fetch coverage info

### DIFF
--- a/app/coverage/service.js
+++ b/app/coverage/service.js
@@ -29,22 +29,18 @@ export default Service.extend({
       }
     };
 
-    return new EmberPromise((resolve, reject) => {
+    return new EmberPromise((resolve) => {
       // Call the token api to get the session info
       $.ajax(ajaxConfig)
         .done(content => resolve({
           projectUrl: content.projectUrl || '#',
           coverage: content.coverage ? `${content.coverage}%` : 'N/A'
         }))
-        .fail((response) => {
-          let message = `${response.status} Request Failed`;
-
-          if (response && response.responseJSON && typeof response.responseJSON === 'object') {
-            message = `${response.status} ${response.responseJSON.error}`;
-          }
-
-          return reject(message);
-        });
+        .fail(() => resolve({
+          projectUrl: '#',
+          coverage: 'N/A'
+        })
+        );
     });
   }
 });

--- a/tests/unit/coverage/service-test.js
+++ b/tests/unit/coverage/service-test.js
@@ -56,10 +56,43 @@ test('it fetches coverage info', function (assert) {
   });
 });
 
-test('it sets default coverage info', function (assert) {
+test('it sets default coverage info when data not available', function (assert) {
   assert.expect(3);
   server.get('http://localhost:8080/v4/coverage/info', () => [
     200,
+    {
+      'Content-Type': 'application/json'
+    },
+    JSON.stringify({})
+  ]);
+
+  let service = this.subject();
+
+  assert.ok(service);
+
+  const config = {
+    buildId: 123,
+    jobId: 1,
+    startTime: '2018-05-10T19:05:53.123Z',
+    endTime: '2018-05-10T19:06:53.123Z'
+  };
+
+  const p = service.getCoverageInfo(config);
+
+  p.then((data) => {
+    const [request] = server.handledRequests;
+
+    assert.deepEqual(data, { coverage: 'N/A', projectUrl: '#' });
+    assert.deepEqual(request.url,
+    // eslint-disable-next-line max-len
+      'http://localhost:8080/v4/coverage/info?buildId=123&jobId=1&startTime=2018-05-10T19%3A05%3A53.123Z&endTime=2018-05-10T19%3A06%3A53.123Z');
+  });
+});
+
+test('it sets default coverage info when request failed', function (assert) {
+  assert.expect(3);
+  server.get('http://localhost:8080/v4/coverage/info', () => [
+    500,
     {
       'Content-Type': 'application/json'
     },


### PR DESCRIPTION
- set default value when failed to fetch coverage info
- should still be able to get the response from API by inspecting network in browser if needed
