### PR TITLE
fix(1199): redirect to login upon 401

### DIFF
--- a/app/application/adapter.js
+++ b/app/application/adapter.js
@@ -2,15 +2,17 @@ import { computed } from '@ember/object';
 import { inject as service } from '@ember/service';
 import DS from 'ember-data';
 import ENV from 'screwdriver-ui/config/environment';
+import DataAdapterMixin from 'ember-simple-auth/mixins/data-adapter-mixin';
 
 // urls are of the form: https://server.com/namespace/key1s/:id/key2s, but :id and key2s are optional
 const urlPathParser = new RegExp(`/${ENV.APP.SDAPI_NAMESPACE}/([^/]+)(/([^/]+))?(/([^/]+))?`);
 
-export default DS.RESTAdapter.extend({
+export default DS.RESTAdapter.extend(DataAdapterMixin, {
   session: service('session'),
   namespace: ENV.APP.SDAPI_NAMESPACE,
   host: ENV.APP.SDAPI_HOSTNAME,
-
+  /** Just to override the assertion from `DataAdapterMixin` */
+  authorize() {},
   /**
    * Add cors support to all ajax calls
    * @method ajax


### PR DESCRIPTION
## Context
When REST api call returns `401 Unauthorized`, the app should redirect user to the login page, instead of not rendering and error out.

## Objective
Invalidate session upon `401` before reaching the router so the router will check for authenticated session first.

## Related links
https://github.com/screwdriver-cd/screwdriver/issues/1199