### PR TITLE
fix: remove `withCredentials` for SD store

### DIFF
--- a/app/cache/service.js
+++ b/app/cache/service.js
@@ -24,9 +24,6 @@ export default Service.extend({
       type: 'DELETE',
       contentType: 'application/json',
       crossDomain: true,
-      xhrFields: {
-        withCredentials: true
-      },
       headers: {
         Authorization: `Bearer ${get(this, 'session.data.authenticated.token')}`
       }


### PR DESCRIPTION
1. SD store service doesn't need cookies
2. CORS credential mode will need to see `Access-Control-Allow-Credentials: true` in the response