### PR TITLE
feat(937): Hide pipeline options for child pipeline

### DIFF
--- a/app/components/pipeline-options/template.hbs
+++ b/app/components/pipeline-options/template.hbs
@@ -1,8 +1,7 @@
 {{info-message message=errorMessage type="warning" icon="exclamation-triangle"}}
 
 <div class="row">
-  {{#if pipeline.configPipelineId}}
-  {{else}}
+  {{#unless pipeline.configPipelineId}}
     <div class="col-xs-12 col-md-8">
       <section class="pipeline">
         <h3>Pipeline</h3>
@@ -38,7 +37,7 @@
         </ul>
       </section>
     </div>
-  {{/if}}
+  {{/unless}}
 
   <div class="col-xs-12 col-md-8">
     <section class="jobs">
@@ -102,8 +101,7 @@
     </section>
   </div>
 
-  {{#if pipeline.configPipelineId}}
-  {{else}}
+  {{#unless pipeline.configPipelineId}}
     <div class="col-xs-12 col-md-8">
       <section class="danger">
         <h3>Danger Zone</h3>
@@ -133,7 +131,7 @@
 
       </section>
     </div>
-  {{/if}}
+  {{/unless}}
 </div>
 
 {{#if isShowingModal}}

--- a/app/components/pipeline-options/template.hbs
+++ b/app/components/pipeline-options/template.hbs
@@ -1,41 +1,44 @@
 {{info-message message=errorMessage type="warning" icon="exclamation-triangle"}}
 
 <div class="row">
-  <div class="col-xs-12 col-md-8">
-    <section class="pipeline">
-      <h3>Pipeline</h3>
-      <ul>
-        <li>
-          <div class="row">
-            <div class="col-xs-10">
-              <h4>Checkout URL</h4>
-              <p>Update your checkout URL.</p>
-            </div>
-          </div>
-          <div class="row">
-            <div class="col-xs-10">
-              <div>
-                {{input
-                  class="text-input"
-                  key-up="scmChange"
-                  value=scmUrl
-                }}
+  {{#if pipeline.configPipelineId}}
+  {{else}}
+    <div class="col-xs-12 col-md-8">
+      <section class="pipeline">
+        <h3>Pipeline</h3>
+        <ul>
+          <li>
+            <div class="row">
+              <div class="col-xs-10">
+                <h4>Checkout URL</h4>
+                <p>Update your checkout URL.</p>
               </div>
             </div>
-            <div class="col-xs-2 right">
-              <button {{action "updatePipeline"}} disabled={{isDisabled}} class="blue-button{{if isSaving ' saving'}}">
-                <div class="saving-loading">
-                  Updating pipeline
+            <div class="row">
+              <div class="col-xs-10">
+                <div>
+                  {{input
+                    class="text-input"
+                    key-up="scmChange"
+                    value=scmUrl
+                  }}
                 </div>
-                <div class="button-label">Update</div>
-              </button>
-              {{#if isSaving}}{{fa-icon "spinner" spin=true}}{{/if}}
+              </div>
+              <div class="col-xs-2 right">
+                <button {{action "updatePipeline"}} disabled={{isDisabled}} class="blue-button{{if isSaving ' saving'}}">
+                  <div class="saving-loading">
+                    Updating pipeline
+                  </div>
+                  <div class="button-label">Update</div>
+                </button>
+                {{#if isSaving}}{{fa-icon "spinner" spin=true}}{{/if}}
+              </div>
             </div>
-          </div>
-        </li>
-      </ul>
-    </section>
-  </div>
+          </li>
+        </ul>
+      </section>
+    </div>
+  {{/if}}
 
   <div class="col-xs-12 col-md-8">
     <section class="jobs">
@@ -99,35 +102,38 @@
     </section>
   </div>
 
-  <div class="col-xs-12 col-md-8">
-    <section class="danger">
-      <h3>Danger Zone</h3>
-      <ul>
-        <li>
-          {{#if showDangerButton}}
-          <div class="row">
-            <div class="col-xs-1 col-md-8">
-              <h4>Remove this pipeline</h4>
-              <p>Once you remove a pipeline, there is no going back.</p>
+  {{#if pipeline.configPipelineId}}
+  {{else}}
+    <div class="col-xs-12 col-md-8">
+      <section class="danger">
+        <h3>Danger Zone</h3>
+        <ul>
+          <li>
+            {{#if showDangerButton}}
+            <div class="row">
+              <div class="col-xs-1 col-md-8">
+                <h4>Remove this pipeline</h4>
+                <p>Once you remove a pipeline, there is no going back.</p>
+              </div>
+              <div class="col-xs-1 col-md-4 right">
+                <a href="#" {{action "showRemoveButtons"}} class="trash">{{fa-icon "trash"}}</a>
+              </div>
             </div>
-            <div class="col-xs-1 col-md-4 right">
-              <a href="#" {{action "showRemoveButtons"}} class="trash">{{fa-icon "trash"}}</a>
-            </div>
-          </div>
-          {{/if}}
-          {{#if showRemoveButtons}}
-            <h4>Are you absolutely sure?</h4>
-            <a href="#" {{action "cancelRemove"}} class="cancel">{{fa-icon "ban"}} Cancel</a>
-            <a href="#" {{action "removePipeline"}} class="remove">{{fa-icon "trash"}} Remove</a>
-          {{/if}}
-          {{#if isRemoving}}
-            <p>Please wait...</p>
-          {{/if}}
-        </li>
-      </ul>
+            {{/if}}
+            {{#if showRemoveButtons}}
+              <h4>Are you absolutely sure?</h4>
+              <a href="#" {{action "cancelRemove"}} class="cancel">{{fa-icon "ban"}} Cancel</a>
+              <a href="#" {{action "removePipeline"}} class="remove">{{fa-icon "trash"}} Remove</a>
+            {{/if}}
+            {{#if isRemoving}}
+              <p>Please wait...</p>
+            {{/if}}
+          </li>
+        </ul>
 
-    </section>
-  </div>
+      </section>
+    </div>
+  {{/if}}
 </div>
 
 {{#if isShowingModal}}

--- a/app/pipeline/model.js
+++ b/app/pipeline/model.js
@@ -9,6 +9,7 @@ export default DS.Model.extend({
   scmRepo: DS.attr(),
   scmUri: DS.attr('string'),
   workflowGraph: DS.attr(),
+  configPipelineId: DS.attr('string'),
 
   events: DS.hasMany('event', { async: true }),
   jobs: DS.hasMany('job', { async: true }),

--- a/tests/integration/components/pipeline-options/component-test.js
+++ b/tests/integration/components/pipeline-options/component-test.js
@@ -286,3 +286,51 @@ test('it fails to sync the pipeline', function (assert) {
       assert.equal(this.$('.alert > span').text().trim(), 'something conflicting');
     });
 });
+
+test('it does not render pipeline and danger for child pipeline', function (assert) {
+  this.set('mockPipeline', EmberObject.create({
+    appId: 'foo/bar',
+    scmUri: 'github.com:84604643:master',
+    id: 'abc1234',
+    configPipelineId: '123'
+  }));
+
+  this.set('mockJobs', A([
+    EmberObject.create({
+      id: '3456',
+      name: 'B',
+      isDisabled: false
+    }),
+    EmberObject.create({
+      id: '1234',
+      name: 'main',
+      isDisabled: false
+    }),
+    EmberObject.create({
+      id: '2345',
+      name: 'A',
+      isDisabled: false
+    })
+  ]));
+
+  this.render(hbs`{{pipeline-options pipeline=mockPipeline jobs=mockJobs}}`);
+
+  // Pipeline should not render
+  assert.equal(this.$('section.pipeline h3').text().trim(), '');
+
+  // Jobs should render
+  assert.equal(this.$('section.jobs h3').text().trim(), 'Jobs');
+  assert.equal(this.$('section.jobs li').length, 3);
+  assert.equal(this.$('section.jobs h4').text().trim(), 'ABmain');
+  // eslint-disable-next-line max-len
+  assert.equal(this.$('section.jobs p').text().trim(), 'Toggle to disable the A job.Toggle to disable the B job.Toggle to disable the main job.');
+  assert.ok(this.$('.x-toggle-container').hasClass('x-toggle-container-checked'));
+
+  // Sync should render
+  assert.equal(this.$(this.$('section.sync h4').get(0)).text().trim(), 'SCM webhooks');
+  assert.equal(this.$(this.$('section.sync h4').get(1)).text().trim(), 'Pull requests');
+  assert.equal(this.$(this.$('section.sync h4').get(2)).text().trim(), 'Pipeline');
+
+  // Danger Zone should not render
+  assert.equal(this.$('section.danger h3').text().trim(), '');
+});


### PR DESCRIPTION
## Context
Child pipelines should only be able to be updated/deleted via changing the `screwdriver.yaml` of its parent pipeline.

## Objective
Hide the "Pipeline" and "Danger zone" sections from the pipeline options UI.

![screen shot 2018-06-12 at 10 54 11 am](https://user-images.githubusercontent.com/11892496/41307805-09102e18-6e2f-11e8-91b2-0f78d645e97a.png)


## Reference
https://github.com/screwdriver-cd/screwdriver/issues/937