### PR TITLE
fix: modify root url in css files too

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -61,6 +61,7 @@ http {
         }
 
         location / {
+            sub_filter_types text/html text/css;
             sub_filter "/assets" "$rootURL/assets";
             sub_filter_once off;
             index index.html;


### PR DESCRIPTION
we have some hardcoded rootUrl value in css files too. by default, sub_filter only do replace for html
https://github.com/screwdriver-cd/ui/blob/master/app/components/workflow-graph-d3/styles.scss