### PR TITLE
feat(1114): Add lazy fetch logic for Go-To-Top

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -54,7 +54,7 @@ module.exports = (environment) => {
       LOG_RELOAD_TIMER: 1000,
       NUM_EVENTS_LISTED: 5,
       MAX_LOG_LINES: 1000,
-      MAX_LOG_PAGES: 10,
+      DEFAULT_LOG_PAGE_SIZE: 10,
       FORCE_RELOAD_WAIT: 100 // Wait 100ms before force reload
     },
     moment: {


### PR DESCRIPTION
## Context
To improve load time for steps with huge amount of logs

## Objective
Fetch the remaining old step logs when users click on `Go to Top`

## Related links
Related to:
- https://github.com/screwdriver-cd/screwdriver/issues/1114
- https://github.com/screwdriver-cd/ui/pull/354