### PR TITLE
fix: fix css for pr-view

### DIFF
--- a/app/components/pipeline-pr-view/styles.scss
+++ b/app/components/pipeline-pr-view/styles.scss
@@ -27,6 +27,6 @@ a {
   font-size: 14px;
 }
 
-a span {
+span {
   margin-left: 10px;
 }


### PR DESCRIPTION
Currently, the name for the PR is a bit off if it's not linkable.
This PR will add the `margin-left` for that kind of PR.

Example:
<img width="205" alt="screen shot 2018-07-06 at 1 58 50 pm" src="https://user-images.githubusercontent.com/20427140/42400312-e9965a58-8125-11e8-94c3-2e8b789b085e.png">
