### PR TITLE
feat(677): Command tag UI

### DIFF
--- a/app/command/service.js
+++ b/app/command/service.js
@@ -15,6 +15,13 @@ export default Service.extend({
 
     return this.fetchData(url);
   },
+  getCommandTags(namespace, name) {
+    const url =
+      `${ENV.APP.SDAPI_HOSTNAME}/${ENV.APP.SDAPI_NAMESPACE}/commands/` +
+      `${encodeURIComponent(namespace)}/${encodeURIComponent(name)}/tags`;
+
+    return this.fetchData(url);
+  },
   getAllCommands() {
     const url = `${ENV.APP.SDAPI_HOSTNAME}/${ENV.APP.SDAPI_NAMESPACE}/commands`;
 

--- a/app/commands/detail/route.js
+++ b/app/commands/detail/route.js
@@ -6,9 +6,16 @@ export default Route.extend({
   command: service(),
   model(params) {
     return RSVP.all([
-      this.get('command').getOneCommand(params.namespace, params.name)
+      this.get('command').getOneCommand(params.namespace, params.name),
+      this.get('command').getCommandTags(params.namespace, params.name)
     ]).then((arr) => {
-      const [verPayload] = arr;
+      const [verPayload, tagPayload] = arr;
+
+      tagPayload.forEach((tagObj) => {
+        const taggedVerObj = verPayload.find(verObj => verObj.version === tagObj.version);
+
+        taggedVerObj.tag = taggedVerObj.tag ? `${taggedVerObj.tag} ${tagObj.tag}` : tagObj.tag;
+      });
 
       return verPayload;
     });

--- a/app/components/command-versions/template.hbs
+++ b/app/components/command-versions/template.hbs
@@ -1,10 +1,6 @@
 <h4>Versions:</h4>
 <ul>
   {{#each commands as |c|}}
-    {{#if c.tag}}
-      <li {{action changeVersion c.version on="click"}}><span class="version">{{c.version}} - {{c.tag}}</span>{{#if c.lastUpdated}} {{c.lastUpdated}}{{/if}}</li>
-    {{else}}
-      <li {{action changeVersion c.version on="click"}}><span class="version">{{c.version}}</span>{{#if c.lastUpdated}} {{c.lastUpdated}}{{/if}}</li>
-    {{/if}}
+      <li><span {{action changeVersion c.version on="click"}} class="version">{{c.version}}{{#if c.tag}} - {{c.tag}}{{/if}}</span>{{#if c.lastUpdated}} {{c.lastUpdated}}{{/if}}</li>
   {{/each}}
 </ul>

--- a/app/components/template-versions/template.hbs
+++ b/app/components/template-versions/template.hbs
@@ -1,10 +1,6 @@
 <h4>Versions:</h4>
 <ul>
   {{#each templates as |t|}}
-    {{#if t.tag}}
-      <li {{action changeVersion t.version on="click"}}><span class="version">{{t.version}} - {{t.tag}}</span>{{#if t.lastUpdated}} {{t.lastUpdated}}{{/if}}</li>
-    {{else}}
-      <li {{action changeVersion t.version on="click"}}><span class="version">{{t.version}}</span>{{#if t.lastUpdated}} {{t.lastUpdated}}{{/if}}</li>
-    {{/if}}
+      <li><span {{action changeVersion t.version on="click"}} class="version">{{t.version}}{{#if t.tag}} - {{t.tag}}{{/if}}</span>{{#if t.lastUpdated}} {{t.lastUpdated}}{{/if}}</li>
   {{/each}}
 </ul>

--- a/package.json
+++ b/package.json
@@ -91,7 +91,5 @@
     "humanize-duration": "^3.15.0",
     "loader.js": "^4.7.0"
   },
-  "dependencies": {
-    "bower": "^1.8.4"
-  }
+  "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -91,5 +91,7 @@
     "humanize-duration": "^3.15.0",
     "loader.js": "^4.7.0"
   },
-  "dependencies": {}
+  "dependencies": {
+    "bower": "^1.8.4"
+  }
 }

--- a/tests/integration/components/command-versions/component-test.js
+++ b/tests/integration/components/command-versions/component-test.js
@@ -33,5 +33,5 @@ test('it handles clicks on versions', function (assert) {
 
   assert.equal(this.$('h4').text().trim(), 'Versions:');
   assert.equal(this.$('ul li').text().trim(), '3.0.0 - latest stable2.0.0 - meeseeks1.0.0');
-  this.$('ul li:last-child').click();
+  this.$('ul li:last-child span').click();
 });

--- a/tests/integration/components/template-versions/component-test.js
+++ b/tests/integration/components/template-versions/component-test.js
@@ -33,5 +33,5 @@ test('it handles clicks on versions', function (assert) {
 
   assert.equal(this.$('h4').text().trim(), 'Versions:');
   assert.equal(this.$('ul li').text().trim(), '3.0.0 - latest stable2.0.0 - meeseeks1.0.0');
-  this.$('ul li:last-child').click();
+  this.$('ul li:last-child span').click();
 });

--- a/tests/unit/command/service-test.js
+++ b/tests/unit/command/service-test.js
@@ -12,6 +12,24 @@ const sessionStub = Service.extend({
 const createTime = '2016-09-23T16:53:00.274Z';
 const created = new Date(createTime).getTime();
 const lastUpdated = `${humanizeDuration(Date.now() - created, { round: true, largest: 1 })} ago`;
+const dummyCommands = [
+  { id: 2, namespace: 'foo', name: 'bar', version: '2.0.0', createTime },
+  { id: 1, namespace: 'foo', name: 'bar', version: '1.0.0', createTime }
+];
+const dummyCommandsResult = dummyCommands.map((c) => {
+  c.lastUpdated = lastUpdated;
+
+  return c;
+});
+const dummyCommandTags = [
+  { id: 2, namespace: 'foo', name: 'bar', tag: 'latest', version: '2.0.0', createTime },
+  { id: 1, namespace: 'foo', name: 'bar', tag: 'stable', version: '1.0.0', createTime }
+];
+const dummyCommandTagsResult = dummyCommandTags.map((c) => {
+  c.lastUpdated = lastUpdated;
+
+  return c;
+});
 
 let server;
 
@@ -34,10 +52,7 @@ test('it fetches one set of command version', function (assert) {
     {
       'Content-Type': 'application/json'
     },
-    JSON.stringify([
-      { id: 2, namespace: 'foo', name: 'bar', version: '2.0.0', createTime },
-      { id: 1, namespace: 'foo', name: 'bar', version: '1.0.0', createTime }
-    ])
+    JSON.stringify(dummyCommands)
   ]);
 
   let service = this.subject();
@@ -47,12 +62,29 @@ test('it fetches one set of command version', function (assert) {
   const t = service.getOneCommand('foo', 'bar');
 
   t.then((commands) => {
-    /* eslint-disable max-len */
-    assert.deepEqual(commands, [
-      { id: 2, namespace: 'foo', name: 'bar', version: '2.0.0', createTime, lastUpdated },
-      { id: 1, namespace: 'foo', name: 'bar', version: '1.0.0', createTime, lastUpdated }
-    ]);
-    /* eslint-enable max-len */
+    assert.deepEqual(commands, dummyCommandsResult);
+  });
+});
+
+test('it fetches one set of command tags', function (assert) {
+  assert.expect(2);
+
+  server.get('http://localhost:8080/v4/commands/foo/bar/tags', () => [
+    200,
+    {
+      'Content-Type': 'application/json'
+    },
+    JSON.stringify(dummyCommandTags)
+  ]);
+
+  let service = this.subject();
+
+  assert.ok(service);
+
+  const t = service.getCommandTags('foo', 'bar');
+
+  t.then((commands) => {
+    assert.deepEqual(commands, dummyCommandTagsResult);
   });
 });
 
@@ -64,10 +96,7 @@ test('it fetches all commands', function (assert) {
     {
       'Content-Type': 'application/json'
     },
-    JSON.stringify([
-      { id: 2, namespace: 'foo', name: 'baz', version: '2.0.0', createTime },
-      { id: 1, namespace: 'foo', name: 'bar', version: '1.0.0', createTime }
-    ])
+    JSON.stringify(dummyCommands)
   ]);
 
   let service = this.subject();
@@ -77,12 +106,7 @@ test('it fetches all commands', function (assert) {
   const t = service.getAllCommands();
 
   t.then((commands) => {
-    assert.deepEqual(commands, [
-      /* eslint-disable max-len */
-      { id: 2, namespace: 'foo', name: 'baz', version: '2.0.0', createTime, lastUpdated },
-      { id: 1, namespace: 'foo', name: 'bar', version: '1.0.0', createTime, lastUpdated }
-    ]);
-    /* eslint-enable max-len */
+    assert.deepEqual(commands, dummyCommandsResult);
   });
 });
 

--- a/tests/unit/commands/detail/router-test.js
+++ b/tests/unit/commands/detail/router-test.js
@@ -9,6 +9,13 @@ const commandServiceStub = Service.extend({
       { id: 2, namespace, name, version: '2.0.0' },
       { id: 1, namespace, name, version: '1.0.0' }
     ]);
+  },
+  getCommandTags(namespace, name) {
+    return resolve([
+      { id: 3, namespace, name, version: '3.0.0', tag: 'latest' },
+      { id: 2, namespace, name, version: '2.0.0', tag: 'stable' },
+      { id: 1, namespace, name, version: '1.0.0' }
+    ]);
   }
 });
 
@@ -28,5 +35,6 @@ test('it asks for the list of commands for a given namespace and name', function
   return route.model({ namespace: 'foo', name: 'bar' }).then((commands) => {
     assert.equal(commands[0].name, 'bar');
     assert.equal(commands[0].namespace, 'foo');
+    assert.equal(commands[0].tag, 'latest');
   });
 });


### PR DESCRIPTION
## Context
UI does not show command tags.

## Objective
This PR provides to UI for command tags like tempalate's.
It works locally.
![image](https://user-images.githubusercontent.com/3445553/41774141-701416a6-7659-11e8-92da-81b90ea23338.png)
(Tag name looks inverse but it's my command execution order.)

This PR also fixed links area for select template version. Current UI switches a version even if the users click white space like the below image.
![image](https://user-images.githubusercontent.com/3445553/41774342-4535656a-765a-11e8-98bb-24677b437664.png)

## Reference
- Issue: https://github.com/screwdriver-cd/screwdriver/issues/677 