### PR TITLE
fix: add start button for restricted PR

### DIFF
--- a/app/build/model.js
+++ b/app/build/model.js
@@ -75,6 +75,10 @@ export default DS.Model.extend({
   }),
   endTimeWords: computed('endTime', {
     get() {
+      if (!this.get('endTime')) {
+        return null;
+      }
+
       return `${durationText.call(this, 'endTime', 'now')} ago`;
     }
   }),

--- a/app/components/pipeline-pr-list/component.js
+++ b/app/components/pipeline-pr-list/component.js
@@ -1,4 +1,17 @@
 import Component from '@ember/component';
+import { computed } from '@ember/object';
 
 export default Component.extend({
+  didInsertElement() {
+    this._super(...arguments);
+    this.set('inited', false);
+  },
+  inited: true,
+  showJobs: computed('pullRequestGroups.[]', {
+    get() {
+      return this.get('pullRequestGroups').map(
+        group => this.get('inited') || group.some(g => !!g.get('builds.length'))
+      );
+    }
+  })
 });

--- a/app/components/pipeline-pr-list/styles.scss
+++ b/app/components/pipeline-pr-list/styles.scss
@@ -24,3 +24,18 @@
 
   height: 100%;
 }
+
+.startButton {
+  float: right;
+  border: 1px solid $sd-link;
+  background-color: $sd-white;
+  color: $sd-link;
+  border-radius: 2px;
+  padding: 5px 15px;
+  margin-top: 5px;
+
+  &:hover {
+    border-color: $sd-link;
+    color: $sd-white;
+  }
+}

--- a/app/components/pipeline-pr-list/template.hbs
+++ b/app/components/pipeline-pr-list/template.hbs
@@ -1,4 +1,4 @@
-{{#each pullRequestGroups as |groups|}}
+{{#each pullRequestGroups as |groups i|}}
   <div class="view">
     <div class="detail">
       <div class="name">
@@ -11,9 +11,15 @@
       </div>
       <div class="date greyOut">Opened {{groups.0.createTimeWords}}</div>
       <div class="by"><a href="{{groups.0.userProfile}}" target="_blank">{{groups.0.username}}</a></div>
-      {{#each groups as |job|}}
-        {{pipeline-pr-view job=job}}
-      {{/each}}
+      {{#if (get showJobs i)}}
+        {{#each groups as |job|}}
+          {{pipeline-pr-view job=job}}
+        {{/each}}
+      {{else}}
+        {{#if isRestricted}}
+          {{#bs-button type="primary" class="startButton" onClick=(action startBuild groups.0.group)}}Start{{/bs-button}}
+        {{/if}}
+      {{/if}}
     </div>
   </div>
 {{else}}

--- a/app/event/model.js
+++ b/app/event/model.js
@@ -18,6 +18,7 @@ export default DS.Model.extend(ModelReloaderMixin, {
   parentEventId: DS.attr('number'),
   pipelineId: DS.attr('string'),
   pr: DS.attr(),
+  prNum: DS.attr('number'),
   sha: DS.attr('string'),
   startFrom: DS.attr('string'),
   status: DS.attr('string', { defaultValue: 'UNKNOWN' }),

--- a/app/event/serializer.js
+++ b/app/event/serializer.js
@@ -31,7 +31,8 @@ export default DS.RESTSerializer.extend({
   serializeIntoHash(hash, typeClass, snapshot) {
     const data = {
       pipelineId: snapshot.attr('pipelineId'),
-      startFrom: snapshot.attr('startFrom')
+      startFrom: snapshot.attr('startFrom'),
+      prNum: snapshot.attr('prNum')
     };
 
     if (snapshot.attr('causeMessage')) {

--- a/app/pipeline/events/template.hbs
+++ b/app/pipeline/events/template.hbs
@@ -39,17 +39,21 @@
       <div class="tab-content">
         {{#tab.pane activeId=activeTab elementId="events" title="Events"}}
           {{pipeline-events-list
-          events=events
-          selected=(mut selected)
-          selectedEvent=selectedEvent
-          lastSuccessful=lastSuccessful
-          mostRecent=mostRecent
-          eventsPage=eventsPage
-          updateEvents=(action "updateEvents")
-        }}
+            events=events
+            selected=(mut selected)
+            selectedEvent=selectedEvent
+            lastSuccessful=lastSuccessful
+            mostRecent=mostRecent
+            eventsPage=eventsPage
+            updateEvents=(action "updateEvents")
+          }}
         {{/tab.pane}}
         {{#tab.pane activeId=activeTab elementId="pulls" title="Pull Requests"}}
-          {{pipeline-pr-list pullRequestGroups=pullRequestGroups}}
+          {{pipeline-pr-list
+            pullRequestGroups=pullRequestGroups
+            isRestricted=isRestricted
+            startBuild=(action "startPRBuild")
+          }}
         {{/tab.pane}}
       </div>
     {{/bs-tab}}

--- a/app/pipeline/model.js
+++ b/app/pipeline/model.js
@@ -3,6 +3,7 @@ import DS from 'ember-data';
 
 export default DS.Model.extend({
   admins: DS.attr(),
+  annotations: DS.attr(),
   checkoutUrl: DS.attr('string'),
   scmContext: DS.attr('string'),
   createTime: DS.attr('date'),

--- a/tests/integration/components/pipeline-pr-list/component-test.js
+++ b/tests/integration/components/pipeline-pr-list/component-test.js
@@ -46,3 +46,32 @@ test('it renders', function (assert) {
 
   assert.equal(this.$('.alert').text().trim(), 'No open pull requests');
 });
+
+test('it renders start build for restricted PR pipeline', function (assert) {
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+  const jobs = [[
+    EmberObject.create({
+      id: 'abcd',
+      name: 'PR-1234:main',
+      createTimeWords: 'now',
+      title: 'update readme',
+      username: 'anonymous',
+      builds: []
+    })
+  ]];
+
+  this.set('jobsMock', jobs);
+  this.set('isRestricted', true);
+  this.set('startBuild', Function.prototype);
+
+  this.render(hbs`{{pipeline-pr-list
+    pullRequestGroups=jobsMock
+    isRestricted=isRestricted
+    startBuild=startBuild}}`);
+
+  assert.equal(this.$('.view .detail .view').length, 0);
+  assert.equal(this.$('.title').text().trim(), 'update readme');
+  assert.equal(this.$('.by').text().trim(), 'anonymous');
+  assert.equal(this.$('.view .startButton').length, 0);
+});


### PR DESCRIPTION
Since the job & build models are lazily fetched, meaning, you will see the jobs first before their builds info got loaded into the models, the start button won't appear until the next render to accommodate for this flow.

Currently, two possible situations that a PR job that has no build.
1. PR's changed files are not in the sourcePaths of any of the jobs in that PR
2. Restricted PR setting causes no build is ever created (thus https://github.com/screwdriver-cd/screwdriver/issues/1528)

Because we do not mark PR job (whether it's restricted or no build simply becuz of no changed file), the UI has to know when to display the start button only for the (2) case.

There could be more edge cases involving PR restriction. But this PR only address the most common ones.

<img width="478" alt="Screen Shot 2019-03-11 at 5 21 43 PM" src="https://user-images.githubusercontent.com/1331106/54163574-dc331e00-442f-11e9-99e8-9d3586356f45.png">


blocked by: https://github.com/screwdriver-cd/screwdriver/pull/1536
related: https://github.com/screwdriver-cd/screwdriver/issues/1528