### PR TITLE
Fix: Make clickable area for collections larger

### DIFF
--- a/app/components/collections-flyout/styles.scss
+++ b/app/components/collections-flyout/styles.scss
@@ -58,6 +58,7 @@
     &__delete {
       position: absolute;
       right: 10px;
+      top: 10px;
       border: none;
       background: none;
     }

--- a/app/components/collections-flyout/styles.scss
+++ b/app/components/collections-flyout/styles.scss
@@ -20,7 +20,6 @@
     float: right;
   }
   .collection-wrapper {
-    padding: 10px 15px;
     border-bottom: 1px solid $sd-white;
     position: relative;
 
@@ -29,6 +28,13 @@
 
       .name {
         text-decoration: underline;
+      }
+    }
+
+    &.row {
+      a {
+        display: block;
+        padding: 10px 15px;
       }
     }
 


### PR DESCRIPTION
The collections flyout has a hover effect over the whole "button" but only the text is clickable.  Makes it harder to toggle between collections.  This style tweak should make the whole button area interactive.