### PR TITLE
fix: disabled jobs display in event graph is broken

### DIFF
--- a/app/pipeline/events/route.js
+++ b/app/pipeline/events/route.js
@@ -15,7 +15,7 @@ export default Route.extend({
     this.controllerFor('pipeline.events').set('pipeline', this.get('pipeline'));
 
     return RSVP.hash({
-      jobs: [],
+      jobs: this.get('pipeline.jobs'),
       events: this.store.query('event', {
         pipelineId: this.get('pipeline.id'),
         page: 1,


### PR DESCRIPTION
in my previous reload [fix](https://github.com/screwdriver-cd/ui/pull/427/files#diff-c4994ca67dc637b1b5acc8e3227cee80L18) I removed it thinking it's not used anywhere