### PR TITLE
fix(1274): add err handling for restart/stop builds

### DIFF
--- a/app/pipeline/build/controller.js
+++ b/app/pipeline/build/controller.js
@@ -19,6 +19,7 @@ export default Controller.extend({
   pipeline: reads('model.pipeline'),
   stepList: mapBy('build.steps', 'name'),
   isShowingModal: false,
+  errorMessage: '',
   prEvents: computed('model.{event.pr.url,pipeline.id}', {
     get() {
       if (this.get('model.event.type') === 'pr') {
@@ -41,7 +42,10 @@ export default Controller.extend({
       const build = this.get('build');
 
       build.set('status', 'ABORTED');
-      build.save();
+
+      return build.save().catch((e) => {
+        this.set('errorMessage', Array.isArray(e.errors) ? e.errors[0].detail : '');
+      });
     },
 
     startBuild() {
@@ -64,8 +68,11 @@ export default Controller.extend({
 
             return this.transitionToRoute('pipeline.build',
               builds.get('lastObject.id'));
-          }
-          ));
+          }))
+        .catch((e) => {
+          this.set('isShowingModal', false);
+          this.set('errorMessage', Array.isArray(e.errors) ? e.errors[0].detail : '');
+        });
     },
 
     reload() {

--- a/app/pipeline/build/template.hbs
+++ b/app/pipeline/build/template.hbs
@@ -26,6 +26,7 @@
   {{/modal-dialog}}
 {{/if}}
 
+{{info-message message=errorMessage type="warning" icon="exclamation-triangle"}}
 {{#if build.statusMessage}}
   {{info-message message=build.statusMessage type="warning" icon="exclamation-triangle"}}
 {{/if}}


### PR DESCRIPTION
Currently, if restart / stop build failed, there is no err handling.

Resolves https://github.com/screwdriver-cd/screwdriver/issues/1247