### PR TITLE
fix: add side icons for FROZEN and COLLAPSED

### DIFF
--- a/app/utils/build.js
+++ b/app/utils/build.js
@@ -29,6 +29,13 @@ const statusIcon = (status, isLight) => {
   case 'UNSTABLE':
     icon = 'exclamation-circle';
     break;
+  case 'FROZEN':
+    icon = 'fa-snowflake-o';
+    break;
+  case 'BLOCKED':
+  case 'COLLAPSED':
+    icon = 'fa-ban fa-flip-horizontal';
+    break;
   default:
     icon = `times-circle${isLight ? '-o' : ''}`;
     break;


### PR DESCRIPTION
the icon for `FROZEN` is not exactly the same as what we have in the graph cuz that one is from icomoon, not font awesome

https://fontawesome.com/icons/snowflake?style=solid

<img width="258" alt="screen shot 2019-02-20 at 3 02 19 pm" src="https://user-images.githubusercontent.com/20427140/53131061-aa115900-3520-11e9-80e8-7e2752246fcf.png">
<img width="270" alt="screen shot 2019-02-20 at 3 02 02 pm" src="https://user-images.githubusercontent.com/20427140/53131064-ada4e000-3520-11e9-8702-4e0db5412dd1.png">
