### PR TITLE
Tweak log color

### DIFF
--- a/app/components/build-log/styles.scss
+++ b/app/components/build-log/styles.scss
@@ -64,3 +64,36 @@
 .right {
   text-align: right;
 }
+
+.ansi-black-fg { color: #3A3A3A; }
+.ansi-red-fg { color: #FF3B20; }
+.ansi-green-fg { color: #11D911; }
+.ansi-yellow-fg { color: #D9D911; }
+.ansi-blue-fg { color: #2235D7; }
+.ansi-magenta-fg { color: #D950D7; }
+.ansi-cyan-fg { color: #00C5C7; }
+.ansi-white-fg { color: #C7C7C7; }
+.ansi-bright-black-fg { color: #676767; }
+.ansi-bright-red-fg { color: #FF6D67; }
+.ansi-bright-green-fg { color: #5FF967; }
+.ansi-bright-yellow-fg { color: #FEFB67; }
+.ansi-bright-blue-fg { color: #6871FF; }
+.ansi-bright-magenta-fg { color: #FF76FF; }
+.ansi-bright-cyan-fg { color: #5FFDFF; }
+.ansi-bright-white-fg { color: #FEFFFF; }
+.ansi-black-bg { background-color: #2A2A2A; }
+.ansi-red-bg { background-color: #D92B10; }
+.ansi-green-bg { background-color: #11D911; }
+.ansi-yellow-bg { background-color: #D9D911; }
+.ansi-blue-bg { background-color: #2235D7; }
+.ansi-magenta-bg { background-color: #D950D7; }
+.ansi-cyan-bg { background-color: #00C5C7; }
+.ansi-white-bg { background-color: #C7C7C7; }
+.ansi-bright-black-bg { background-color: #676767; }
+.ansi-bright-red-bg { background-color: #FF6D67; }
+.ansi-bright-green-bg { background-color: #5FF967; }
+.ansi-bright-yellow-bg { background-color: #FEFB67; }
+.ansi-bright-blue-bg { background-color: #6871FF; }
+.ansi-bright-magenta-bg { background-color: #FF76FF; }
+.ansi-bright-cyan-bg { background-color: #5FFDFF; }
+.ansi-bright-white-bg { background-color: #FEFFFF; }

--- a/app/helpers/ansi-colorize.js
+++ b/app/helpers/ansi-colorize.js
@@ -6,6 +6,7 @@ const ansiUp = new AnsiUp();
 
 // Prevent double-encoding
 ansiUp.escape_for_html = false;
+ansiUp.use_classes = true;
 
 /**
  * Transform ansi color codes to html tags

--- a/tests/unit/helpers/ansi-colorize-test.js
+++ b/tests/unit/helpers/ansi-colorize-test.js
@@ -14,5 +14,5 @@ test('it escapes html', function (assert) {
 test('colorizes ansi codes', function (assert) {
   let result = ansiColorize(['\u001b[32m<main>\u001b[0m']);
 
-  assert.equal(result.toString(), '<span style="color:rgb(0,187,0)">&lt;main&gt;</span>');
+  assert.equal(result.toString(), '<span class="ansi-green-fg">&lt;main&gt;</span>');
 });


### PR DESCRIPTION
## Context
I think logs displayed on bulid page is hard to read for users especially red one.

## Objective
I fixed it by specifying color codes for each ansi color.

**Color diff**:

<img width="680" alt="2019-02-11 21 31 25" src="https://user-images.githubusercontent.com/1608595/52563704-87f34900-2e45-11e9-9da7-72bcb0d042ec.png">
<img width="684" alt="2019-02-11 21 28 33" src="https://user-images.githubusercontent.com/1608595/52563689-7f027780-2e45-11e9-86fb-816a1d87bbc9.png">

<img width="323" alt="2019-02-11 21 32 27" src="https://user-images.githubusercontent.com/1608595/52563738-9ccfdc80-2e45-11e9-8a8e-2d808ff22797.png">
<img width="324" alt="2019-02-11 21 30 24" src="https://user-images.githubusercontent.com/1608595/52563744-a0636380-2e45-11e9-932d-f95e60296667.png">

<img width="408" alt="2019-02-11 21 31 56" src="https://user-images.githubusercontent.com/1608595/52563753-a6f1db00-2e45-11e9-8b99-10936624a020.png">
<img width="414" alt="2019-02-11 21 29 48" src="https://user-images.githubusercontent.com/1608595/52563763-a9eccb80-2e45-11e9-9e3a-58e4008a62d6.png">
