### PR TITLE
[fix 1068] Save time format choice

### DIFF
--- a/app/components/build-log/component.js
+++ b/app/components/build-log/component.js
@@ -5,6 +5,8 @@ import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import ENV from 'screwdriver-ui/config/environment';
 
+const timeTypes = ['datetime', 'elapsedBuild', 'elapsedStep'];
+
 export default Component.extend({
   logger: service('build-logs'),
   classNames: ['build-log'],
@@ -57,6 +59,12 @@ export default Component.extend({
 
   init() {
     this._super(...arguments);
+
+    const timeFormat = localStorage.getItem('screwdriver.logs.timeFormat');
+
+    if (timeFormat && timeTypes.includes(timeFormat)) {
+      set(this, 'timeFormat', timeFormat);
+    }
 
     set(this, 'logCache', {});
   },
@@ -145,11 +153,10 @@ export default Component.extend({
       set(this, 'autoscroll', this.$('.bottom')[0].getBoundingClientRect().top < 1000);
     },
     toggleTimeDisplay() {
-      const timeTypes = ['datetime', 'elapsedBuild', 'elapsedStep'];
       let index = timeTypes.indexOf(get(this, 'timeFormat'));
 
       index = index + 1 >= timeTypes.length ? 0 : index + 1;
-
+      localStorage.setItem('screwdriver.logs.timeFormat', timeTypes[index]);
       set(this, 'timeFormat', timeTypes[index]);
     }
   }

--- a/app/components/build-log/styles.scss
+++ b/app/components/build-log/styles.scss
@@ -5,34 +5,29 @@
   padding: 0 15px 10px;
 }
 
-.row1 {
+.row {
   display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
+  grid-template-columns: 1fr;
 }
 
-.row1 a:first-child {
+.row div:first-child {
   grid-column: 1;
   cursor: pointer;
-}
-
-.row1 a:last-child {
-  grid-column: 3;
-  cursor: pointer;
-}
-
-.row2 {
-  display: grid;
-  grid-template-columns: 1fr 10fr;
+  padding: 5px 15px;
   color: $sd-text-med;
 }
 
-.row2 .time {
-  grid-column: 1;
-  cursor: pointer;
-}
-
-.row2 .content {
+.row div:last-child {
   grid-column: 2;
+  cursor: pointer;
+  text-align: right;
+  padding: 5px 15px;
+  i {
+    margin-right: 5px;
+  }
+  a {
+    margin-left: 15px;
+  }
 }
 
 .wrap {

--- a/app/components/build-log/template.hbs
+++ b/app/components/build-log/template.hbs
@@ -1,20 +1,22 @@
 {{#if (gt logs.length 1)}}
 <div class="heading">
-  <div class="row1">
-    <a onClick={{action "scrollToTop"}}>Go to Top</a>
-    <a onClick={{action "scrollToBottom"}}>Go to Bottom</a>
-  </div>
-  <div class="row2">
-    <span class="time" onClick={{action "toggleTimeDisplay"}}>
-      {{#if (eq timeFormat "datetime")}}
-        Local Timestamp
-      {{else if (eq timeFormat "elapsedBuild")}}
-        Since build started
-      {{else if (eq timeFormat "elapsedStep")}}
-        Since step started
-      {{/if}}
-    </span>
-    <span class="content"></span>
+  <div class="row">
+    <div>
+      <span class="time" onClick={{action "toggleTimeDisplay"}}>
+        {{#if (eq timeFormat "datetime")}}
+          Local Timestamp
+        {{else if (eq timeFormat "elapsedBuild")}}
+          Since build started
+        {{else if (eq timeFormat "elapsedStep")}}
+          Since step started
+        {{/if}}
+      </span>
+      <span class="content"></span>
+    </div>
+    <div>
+      <a onClick={{action "scrollToTop"}}>{{fa-icon "arrow-up"}}Go to Top</a>
+      <a onClick={{action "scrollToBottom"}}>{{fa-icon "arrow-down"}}Go to Bottom</a>
+    </div>
   </div>
 </div>
 {{/if}}


### PR DESCRIPTION
Context
========
There's a lot of wasted space in the header of the build logs.
Time format is not persistent from one build to the next

Objective
-----------
Squash the logs header into one line
Save the selected time formate in localStorage, and load it back when the log  component initializes.

<img width="893" alt="screen shot 2018-06-11 at 2 15 03 pm" src="https://user-images.githubusercontent.com/78533/41257730-c4a9a512-6d82-11e8-921f-8c541fc9aef4.png">

Resolves https://github.com/screwdriver-cd/screwdriver/issues/1068