### PR TITLE
fix(677): fetch commands with token

### DIFF
--- a/app/command/service.js
+++ b/app/command/service.js
@@ -26,6 +26,9 @@ export default Service.extend({
       crossDomain: true,
       xhrFields: {
         withCredentials: true
+      },
+      headers: {
+        Authorization: `Bearer ${get(this, 'session.data.authenticated.token')}`
       }
     };
 


### PR DESCRIPTION
## Contexts
Command endpoints should also have auth strategy same as other endpoints.

## Objective
This PR adds token to fetch command data.

## Related
- https://github.com/screwdriver-cd/screwdriver/issues/677
- https://github.com/screwdriver-cd/screwdriver/pull/1136