### PR TITLE
fix(1474): Show more detail for build durations

### DIFF
--- a/app/build/model.js
+++ b/app/build/model.js
@@ -38,8 +38,8 @@ function calcDuration(start, end) {
  * @param  {String}         end   key for end time
  * @return {String}               human readable text for duration
  */
-function durationText(start, end) {
-  return humanizeDuration(calcDuration.call(this, start, end), { round: true, largest: 1 });
+function durationText(start, end, largest = 1) {
+  return humanizeDuration(calcDuration.call(this, start, end), { round: true, largest });
 }
 
 export default DS.Model.extend({
@@ -72,23 +72,23 @@ export default DS.Model.extend({
   // Queue time and blocked time are merged into blockedDuration
   blockedDuration: computed('createTime', 'stats.imagePullStartTime', {
     get() {
-      return durationText.call(this, 'createTime', 'stats.imagePullStartTime');
+      return durationText.call(this, 'createTime', 'stats.imagePullStartTime', 2);
     }
   }),
   // Time it takes to pull the image
   imagePullDuration: computed('stats.imagePullStartTime', 'startTime', {
     get() {
-      return durationText.call(this, 'stats.imagePullStartTime', 'startTime');
+      return durationText.call(this, 'stats.imagePullStartTime', 'startTime', 2);
     }
   }),
   buildDuration: computed('startTime', 'endTime', {
     get() {
-      return durationText.call(this, 'startTime', 'endTime');
+      return durationText.call(this, 'startTime', 'endTime', 2);
     }
   }),
   totalDuration: computed('createTime', 'endTime', {
     get() {
-      return durationText.call(this, 'createTime', 'endTime');
+      return durationText.call(this, 'createTime', 'endTime', 2);
     }
   }),
   totalDurationMS: computed('createTime', 'endTime', {

--- a/tests/unit/build/model-test.js
+++ b/tests/unit/build/model-test.js
@@ -37,7 +37,7 @@ test('it calculates imagePullDuration', function (assert) {
   });
 
   run(() => {
-    assert.equal(model.get('imagePullDuration'), '1 minute');
+    assert.equal(model.get('imagePullDuration'), '1 minute, 1 second');
     model.set('startTime', null);
     assert.equal(model.get('imagePullDuration'), '0 seconds');
   });


### PR DESCRIPTION
## Context
Currently, we're rounding up to 1 unit of time. It can be confusing for people to see numbers that don't add up in their build duration breakdown.
Example:
<img width="161" alt="screen shot 2019-02-07 at 11 50 13 am" src="https://user-images.githubusercontent.com/3230529/52438625-9270b400-2ace-11e9-8d93-9b87d3b99276.png">

## Objective
This PR changes the durations to show to 2 units by default.
Example:
<img width="180" alt="screen shot 2019-02-07 at 11 56 36 am" src="https://user-images.githubusercontent.com/3230529/52439029-74578380-2acf-11e9-8b41-7fd16001ed00.png">

## Related Links
Related to https://github.com/screwdriver-cd/screwdriver/issues/1474
