### PR TITLE
fix(1200): Use checkoutUrl regex from data-schema [2]

### DIFF
--- a/app/utils/git.js
+++ b/app/utils/git.js
@@ -1,3 +1,6 @@
+const schema = require('screwdriver-data-schema');
+const CHECKOUT_URL_REGEX = schema.config.regex.CHECKOUT_URL;
+
 /**
  * Parse a git or https checkout url and get info about the repo
  * @method git
@@ -6,7 +9,7 @@
  */
 function parse(scmUrl) {
   // eslint-disable-next-line max-len
-  const match = scmUrl.match(/^(?:(?:https?|git):\/\/)?(?:[^@]+@)?([^/:]+)(?:\/|:)([^/]+)\/(.+?)(?:\.git)?(#.+)?$/);
+  const match = scmUrl.match(CHECKOUT_URL_REGEX);
 
   if (!match) {
     return {

--- a/app/utils/git.js
+++ b/app/utils/git.js
@@ -1,6 +1,3 @@
-const schema = require('screwdriver-data-schema');
-const CHECKOUT_URL_REGEX = schema.config.regex.CHECKOUT_URL;
-
 /**
  * Parse a git or https checkout url and get info about the repo
  * @method git
@@ -9,7 +6,7 @@ const CHECKOUT_URL_REGEX = schema.config.regex.CHECKOUT_URL;
  */
 function parse(scmUrl) {
   // eslint-disable-next-line max-len
-  const match = scmUrl.match(CHECKOUT_URL_REGEX);
+  const match = scmUrl.match(/^(?:(?:https:\/\/(?:[^@/:\s]+@)?)|git@)+([^/:\s]+)(?:\/|:)([^/:\s]+)\/([^\s]+?)(?:\.git)?(#[^\s]+)?$/);
 
   if (!match) {
     return {


### PR DESCRIPTION
## Related links
Blocked by https://github.com/screwdriver-cd/data-schema/pull/265
Related to https://github.com/screwdriver-cd/screwdriver/issues/1200

*Note: wanted to pull in data-schema and use the regex directly from there but it seems to cause havoc with UI tests.*