### PR TITLE
add indicators for add to collection on pipeline

### DIFF
--- a/app/components/pipeline-header/styles.scss
+++ b/app/components/pipeline-header/styles.scss
@@ -1,10 +1,9 @@
 & {
   background-color: $brand-100;
   color: $grey-800;
-  height: 50px;
-  line-height: 50px;
+  min-height: 50px;
   margin: 0;
-  padding: 0 25px;
+  padding: 20px 25px;
   white-space: nowrap;
 }
 

--- a/app/components/pipeline-header/template.hbs
+++ b/app/components/pipeline-header/template.hbs
@@ -1,3 +1,9 @@
+{{#if addCollectionError}}
+  {{info-message message=addCollectionError type="warning" icon="exclamation-triangle"}}
+{{/if}}
+{{#if addCollectionSuccess}}
+  {{info-message message=addCollectionSuccess type="success" icon="check"}}
+{{/if}}
 {{#link-to "pipeline" pipeline.id}}<h1>{{pipeline.appId}}</h1>{{/link-to}}
 <a href="{{pipeline.hubUrl}}" class="branch">{{fa-icon "code-fork"}} {{pipeline.branch}}</a>
 <span class="scm">{{fa-icon scmContext.scmIcon}} {{scmContext.scm}}</span>
@@ -8,4 +14,6 @@
   pipeline=pipeline
   collections=collections
   onAddToCollection=onAddToCollection
+  addCollectionSuccess=addCollectionSuccess
+  addCollectionError=addCollectionError
   dropdownText=dropdownText}}


### PR DESCRIPTION
When you successfully (or unsuccessfully) add a pipeline to a collection from the pipeline page, an indicator will popup.

<img width="1680" alt="screen shot 2018-07-27 at 2 16 38 pm" src="https://user-images.githubusercontent.com/9649910/43346866-cdfebec4-91a7-11e8-83e3-13f4fd90033a.png">
