### PR TITLE
fix(1158): dedeup templates based on full name.

### DIFF
--- a/app/template/service.js
+++ b/app/template/service.js
@@ -41,8 +41,8 @@ export default Service.extend({
         const names = {};
 
         templates.forEach((t) => {
-          if (!names[t.name]) {
-            names[t.name] = 1;
+          if (!names[t.fullName]) {
+            names[t.fullName] = 1;
             result.push(t);
           }
         });

--- a/app/templates/detail/route.js
+++ b/app/templates/detail/route.js
@@ -9,7 +9,9 @@ export default Route.extend({
       this.get('template').getOneTemplate(params.name),
       this.get('template').getTemplateTags(params.name)
     ]).then((arr) => {
-      const [verPayload, tagPayload] = arr;
+      let [verPayload, tagPayload] = arr;
+
+      verPayload = verPayload.filter(t => t.namespace === params.namespace);
 
       tagPayload.forEach((tagObj) => {
         const taggedVerObj = verPayload.find(verObj => verObj.version === tagObj.version);

--- a/tests/unit/template/service-test.js
+++ b/tests/unit/template/service-test.js
@@ -67,6 +67,7 @@ test('it fetches all templates', function (assert) {
       'Content-Type': 'application/json'
     },
     JSON.stringify([
+      { id: 3, namespace: 'boo', name: 'baz', version: '2.0.0', createTime },
       { id: 2, namespace: 'foo', name: 'baz', version: '2.0.0', createTime },
       { id: 1, namespace: 'foo', name: 'bar', version: '1.0.0', createTime }
     ])
@@ -81,6 +82,7 @@ test('it fetches all templates', function (assert) {
   t.then((templates) => {
     assert.deepEqual(templates, [
       /* eslint-disable max-len */
+      { id: 3, fullName: 'boo/baz', namespace: 'boo', name: 'baz', version: '2.0.0', createTime, lastUpdated },
       { id: 2, fullName: 'foo/baz', namespace: 'foo', name: 'baz', version: '2.0.0', createTime, lastUpdated },
       { id: 1, fullName: 'foo/bar', namespace: 'foo', name: 'bar', version: '1.0.0', createTime, lastUpdated }
     ]);

--- a/tests/unit/templates/detail/route-test.js
+++ b/tests/unit/templates/detail/route-test.js
@@ -5,9 +5,12 @@ import { moduleFor, test } from 'ember-qunit';
 const templateServiceStub = Service.extend({
   getOneTemplate(name) {
     return resolve([
-      { id: 3, name, version: '3.0.0' },
-      { id: 2, name, version: '2.0.0' },
-      { id: 1, name, version: '1.0.0' }
+      { id: 3, name, version: '3.0.0', namespace: 'foo' },
+      { id: 2, name, version: '2.0.0', namespace: 'foo' },
+      { id: 1, name, version: '1.0.0', namespace: 'foo' },
+      { id: 6, name, version: '3.0.0', namespace: 'bar' },
+      { id: 5, name, version: '2.0.0', namespace: 'bar' },
+      { id: 4, name, version: '1.0.0', namespace: 'bar' }
     ]);
   },
   getTemplateTags(name) {
@@ -32,7 +35,9 @@ test('it asks for the list of templates for a given name', function (assert) {
 
   assert.ok(route);
 
-  return route.model({ name: 'foo/bar' }).then((templates) => {
-    assert.equal(templates[0].name, 'foo/bar');
+  return route.model({ namespace: 'foo', name: 'bar' }).then((templates) => {
+    assert.equal(templates.length, 3);
+    assert.equal(templates[0].namespace, 'foo');
+    assert.equal(templates[0].name, 'bar');
   });
 });


### PR DESCRIPTION
Template detail should filter on correct namespace

Fixes https://github.com/screwdriver-cd/screwdriver/issues/1158
