### PR TITLE
fix: sleep before checks

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -48,7 +48,7 @@ jobs:
       - get-tag: ./ci/git-latest.sh
       - wait-docker: DOCKER_TAG=`cat VERSION` ./ci/docker-wait.sh
       - deploy-k8s: K8S_TAG=`cat VERSION` ./ci/k8s-deploy.sh
-      - test: curl --silent --fail -o /dev/null https://beta.cd.screwdriver.cd
+      - test: sleep 10; curl --silent --fail -o /dev/null https://beta.cd.screwdriver.cd
     environment:
       DOCKER_REPO: screwdrivercd/ui
       K8S_CONTAINER: screwdriver-ui
@@ -69,7 +69,7 @@ jobs:
       - get-tag: ./ci/git-latest.sh
       - wait-docker: DOCKER_TAG=`cat VERSION` ./ci/docker-wait.sh
       - deploy-k8s: K8S_TAG=`cat VERSION` ./ci/k8s-deploy.sh
-      - test: curl --silent --fail -o /dev/null https://cd.screwdriver.cd
+      - test: sleep 10; curl --silent --fail -o /dev/null https://cd.screwdriver.cd
     environment:
       DOCKER_REPO: screwdrivercd/ui
       K8S_CONTAINER: screwdriver-ui


### PR DESCRIPTION
Builds failed intermittently because it's not available immediately after deploying. Need to sleep a bit before check