### PR TITLE
fix: fix event duration

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -50,7 +50,7 @@ module.exports = (environment) => {
       SDSTORE_HOSTNAME: 'http://localhost:8081',
       SDSTORE_NAMESPACE: 'v1',
       BUILD_RELOAD_TIMER: 5000, // 5 seconds
-      EVENT_RELOAD_TIMER: 90000, // 1.5 minutes
+      EVENT_RELOAD_TIMER: 60000, // 1 minutes
       LOG_RELOAD_TIMER: 1000,
       NUM_EVENTS_LISTED: 5,
       MAX_LOG_LINES: 1000,


### PR DESCRIPTION
### Context
Currently, if you have multiple workflow inside the pipeline. The event duration is wrong even only partial flow is triggered. Because it's using number of jobs inside the workflowGraph to determine if an event finishes or not. 

### Solution
There is no good way to determine if an event is done with sourcePaths unless we store sourcePaths info in the event itself. Instead of checking number of builds, in this PR, If no new builds added in 2 reloads(each reload has 1 min delay), we consider the event as complete.

Related to: https://github.com/screwdriver-cd/screwdriver/issues/1173