### PR TITLE
fix: Show breakdown of total build time

### DIFF
--- a/app/build/model.js
+++ b/app/build/model.js
@@ -75,7 +75,7 @@ export default DS.Model.extend({
   }),
   imagePullDuration: computed('stats.imagePullStartTime', 'startTime', {
     get() {
-      return durationText.call(this, 'stats.imagePullStartTime', 'stats.startTime');
+      return durationText.call(this, 'stats.imagePullStartTime', 'startTime');
     }
   }),
   truncatedMessage: computed('commit.message', {

--- a/app/build/model.js
+++ b/app/build/model.js
@@ -75,14 +75,6 @@ export default DS.Model.extend({
       return durationText.call(this, 'stats.imagePullStartTime', 'startTime');
     }
   }),
-  truncatedMessage: computed('commit.message', {
-    get() {
-      const msg = this.get('commit.message');
-      const cutOff = 150;
-
-      return msg.length > cutOff ? `${msg.substring(0, cutOff)}...` : msg;
-    }
-  }),
   buildDuration: computed('startTime', 'endTime', {
     get() {
       return durationText.call(this, 'startTime', 'endTime');

--- a/app/build/model.js
+++ b/app/build/model.js
@@ -63,16 +63,13 @@ export default DS.Model.extend({
       return `${dt} ago`;
     }
   }),
-  queuedDuration: computed('createTime', 'stats.blockedStartTime', {
+  // Queue time and blocked time are merged into blockedDuration
+  blockedDuration: computed('createTime', 'stats.imagePullStartTime', {
     get() {
-      return durationText.call(this, 'createTime', 'stats.blockedStartTime');
+      return durationText.call(this, 'createTime', 'stats.imagePullStartTime');
     }
   }),
-  blockedDuration: computed('stats.{blockedStartTime,imagePullStartTime}', {
-    get() {
-      return durationText.call(this, 'stats.blockedStartTime', 'stats.imagePullStartTime');
-    }
-  }),
+  // Time it takes to pull the image
   imagePullDuration: computed('stats.imagePullStartTime', 'startTime', {
     get() {
       return durationText.call(this, 'stats.imagePullStartTime', 'startTime');

--- a/app/build/model.js
+++ b/app/build/model.js
@@ -68,7 +68,12 @@ export default DS.Model.extend({
       return durationText.call(this, 'createTime', 'startTime');
     }
   }),
-  buildDuration: computed('createTime', 'endTime', {
+  buildDuration: computed('startTime', 'endTime', {
+    get() {
+      return durationText.call(this, 'startTime', 'endTime');
+    }
+  }),
+  totalDuration: computed('createTime', 'endTime', {
     get() {
       return durationText.call(this, 'createTime', 'endTime');
     }

--- a/app/build/model.js
+++ b/app/build/model.js
@@ -63,9 +63,27 @@ export default DS.Model.extend({
       return `${dt} ago`;
     }
   }),
-  queuedDuration: computed('createTime', 'startTime', {
+  queuedDuration: computed('createTime', 'stats.blockedStartTime', {
     get() {
-      return durationText.call(this, 'createTime', 'startTime');
+      return durationText.call(this, 'createTime', 'stats.blockedStartTime');
+    }
+  }),
+  blockedDuration: computed('stats.{blockedStartTime,imagePullStartTime}', {
+    get() {
+      return durationText.call(this, 'stats.blockedStartTime', 'stats.imagePullStartTime');
+    }
+  }),
+  imagePullDuration: computed('stats.imagePullStartTime', 'startTime', {
+    get() {
+      return durationText.call(this, 'stats.imagePullStartTime', 'stats.startTime');
+    }
+  }),
+  truncatedMessage: computed('commit.message', {
+    get() {
+      const msg = this.get('commit.message');
+      const cutOff = 150;
+
+      return msg.length > cutOff ? `${msg.substring(0, cutOff)}...` : msg;
     }
   }),
   buildDuration: computed('startTime', 'endTime', {

--- a/app/components/build-banner/component.js
+++ b/app/components/build-banner/component.js
@@ -103,7 +103,6 @@ export default Component.extend({
     this._super(...arguments);
 
     this.set('coverageInfoSet', false);
-    this.set('showDurationDetail', false);
 
     this.coverageInfoCompute();
   },
@@ -134,10 +133,6 @@ export default Component.extend({
       } else {
         this.get('onStart')();
       }
-    },
-
-    toggleDurationDetail() {
-      this.set('showDurationDetail', !this.get('showDurationDetail'));
     }
   }
 });

--- a/app/components/build-banner/component.js
+++ b/app/components/build-banner/component.js
@@ -103,6 +103,7 @@ export default Component.extend({
     this._super(...arguments);
 
     this.set('coverageInfoSet', false);
+    this.set('showDurationDetail', false);
 
     this.coverageInfoCompute();
   },
@@ -133,6 +134,10 @@ export default Component.extend({
       } else {
         this.get('onStart')();
       }
+    },
+
+    toggleDurationDetail() {
+      this.set('showDurationDetail', !this.get('showDurationDetail'));
     }
   }
 });

--- a/app/components/build-banner/styles.scss
+++ b/app/components/build-banner/styles.scss
@@ -14,6 +14,12 @@ ul {
   grid-column: 9;
 }
 
+li .subsection {
+  border-left: none;
+  font-weight: $weight-normal;
+  font-size: 12px;
+}
+
 li {
   border-left: 1px solid $sd-text-med;
   padding: 5px 10px;

--- a/app/components/build-banner/template.hbs
+++ b/app/components/build-banner/template.hbs
@@ -34,9 +34,8 @@
   {{/if}}
   <li class="duration">
     <details>
-      <summary><a><span class="banner-value" title="Total duration: {{duration}}, Queue time: {{queueDuration}}, Blocked time: {{blockDuration}}, Image pull time: {{imagePullDuration}}, Build time: {{buildDuration}}">{{duration}}</span></a></summary>
-        <li class="subsection"><span class="banner-value">{{queueDuration}} in queue</span></li>
-        <li class="subsection"><span class="banner-value">{{blockDuration}} blocked</span></li>
+      <summary><a><span class="banner-value" title="Total duration: {{duration}}, Blocked time: {{blockDuration}}, Image pull time: {{imagePullDuration}}, Build time: {{buildDuration}}">{{duration}}</span></a></summary>
+        {{#unless (eq blockDuration "0 seconds")}}<li class="subsection"><span class="banner-value">{{blockDuration}} blocked</span></li>{{/unless}}
         <li class="subsection"><span class="banner-value">{{imagePullDuration}} pulling image</span></li>
         <li class="subsection"><span class="banner-value">{{buildDuration}} in build</span></li>
     </details>

--- a/app/components/build-banner/template.hbs
+++ b/app/components/build-banner/template.hbs
@@ -33,7 +33,11 @@
     </li>
   {{/if}}
   <li class="duration">
-    <span class="banner-value">{{duration}}</span>
+    <a onClick={{action "toggleDurationDetail"}}><span class="banner-value showClick show" title="Total duration: {{duration}}, Queue time: {{queueDuration}}, Build time: {{buildDuration}}">{{duration}}</span></a>
+    {{#if showDurationDetail}}
+      <li class="subsection"><span class="banner-value">{{queueDuration}} in queue</span></li>
+      <li class="subsection"><span class="banner-value">{{buildDuration}} in build</span></li>
+    {{/if}}
     <span class="banner-label">Duration</span>
   </li>
   <li class="created">

--- a/app/components/build-banner/template.hbs
+++ b/app/components/build-banner/template.hbs
@@ -33,11 +33,13 @@
     </li>
   {{/if}}
   <li class="duration">
-    <a onClick={{action "toggleDurationDetail"}}><span class="banner-value showClick show" title="Total duration: {{duration}}, Queue time: {{queueDuration}}, Build time: {{buildDuration}}">{{duration}}</span></a>
-    {{#if showDurationDetail}}
-      <li class="subsection"><span class="banner-value">{{queueDuration}} in queue</span></li>
-      <li class="subsection"><span class="banner-value">{{buildDuration}} in build</span></li>
-    {{/if}}
+    <details>
+      <summary><a><span class="banner-value" title="Total duration: {{duration}}, Queue time: {{queueDuration}}, Blocked time: {{blockDuration}}, Image pull time: {{imagePullDuration}}, Build time: {{buildDuration}}">{{duration}}</span></a></summary>
+        <li class="subsection"><span class="banner-value">{{queueDuration}} in queue</span></li>
+        <li class="subsection"><span class="banner-value">{{blockDuration}} blocked</span></li>
+        <li class="subsection"><span class="banner-value">{{imagePullDuration}} pulling image</span></li>
+        <li class="subsection"><span class="banner-value">{{buildDuration}} in build</span></li>
+    </details>
     <span class="banner-label">Duration</span>
   </li>
   <li class="created">

--- a/app/components/workflow-graph-d3/component.js
+++ b/app/components/workflow-graph-d3/component.js
@@ -177,7 +177,7 @@ export default Component.extend({
       })
       // add a tooltip
       .insert('title')
-      .text(d => `${d.name} - ${d.status}`);
+      .text(d => (d.status ? (`${d.name} - ${d.status}`) : d.name));
 
     // Job Names
     if (TITLE_SIZE && get(this, 'displayJobNames')) {

--- a/app/pipeline/build/template.hbs
+++ b/app/pipeline/build/template.hbs
@@ -2,6 +2,8 @@
   buildContainer=build.buildContainer
   duration=build.totalDuration
   queueDuration=build.queuedDuration
+  blockDuration=build.blockedDuration
+  imagePullDuration=build.imagePullDuration
   buildDuration=build.buildDuration
   buildStatus=build.status
   buildCreate=build.createTime

--- a/app/pipeline/build/template.hbs
+++ b/app/pipeline/build/template.hbs
@@ -1,6 +1,8 @@
 {{build-banner
   buildContainer=build.buildContainer
-  duration=build.buildDuration
+  duration=build.totalDuration
+  queueDuration=build.queuedDuration
+  buildDuration=build.buildDuration
   buildStatus=build.status
   buildCreate=build.createTime
   buildStart=build.startTime

--- a/app/pipeline/build/template.hbs
+++ b/app/pipeline/build/template.hbs
@@ -1,7 +1,6 @@
 {{build-banner
   buildContainer=build.buildContainer
   duration=build.totalDuration
-  queueDuration=build.queuedDuration
   blockDuration=build.blockedDuration
   imagePullDuration=build.imagePullDuration
   buildDuration=build.buildDuration

--- a/tests/integration/components/build-banner/component-test.js
+++ b/tests/integration/components/build-banner/component-test.js
@@ -85,7 +85,11 @@ test('it renders', function (assert) {
   this.set('eventMock', eventMock);
   this.render(hbs`{{build-banner
     buildContainer="node:6"
-    duration="5 seconds"
+    duration="11 seconds"
+    queueDuration="1 second"
+    blockDuration="3 seconds"
+    imagePullDuration="5 seconds"
+    buildDuration="2 seconds"
     buildStatus="RUNNING"
     buildCreate="2016-11-04T20:08:41.238Z"
     buildStart="2016-11-04T20:09:41.238Z"
@@ -103,7 +107,8 @@ test('it renders', function (assert) {
   assert.equal($('.commit a').prop('href'),
     'http://example.com/batcave/batmobile/commit/abcdef1029384');
   assert.equal($('.commit a').text().trim(), '#abcdef');
-  assert.equal($('.duration .banner-value').text().trim(), '5 seconds');
+  assert.equal($('.duration .banner-value').text().trim(), '11 seconds1 second ' +
+  'in queue3 seconds blocked5 seconds pulling image2 seconds in build');
   assert.equal($('.created .banner-value').text().trim(), expectedTime);
   assert.equal($('.user .banner-value').text().trim(), 'Bruce W');
   assert.equal($('.docker-container .banner-value').text().trim(), 'node:6');
@@ -127,6 +132,10 @@ test('it renders pr link if pr url info is available', function (assert) {
   this.render(hbs`{{build-banner
     buildContainer="node:6"
     duration="5 seconds"
+    queueDuration="0 seconds"
+    blockDuration="0 seconds"
+    imagePullDuration="0 seconds"
+    buildDuration="0 seconds"
     buildStatus="RUNNING"
     buildCreate="2016-11-04T20:08:41.238Z"
     buildStart="2016-11-04T20:09:41.238Z"
@@ -146,7 +155,8 @@ test('it renders pr link if pr url info is available', function (assert) {
   assert.equal($('.commit a').prop('href'),
     'http://example.com/batcave/batmobile/commit/abcdef1029384');
   assert.equal($('.commit a').text().trim(), '#abcdef');
-  assert.equal($('.duration .banner-value').text().trim(), '5 seconds');
+  assert.equal($('.duration .banner-value').text().trim(), '5 seconds0 seconds' +
+  ' in queue0 seconds blocked0 seconds pulling image0 seconds in build');
   assert.equal($('.created .banner-value').text().trim(), expectedTime);
   assert.equal($('.user .banner-value').text().trim(), 'Bruce W');
   assert.equal($('.docker-container .banner-value').text().trim(), 'node:6');
@@ -171,6 +181,10 @@ test('it renders prCommit dropdown if event type is pr', function (assert) {
   this.render(hbs`{{build-banner
     buildContainer="node:6"
     duration="5 seconds"
+    queueDuration="0 seconds"
+    blockDuration="0 seconds"
+    imagePullDuration="0 seconds"
+    buildDuration="0 seconds"
     buildStatus="RUNNING"
     buildCreate="2016-11-04T20:08:41.238Z"
     buildStart="2016-11-04T20:09:41.238Z"
@@ -191,7 +205,8 @@ test('it renders prCommit dropdown if event type is pr', function (assert) {
     'http://example.com/batcave/batmobile/commit/abcdef1029384');
   assert.equal($('.commit .commit-sha').text().trim(), '#abcdef');
   assert.equal($('.commit ul li').text().trim(), '1. abcdef');
-  assert.equal($('.duration .banner-value').text().trim(), '5 seconds');
+  assert.equal($('.duration .banner-value').text().trim(), '5 seconds0 seconds' +
+  ' in queue0 seconds blocked0 seconds pulling image0 seconds in build');
   assert.equal($('.created .banner-value').text().trim(), expectedTime);
   assert.equal($('.user .banner-value').text().trim(), 'Bruce W');
   assert.equal($('.docker-container .banner-value').text().trim(), 'node:6');

--- a/tests/integration/components/build-banner/component-test.js
+++ b/tests/integration/components/build-banner/component-test.js
@@ -86,8 +86,7 @@ test('it renders', function (assert) {
   this.render(hbs`{{build-banner
     buildContainer="node:6"
     duration="11 seconds"
-    queueDuration="1 second"
-    blockDuration="3 seconds"
+    blockDuration="4 seconds"
     imagePullDuration="5 seconds"
     buildDuration="2 seconds"
     buildStatus="RUNNING"
@@ -107,8 +106,8 @@ test('it renders', function (assert) {
   assert.equal($('.commit a').prop('href'),
     'http://example.com/batcave/batmobile/commit/abcdef1029384');
   assert.equal($('.commit a').text().trim(), '#abcdef');
-  assert.equal($('.duration .banner-value').text().trim(), '11 seconds1 second ' +
-  'in queue3 seconds blocked5 seconds pulling image2 seconds in build');
+  assert.equal($('.duration .banner-value').text().trim(), '11 seconds' +
+  '4 seconds blocked5 seconds pulling image2 seconds in build');
   assert.equal($('.created .banner-value').text().trim(), expectedTime);
   assert.equal($('.user .banner-value').text().trim(), 'Bruce W');
   assert.equal($('.docker-container .banner-value').text().trim(), 'node:6');
@@ -132,7 +131,6 @@ test('it renders pr link if pr url info is available', function (assert) {
   this.render(hbs`{{build-banner
     buildContainer="node:6"
     duration="5 seconds"
-    queueDuration="0 seconds"
     blockDuration="0 seconds"
     imagePullDuration="0 seconds"
     buildDuration="0 seconds"
@@ -156,7 +154,7 @@ test('it renders pr link if pr url info is available', function (assert) {
     'http://example.com/batcave/batmobile/commit/abcdef1029384');
   assert.equal($('.commit a').text().trim(), '#abcdef');
   assert.equal($('.duration .banner-value').text().trim(), '5 seconds0 seconds' +
-  ' in queue0 seconds blocked0 seconds pulling image0 seconds in build');
+  ' pulling image0 seconds in build');
   assert.equal($('.created .banner-value').text().trim(), expectedTime);
   assert.equal($('.user .banner-value').text().trim(), 'Bruce W');
   assert.equal($('.docker-container .banner-value').text().trim(), 'node:6');
@@ -181,7 +179,6 @@ test('it renders prCommit dropdown if event type is pr', function (assert) {
   this.render(hbs`{{build-banner
     buildContainer="node:6"
     duration="5 seconds"
-    queueDuration="0 seconds"
     blockDuration="0 seconds"
     imagePullDuration="0 seconds"
     buildDuration="0 seconds"
@@ -206,7 +203,7 @@ test('it renders prCommit dropdown if event type is pr', function (assert) {
   assert.equal($('.commit .commit-sha').text().trim(), '#abcdef');
   assert.equal($('.commit ul li').text().trim(), '1. abcdef');
   assert.equal($('.duration .banner-value').text().trim(), '5 seconds0 seconds' +
-  ' in queue0 seconds blocked0 seconds pulling image0 seconds in build');
+  ' pulling image0 seconds in build');
   assert.equal($('.created .banner-value').text().trim(), expectedTime);
   assert.equal($('.user .banner-value').text().trim(), 'Bruce W');
   assert.equal($('.docker-container .banner-value').text().trim(), 'node:6');

--- a/tests/unit/build/model-test.js
+++ b/tests/unit/build/model-test.js
@@ -16,13 +16,45 @@ test('it exists and has statusMessage defaults to null', function (assert) {
 test('it calculates queuedDuration', function (assert) {
   let model = this.subject({
     createTime: new Date(1472244582531),
-    startTime: new Date(1472244592531)
+    stats: {
+      blockedStartTime: new Date(1472244592531)
+    }
   });
 
   run(() => {
     assert.equal(model.get('queuedDuration'), '10 seconds');
-    model.set('startTime', null);
+    model.set('stats.blockedStartTime', null);
     assert.equal(model.get('queuedDuration'), '0 seconds');
+  });
+});
+
+test('it calculates blockedDuration', function (assert) {
+  let model = this.subject({
+    stats: {
+      blockedStartTime: new Date(1472244582531),
+      imagePullStartTime: new Date(1472244592531)
+    }
+  });
+
+  run(() => {
+    assert.equal(model.get('blockedDuration'), '10 seconds');
+    model.set('stats.imagePullStartTime', null);
+    assert.equal(model.get('blockedDuration'), '0 seconds');
+  });
+});
+
+test('it calculates imagePullDuration', function (assert) {
+  let model = this.subject({
+    stats: {
+      imagePullStartTime: new Date(1472244582531)
+    },
+    startTime: new Date(1472244592531)
+  });
+
+  run(() => {
+    assert.equal(model.get('imagePullDuration'), '10 seconds');
+    model.set('startTime', null);
+    assert.equal(model.get('imagePullDuration'), '0 seconds');
   });
 });
 

--- a/tests/unit/build/model-test.js
+++ b/tests/unit/build/model-test.js
@@ -13,25 +13,10 @@ test('it exists and has statusMessage defaults to null', function (assert) {
   assert.equal(model.get('statusMessage'), null);
 });
 
-test('it calculates queuedDuration', function (assert) {
+test('it calculates blockedDuration', function (assert) {
   let model = this.subject({
     createTime: new Date(1472244582531),
     stats: {
-      blockedStartTime: new Date(1472244592531)
-    }
-  });
-
-  run(() => {
-    assert.equal(model.get('queuedDuration'), '10 seconds');
-    model.set('stats.blockedStartTime', null);
-    assert.equal(model.get('queuedDuration'), '0 seconds');
-  });
-});
-
-test('it calculates blockedDuration', function (assert) {
-  let model = this.subject({
-    stats: {
-      blockedStartTime: new Date(1472244582531),
       imagePullStartTime: new Date(1472244592531)
     }
   });

--- a/tests/unit/build/model-test.js
+++ b/tests/unit/build/model-test.js
@@ -28,7 +28,8 @@ test('it calculates queuedDuration', function (assert) {
 
 test('it calculates buildDuration', function (assert) {
   let model = this.subject({
-    createTime: new Date(1472244582531),
+    createTime: new Date(1472244572531),
+    startTime: new Date(1472244582531),
     endTime: new Date(1472244592531)
   });
 
@@ -40,8 +41,28 @@ test('it calculates buildDuration', function (assert) {
     assert.equal(model.get('buildDuration'), '0 seconds');
     // no start time, so duration is 0
     model.set('endTime', new Date(1472244592531));
-    model.set('createTime', null);
+    model.set('startTime', null);
     assert.equal(model.get('buildDuration'), '0 seconds');
+  });
+});
+
+test('it calculates totalDuration', function (assert) {
+  let model = this.subject({
+    createTime: new Date(1472244572531),
+    startTime: new Date(1472244582531),
+    endTime: new Date(1472244592531)
+  });
+
+  run(() => {
+    // valid duration
+    assert.equal(model.get('totalDuration'), '20 seconds');
+    // no end time, so duration is 0
+    model.set('endTime', null);
+    assert.equal(model.get('totalDuration'), '0 seconds');
+    // no start time, so duration is 0
+    model.set('endTime', new Date(1472244592531));
+    model.set('createTime', null);
+    assert.equal(model.get('totalDuration'), '0 seconds');
   });
 });
 


### PR DESCRIPTION
## Context
It can be confusing for users to see the Duration text in the banner since they might think the build took all that time, when actually the Duration is made up of queue time, blocked by time, image pull time, and build time.

## Objective
This PR adds a title when hovering over build duration banner and expands to show a slight build duration breakdown when clicked. Clicking again hides the breakdown.

_Note: This PR might not be a good idea since we still don't have a good way to break down image pull time vs blocked by time. Not sure if it would be better to wait until we have those times before adding any info to the banner._

Hover example with title:
<img width="970" alt="screen shot 2019-02-01 at 2 13 33 pm" src="https://user-images.githubusercontent.com/3230529/52154398-84381900-2632-11e9-861f-2f3575658cbf.png">

Expansion example:
<img width="964" alt="screen shot 2019-02-05 at 2 06 44 pm" src="https://user-images.githubusercontent.com/3230529/52307389-5400bb00-294f-11e9-9369-f397f591615b.png">

This PR also fixes so it will not show undefined for build status on hover over a build in the workflow graph (e.g.: `main - undefined`). It will just show job name until status is generated.
