### PR TITLE
fix: correct behavior for PR start button

### DIFF
--- a/app/components/pipeline-pr-list/component.js
+++ b/app/components/pipeline-pr-list/component.js
@@ -7,11 +7,9 @@ export default Component.extend({
     this.set('inited', false);
   },
   inited: true,
-  showJobs: computed('pullRequestGroups.[]', {
+  showJobs: computed('jobs.@each.builds', 'inited', {
     get() {
-      return this.get('pullRequestGroups').map(
-        group => this.get('inited') || group.some(g => !!g.get('builds.length'))
-      );
+      return this.get('inited') || this.get('jobs').some(j => !!j.get('builds.length'));
     }
   })
 });

--- a/app/components/pipeline-pr-list/styles.scss
+++ b/app/components/pipeline-pr-list/styles.scss
@@ -6,6 +6,10 @@
     padding: 0 15px;
   }
 
+  &:last-child > .view {
+    border: none;
+  }
+
   &:hover {
     background: none;
   }
@@ -13,12 +17,9 @@
   .view {
     padding-top: 10px;
 
-    &:last-child {
-      border: none;
-    }
-
     .view {
       padding-top: 0;
+      border: none;
     }
   }
 

--- a/app/components/pipeline-pr-list/template.hbs
+++ b/app/components/pipeline-pr-list/template.hbs
@@ -1,30 +1,28 @@
-{{#each pullRequestGroups as |groups i|}}
+{{#if jobs.length }}
   <div class="view">
     <div class="detail">
       <div class="name">
-        <a href="{{groups.0.url}}" target="_blank">
-          PR #{{groups.0.group}}
+        <a href="{{jobs.0.url}}" target="_blank">
+          PR #{{jobs.0.group}}
           <span class="scm">{{fa-icon "code-fork"}}</span>
         </a>
         <br/>
-        <span class="title">{{groups.0.title}}</span>
+        <span class="title">{{jobs.0.title}}</span>
       </div>
-      <div class="date greyOut">Opened {{groups.0.createTimeWords}}</div>
-      <div class="by"><a href="{{groups.0.userProfile}}" target="_blank">{{groups.0.username}}</a></div>
-      {{#if (get showJobs i)}}
-        {{#each groups as |job|}}
+      <div class="date greyOut">Opened {{jobs.0.createTimeWords}}</div>
+      <div class="by"><a href="{{jobs.0.userProfile}}" target="_blank">{{jobs.0.username}}</a></div>
+      {{#if showJobs }}
+        {{#each jobs as |job|}}
           {{pipeline-pr-view job=job}}
         {{/each}}
       {{else}}
         {{#if isRestricted}}
-          {{#bs-button type="primary" class="startButton" onClick=(action startBuild groups.0.group)}}Start{{/bs-button}}
+          {{#bs-button type="primary" class="startButton" onClick=(action startBuild jobs.0.group jobs)}}Start{{/bs-button}}
         {{/if}}
       {{/if}}
     </div>
   </div>
-{{else}}
-  <div class="alert">No open pull requests</div>
-{{/each}}
+{{/if}}
 
 
 

--- a/app/pipeline/events/controller.js
+++ b/app/pipeline/events/controller.js
@@ -245,7 +245,7 @@ export default Controller.extend(ModelReloaderMixin, {
         this.set('errorMessage', Array.isArray(e.errors) ? e.errors[0].detail : '');
       });
     },
-    startPRBuild(prNum) {
+    startPRBuild(prNum, jobs) {
       this.set('isShowingModal', true);
       const user = get(decoder(this.get('session.data.authenticated.token')), 'username');
       const newEvent = this.store.createRecord('event', {
@@ -262,7 +262,7 @@ export default Controller.extend(ModelReloaderMixin, {
           this.set('isShowingModal', false);
           this.set('errorMessage', Array.isArray(e.errors) ? e.errors[0].detail : '');
         })
-        .finally(() => this.forceReload());
+        .finally(() => jobs.forEach(j => j.hasMany('builds').reload()));
     }
   },
   willDestroy() {

--- a/app/pipeline/events/template.hbs
+++ b/app/pipeline/events/template.hbs
@@ -49,11 +49,15 @@
           }}
         {{/tab.pane}}
         {{#tab.pane activeId=activeTab elementId="pulls" title="Pull Requests"}}
-          {{pipeline-pr-list
-            pullRequestGroups=pullRequestGroups
-            isRestricted=isRestricted
-            startBuild=(action "startPRBuild")
-          }}
+          {{#each pullRequestGroups as |prg|}}
+            {{pipeline-pr-list
+              jobs=prg
+              isRestricted=isRestricted
+              startBuild=(action "startPRBuild")
+            }}
+          {{else}}
+            <div class="alert">No open pull requests</div>
+          {{/each}}
         {{/tab.pane}}
       </div>
     {{/bs-tab}}

--- a/tests/integration/components/pipeline-pr-list/component-test.js
+++ b/tests/integration/components/pipeline-pr-list/component-test.js
@@ -9,7 +9,7 @@ moduleForComponent('pipeline-pr-list', 'Integration | Component | pipeline pr li
 test('it renders', function (assert) {
   // Set any properties with this.set('myProperty', 'value');
   // Handle any actions with this.on('myAction', function(val) { ... });
-  const jobs = [[
+  const jobs = [
     EmberObject.create({
       id: 'abcd',
       name: 'PR-1234:main',
@@ -32,25 +32,21 @@ test('it renders', function (assert) {
         status: 'FAILURE'
       }]
     })
-  ]];
+  ];
 
   this.set('jobsMock', jobs);
 
-  this.render(hbs`{{pipeline-pr-list pullRequestGroups=jobsMock}}`);
+  this.render(hbs`{{pipeline-pr-list jobs=jobsMock}}`);
 
-  assert.equal(this.$('.view .detail .view').length, 2);
+  assert.equal(this.$('.view .view .detail').length, 2);
   assert.equal(this.$('.title').text().trim(), 'update readme');
   assert.equal(this.$('.by').text().trim(), 'anonymous');
-
-  this.set('jobsMock', []);
-
-  assert.equal(this.$('.alert').text().trim(), 'No open pull requests');
 });
 
 test('it renders start build for restricted PR pipeline', function (assert) {
   // Set any properties with this.set('myProperty', 'value');
   // Handle any actions with this.on('myAction', function(val) { ... });
-  const jobs = [[
+  const jobs = [
     EmberObject.create({
       id: 'abcd',
       name: 'PR-1234:main',
@@ -59,19 +55,19 @@ test('it renders start build for restricted PR pipeline', function (assert) {
       username: 'anonymous',
       builds: []
     })
-  ]];
+  ];
 
   this.set('jobsMock', jobs);
   this.set('isRestricted', true);
   this.set('startBuild', Function.prototype);
 
   this.render(hbs`{{pipeline-pr-list
-    pullRequestGroups=jobsMock
+    jobs=jobsMock
     isRestricted=isRestricted
     startBuild=startBuild}}`);
 
-  assert.equal(this.$('.view .detail .view').length, 0);
+  assert.equal(this.$('.view .view .detail').length, 0);
   assert.equal(this.$('.title').text().trim(), 'update readme');
   assert.equal(this.$('.by').text().trim(), 'anonymous');
-  assert.equal(this.$('.view .startButton').length, 0);
+  assert.equal(this.$('.view .startButton').length, 1);
 });

--- a/tests/unit/pipeline/events/controller-test.js
+++ b/tests/unit/pipeline/events/controller-test.js
@@ -160,30 +160,26 @@ test('it starts PR build(s)', function (assert) {
     201,
     { 'Content-Type': 'application/json' },
     JSON.stringify({
-      id: '5678',
+      id: '5679',
       pipelineId: '1234'
     })
   ]);
 
   let controller = this.subject();
 
+  const jobs = [{ hasMany: () => ({ reload: () => assert.ok(true) }) }];
+
   run(() => {
     controller.set('pipeline', EmberObject.create({
       id: '1234'
     }));
-
-    controller.set('reload', () => {
-      assert.ok(true);
-
-      return Promise.resolve({});
-    });
 
     controller.set('model', {
       events: EmberObject.create({})
     });
 
     assert.notOk(controller.get('isShowingModal'));
-    controller.send('startPRBuild', prNum);
+    controller.send('startPRBuild', prNum, jobs);
     assert.ok(controller.get('isShowingModal'));
   });
 


### PR DESCRIPTION
* fix: refactor pipeline-pr-list to be one nested layer less
* fix: correctly reload "job.builds" for started jobs by PR start button
* fix: show start button first then have lazy model taking it out (faster this way without tweaking timer)

related: https://github.com/screwdriver-cd/screwdriver/issues/1528