### PR TITLE
fix build page spamming api constantly when build is queued

### DIFF
--- a/app/components/nav-banner/component.js
+++ b/app/components/nav-banner/component.js
@@ -1,4 +1,4 @@
-import { set } from '@ember/object';
+import { get, set } from '@ember/object';
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 
@@ -13,7 +13,9 @@ export default Component.extend({
 
   setBanners() {
     this.get('banner').fetchBanners().then((banners) => {
-      set(this, 'banners', banners);
+      if (!get(this, 'isDestroying') && !get(this, 'isDestroyed')) {
+        set(this, 'banners', banners);
+      }
     });
   },
 

--- a/app/pipeline/build/controller.js
+++ b/app/pipeline/build/controller.js
@@ -1,4 +1,4 @@
-import { later, once } from '@ember/runloop';
+import { later, throttle } from '@ember/runloop';
 import { get, computed } from '@ember/object';
 import { reads, mapBy } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
@@ -66,9 +66,7 @@ export default Controller.extend({
     },
 
     reload() {
-      // If there is already a reload scheduled in the runloop,
-      // this replaces it with one with no timeout
-      once(this, 'reloadBuild', 0);
+      throttle(this, 'reloadBuild', ENV.APP.BUILD_RELOAD_TIMER);
     },
 
     changeBuild(pipelineId, buildId) {
@@ -94,7 +92,7 @@ export default Controller.extend({
 
             build.reload().then(() => {
               this.set('loading', false);
-              once(this, 'reloadBuild');
+              throttle(this, 'reloadBuild', timeout);
             });
           }
         }, timeout);


### PR DESCRIPTION
Context
=======
When a build page is opened for a build that is still enqueued, the API will be spammed several times a second. This happens because the build-banner component calls `reloadBuild()` when it is either queued or running during the willRender event of the component lifecycle. When the build info is fetched, it causes the willRender event to fire again, and this loop can be extremely short. The current reload event only allows firing once per render loop, but this loop is very fast.

Objective
----------
Hit the API only as often as `BUILD_RELOAD_TIMER`, by throttling all requests to the reload handler.

Misc
------
Fix tests broken in firefox due to nav-banner component writing a value after it has been destroyed.