### PR TITLE
fix(1460): Add build blocked info in init step [3]

### DIFF
--- a/app/components/build-log/component.js
+++ b/app/components/build-log/component.js
@@ -77,6 +77,14 @@ export default Component.extend({
             n: 1
           });
 
+          if (buildStats.blockedStartTime) {
+            initLogs.push({
+              t: new Date(buildStats.blockedStartTime).getTime(),
+              m: 'Build blocked, putting back into queue.',
+              n: 1
+            });
+          }
+
           if (buildStats.hostname) {
             initLogs.push({
               t: new Date(buildStats.imagePullStartTime).getTime(),

--- a/tests/integration/components/build-log/component-test.js
+++ b/tests/integration/components/build-log/component-test.js
@@ -148,6 +148,52 @@ test('it generate logs for init step', function (assert) {
   });
 });
 
+test('it generate logs for init step when build is blocked', function (assert) {
+  this.set('stats', {
+    queueEnterTime: '2019-01-14T20:10:41.238Z',
+    blockedStartTime: '2019-01-14T20:10:42.238Z',
+    imagePullStartTime: '2019-01-14T20:11:41.238Z',
+    hostname: 'node12.foo.bar.com'
+  });
+  this.set('step', 'sd-setup-init');
+  this.render(hbs`{{build-log
+    stepName=step
+    buildId=1
+    buildStartTime="2019-01-14T20:12:41.238Z"
+    stepStartTime="2019-01-14T20:09:41.238Z"
+    stepEndTime="2019-01-14T20:12:41.238Z"
+    buildStats=stats
+  }}`);
+
+  return wait().then(() => {
+    assert.ok(
+      this.$('.line:first').text().trim().match(
+        'Build created'
+      )
+    );
+    assert.ok(
+      this.$('.line:eq(1)').text().trim().match(
+        'Build enqueued'
+      )
+    );
+    assert.ok(
+      this.$('.line:eq(2)').text().trim().match(
+        'Build blocked, putting back into queue'
+      )
+    );
+    assert.ok(
+      this.$('.line:eq(3)').text().trim().match(
+        'Build scheduled on node12.foo.bar.com'
+      )
+    );
+    assert.ok(
+      this.$('.line:last').text().trim().match(
+        'Image pull completed'
+      )
+    );
+  });
+});
+
 test('it generate logs for failed init step', function (assert) {
   this.set('stats', {
     queueEnterTime: '2019-01-14T20:10:41.238Z',


### PR DESCRIPTION
Adding `blockedStartTime` to build stats to track gap of time between time when build is enqueued and when it starts running.

Note: Need to merge changes in /screwdriver pipeline to prod first.

Related to https://github.com/screwdriver-cd/screwdriver/issues/1460
