### PR TITLE
Fix duration for parallel/running workflow

### DIFF
--- a/app/event/model.js
+++ b/app/event/model.js
@@ -38,7 +38,19 @@ export default DS.Model.extend(ModelReloaderMixin, {
   }),
   duration: computed('builds.[]', 'isComplete', {
     get() {
-      return get(this, 'builds').reduce((val = 0, item) => val + get(item, 'totalDurationMS'));
+      const builds = get(this, 'builds');
+      const firstCreateTime = builds.map(item => get(item, 'createTime')).sort()[0];
+      let lastEndTime = new Date();
+
+      if (get(this, 'isComplete')) {
+        lastEndTime = builds.map(item => get(item, 'endTime')).sort().pop();
+      }
+
+      if (!firstCreateTime || !lastEndTime) {
+        return 0;
+      }
+
+      return lastEndTime.getTime() - firstCreateTime.getTime();
     }
   }),
   durationText: computed('duration', {


### PR DESCRIPTION
Pipeline page can show longer duration than real with parallel workflow.
I fix this by compute duration using (latest end time) - (earliest create time) for completed event, and (now) - (earliest create time) for running event.

references: [current build.totalDurationMS implementation](https://github.com/screwdriver-cd/ui/blob/4b299ce233419170828edb62e2eb24eba721c262/app/build/model.js#L75-L79)