### PR TITLE
fix: replace rootUrl during runtime

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -56,8 +56,11 @@ http {
         add_header x-xss-protection '1; mode=block';
         add_header Content-Security-Policy $csp_header;
 
+        set_by_lua $rootURL 'return os.getenv("ROOT_URL") or ""';
 
         location / {
+            sub_filter "/assets" "$rootURL/assets";
+            sub_filter_once off;
             index index.html;
             try_files $uri $uri/ /index.html?/$request_uri;
         }

--- a/nginx.conf
+++ b/nginx.conf
@@ -56,7 +56,9 @@ http {
         add_header x-xss-protection '1; mode=block';
         add_header Content-Security-Policy $csp_header;
 
-        set_by_lua $rootURL 'return os.getenv("ROOT_URL") or ""';
+        set_by_lua_block $rootURL {
+          return os.getenv("ROOT_URL") or "";
+        }
 
         location / {
             sub_filter "/assets" "$rootURL/assets";


### PR DESCRIPTION
rootURL is compiled during build time for index.html.
to override that during runtime, we can use nginx sub_filter to replace it.

http://nginx.org/en/docs/http/ngx_http_sub_module.html