### PR TITLE
fix(1237): Refactor to show version list in template deatil page.

### DIFF
--- a/app/template/service.js
+++ b/app/template/service.js
@@ -15,10 +15,11 @@ export default Service.extend({
 
     return this.fetchData(url).then(templatesFormatter);
   },
-  getTemplateTags(name) {
+  getTemplateTags(namespace, name) {
+    const fullName = `${namespace}/${name}`;
     const url =
       // eslint-disable-next-line max-len
-      `${ENV.APP.SDAPI_HOSTNAME}/${ENV.APP.SDAPI_NAMESPACE}/templates/${encodeURIComponent(name)}/tags`;
+      `${ENV.APP.SDAPI_HOSTNAME}/${ENV.APP.SDAPI_NAMESPACE}/templates/${encodeURIComponent(fullName)}/tags`;
 
     return this.fetchData(url);
   },

--- a/app/templates/detail/route.js
+++ b/app/templates/detail/route.js
@@ -7,7 +7,7 @@ export default Route.extend({
   model(params) {
     return RSVP.all([
       this.get('template').getOneTemplate(params.name),
-      this.get('template').getTemplateTags(params.name)
+      this.get('template').getTemplateTags(params.namespace, params.name)
     ]).then((arr) => {
       let [verPayload, tagPayload] = arr;
 

--- a/tests/unit/templates/detail/route-test.js
+++ b/tests/unit/templates/detail/route-test.js
@@ -13,7 +13,7 @@ const templateServiceStub = Service.extend({
       { id: 4, name, version: '1.0.0', namespace: 'bar' }
     ]);
   },
-  getTemplateTags(name) {
+  getTemplateTags(namespace, name) {
     return resolve([
       { id: 5, name, version: '3.0.0', tag: 'latest' },
       { id: 6, name, version: '3.0.0', tag: 'stable' },


### PR DESCRIPTION
## Context
We have migrated templatedTags table for the namespace issue.
After that, in template detail page, it became that tag names are displayed duplicate in version list.
That's because UI still tries to get tag lists by only the tag name, not include namespace.

<img width="284" alt="2018-08-16 15 17 09" src="https://user-images.githubusercontent.com/16560466/44191722-816e6800-a167-11e8-973a-4738b5814fac.png">

As example above, `stable`, `latest` tag next to version `0.0.1` are displayed duplicate.
These duplicate tags come from other template which has same template name (but different namespace).

## Objective
Refactor template detail page to get tag lists by namespace and name.
Version lists should be like below in this case.
<img width="284" alt="2018-08-16 15 17 09" src="https://user-images.githubusercontent.com/16560466/44192032-c941bf00-a168-11e8-99e4-ca2cc7f1c088.png">

## Notes
This refactor must be applied only after the migration of namespace in `templateTags` table.
Otherwise it becomes error.

## Related
Issue: https://github.com/screwdriver-cd/screwdriver/issues/1237