### PR TITLE
feat: Add cache invalidation to pipeline options page

### DIFF
--- a/app/cache/service.js
+++ b/app/cache/service.js
@@ -1,0 +1,53 @@
+import $ from 'jquery';
+import { Promise as EmberPromise } from 'rsvp';
+import Service, { inject as service } from '@ember/service';
+import { get } from '@ember/object';
+import ENV from 'screwdriver-ui/config/environment';
+
+export default Service.extend({
+  session: service('session'),
+
+  /**
+   * Calls the store api service to clear the cache data
+   * @method clearCache
+   * @param   {Object}  config
+   * @param   {String}  config.id       The ID of pipeline, event, or job to clear the cache from
+   * @param   {String}  config.scope    The scope of the cache, e.g. pipelines, events, jobs
+   * @return  {Promise}                 Resolve nothing if success otherwise reject with error message
+   */
+  clearCache(config) {
+    const { scope, id } = config;
+    const url = `${ENV.APP.SDSTORE_HOSTNAME}/${ENV.APP.SDSTORE_NAMESPACE}` +
+      `/caches/${scope}/${id}`;
+    const ajaxConfig = {
+      url,
+      type: 'DELETE',
+      contentType: 'application/json',
+      crossDomain: true,
+      xhrFields: {
+        withCredentials: true
+      },
+      headers: {
+        Authorization: `Bearer ${get(this, 'session.data.authenticated.token')}`
+      }
+    };
+
+    return new EmberPromise((resolve, reject) => {
+      $.ajax(ajaxConfig)
+        .done(content => resolve(content))
+        .fail((response) => {
+          let message = `${response.status} Request Failed`;
+
+          if (response && response.responseJSON && typeof response.responseJSON === 'object') {
+            message = `${response.status} ${response.responseJSON.error}`;
+          }
+
+          if (response.status === 401) {
+            message = 'You do not have the permissions to clear the cache.';
+          }
+
+          return reject(message);
+        });
+    });
+  }
+});

--- a/app/components/build-banner/component.js
+++ b/app/components/build-banner/component.js
@@ -1,5 +1,5 @@
 import { computed } from '@ember/object';
-import { alias, match } from '@ember/object/computed';
+import { alias } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { isActiveBuild, isPRJob } from 'screwdriver-ui/utils/build';
@@ -8,7 +8,6 @@ export default Component.extend({
   classNames: ['build-banner', 'row'],
   classNameBindings: ['buildStatus'],
   coverage: service(),
-  isPR: match('jobName', /^PR-/),
   coverageStep: computed('buildSteps', {
     get() {
       const buildSteps = this.get('buildSteps');

--- a/app/components/pipeline-options/component.js
+++ b/app/components/pipeline-options/component.js
@@ -9,6 +9,8 @@ import { parse, getCheckoutUrl } from '../../utils/git';
 export default Component.extend({
   // Syncing a pipeline
   sync: service('sync'),
+  // Clearing a cache
+  cache: service('cache'),
   errorMessage: '',
   scmUrl: '',
   // Removing a pipeline
@@ -72,6 +74,22 @@ export default Component.extend({
       this.set('isShowingModal', true);
 
       return this.get('sync').syncRequests(this.get('pipeline.id'), syncPath)
+        .catch(error => this.set('errorMessage', error))
+        .finally(() => this.set('isShowingModal', false));
+    },
+    clearCache(scope, id) {
+      let config = {
+        scope,
+        id
+      };
+
+      this.set('isShowingModal', true);
+
+      if (scope === 'pipelines') {
+        config.id = this.get('pipeline.id');
+      }
+
+      return this.get('cache').clearCache(config)
         .catch(error => this.set('errorMessage', error))
         .finally(() => this.set('isShowingModal', false));
     }

--- a/app/components/pipeline-options/template.hbs
+++ b/app/components/pipeline-options/template.hbs
@@ -101,6 +101,40 @@
     </section>
   </div>
 
+  <div class="col-xs-12 col-md-8">
+    <section class="cache">
+      <h3>Cache</h3>
+      <ul>
+        <li>
+          <div class="row">
+            <div class="col-xs-10">
+              <h4>Pipeline</h4>
+              <p>Click to clear the cache for the pipeline.</p>
+            </div>
+            <div class="col-xs-2 right">
+              <a href="#" {{action "clearCache" "pipelines"}} >{{fa-icon "trash"}}</a>
+            </div>
+          </div>
+        </li>
+        {{#each sortedJobs as |job|}}
+        {{#unless job.isPR}}
+        <li>
+          <div class="row">
+            <div class="col-xs-10">
+              <h4>Job {{job.name}}</h4>
+              <p>Click to clear the cache for the {{job.name}} job.</p>
+            </div>
+            <div class="col-xs-2 right" title="Click to clear cache for {{job.name}} job.">
+              <a href="#" {{action "clearCache" "jobs" job.id}}>{{fa-icon "trash"}}</a>
+            </div>
+          </div>
+        </li>
+        {{/unless}}
+        {{/each}}
+      </ul>
+    </section>
+  </div>
+
   {{#unless pipeline.configPipelineId}}
     <div class="col-xs-12 col-md-8">
       <section class="danger">

--- a/app/job/model.js
+++ b/app/job/model.js
@@ -1,10 +1,11 @@
 import EmberObject, { computed } from '@ember/object';
-import { equal } from '@ember/object/computed';
+import { equal, match } from '@ember/object/computed';
 import DS from 'ember-data';
 
 export default DS.Model.extend({
   pipelineId: DS.attr('string'),
   name: DS.attr('string'),
+  isPR: match('name', /^PR-/),
   state: DS.attr('string'),
   permutations: DS.attr(),
   builds: DS.hasMany('build', { async: true }),

--- a/tests/unit/cache/service-test.js
+++ b/tests/unit/cache/service-test.js
@@ -1,0 +1,94 @@
+import { moduleFor, test } from 'ember-qunit';
+import Pretender from 'pretender';
+import Service from '@ember/service';
+
+let server;
+
+const sessionStub = Service.extend({
+  data: {
+    authenticated: {
+      token: 'faketoken'
+    }
+  }
+});
+
+moduleFor('service:cache', 'Unit | Service | cache', {
+  // Specify the other units that are required for this test.
+  // needs: ['service:session'],
+
+  beforeEach() {
+    server = new Pretender();
+    this.register('service:session', sessionStub);
+  },
+
+  afterEach() {
+    server.shutdown();
+  }
+});
+
+test('it exists', function (assert) {
+  const service = this.subject();
+
+  assert.ok(service);
+});
+
+test('it makes a call to delete pipeline cache successfully', function (assert) {
+  server.delete('http://localhost:8081/v1/caches/pipelines/1', () => [204]);
+
+  let service = this.subject();
+
+  assert.ok(service);
+
+  const p = service.clearCache({ scope: 'pipelines', id: '1' });
+
+  p.then(() => {
+    const [request] = server.handledRequests;
+
+    assert.equal(request.status, '204');
+    assert.equal(request.method, 'DELETE');
+    assert.equal(request.url, 'http://localhost:8081/v1/caches/pipelines/1');
+  });
+});
+
+test('it makes a call to delete job cache successfully', function (assert) {
+  server.delete('http://localhost:8081/v1/caches/jobs/1', () => [204]);
+
+  let service = this.subject();
+
+  assert.ok(service);
+
+  const p = service.clearCache({ scope: 'jobs', id: '1' });
+
+  p.then(() => {
+    const [request] = server.handledRequests;
+
+    assert.equal(request.status, '204');
+    assert.equal(request.method, 'DELETE');
+    assert.equal(request.url, 'http://localhost:8081/v1/caches/jobs/1');
+  });
+});
+
+test('it returns 401 on unauthorized deletion', function (assert) {
+  assert.expect(2);
+
+  server.delete('http://localhost:8081/v1/caches/pipelines/1', () => [
+    401,
+    {
+      'Content-Type': 'application/json'
+    },
+    'Unauthorized'
+  ]);
+
+  let service = this.subject();
+
+  assert.ok(service);
+
+  const p = service.clearCache({ scope: 'pipelines', id: '1' });
+
+  p.then(
+    () => {},
+    (err) => {
+      assert.equal(err, 'You do not have the permissions to clear the cache.');
+    }
+  );
+});


### PR DESCRIPTION
## Context
It would be nice if users could invalidate their pipeline or job caches through the UI.

## Objective
This PR adds functionality for clearing job or pipeline cache.

![screencapture-localhost-4200-pipelines-1-options-2018-12-06-16_18_20](https://user-images.githubusercontent.com/3230529/49619720-a71bb900-f972-11e8-8887-e87c126050ba.png)

_Note: not sure how/if we need to add event cache invalidation._

## Related links
Related to https://github.com/screwdriver-cd/screwdriver/issues/1385