### PR TITLE
fix: make rootUrl configurable for production

### DIFF
--- a/app/instance-initializers/supplementary-config.js
+++ b/app/instance-initializers/supplementary-config.js
@@ -20,6 +20,9 @@ export function initialize() {
   if (window.SUPPLEMENTARY_CONFIG && window.SUPPLEMENTARY_CONFIG.SDDOC_URL) {
     ENV.APP.SDDOC_URL = window.SUPPLEMENTARY_CONFIG.SDDOC_URL;
   }
+  if (window.SUPPLEMENTARY_CONFIG && window.SUPPLEMENTARY_CONFIG.rootURL) {
+    ENV.rootURL = window.SUPPLEMENTARY_CONFIG.ROOT_URL;
+  }
 }
 
 export default {

--- a/nginx.conf
+++ b/nginx.conf
@@ -64,7 +64,7 @@ http {
         # Dynamic configuration for the ember app
         location /assets/supplementary_config.js {
            content_by_lua_block {
-               ngx.say("window.SUPPLEMENTARY_CONFIG = { SDAPI_HOSTNAME: '", os.getenv("ECOSYSTEM_API"), "', SDSTORE_HOSTNAME: '", os.getenv("ECOSYSTEM_STORE"), "', SDDOC_URL: '", os.getenv("SDDOC_URL") or "", "'  };")
+               ngx.say("window.SUPPLEMENTARY_CONFIG = { ROOT_URL: '", os.getenv("ROOT_URL") or "", "', SDAPI_HOSTNAME: '", os.getenv("ECOSYSTEM_API"), "', SDSTORE_HOSTNAME: '", os.getenv("ECOSYSTEM_STORE"), "', SDDOC_URL: '", os.getenv("SDDOC_URL") or "", "'  };")
            }
         }
 


### PR DESCRIPTION
To allow ppl to run UI under a subdir, e.g. `mydomain.com/ui/`, we need to make the rootUrl configurable.

https://github.com/screwdriver-cd/ui/blob/master/config/environment.js#L7