### PR TITLE
fix(1335): Allow user to trigger any job

### DIFF
--- a/app/components/pipeline-workflow/component.js
+++ b/app/components/pipeline-workflow/component.js
@@ -61,14 +61,15 @@ export default Component.extend({
     graphClicked(job, mouseevent, sizes) {
       const edges = get(this, 'directedGraph.edges');
       let isRootNode = true;
+      let isTrigger = job ? /^~/.test(job.name) : false;
 
-      // Allow popup when clicking on the root node of a detached pipeline
+      // Find root nodes to determine position of tooltip
       if (job && edges && !/^~/.test(job.name)) {
         isRootNode = isRoot(edges, job.name);
       }
 
       // hide tooltip when not clicking on an active job node or root node
-      if (!job || (!get(job, 'buildId') && isRootNode)) {
+      if (!job || isTrigger) {
         this.set('showTooltip', false);
 
         return false;
@@ -76,6 +77,7 @@ export default Component.extend({
 
       setProperties(this, {
         showTooltip: true,
+        // detached jobs should show tooltip on the left
         showTooltipPosition: isRootNode ? 'left' : 'center',
         tooltipData: {
           job,

--- a/app/components/pipeline-workflow/component.js
+++ b/app/components/pipeline-workflow/component.js
@@ -60,7 +60,7 @@ export default Component.extend({
   actions: {
     graphClicked(job, mouseevent, sizes) {
       const edges = get(this, 'directedGraph.edges');
-      let isRootNode = false;
+      let isRootNode = true;
 
       // Allow popup when clicking on the root node of a detached pipeline
       if (job && edges && !/^~/.test(job.name)) {
@@ -68,7 +68,7 @@ export default Component.extend({
       }
 
       // hide tooltip when not clicking on an active job node or root node
-      if (!job || (!get(job, 'buildId') && !isRootNode)) {
+      if (!job || (!get(job, 'buildId') && isRootNode)) {
         this.set('showTooltip', false);
 
         return false;


### PR DESCRIPTION
## Context
Users should be able to start from any job.

## Objective
This PR fixes a bug that set all jobs to `isRootNode = false` and allows users to start any job as long as it is not root.

## Related links
Related to https://github.com/screwdriver-cd/screwdriver/issues/1335