### PR TITLE
feat(1010): [4] show workflowGraph of PR events when prChain is enabled

### DIFF
--- a/app/components/pipeline-event-row/template.hbs
+++ b/app/components/pipeline-event-row/template.hbs
@@ -2,7 +2,11 @@
   <div class="status">{{fa-icon icon fixedWidth=true}}</div>
   <div class="detail">
     <div class="commit" title="{{event.causeMessage}}">
-      <a class="{{if (eq event.id lastSuccessful) "last-successful"}}" href="{{event.commit.url}}">#{{event.truncatedSha}}</a>
+      {{#if (eq event.type 'pr') }}
+        <a href="{{event.pr.url}}">PR-{{event.prNum}}</a>
+      {{else}}
+        <a class="{{if (eq event.id lastSuccessful) "last-successful"}}" href="{{event.commit.url}}">#{{event.truncatedSha}}</a>
+      {{/if}}
     </div>
     <div class="date greyOut">Started {{event.createTimeWords}}</div>
     <span class="message" title="{{event.commit.message}}">{{event.truncatedMessage}}</span>

--- a/app/components/pipeline-graph-nav/component.js
+++ b/app/components/pipeline-graph-nav/component.js
@@ -5,13 +5,23 @@ import { statusIcon } from 'screwdriver-ui/utils/build';
 
 export default Component.extend({
   session: service(),
-  eventOptions: computed('lastSuccessful', 'mostRecent', {
+  isPR: computed('graphType', {
     get() {
-      return [
+      return this.get('graphType') === 'pr';
+    }
+  }),
+  eventOptions: computed('lastSuccessful', 'mostRecent', 'isPR', {
+    get() {
+      const options = [
         { label: 'Most Recent', value: get(this, 'mostRecent') },
-        { label: 'Last Successful', value: get(this, 'lastSuccessful') },
-        { label: 'Aggregate', value: 'aggregate' }
+        { label: 'Last Successful', value: get(this, 'lastSuccessful') }
       ];
+
+      if (!this.get('isPR')) {
+        options.push({ label: 'Aggregate', value: 'aggregate' });
+      }
+
+      return options;
     }
   }),
   icon: computed('selectedEventObj.status', {

--- a/app/components/pipeline-graph-nav/component.js
+++ b/app/components/pipeline-graph-nav/component.js
@@ -10,6 +10,14 @@ export default Component.extend({
       return this.get('graphType') === 'pr';
     }
   }),
+  prJobs: computed('selectedEventObj.prNum', 'prGroups', {
+    get() {
+      const prNum = this.get('selectedEventObj.prNum');
+      const prGroups = this.get('prGroups');
+
+      return prGroups[prNum];
+    }
+  }),
   eventOptions: computed('lastSuccessful', 'mostRecent', 'isPR', {
     get() {
       const options = [

--- a/app/components/pipeline-graph-nav/template.hbs
+++ b/app/components/pipeline-graph-nav/template.hbs
@@ -1,6 +1,10 @@
 <div class="row">
   <div class="col-xs-10">
-    <strong>Pipeline</strong>
+    {{#if isPR}}
+      <strong>Pull Requests</strong>
+    {{else}}
+      <strong>Pipeline</strong>
+    {{/if}}
     {{#bs-button-group
       value=selectedEvent
       type='radio'
@@ -13,7 +17,11 @@
   </div>
   <div class="col-xs-2">
     {{#if session.isAuthenticated}}
-    {{pipeline-start startBuild=(action startBuild)}}
+      {{#if (eq selectedEventObj.type "pr")}}
+        {{pipeline-start startBuild=(action startPRBuild) prNum=selectedEventObj.prNum}}
+      {{else}}
+        {{pipeline-start startBuild=(action startMainBuild)}}
+      {{/if}}
     {{/if}}
   </div>
 </div>

--- a/app/components/pipeline-graph-nav/template.hbs
+++ b/app/components/pipeline-graph-nav/template.hbs
@@ -18,7 +18,7 @@
   <div class="col-xs-2">
     {{#if session.isAuthenticated}}
       {{#if (eq selectedEventObj.type "pr")}}
-        {{pipeline-start startBuild=(action startPRBuild) prNum=selectedEventObj.prNum}}
+        {{pipeline-start startBuild=(action startPRBuild) prNum=selectedEventObj.prNum jobs=prJobs}}
       {{else}}
         {{pipeline-start startBuild=(action startMainBuild)}}
       {{/if}}

--- a/app/components/pipeline-start/component.js
+++ b/app/components/pipeline-start/component.js
@@ -1,12 +1,26 @@
 import Component from '@ember/component';
+import { computed } from '@ember/object';
 
 export default Component.extend({
+  startArgs: computed('prNum', 'jobs', {
+    get() {
+      const prNum = this.get('prNum');
+      const jobs = this.get('jobs') || [];
+
+      if (!prNum) {
+        return [];
+      }
+
+      // Pass arguments with PR number and jobs to reload when starting PR event.
+      return [prNum, jobs];
+    }
+  }),
   actions: {
     startBuild() {
-      const prNum = this.get('prNum');
+      const args = this.get('startArgs');
       const startFunc = this.get('startBuild');
 
-      startFunc.apply(null, prNum ? [prNum] : []);
+      startFunc.apply(null, args);
     }
   }
 });

--- a/app/components/pipeline-start/component.js
+++ b/app/components/pipeline-start/component.js
@@ -3,7 +3,10 @@ import Component from '@ember/component';
 export default Component.extend({
   actions: {
     startBuild() {
-      this.get('startBuild')();
+      const prNum = this.get('prNum');
+      const startFunc = this.get('startBuild');
+
+      startFunc.apply(null, prNum ? [prNum] : []);
     }
   }
 });

--- a/app/components/pipeline-start/template.hbs
+++ b/app/components/pipeline-start/template.hbs
@@ -1,1 +1,1 @@
-<button {{action "startBuild"}} class="start-button">Start</button>
+<button {{action "startBuild"}} class="start-button">Start{{#if prNum}} PR-{{prNum}}{{/if}}</button>

--- a/app/pipeline/events/controller.js
+++ b/app/pipeline/events/controller.js
@@ -2,9 +2,11 @@ import Controller from '@ember/controller';
 import { inject as service } from '@ember/service';
 import { get, computed } from '@ember/object';
 import { jwt_decode as decoder } from 'ember-cli-jwt-decode';
+import { alias } from '@ember/object/computed';
 
 import ENV from 'screwdriver-ui/config/environment';
 import ModelReloaderMixin from 'screwdriver-ui/mixins/model-reloader';
+import { isPRJob } from 'screwdriver-ui/utils/build';
 
 export default Controller.extend(ModelReloaderMixin, {
   session: service(),
@@ -32,10 +34,16 @@ export default Controller.extend(ModelReloaderMixin, {
     get() {
       const jobs = this.get('model.jobs');
 
-      return jobs.filter(j => !/^PR-/.test(j.get('name')));
+      return jobs.filter(j => !isPRJob(j.get('name')));
     }
   }),
   paginateEvents: [],
+  prChainEnabled: alias('pipeline.prChain'),
+  currentEventType: computed('activeTab', {
+    get() {
+      return this.get('activeTab') === 'pulls' ? 'pr' : 'pipeline';
+    }
+  }),
   // Aggregates first page events and events via ModelReloaderMixin
   modelEvents: computed('model.events', {
     get() {
@@ -65,9 +73,27 @@ export default Controller.extend(ModelReloaderMixin, {
       return newModelEvents;
     }
   }),
-  events: computed('modelEvents', 'paginateEvents', {
+  pipelineEvents: computed('modelEvents', 'paginateEvents', {
     get() {
       return [].concat(this.get('modelEvents'), this.get('paginateEvents'));
+    }
+  }),
+  prEvents: computed('model.events', 'prChainEnabled', {
+    get() {
+      if (this.get('prChainEnabled')) {
+        return this.get('model.events').filter(e => e.prNum).sortBy('createTime').reverse();
+      }
+
+      return [];
+    }
+  }),
+  events: computed('pipelineEvents', 'prEvents', 'currentEventType', {
+    get() {
+      if (this.get('currentEventType') === 'pr') {
+        return this.get('prEvents');
+      }
+
+      return this.get('pipelineEvents');
     }
   }),
   pullRequestGroups: computed('model.jobs', {
@@ -144,6 +170,10 @@ export default Controller.extend(ModelReloaderMixin, {
   }),
 
   updateEvents(page) {
+    if (this.get('currentEventType') === 'pr') {
+      return null;
+    }
+
     this.set('isFetching', true);
 
     return get(this, 'store').query('event', {

--- a/app/pipeline/events/controller.js
+++ b/app/pipeline/events/controller.js
@@ -269,7 +269,9 @@ export default Controller.extend(ModelReloaderMixin, {
         this.set('isShowingModal', false);
         this.forceReload();
 
-        return this.transitionToRoute('pipeline', newEvent.get('pipelineId'));
+        const path = `pipeline/${newEvent.get('pipelineId')}/${this.get('activeTab')}`;
+
+        return this.transitionToRoute(path);
       }).catch((e) => {
         this.set('isShowingModal', false);
         this.set('errorMessage', Array.isArray(e.errors) ? e.errors[0].detail : '');

--- a/app/pipeline/events/controller.js
+++ b/app/pipeline/events/controller.js
@@ -288,7 +288,19 @@ export default Controller.extend(ModelReloaderMixin, {
       });
 
       return newEvent.save().then(() =>
-        newEvent.get('builds').then(() => this.set('isShowingModal', false))
+        newEvent.get('builds').then(() => {
+          this.set('isShowingModal', false);
+
+          // PR events are aggregated by each PR jobs when prChain is enabled.
+          if (this.get('prChainEnabled')) {
+            const newEvents = this.get('prEvents')
+              .filter(e => e.get('prNum') !== prNum);
+
+            newEvents.unshiftObject(newEvent);
+
+            this.set('prEvents', newEvents);
+          }
+        })
       )
         .catch((e) => {
           this.set('isShowingModal', false);

--- a/app/pipeline/events/template.hbs
+++ b/app/pipeline/events/template.hbs
@@ -10,10 +10,12 @@
     {{pipeline-graph-nav
       mostRecent=mostRecent
       lastSuccessful=lastSuccessful
+      graphType=currentEventType
       selectedEvent=selectedEvent
       selectedEventObj=selectedEventObj
       selected=selected
-      startBuild=(action "startMainBuild")
+      startMainBuild=(action "startMainBuild")
+      startPRBuild=(action "startPRBuild")
     }}
 
     {{pipeline-workflow
@@ -49,15 +51,26 @@
           }}
         {{/tab.pane}}
         {{#tab.pane activeId=activeTab elementId="pulls" title="Pull Requests"}}
-          {{#each pullRequestGroups as |prg|}}
-            {{pipeline-pr-list
-              jobs=prg
-              isRestricted=isRestricted
-              startBuild=(action "startPRBuild")
+          {{#if prChainEnabled}}
+            {{pipeline-events-list
+            events=events
+            selected=(mut selected)
+            selectedEvent=selectedEvent
+            lastSuccessful=lastSuccessful
+            eventsPage=eventsPage
+            updateEvents=(action "updateEvents")
             }}
           {{else}}
-            <div class="alert">No open pull requests</div>
-          {{/each}}
+            {{#each pullRequestGroups as |prg|}}
+              {{pipeline-pr-list
+                jobs=prg
+                isRestricted=isRestricted
+                startBuild=(action "startPRBuild")
+              }}
+            {{else}}
+              <div class="alert">No open pull requests</div>
+            {{/each}}
+          {{/if}}
         {{/tab.pane}}
       </div>
     {{/bs-tab}}

--- a/app/pipeline/events/template.hbs
+++ b/app/pipeline/events/template.hbs
@@ -16,6 +16,7 @@
       selected=selected
       startMainBuild=(action "startMainBuild")
       startPRBuild=(action "startPRBuild")
+      prGroups=pullRequestGroups
     }}
 
     {{pipeline-workflow

--- a/app/pipeline/model.js
+++ b/app/pipeline/model.js
@@ -13,6 +13,7 @@ export default DS.Model.extend({
   workflowGraph: DS.attr(),
   configPipelineId: DS.attr('string'),
   childPipelines: DS.attr(),
+  prChain: DS.attr('boolean', { defaultValue: false }),
 
   jobs: DS.hasMany('job', { async: true }),
   secrets: DS.hasMany('secret', { async: true }),

--- a/app/pipeline/pulls/route.js
+++ b/app/pipeline/pulls/route.js
@@ -1,4 +1,7 @@
 // import Route from '@ember/routing/route';
+import { A as newArray } from '@ember/array';
+import RSVP from 'rsvp';
+import { isPRJob } from 'screwdriver-ui/utils/build';
 import EventsRoute from '../events/route';
 
 export default EventsRoute.extend({
@@ -9,5 +12,46 @@ export default EventsRoute.extend({
   },
   renderTemplate() {
     this.render('pipeline.events');
+  },
+  model() {
+    this.controllerFor('pipeline.events').set('pipeline', this.get('pipeline'));
+    const jobsPromise = this.get('pipeline.jobs');
+    let events = [];
+
+    // fetch latest events which belongs to each PR jobs, if the prChain feature is enabled
+    if (this.get('pipeline.prChain')) {
+      const prNumbers = jobsPromise.then(jobs => jobs.filter(job => isPRJob(job.get('name')))
+        .map(job => job.get('name'))
+        .map(jobName => jobName.split('PR-')[1].split(':')[0])
+        .reduce((prNums, prNum) => {
+          if (prNums.includes(prNum)) {
+            return prNums;
+          }
+
+          return prNums.concat(prNum);
+        }, [])
+      );
+
+      events = prNumbers.then(prNums => Promise.all(prNums.map(prNum =>
+        this.store.query('event', { pipelineId: this.get('pipeline.id'),
+          page: 1,
+          count: 1,
+          prNum
+        }))).then((queryReults) => {
+        // merge pr-events from separate query results
+        const prEvents = newArray();
+
+        queryReults.forEach((prEvent) => {
+          prEvents.pushObjects(prEvent.toArray());
+        });
+
+        return prEvents;
+      }));
+    }
+
+    return RSVP.hash({
+      jobs: jobsPromise,
+      events
+    });
   }
 });

--- a/app/utils/graph-tools.js
+++ b/app/utils/graph-tools.js
@@ -282,7 +282,14 @@ const subgraphFilter = ({ nodes, edges }, startNode) => {
     return { nodes, edges };
   }
 
-  let visiting = [startNode];
+  let start = startNode;
+
+  // startNode can be a PR job in PR events, so trim PR prefix from node name
+  if (startNode.match(/^PR-[0-9]+:/)) {
+    start = startNode.split(':')[1];
+  }
+
+  let visiting = [start];
   let visited = new Set(visiting);
 
   if (edges.length) {

--- a/tests/acceptance/pipeline-pr-chain-test.js
+++ b/tests/acceptance/pipeline-pr-chain-test.js
@@ -11,12 +11,14 @@ import makeJobs from '../mock/jobs';
 
 let server;
 
-moduleForAcceptance('Acceptance | pipeline build', {
+moduleForAcceptance('Acceptance | pipeline pr-chain', {
   beforeEach() {
     const graph = makeGraph();
     const jobs = makeJobs();
     const pipeline = makePipeline(graph);
     const events = makeEvents(graph);
+
+    pipeline.prChain = true;
 
     server = new Pretender();
 
@@ -32,11 +34,15 @@ moduleForAcceptance('Acceptance | pipeline build', {
       JSON.stringify(jobs)
     ]);
 
-    server.get('http://localhost:8080/v4/pipelines/4/events', () => [
-      200,
-      { 'Content-Type': 'application/json' },
-      JSON.stringify(events)
-    ]);
+    server.get('http://localhost:8080/v4/pipelines/4/events', (request) => {
+      const prNum = parseInt(request.queryParams.prNum, 10);
+
+      return [
+        200,
+        { 'Content-Type': 'application/json' },
+        JSON.stringify([].concat(events.find(e => e.prNum === prNum)))
+      ];
+    });
 
     server.get('http://localhost:8080/v4/events/:eventId/builds', (request) => {
       const eventId = parseInt(request.params.eventId, 10);
@@ -69,36 +75,20 @@ moduleForAcceptance('Acceptance | pipeline build', {
   }
 });
 
-test('visiting /pipelines/4 when not logged in', function (assert) {
-  visit('/pipelines/4');
-
-  andThen(() => {
-    assert.equal(currentURL(), '/login');
-  });
-});
-
-test('visiting /pipelines/4 when logged in', function (assert) {
+test('visiting /pipelines/4/pulls when the pipeline is enabled for prChain', function (assert) {
   authenticateSession(this.application, { token: 'fakeToken' });
 
-  visit('/pipelines/4');
+  visit('/pipelines/4/pulls');
 
-  andThen(() => {
-    assert.equal(currentURL(), '/pipelines/4/events');
+  wait().andThen(() => {
     assert.equal(find('a h1').text().trim(), 'foo/bar', 'incorrect pipeline name');
     assert.equal(find('.pipelineWorkflow svg').length, 1, 'not enough workflow');
-    assert.equal(find('button.start-button').length, 1, 'should have a start button');
     assert.equal(find('ul.nav-pills').length, 1, 'should show tabs');
     assert.equal(find('.column-tabs-view .nav-link').eq(0).text().trim(), 'Events');
-    assert.equal(find('.column-tabs-view .nav-link.active').eq(0).text().trim(), 'Events');
+    assert.equal(find('.column-tabs-view .nav-link.active').eq(0).text().trim(), 'Pull Requests');
     assert.equal(find('.column-tabs-view .nav-link').eq(1).text().trim(), 'Pull Requests');
+    assert.equal(find('.column-tabs-view .view .detail .commit').eq(0).text().trim(), 'PR-42');
     assert.equal(find('.separator').length, 1);
     assert.equal(find('.partial-view').length, 2);
-
-    visit('/pipelines/4/pulls');
-
-    andThen(() => {
-      assert.equal(currentURL(), '/pipelines/4/pulls');
-      assert.equal(find('.column-tabs-view .nav-link.active').eq(0).text().trim(), 'Pull Requests');
-    });
   });
 });

--- a/tests/integration/components/pipeline-event-row/component-test.js
+++ b/tests/integration/components/pipeline-event-row/component-test.js
@@ -1,64 +1,100 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
+import { merge } from '@ember/polyfills';
+import { copy } from '@ember/object/internals';
+
+const event = {
+  id: 3,
+  startFrom: '~commit',
+  status: 'SUCCESS',
+  type: 'pipeline',
+  causeMessage: 'test',
+  commit: {
+    url: '#',
+    message: 'this was a test'
+  },
+  creator: {
+    url: '#',
+    name: 'batman'
+  },
+  createTimeWords: 'now',
+  durationText: '1 sec',
+  truncatedMessage: 'this was a test',
+  truncatedSha: 'abc123',
+  workflowGraph: {
+    nodes: [
+      { name: '~pr' },
+      { name: '~commit' },
+      { id: 1, name: 'main' },
+      { id: 2, name: 'A' },
+      { id: 3, name: 'B' }
+    ],
+    edges: [
+      { src: '~pr', dest: 'main' },
+      { src: '~commit', dest: 'main' },
+      { src: 'main', dest: 'A' },
+      { src: 'A', dest: 'B' }
+    ]
+  },
+  builds: [
+    { jobId: 1, id: 4, status: 'SUCCESS' },
+    { jobId: 2, id: 5, status: 'SUCCESS' },
+    { jobId: 3, id: 6, status: 'FAILURE' }
+  ]
+};
 
 moduleForComponent('pipeline-event-row', 'Integration | Component | pipeline event row', {
   integration: true
 });
 
-test('it renders', function (assert) {
+test('it renders with pipeline event', function (assert) {
   // Set any properties with this.set('myProperty', 'value');
   // Handle any actions with this.on('myAction', function(val) { ... });
   this.on('eventClick', () => {
     assert.ok(true);
   });
 
-  const event = EmberObject.create({
-    id: 3,
-    startFrom: '~commit',
-    status: 'SUCCESS',
-    causeMessage: 'test',
-    commit: {
-      url: '#',
-      message: 'this was a test'
-    },
-    creator: {
-      url: '#',
-      name: 'batman'
-    },
-    createTimeWords: 'now',
-    durationText: '1 sec',
-    truncatedMessage: 'this was a test',
-    truncatedSha: 'abc123',
-    workflowGraph: {
-      nodes: [
-        { name: '~pr' },
-        { name: '~commit' },
-        { id: 1, name: 'main' },
-        { id: 2, name: 'A' },
-        { id: 3, name: 'B' }
-      ],
-      edges: [
-        { src: '~pr', dest: 'main' },
-        { src: '~commit', dest: 'main' },
-        { src: 'main', dest: 'A' },
-        { src: 'A', dest: 'B' }
-      ]
-    },
-    builds: [
-      { jobId: 1, id: 4, status: 'SUCCESS' },
-      { jobId: 2, id: 5, status: 'SUCCESS' },
-      { jobId: 3, id: 6, status: 'FAILURE' }
-    ]
-  });
+  const eventMock = EmberObject.create(copy(event, true));
 
-  this.set('event', event);
+  this.set('event', eventMock);
 
   this.render(hbs`{{pipeline-event-row event=event selectedEvent=3 lastSuccessful=3}}`);
 
   assert.equal(this.$('.SUCCESS').length, 1);
   assert.equal(this.$('.status .fa-check-circle-o').length, 1);
   assert.equal(this.$('.commit').text().trim(), '#abc123');
+  assert.equal(this.$('.message').text().trim(), 'this was a test');
+  assert.equal(this.$('svg').length, 1);
+  assert.equal(this.$('.graph-node').length, 4);
+  assert.equal(this.$('.graph-edge').length, 3);
+  assert.equal(this.$('.by').text().trim(), 'batman');
+  assert.equal(this.$('.date').text().trim(), 'Started now');
+});
+
+test('it renders with pr event', function (assert) {
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+  this.on('eventClick', () => {
+    assert.ok(true);
+  });
+
+  const eventMock = EmberObject.create(merge(copy(event, true), {
+    startFrom: '~pr',
+    type: 'pr',
+    pr: {
+      url: 'https://foo/bar/baz/pull/2'
+    },
+    prNum: 2
+  }));
+
+  this.set('event', eventMock);
+
+  this.render(hbs`{{pipeline-event-row event=event selectedEvent=3 lastSuccessful=3}}`);
+
+  assert.equal(this.$('.SUCCESS').length, 1);
+  assert.equal(this.$('.status .fa-check-circle-o').length, 1);
+  assert.equal(this.$('.commit').text().trim(), 'PR-2');
   assert.equal(this.$('.message').text().trim(), 'this was a test');
   assert.equal(this.$('svg').length, 1);
   assert.equal(this.$('.graph-node').length, 4);

--- a/tests/integration/components/pipeline-graph-nav/component-test.js
+++ b/tests/integration/components/pipeline-graph-nav/component-test.js
@@ -12,6 +12,7 @@ test('it renders', function (assert) {
   set(this, 'startBuild', () => {
     assert.ok(true);
   });
+  set(this, 'currentEventType', 'pipeline');
 
   this.render(hbs`{{pipeline-graph-nav
     mostRecent=3
@@ -19,8 +20,13 @@ test('it renders', function (assert) {
     selectedEvent=2
     selectedEventObj=obj
     selected=selected
-    startBuild=startBuild
+    startMainBuild=startBuild
+    startPRBuild=startBuild
+    graphType=currentEventType
   }}`);
+
+  assert.equal(this.$('.row strong').text().trim(), 'Pipeline');
+  assert.equal(this.$('.row button').length, 3);
 
   const $columnTitles = this.$('.event-info .title');
   const $links = this.$('.event-info a');
@@ -48,6 +54,7 @@ test('it updates selected event id', function (assert) {
   set(this, 'startBuild', () => {
     assert.ok(true);
   });
+  set(this, 'currentEventType', 'pipeline');
 
   this.render(hbs`{{pipeline-graph-nav
     mostRecent=3
@@ -55,9 +62,41 @@ test('it updates selected event id', function (assert) {
     selectedEvent=2
     selectedEventObj=obj
     selected=selected
-    startBuild=startBuild
+    startMainBuild=startBuild
+    startPRBuild=startBuild
+    graphType=currentEventType
   }}`);
 
   this.$('button').filter(':first').click();
   assert.equal(get(this, 'selected'), 3);
+});
+
+test('it render when selectedEvent is a PR event', function (assert) {
+  assert.expect(2);
+  set(this, 'obj', {
+    truncatedSha: 'abc123',
+    status: 'SUCCESS',
+    creator: { name: 'anonymous' },
+    prNum: 1,
+    type: 'pr'
+  });
+  set(this, 'selected', 2);
+  set(this, 'startBuild', () => {
+    assert.ok(true);
+  });
+  set(this, 'currentEventType', 'pr');
+
+  this.render(hbs`{{pipeline-graph-nav
+    mostRecent=3
+    lastSuccessful=2
+    selectedEvent=2
+    selectedEventObj=obj
+    selected=selected
+    startMainBuild=startBuild
+    startPRBuild=startBuild
+    graphType=currentEventType
+  }}`);
+
+  assert.equal(this.$('.row strong').text().trim(), 'Pull Requests');
+  assert.equal(this.$('.row button').length, 2);
 });

--- a/tests/integration/components/pipeline-graph-nav/component-test.js
+++ b/tests/integration/components/pipeline-graph-nav/component-test.js
@@ -71,7 +71,7 @@ test('it updates selected event id', function (assert) {
   assert.equal(get(this, 'selected'), 3);
 });
 
-test('it render when selectedEvent is a PR event', function (assert) {
+test('it renders when selectedEvent is a PR event', function (assert) {
   assert.expect(2);
   set(this, 'obj', {
     truncatedSha: 'abc123',
@@ -81,10 +81,15 @@ test('it render when selectedEvent is a PR event', function (assert) {
     type: 'pr'
   });
   set(this, 'selected', 2);
-  set(this, 'startBuild', () => {
-    assert.ok(true);
+  set(this, 'startBuild', (prNum, jobs) => {
+    assert.equal(prNum, 1);
+    assert.equal(jobs[0].group, 1);
   });
   set(this, 'currentEventType', 'pr');
+  set(this, 'pullRequestGroups', {
+    1: [{ name: 'PR-1:foo', isPR: true, group: 1 }, { name: 'PR-1:bar', isPR: true, group: 1 }],
+    2: [{ name: 'PR-2:foo', isPR: true, group: 2 }]
+  });
 
   this.render(hbs`{{pipeline-graph-nav
     mostRecent=3
@@ -95,6 +100,7 @@ test('it render when selectedEvent is a PR event', function (assert) {
     startMainBuild=startBuild
     startPRBuild=startBuild
     graphType=currentEventType
+    prGroups=pullrequestGroups
   }}`);
 
   assert.equal(this.$('.row strong').text().trim(), 'Pull Requests');

--- a/tests/integration/components/pipeline-start/component-test.js
+++ b/tests/integration/components/pipeline-start/component-test.js
@@ -19,13 +19,16 @@ test('it renders', function (assert) {
 });
 
 test('it renders start PR', function (assert) {
-  assert.expect(2);
+  assert.expect(3);
+  // Starting PR job requires the PR number and PR jobs
+  this.set('jobs', ['job1', 'job2']);
   // Set any properties with this.set('myProperty', 'value');
   // Handle any actions with this.on('myAction', function(val) { ... });
-  this.set('onPRStartBuild', () => {
-    assert.ok(true);
+  this.set('onPRStartBuild', (prNum, prJobs) => {
+    assert.equal(prNum, 5);
+    assert.equal(prJobs.length, 2);
   });
-  this.render(hbs`{{pipeline-start startBuild=onPRStartBuild prNum=5}}`);
+  this.render(hbs`{{pipeline-start startBuild=onPRStartBuild prNum=5 jobs=jobs}}`);
 
   assert.equal(this.$('button').text().trim(), 'Start PR-5');
   this.$('button').click();

--- a/tests/integration/components/pipeline-start/component-test.js
+++ b/tests/integration/components/pipeline-start/component-test.js
@@ -17,3 +17,16 @@ test('it renders', function (assert) {
   assert.equal(this.$('button').text().trim(), 'Start');
   this.$('button').click();
 });
+
+test('it renders start PR', function (assert) {
+  assert.expect(2);
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+  this.set('onPRStartBuild', () => {
+    assert.ok(true);
+  });
+  this.render(hbs`{{pipeline-start startBuild=onPRStartBuild prNum=5}}`);
+
+  assert.equal(this.$('button').text().trim(), 'Start PR-5');
+  this.$('button').click();
+});

--- a/tests/mock/builds.js
+++ b/tests/mock/builds.js
@@ -1,0 +1,60 @@
+import { copy } from '@ember/object/internals';
+import { merge } from '@ember/polyfills';
+
+const build = {
+  id: '1234',
+  jobId: '1',
+  number: 1474649580274,
+  container: 'node:6',
+  cause: 'Started by user batman',
+  sha: 'c96f36886e084d18bd068b8156d095cd9b31e1d6',
+  createTime: '2016-09-23T16:53:00.274Z',
+  startTime: '2016-09-23T16:53:08.601Z',
+  endTime: '2016-09-23T16:58:47.355Z',
+  meta: {},
+  steps: [{
+    startTime: '2016-09-23T16:53:07.497654442Z',
+    name: 'sd-setup',
+    code: 0,
+    endTime: '2016-09-23T16:53:12.46806858Z'
+  }, {
+    startTime: '2016-09-23T16:53:12.902784483Z',
+    name: 'install',
+    code: 137,
+    endTime: '2016-09-23T16:58:46.924844475Z'
+  }, {
+    name: 'bower'
+  }, {
+    name: 'test'
+  }],
+  status: 'FAILURE'
+};
+
+const shas = [
+  'abcd1234567890',
+  'bcd1234567890a',
+  'cd1234567890ab',
+  'd1234567890abc',
+  '1234567890abcd'
+];
+
+export default (eventId) => {
+  const builds = [];
+
+  shas.forEach((sha) => {
+    const b = copy(build, true);
+    const config = {
+      id: Math.floor(Math.random() * 99999999999),
+      eventId,
+      sha,
+      number: Date.now(),
+      status: ['SUCCESS', 'FAILURE', 'RUNNING'][Math.floor(Math.random() * 2)]
+    };
+
+    merge(b, config);
+
+    builds.push(b);
+  });
+
+  return builds;
+};

--- a/tests/mock/events.js
+++ b/tests/mock/events.js
@@ -1,0 +1,100 @@
+import { copy } from '@ember/object/internals';
+import { merge } from '@ember/polyfills';
+
+const events = [
+  {
+    id: '2',
+    causeMessage: 'Merged by batman',
+    commit: {
+      message: 'Merge pull request #2 from batcave/batmobile',
+      author: {
+        username: 'batman',
+        name: 'Bruce W',
+        avatar: 'http://example.com/u/batman/avatar',
+        url: 'http://example.com/u/batman'
+      },
+      url: 'http://example.com/batcave/batmobile/commit/abcdef1029384'
+    },
+    createTime: '2016-11-04T20:09:41.238Z',
+    creator: {
+      username: 'batman',
+      name: 'Bruce W',
+      avatar: 'http://example.com/u/batman/avatar',
+      url: 'http://example.com/u/batman'
+    },
+    startFrom: '~commit',
+    pipelineId: '12345',
+    sha: 'abcdef1029384',
+    type: 'pipeline',
+    workflowGraph: {
+      nodes: [],
+      edges: []
+    }
+  }, {
+    id: '3',
+    causeMessage: 'Opened by github:robin',
+    commit: {
+      message: 'fix bug',
+      author: {
+        username: 'robin',
+        name: 'Tim D',
+        avatar: 'http://example.com/u/robin/avatar',
+        url: 'http://example.com/u/robin'
+      },
+      url: 'http://example.com/batcave/batmobile/commit/1029384bbb'
+    },
+    createTime: '2016-11-05T20:09:41.238Z',
+    creator: {
+      username: 'robin',
+      name: 'Tim D',
+      avatar: 'http://example.com/u/robin/avatar',
+      url: 'http://example.com/u/robin'
+    },
+    startFrom: '~pr',
+    pr: {
+      url: 'http://example.com/batcave/batmobile/pulls/42'
+    },
+    pipelineId: '12345',
+    type: 'pr',
+    prNum: 42,
+    sha: '1029384bbb',
+    workflowGraph: {
+      nodes: [],
+      edges: []
+    }
+  }, {
+    id: '4',
+    causeMessage: 'Opened by github:robin',
+    commit: {
+      message: 'fix docs',
+      author: {
+        username: 'robin',
+        name: 'Tim D',
+        avatar: 'http://example.com/u/robin/avatar',
+        url: 'http://example.com/u/robin'
+      },
+      url: 'http://example.com/batcave/batmobile/commit/1030384bbb'
+    },
+    createTime: '2016-11-04T20:09:41.238Z',
+    creator: {
+      username: 'robin',
+      name: 'Tim D',
+      avatar: 'http://example.com/u/robin/avatar',
+      url: 'http://example.com/u/robin'
+    },
+    startFrom: '~pr',
+    pr: {
+      url: 'http://example.com/batcave/batmobile/pulls/43'
+    },
+    pipelineId: '12345',
+    sha: '1030384bbb',
+    type: 'pr',
+    prNum: 43,
+    workflowGraph: {
+      nodes: [],
+      edges: []
+    }
+  }
+];
+
+export default workflowGraph => events.map(e => merge(copy(e, true), { workflowGraph }));

--- a/tests/mock/jobs.js
+++ b/tests/mock/jobs.js
@@ -1,0 +1,39 @@
+import { copy } from '@ember/object/internals';
+
+export default () => copy([
+  {
+    id: '12345',
+    name: 'main',
+    pipelineId: '4',
+    state: 'ENABLED',
+    archived: false
+  },
+  {
+    id: '12346',
+    name: 'publish',
+    pipelineId: '4',
+    state: 'ENABLED',
+    archived: false
+  },
+  {
+    id: '12347',
+    name: 'PR-42:main',
+    pipelineId: '4',
+    state: 'ENABLED',
+    archived: false
+  },
+  {
+    id: '12348',
+    name: 'PR-42:publish',
+    pipelineId: '4',
+    state: 'ENABLED',
+    archived: false
+  },
+  {
+    id: '12349',
+    name: 'PR-43:main',
+    pipelineId: '4',
+    state: 'ENABLED',
+    archived: false
+  }
+], true);

--- a/tests/mock/pipeline.js
+++ b/tests/mock/pipeline.js
@@ -1,0 +1,20 @@
+import { copy } from '@ember/object/internals';
+import { merge } from '@ember/polyfills';
+
+const pipeline = {
+  id: '4',
+  scmUrl: 'git@github.com:foo/bar.git#master',
+  scmRepo: {
+    name: 'foo/bar',
+    branch: 'master',
+    url: 'https://github.com/foo/bar'
+  },
+  createTime: '2016-09-15T23:12:23.760Z',
+  admins: { batman: true },
+  workflowGraph: {
+    nodes: [],
+    edges: []
+  }
+};
+
+export default workflowGraph => merge(copy(pipeline, true), { workflowGraph });

--- a/tests/mock/workflow-graph.js
+++ b/tests/mock/workflow-graph.js
@@ -1,0 +1,15 @@
+import { copy } from '@ember/object/internals';
+
+export default () => copy({
+  nodes: [
+    { name: '~pr' },
+    { name: '~commit' },
+    { id: 12345, name: 'main' },
+    { is: 123456, name: 'publish' }
+  ],
+  edges: [
+    { src: '~pr', dest: 'main' },
+    { src: '~commit', dest: 'main' },
+    { src: 'main', dest: 'publish' }
+  ]
+}, true);

--- a/tests/unit/pipeline/events/controller-test.js
+++ b/tests/unit/pipeline/events/controller-test.js
@@ -1,9 +1,12 @@
 import EmberObject from '@ember/object';
+import { A as newArray } from '@ember/array';
 import { run } from '@ember/runloop';
 import { moduleFor, test } from 'ember-qunit';
 import Pretender from 'pretender';
 import Service from '@ember/service';
 import wait from 'ember-test-helpers/wait';
+import sinon from 'sinon';
+
 const sessionServiceMock = Service.extend({
   isAuthenticated: true,
   data: {
@@ -193,5 +196,70 @@ test('it starts PR build(s)', function (assert) {
       startFrom: '~pr',
       prNum
     });
+  });
+});
+
+test('New event comes top of PR list when it start a PR build with prChain', function (assert) {
+  const prNum = 3;
+  const jobs = [{ hasMany: () => ({ reload: () => assert.ok(true) }) }];
+
+  assert.expect(5);
+
+  server.post('http://localhost:8080/v4/events', () => [
+    201,
+    { 'Content-Type': 'application/json' },
+    JSON.stringify({
+      id: '2'
+    })
+  ]);
+
+  const createRecordStub = sinon.stub();
+  let controller = this.subject({
+    store: {
+      createRecord: createRecordStub
+    }
+  });
+
+  const newEvent = EmberObject.create({
+    id: 3,
+    prNum: '3',
+    sha: 'sha1',
+    save: () => Promise.resolve(),
+    get: () => Promise.resolve()
+  });
+
+  createRecordStub.returns(newEvent);
+
+  run(() => {
+    const event1 = EmberObject.create({
+      id: '1',
+      prNum: '2',
+      sha: 'sha1'
+    });
+    const event2 = EmberObject.create({
+      id: '2',
+      prNum: '3',
+      sha: 'sha2'
+    });
+
+    controller.set('prEvents', newArray([event1, event2]));
+
+    controller.set('pipeline', EmberObject.create({
+      id: '1234',
+      prChain: true
+    }));
+
+    controller.set('model', {
+      events: EmberObject.create({})
+    });
+
+    assert.notOk(controller.get('isShowingModal'));
+    controller.send('startPRBuild', prNum, jobs);
+    assert.ok(controller.get('isShowingModal'));
+  });
+
+  return wait().then(() => {
+    assert.equal(controller.get('prEvents')[0].id, 3);
+    assert.equal(controller.get('prEvents')[0].prNum, '3');
   });
 });

--- a/tests/unit/pipeline/events/controller-test.js
+++ b/tests/unit/pipeline/events/controller-test.js
@@ -86,7 +86,7 @@ test('it starts a build', function (assert) {
 });
 
 test('it restarts a build', function (assert) {
-  assert.expect(7);
+  assert.expect(6);
   server.post('http://localhost:8080/v4/events', () => [
     201,
     { 'Content-Type': 'application/json' },
@@ -126,9 +126,8 @@ test('it restarts a build', function (assert) {
       events: EmberObject.create({})
     });
 
-    controller.transitionToRoute = (path, id) => {
-      assert.equal(path, 'pipeline');
-      assert.equal(id, 1234);
+    controller.transitionToRoute = (path) => {
+      assert.equal(path, 'pipeline/1234/events');
     };
 
     assert.notOk(controller.get('isShowingModal'));

--- a/tests/unit/pipeline/events/controller-test.js
+++ b/tests/unit/pipeline/events/controller-test.js
@@ -199,7 +199,7 @@ test('it starts PR build(s)', function (assert) {
   });
 });
 
-test('New event comes top of PR list when it start a PR build with prChain', function (assert) {
+test('New event comes top of PR list when it starts a PR build with prChain', function (assert) {
   const prNum = 3;
   const jobs = [{ hasMany: () => ({ reload: () => assert.ok(true) }) }];
 


### PR DESCRIPTION
This PR allows a pipeline page to show the workflowGraph of PR events if the prChain of the pipeline is enabled.

![image](https://user-images.githubusercontent.com/5774825/54531223-1a988200-49c8-11e9-96a1-172c2ecb98c7.png)

As above, Pipeline page shows PR event workflow graph same as Pipeline event.
It also showed mini workflow graph in PR tab in left side.
These are showed only when the pipeline is enabled for prChain.

The details of this feature is following
1. PR events are aggregated by each PR.
   * One latest event is listed for each PR in left side `Pull Requests` tab, even if many events are exists for the PR
   * This is realized to use prNum query in [this PR](https://github.com/screwdriver-cd/screwdriver/pull/1550)
1. The user of the pipeline with prChain enabled can start detached job in workflow graph of PR event.
1. The start button of pipeline page starts PR event which is selected in PR lists.
1. Aggregate button is dropped when a PR event is selected, because which is useless in PRs.

![image](https://user-images.githubusercontent.com/5774825/54541319-0448f100-49dd-11e9-8cae-e452d8da5193.png)

### references
* The issue for prChain feature: https://github.com/screwdriver-cd/screwdriver/issues/1010
* The dependencies of this PR: https://github.com/screwdriver-cd/screwdriver/pull/1550
