### PR TITLE
fix(1025): Display error messages on pipeline options page

### DIFF
--- a/app/pipeline/options/controller.js
+++ b/app/pipeline/options/controller.js
@@ -13,12 +13,14 @@ export default Controller.extend({
       const job = this.store.peekRecord('job', id);
 
       job.set('state', state);
-      job.save().catch(error => this.set('errorMessage', error.errors[0].detail || {}));
+      job.save()
+        .catch(error => this.set('errorMessage', error.errors[0].detail || ''));
     },
     removePipeline() {
       this.get('pipeline').destroyRecord().then(() => {
         this.transitionToRoute('home');
-      }).catch(error => this.set('errorMessage', error.errors[0].detail || {}));
+      })
+        .catch(error => this.set('errorMessage', error.errors[0].detail || ''));
     },
     updatePipeline(scmUrl) {
       let pipeline = this.get('pipeline');
@@ -30,7 +32,7 @@ export default Controller.extend({
       pipeline.save()
         .then(() => this.set('errorMessage', ''))
         .catch((err) => {
-          this.set('errorMessage', err.errors[0].detail || {});
+          this.set('errorMessage', err.errors[0].detail || '');
         })
         .finally(() => {
           this.set('isSaving', false);

--- a/app/pipeline/options/controller.js
+++ b/app/pipeline/options/controller.js
@@ -13,12 +13,12 @@ export default Controller.extend({
       const job = this.store.peekRecord('job', id);
 
       job.set('state', state);
-      job.save();
+      job.save().catch(error => this.set('errorMessage', error.errors[0].detail || {}));
     },
     removePipeline() {
       this.get('pipeline').destroyRecord().then(() => {
         this.transitionToRoute('home');
-      });
+      }).catch(error => this.set('errorMessage', error.errors[0].detail || {}));
     },
     updatePipeline(scmUrl) {
       let pipeline = this.get('pipeline');
@@ -30,7 +30,7 @@ export default Controller.extend({
       pipeline.save()
         .then(() => this.set('errorMessage', ''))
         .catch((err) => {
-          this.set('errorMessage', err);
+          this.set('errorMessage', err.errors[0].detail || {});
         })
         .finally(() => {
           this.set('isSaving', false);

--- a/app/pipeline/options/route.js
+++ b/app/pipeline/options/route.js
@@ -15,5 +15,11 @@ export default Route.extend({
 
     // Prevent double render when jobs list updates asynchronously
     return pipeline.get('jobs').then(jobs => ({ pipeline, jobs }));
+  },
+  actions: {
+    willTransition() {
+      // Reset error message when switching pages
+      this.controller.set('errorMessage', '');
+    }
   }
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -2747,7 +2747,7 @@
     "broccoli-style-manifest": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/broccoli-style-manifest/-/broccoli-style-manifest-1.5.2.tgz",
-      "integrity": "sha512-68IUg6TAD/hBBsg2/MYTQpdpzBpkg6vLAbHvlcebgS3AckkKvZCSC7XXlgnCHJ5xj0L/LPbS8VOzSjpz8IiYow==",
+      "integrity": "sha1-JJrMyBp1uD+1gc2MLRalGkmJZk0=",
       "dev": true,
       "requires": {
         "broccoli-caching-writer": "3.0.3",
@@ -2760,7 +2760,7 @@
         "rsvp": {
           "version": "4.8.2",
           "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.2.tgz",
-          "integrity": "sha512-8CU1Wjxvzt6bt8zln+hCjyieneU9s0LRW+lPRsjyVCY8Vm1kTbK7btBIrCGg6yY9U4undLDm/b1hKEEi1tLypg==",
+          "integrity": "sha1-nVZHEIc1eE6xNBjN3bVvdbkZ1yI=",
           "dev": true
         }
       }
@@ -3339,7 +3339,7 @@
     "clean-up-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/clean-up-path/-/clean-up-path-1.0.0.tgz",
-      "integrity": "sha512-PHGlEF0Z6976qQyN6gM7kKH6EH0RdfZcc8V+QhFe36eRxV0SMH5OUBZG7Bxa9YcreNzyNbK63cGiZxdSZgosRw==",
+      "integrity": "sha1-3p6BllGZEudJyer2fBPWT6xyo+U=",
       "dev": true
     },
     "cli-cursor": {
@@ -6272,7 +6272,7 @@
         "broccoli-funnel": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.1.tgz",
-          "integrity": "sha512-C8Lnp9TVsSSiZMGEF16C0dCiNg2oJqUKwuZ1K4kVC6qRPG/2Cj/rtB5kRCC9qEbwqhX71bDbfHROx0L3J7zXQg==",
+          "integrity": "sha1-aCPHO2de94//p6uADwg+dotR1Ek=",
           "dev": true,
           "requires": {
             "array-equal": "1.0.0",
@@ -6293,7 +6293,7 @@
         "broccoli-merge-trees": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-3.0.0.tgz",
-          "integrity": "sha512-yyk4J3KSeohlzsmVaRx7ZgAq57K2wzyVtGDaARLG/WuTNlRjKeYEW+atxblvrf0zAOsYMOi8YCpMLRBQUa9jjg==",
+          "integrity": "sha1-kOSVn548V88fBPqzUVLz2ElGjYs=",
           "dev": true,
           "requires": {
             "broccoli-plugin": "1.3.0",
@@ -6303,7 +6303,7 @@
         "merge-trees": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/merge-trees/-/merge-trees-2.0.0.tgz",
-          "integrity": "sha512-5xBbmqYBalWqmhYm51XlohhkmVOua3VAUrrWh8t9iOkaLpS6ifqm/UVuUjQCeDVJ9Vx3g2l6ihfkbLSTeKsHbw==",
+          "integrity": "sha1-pWDXluVmxdmyxARyopZ8ykjYUWE=",
           "dev": true,
           "requires": {
             "fs-updater": "1.0.4",
@@ -6313,7 +6313,7 @@
         "rsvp": {
           "version": "4.8.2",
           "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.2.tgz",
-          "integrity": "sha512-8CU1Wjxvzt6bt8zln+hCjyieneU9s0LRW+lPRsjyVCY8Vm1kTbK7btBIrCGg6yY9U4undLDm/b1hKEEi1tLypg==",
+          "integrity": "sha1-nVZHEIc1eE6xNBjN3bVvdbkZ1yI=",
           "dev": true
         }
       }
@@ -9753,7 +9753,7 @@
     "fs-updater": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/fs-updater/-/fs-updater-1.0.4.tgz",
-      "integrity": "sha512-0pJX4mJF/qLsNEwTct8CdnnRdagfb+LmjRPJ8sO+nCnAZLW0cTmz4rTgU25n+RvTuWSITiLKrGVJceJPBIPlKg==",
+      "integrity": "sha1-IymYD5mukXbpoOhPdjdTihgs5js=",
       "dev": true,
       "requires": {
         "can-symlink": "1.0.0",
@@ -14394,7 +14394,7 @@
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+          "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
@@ -14480,7 +14480,7 @@
     "postcss-selector-namespace": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/postcss-selector-namespace/-/postcss-selector-namespace-1.5.0.tgz",
-      "integrity": "sha512-tQmqzuqOyH4sCwr+yRmnIKPzNQy1tIVvEZMR9qd82npDJ2X5KwMoeFFjCdupJ00eqMrCYj58wWvSwwZDA3kTmA==",
+      "integrity": "sha1-YjNd6PGZLq6YnRvjO6IpgVarRYs=",
       "dev": true,
       "requires": {
         "postcss": "6.0.19"


### PR DESCRIPTION
## Context
We're currently not displayed error messages on the UI whenever people do not have permissions to perform actions on the pipeline options page.

## Objective
This PR bubbles up the error message so it's clear that the user's attempt was invalid.

Trying to toggle the jobs:
<img width="1167" alt="screen shot 2018-07-02 at 3 03 03 pm" src="https://user-images.githubusercontent.com/3230529/42188557-3def22a8-7e09-11e8-9724-44931e0b0fed.png">

Trying to sync:
<img width="942" alt="screen shot 2018-07-02 at 3 03 29 pm" src="https://user-images.githubusercontent.com/3230529/42188563-4f963a3c-7e09-11e8-9bd1-560fe7d884be.png">

Trying to delete the pipeline:
<img width="947" alt="screen shot 2018-07-02 at 3 03 17 pm" src="https://user-images.githubusercontent.com/3230529/42188564-51bff974-7e09-11e8-9d05-cc9a0afc1dd9.png">

## Related links
Related to https://github.com/screwdriver-cd/screwdriver/issues/1025