### PR TITLE
fix: switch k8s api endpoint

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -53,7 +53,7 @@ jobs:
       DOCKER_REPO: screwdrivercd/ui
       K8S_CONTAINER: screwdriver-ui
       K8S_IMAGE: screwdrivercd/ui
-      K8S_HOST: api.k8s.screwdriver.cd
+      K8S_HOST: api.ossd.k8s.screwdriver.cd
       K8S_DEPLOYMENT: sdui-beta
       SD_UI: beta.cd.screwdriver.cd
     secrets:
@@ -74,7 +74,7 @@ jobs:
       DOCKER_REPO: screwdrivercd/ui
       K8S_CONTAINER: screwdriver-ui
       K8S_IMAGE: screwdrivercd/ui
-      K8S_HOST: api.k8s.screwdriver.cd
+      K8S_HOST: api.ossd.k8s.screwdriver.cd
       K8S_DEPLOYMENT: sdui
       SD_UI: cd.screwdriver.cd
     secrets:


### PR DESCRIPTION
## Context

Our K8S_DEPLOY step is currently failing.
Previously we point `api.k8s.screwdriver.cd`  to the ips for `api.ossd.k8s.screwdriver.cd` in AWS route53. That means whenever we update the cluster, manual change is needed. Switch to the correct endpoint.

## Objective

This PR updates to the correct host.

## References

Related to https://github.com/screwdriver-cd/guide/pull/256