### PR TITLE
feat(1033): Add toggle icon for secret value

### DIFF
--- a/app/components/pipeline-secret-settings/component.js
+++ b/app/components/pipeline-secret-settings/component.js
@@ -2,6 +2,7 @@
 import { sort } from '@ember/object/computed';
 import { computed } from '@ember/object';
 import Component from '@ember/component';
+import $ from 'jquery';
 
 export default Component.extend({
   newName: null,
@@ -36,6 +37,23 @@ export default Component.extend({
       this.set('newAllow', false);
 
       return true;
+    },
+    /**
+     * Toggle eye-icon and password input type
+     * @method togglePasswordInput
+     * @param {Object} event Click event
+     */
+    togglePasswordInput(event) {
+      const target = event.target;
+      const passwordInput = target.previousSibling;
+
+      $(target).toggleClass('fa-eye fa-eye-slash');
+
+      if ($(passwordInput).attr('type') === 'password') {
+        $(passwordInput).attr('type', 'text');
+      } else {
+        $(passwordInput).attr('type', 'password');
+      }
     }
   }
 });

--- a/app/components/pipeline-secret-settings/styles.scss
+++ b/app/components/pipeline-secret-settings/styles.scss
@@ -34,3 +34,9 @@ tfoot button:disabled {
   background-color: inherit;
   color: inherit;
 }
+
+.toggle-icon {
+  margin-left: -25px;
+  position: relative;
+  z-index: 2;
+}

--- a/app/components/pipeline-secret-settings/template.hbs
+++ b/app/components/pipeline-secret-settings/template.hbs
@@ -34,7 +34,7 @@
     <tfoot>
       <tr class="new">
         <td class="key">{{input placeholder="SECRET_KEY" size="40" value=newName title="Secret keys can only consist of numbers, uppercase letters and underscores, and cannot begin with a number."}}</td>
-        <td class="pass">{{input type="password" placeholder="SECRET_VALUE" size="40" value=newValue}}</td>
+        <td class="pass">{{input type="password" placeholder="SECRET_VALUE" size="40" value=newValue}}{{fa-icon "eye" class="toggle-icon" click=(action "togglePasswordInput")}}</td>
         <td class="allow"><div title="Check to allow this secret to be used in pull-requests">{{input type="checkbox" checked=newAllow}}</div></td>
         <td><button disabled={{isButtonDisabled}} {{action "addNewSecret"}}>Add</button></td>
       </tr>

--- a/app/components/secret-view/component.js
+++ b/app/components/secret-view/component.js
@@ -1,5 +1,6 @@
 import { computed } from '@ember/object';
 import Component from '@ember/component';
+import $ from 'jquery';
 
 export default Component.extend({
   tagName: 'tr',
@@ -66,6 +67,23 @@ export default Component.extend({
       }
 
       return Promise.resolve(null);
+    },
+    /**
+     * Toggle eye-icon and password input type
+     * @method togglePasswordInput
+     * @param {Object} event Click event
+     */
+    togglePasswordInput(event) {
+      const target = event.target;
+      const passwordInput = target.previousSibling;
+
+      $(target).toggleClass('fa-eye fa-eye-slash');
+
+      if ($(passwordInput).attr('type') === 'password') {
+        $(passwordInput).attr('type', 'text');
+      } else {
+        $(passwordInput).attr('type', 'password');
+      }
     }
   }
 });

--- a/app/components/secret-view/styles.scss
+++ b/app/components/secret-view/styles.scss
@@ -23,3 +23,9 @@ button {
   width: 100px;
   border-radius: 3px;
 }
+
+.toggle-icon {
+  margin-left: -25px;
+  position: relative;
+  z-index: 2;
+}

--- a/app/components/secret-view/template.hbs
+++ b/app/components/secret-view/template.hbs
@@ -1,4 +1,4 @@
 <td class="name">{{secret.name}}</td>
-<td class="pass">{{input type="password" placeholder=passwordPlaceholder size="40" value=newValue}}</td>
+<td class="pass">{{input type="password" placeholder=passwordPlaceholder size="40" value=newValue}}{{fa-icon "eye" class="toggle-icon" click=(action "togglePasswordInput")}}</td>
 <td class="allow">{{input type="checkbox" checked=secret.allowInPR}}</td>
 <td><button {{action "modifySecret"}}>{{buttonAction}}</button></td>

--- a/tests/integration/components/pipeline-secret-settings/component-test.js
+++ b/tests/integration/components/pipeline-secret-settings/component-test.js
@@ -34,6 +34,14 @@ test('it renders', function (assert) {
   assert.equal(this.$('table').length, 1);
   assert.equal(this.$('tbody tr').length, 1);
   assert.equal(this.$('tfoot tr').length, 1);
+
+  // eye-icons are present and have fa-eye class as default
+  assert.ok(this.$('tbody i').hasClass('fa-eye'));
+  assert.ok(this.$('tfoot i').hasClass('fa-eye'));
+
+  // the type of input is a password as default
+  assert.equal(this.$('tbody .pass input').attr('type'), 'password');
+  assert.equal(this.$('tfoot .pass input').attr('type'), 'password');
 });
 
 test('it updates the add button properly', function (assert) {
@@ -170,4 +178,39 @@ test('it renders differently for a child pipeline', function (assert) {
   assert.equal(this.$('table').length, 1);
   assert.equal(this.$('tbody tr').length, 1);
   assert.equal(this.$('tfoot tr').length, 0);
+});
+
+test('it toggles eye-icon and input type', function (assert) {
+  const testSecret = EmberObject.create({
+    name: 'TEST_SECRET',
+    pipelineId: 123245,
+    value: 'banana',
+    allowInPR: false
+  });
+
+  this.set('mockSecrets', [testSecret]);
+
+  const testPipeline = EmberObject.create({
+    id: '123245'
+  });
+
+  this.set('mockPipeline', testPipeline);
+
+  this.render(hbs`{{pipeline-secret-settings secrets=mockSecrets pipeline=mockPipeline}}`);
+
+  this.$('tbody i').click();
+  this.$('tfoot i').click();
+
+  assert.ok(this.$('tbody i').hasClass('fa-eye-slash'));
+  assert.equal(this.$('tbody .pass input').attr('type'), 'text');
+  assert.ok(this.$('tfoot i').hasClass('fa-eye-slash'));
+  assert.equal(this.$('tfoot .pass input').attr('type'), 'text');
+
+  this.$('tbody i').click();
+  this.$('tfoot i').click();
+
+  assert.ok(this.$('tbody i').hasClass('fa-eye'));
+  assert.equal(this.$('tbody .pass input').attr('type'), 'password');
+  assert.ok(this.$('tfoot i').hasClass('fa-eye'));
+  assert.equal(this.$('tfoot .pass input').attr('type'), 'password');
 });


### PR DESCRIPTION
## Context
We cannot check an input SECRET_VALUE on UI currently. This should cause input or copy and paste mistakes.

## Objective
This PR provides to `eye-icon` 👁 which toggles a type of input to show secret's value for the first pass of https://github.com/screwdriver-cd/screwdriver/issues/1033.
Screen shots are here:
- Default:
![image](https://user-images.githubusercontent.com/3445553/42550014-19953840-850a-11e8-9d5a-1381ef70befa.png)

- After clicking eye-icon:
![image](https://user-images.githubusercontent.com/3445553/42550026-22da6b14-850a-11e8-97b9-a031d58a2bf7.png)

- Gif
![eyes](https://user-images.githubusercontent.com/3445553/42549967-dbd86c34-8509-11e8-94a3-6c80e2c38bf4.gif)

## Reference
- Issue: https://github.com/screwdriver-cd/screwdriver/issues/1033