### PR TITLE
Show full job names

### DIFF
--- a/app/components/workflow-graph-d3/component.js
+++ b/app/components/workflow-graph-d3/component.js
@@ -177,7 +177,7 @@ export default Component.extend({
 
         path.moveTo(startX, startY);
         // curvy line
-        path.bezierCurveTo(endX, startY, endX - X_WIDTH/2, endY, endX, endY);
+        path.bezierCurveTo(endX, startY, endX - (X_WIDTH / 2), endY, endX, endY);
         // arrowhead
         path.lineTo(endX - ARROWHEAD, endY - ARROWHEAD);
         path.moveTo(endX, endY);


### PR DESCRIPTION
Show the full job names by increasing the X distance based on the max job name length.  If job names aren't shown then still use 2*ICONSIZE.

This is for https://github.com/screwdriver-cd/screwdriver/issues/1124