### PR TITLE
fix(1452): display tests results on build page

### DIFF
--- a/app/components/build-banner/component.js
+++ b/app/components/build-banner/component.js
@@ -8,6 +8,7 @@ export default Component.extend({
   classNames: ['build-banner', 'row'],
   classNameBindings: ['buildStatus'],
   coverage: service(),
+  coverageInfo: {},
   coverageStep: computed('buildSteps', {
     get() {
       const buildSteps = this.get('buildSteps');
@@ -71,6 +72,27 @@ export default Component.extend({
     }
   }),
 
+  overrideCoverageInfo() {
+    const buildMeta = this.get('buildMeta');
+
+    // override coverage info if set in build meta
+    if (buildMeta && buildMeta.tests) {
+      let coverageInfo = this.get('coverageInfo');
+
+      if (buildMeta.tests.coverage) {
+        coverageInfo.coverage = `${buildMeta.tests.coverage}%`;
+        coverageInfo.coverageUrl = '#';
+      }
+
+      if (this.get('buildMeta').tests.results) {
+        coverageInfo.tests = buildMeta.tests.results;
+        coverageInfo.testsUrl = '#';
+      }
+
+      this.set('coverageInfo', coverageInfo);
+    }
+  },
+
   coverageInfoCompute() {
     // Set coverage query startTime to build start time since user can do coverage during user step
     const buildStartTime = this.get('buildSteps')[0].startTime;
@@ -78,8 +100,10 @@ export default Component.extend({
 
     if (!coverageStepEndTime) {
       this.set('coverageInfo', {
-        projectUrl: '#',
-        coverage: 'N/A'
+        coverage: 'N/A',
+        coverageUrl: '#',
+        tests: 'N/A',
+        testsUrl: '#'
       });
 
       return;
@@ -105,6 +129,7 @@ export default Component.extend({
     this.set('coverageInfoSet', false);
 
     this.coverageInfoCompute();
+    this.overrideCoverageInfo();
   },
 
   willRender() {
@@ -116,6 +141,10 @@ export default Component.extend({
 
     if (this.get('coverageStepEndTime') && !this.get('coverageInfoSet')) {
       this.coverageInfoCompute();
+    }
+
+    if (!isActiveBuild(this.get('buildStatus'), this.get('buildEnd'))) {
+      this.overrideCoverageInfo();
     }
   },
 

--- a/app/components/build-banner/template.hbs
+++ b/app/components/build-banner/template.hbs
@@ -52,11 +52,19 @@
   {{#if coverageStep}}
     <li class="coverage">
       <span class="banner-value">
-        <a href="{{coverageInfo.projectUrl}}" title="{{if (eq coverageInfo.coverage 'N/A') "Coverage report not generated"}}">
+        <a href="{{coverageInfo.coverageUrl}}" title="{{if (eq coverageInfo.coverage 'N/A') "Coverage report not generated"}}">
           {{coverageInfo.coverage}}
         </a>
       </span>
       <span class="banner-label">Coverage</span>
+    </li>
+    <li class="tests">
+      <span class="banner-value">
+        <a href="{{coverageInfo.testsUrl}}" title="{{if (eq coverageInfo.tests 'N/A') "Tests report not generated"}}">
+          {{coverageInfo.tests}}
+        </a>
+      </span>
+      <span class="banner-label">Tests Passed</span>
     </li>
   {{/if}}
   <li class="docker-container">

--- a/app/coverage/service.js
+++ b/app/coverage/service.js
@@ -33,12 +33,16 @@ export default Service.extend({
       // Call the token api to get the session info
       $.ajax(ajaxConfig)
         .done(content => resolve({
-          projectUrl: content.projectUrl || '#',
-          coverage: content.coverage ? `${content.coverage}%` : 'N/A'
+          coverage: content.coverage !== 'N/A' ? `${content.coverage}%` : 'N/A',
+          coverageUrl: content.projectUrl,
+          tests: content.tests,
+          testsUrl: content.projectUrl
         }))
         .fail(() => resolve({
-          projectUrl: '#',
-          coverage: 'N/A'
+          coverage: 'N/A',
+          coverageUrl: '#',
+          tests: 'N/A',
+          testsUrl: '#'
         })
         );
     });

--- a/app/coverage/service.js
+++ b/app/coverage/service.js
@@ -34,9 +34,9 @@ export default Service.extend({
       $.ajax(ajaxConfig)
         .done(content => resolve({
           coverage: content.coverage !== 'N/A' ? `${content.coverage}%` : 'N/A',
-          coverageUrl: content.projectUrl,
+          coverageUrl: content.coverage !== 'N/A' ? content.projectUrl : '#',
           tests: content.tests,
-          testsUrl: content.projectUrl
+          testsUrl: content.tests !== 'N/A' ? content.projectUrl : '#'
         }))
         .fail(() => resolve({
           coverage: 'N/A',

--- a/app/pipeline/build/template.hbs
+++ b/app/pipeline/build/template.hbs
@@ -10,6 +10,7 @@
   buildEnd=build.endTime
   buildSteps=build.steps
   buildId=build.id
+  buildMeta=build.meta
   jobName=job.name
   jobId=job.id
   isAuthenticated=session.isAuthenticated

--- a/tests/integration/components/build-banner/component-test.js
+++ b/tests/integration/components/build-banner/component-test.js
@@ -59,6 +59,13 @@ const buildMock = EmberObject.create({
   id: '2'
 });
 
+const buildMetaMock = {
+  tests: {
+    coverage: '100',
+    results: '10/10'
+  }
+};
+
 moduleForComponent('build-banner', 'Integration | Component | build banner', {
   integration: true,
 
@@ -318,7 +325,7 @@ test('it renders coverage info if coverage step finished', function (assert) {
     }
   ];
 
-  assert.expect(2);
+  assert.expect(4);
   this.set('eventMock', eventMock);
   this.set('buildStepsMock', coverageStepsMock);
   this.set('prEvents', new EmberPromise(resolves => resolves([])));
@@ -339,7 +346,9 @@ test('it renders coverage info if coverage step finished', function (assert) {
 
   return wait().then(() => {
     assert.equal($('.coverage .banner-value').text().trim(), '98%');
+    assert.equal($('.tests .banner-value').text().trim(), '7/10');
     assert.equal($('.coverage a').prop('href'), 'http://example.com/coverage/123');
+    assert.equal($('.tests a').prop('href'), 'http://example.com/coverage/123');
   });
 });
 
@@ -350,7 +359,7 @@ test('it renders default coverage info if coverage step has not finished', funct
     { name: 'sd-teardown-screwdriver-coverage-bookend' }
   ];
 
-  assert.expect(5);
+  assert.expect(7);
 
   this.set('reloadCb', () => {
     assert.ok(true);
@@ -377,7 +386,48 @@ test('it renders default coverage info if coverage step has not finished', funct
   return wait().then(() => {
     assert.equal(this.$('button').text().trim(), 'Stop');
     assert.equal($('.coverage .banner-value').text().trim(), 'N/A');
+    assert.equal($('.tests .banner-value').text().trim(), 'N/A');
     assert.equal($('.coverage a').prop('title'), 'Coverage report not generated');
+    assert.equal($('.tests a').prop('title'), 'Tests report not generated');
+  });
+});
+
+test('it overrides coverage info if it is set in build meta', function (assert) {
+  const $ = this.$;
+  const coverageStepsMock = [
+    { name: 'sd-setup-screwdriver-scm-bookend',
+      startTime: '2016-11-04T20:09:41.238Z'
+    },
+    {
+      name: 'sd-teardown-screwdriver-coverage-bookend',
+      endTime: '2016-11-04T21:09:41.238Z'
+    }
+  ];
+
+  assert.expect(2);
+  this.set('eventMock', eventMock);
+  this.set('buildStepsMock', coverageStepsMock);
+  this.set('buildMetaMock', buildMetaMock);
+  this.set('prEvents', new EmberPromise(resolves => resolves([])));
+
+  this.render(hbs`{{build-banner
+    buildContainer="node:6"
+    duration="5 seconds"
+    buildId=123
+    buildStatus="SUCCESS"
+    buildStart="2016-11-04T20:09:41.238Z"
+    buildSteps=buildStepsMock
+    buildMeta=buildMetaMock
+    jobId=1
+    jobName="main"
+    isAuthenticated=true
+    event=eventMock
+    prEvents=prEvents
+  }}`);
+
+  return wait().then(() => {
+    assert.equal($('.coverage .banner-value').text().trim(), '100%');
+    assert.equal($('.tests .banner-value').text().trim(), '10/10');
   });
 });
 

--- a/tests/integration/components/build-banner/component-test.js
+++ b/tests/integration/components/build-banner/component-test.js
@@ -11,7 +11,9 @@ const coverageService = Service.extend({
   getCoverageInfo() {
     return resolve({
       coverage: '98%',
-      projectUrl: 'http://example.com/coverage/123'
+      coverageUrl: 'http://example.com/coverage/123',
+      tests: '7/10',
+      testsUrl: 'http://example.com/coverage/123'
     });
   }
 });

--- a/tests/unit/coverage/service-test.js
+++ b/tests/unit/coverage/service-test.js
@@ -30,7 +30,11 @@ test('it fetches coverage info', function (assert) {
     {
       'Content-Type': 'application/json'
     },
-    JSON.stringify({ coverage: 98, projectUrl: 'https://sonar.foo.bar' })
+    JSON.stringify({
+      coverage: 98,
+      projectUrl: 'https://sonar.foo.bar',
+      tests: '7/10'
+    })
   ]);
 
   let service = this.subject();
@@ -49,40 +53,12 @@ test('it fetches coverage info', function (assert) {
   p.then((data) => {
     const [request] = server.handledRequests;
 
-    assert.deepEqual(data, { coverage: '98%', projectUrl: 'https://sonar.foo.bar' });
-    assert.deepEqual(request.url,
-    // eslint-disable-next-line max-len
-      'http://localhost:8080/v4/coverage/info?buildId=123&jobId=1&startTime=2018-05-10T19%3A05%3A53.123Z&endTime=2018-05-10T19%3A06%3A53.123Z');
-  });
-});
-
-test('it sets default coverage info when data not available', function (assert) {
-  assert.expect(3);
-  server.get('http://localhost:8080/v4/coverage/info', () => [
-    200,
-    {
-      'Content-Type': 'application/json'
-    },
-    JSON.stringify({})
-  ]);
-
-  let service = this.subject();
-
-  assert.ok(service);
-
-  const config = {
-    buildId: 123,
-    jobId: 1,
-    startTime: '2018-05-10T19:05:53.123Z',
-    endTime: '2018-05-10T19:06:53.123Z'
-  };
-
-  const p = service.getCoverageInfo(config);
-
-  p.then((data) => {
-    const [request] = server.handledRequests;
-
-    assert.deepEqual(data, { coverage: 'N/A', projectUrl: '#' });
+    assert.deepEqual(data, {
+      coverage: '98%',
+      coverageUrl: 'https://sonar.foo.bar',
+      tests: '7/10',
+      testsUrl: 'https://sonar.foo.bar'
+    });
     assert.deepEqual(request.url,
     // eslint-disable-next-line max-len
       'http://localhost:8080/v4/coverage/info?buildId=123&jobId=1&startTime=2018-05-10T19%3A05%3A53.123Z&endTime=2018-05-10T19%3A06%3A53.123Z');
@@ -115,7 +91,12 @@ test('it sets default coverage info when request failed', function (assert) {
   p.then((data) => {
     const [request] = server.handledRequests;
 
-    assert.deepEqual(data, { coverage: 'N/A', projectUrl: '#' });
+    assert.deepEqual(data, {
+      coverage: 'N/A',
+      coverageUrl: '#',
+      tests: 'N/A',
+      testsUrl: '#'
+    });
     assert.deepEqual(request.url,
     // eslint-disable-next-line max-len
       'http://localhost:8080/v4/coverage/info?buildId=123&jobId=1&startTime=2018-05-10T19%3A05%3A53.123Z&endTime=2018-05-10T19%3A06%3A53.123Z');


### PR DESCRIPTION
- display tests results on build page
- override the sonar coverage / tests results if set in meta

<img width="1059" alt="screen shot 2019-02-27 at 2 58 53 pm" src="https://user-images.githubusercontent.com/20427140/53531536-3c2cda80-3aa8-11e9-9251-b354d7da1fe2.png">


Related to: https://github.com/screwdriver-cd/screwdriver/issues/1452