### PR TITLE
fix: rasterize log container for faster GPU scrolling

### DIFF
--- a/app/components/build-log/styles.scss
+++ b/app/components/build-log/styles.scss
@@ -33,6 +33,7 @@
 .wrap {
   height: 500px;
   overflow-y: auto;
+  transform: translateZ(0);
 }
 
 .logs {


### PR DESCRIPTION
## Context
Once the build log console surpasses the _comfort zone_ size of log, the scrolling will become janky.

## Objective
Rasterize the scroll container on GPU. Bit more memory footprint on the GPU in exchange for exponentially faster scrolling experience, esp with 10000+ lines of log

## Related links
Related to:
- https://github.com/screwdriver-cd/screwdriver/issues/1114