### PR TITLE
fix: set coverage query startTime to first step startTime

### DIFF
--- a/app/components/build-banner/component.js
+++ b/app/components/build-banner/component.js
@@ -75,7 +75,7 @@ export default Component.extend({
 
   coverageInfoCompute() {
     // Set coverage query startTime to build start time since user can do coverage during user step
-    const buildStartTime = this.get('buildStart');
+    const buildStartTime = this.get('buildSteps')[0].startTime;
     const coverageStepEndTime = this.get('coverageStepEndTime');
 
     if (!coverageStepEndTime) {

--- a/tests/integration/components/build-banner/component-test.js
+++ b/tests/integration/components/build-banner/component-test.js
@@ -261,7 +261,9 @@ test('it renders a stop button for running job when authenticated', function (as
 test('it renders coverage info if coverage step finished', function (assert) {
   const $ = this.$;
   const coverageStepsMock = [
-    { name: 'sd-setup-screwdriver-scm-bookend' },
+    { name: 'sd-setup-screwdriver-scm-bookend',
+      startTime: '2016-11-04T20:09:41.238Z'
+    },
     {
       name: 'sd-teardown-screwdriver-coverage-bookend',
       endTime: '2016-11-04T21:09:41.238Z'


### PR DESCRIPTION
Cannot use `buildStart` attr directly cuz it's formatted by ember and our API didn't expect that date format.  Change it to be the startTime of the first step instead.
https://github.com/screwdriver-cd/ui/blob/master/app/build/model.js#L53