### PR TITLE
fix: Fix change displayed collection

### DIFF
--- a/app/components/collections-flyout/component.js
+++ b/app/components/collections-flyout/component.js
@@ -21,10 +21,10 @@ export default Component.extend({
   }),
 
   actions: {
-    changeCollectionDisplayed(collection) {
+    changeCollectionDisplayed() {
       let changeCollection = this.get('changeCollection');
 
-      changeCollection(collection);
+      changeCollection();
     },
     openModal() {
       this.set('showModal', true);

--- a/app/components/collections-flyout/template.hbs
+++ b/app/components/collections-flyout/template.hbs
@@ -13,9 +13,9 @@
   </div>
     {{#each collections as |collection|}}
       <div class="collection-wrapper row {{if (eq collection.id selectedCollectionId) ' row--active'}}">
-        <div class="collection" onClick={{action "changeCollectionDisplayed" collection}}>
+        {{#link-to "dashboard.show" collection.id invokeAction="changeCollectionDisplayed"}}
           {{collection.name}}
-        </div>
+        {{/link-to}}
         {{#if showDeleteButtons}}
           <button
             class="collection-wrapper__delete"

--- a/app/dashboard/show/controller.js
+++ b/app/dashboard/show/controller.js
@@ -20,10 +20,9 @@ export default Controller.extend({
     onDeleteCollection() {
       this.transitionToRoute('home');
     },
-    changeCollection(collection) {
+    changeCollection() {
       this.set('editingDescription', false);
       this.set('editingName', false);
-      this.transitionToRoute('dashboard.show', collection);
     }
   }
 });

--- a/app/search/controller.js
+++ b/app/search/controller.js
@@ -27,10 +27,9 @@ export default Controller.extend({
           return collection.save();
         });
     },
-    changeCollection(collection) {
+    changeCollection() {
       this.set('editingDescription', false);
       this.set('editingName', false);
-      this.transitionToRoute('dashboard.show', collection);
     }
   }
 });

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "ember-highlight": "1.2.5",
     "ember-inline-svg": "^0.1.11",
     "ember-load-initializers": "^1.1.0",
+    "ember-link-action": "^0.1.1",
     "ember-modal-dialog": "^2.4.4",
     "ember-moment": "^7.7.0",
     "ember-promise-helpers": "^1.0.6",

--- a/tests/integration/components/collections-flyout/component-test.js
+++ b/tests/integration/components/collections-flyout/component-test.js
@@ -48,9 +48,9 @@ test('it renders', function (assert) {
 
   assert.equal($('.header__text').text().trim(), 'Collections');
   assert.equal($('.header__text a i').attr('class'), 'fa fa-plus-circle fa-mdx ember-view');
-  assert.equal($($('.collection-wrapper div').get(0)).text().trim(), 'collection1');
-  assert.equal($($('.collection-wrapper div').get(1)).text().trim(), 'collection2');
-  assert.equal($($('.collection-wrapper div').get(2)).text().trim(), 'collection3');
+  assert.equal($($('.collection-wrapper a').get(0)).text().trim(), 'collection1');
+  assert.equal($($('.collection-wrapper a').get(1)).text().trim(), 'collection2');
+  assert.equal($($('.collection-wrapper a').get(2)).text().trim(), 'collection3');
 });
 
 test('it renders with no collections', function (assert) {
@@ -118,7 +118,7 @@ test('it renders an active collection', function (assert) {
 
   assert.equal($('.header__text').text().trim(), 'Collections');
   assert.notOk($('.header__text a i').length);
-  assert.equal($($('.collection-wrapper div').get(0)).text().trim(), 'Test');
+  assert.equal($($('.collection-wrapper a').get(0)).text().trim(), 'Test');
   assert.equal($('.collection-wrapper.row--active').length, 1);
 });
 


### PR DESCRIPTION
## Context
When I changed displayed collection, collection's pipelines were not displayed on the UI.
<img width="1026" alt="2018-08-17 18 03 23" src="https://user-images.githubusercontent.com/8113204/44257861-46903100-a248-11e8-9b70-c4985622fe9c.png">
<img width="1050" alt="2018-08-17 18 03 34" src="https://user-images.githubusercontent.com/8113204/44257869-498b2180-a248-11e8-80d1-0ec0c2c88136.png">

## Objective
To fix this problem, I revert to use link-to in the collections-flyout template and invoke changeCollectionDisplayed using ember-link-action plugin when click link-to tag.