### PR TITLE
feat(939): Allow builds to label event using meta.label

### DIFF
--- a/app/components/pipeline-event-row/styles.scss
+++ b/app/components/pipeline-event-row/styles.scss
@@ -6,4 +6,10 @@
       border: none;
     }
   }
+
+  .label {
+    display: inline-block;
+    float: right;
+    color: $grey-600;
+  }
 }

--- a/app/components/pipeline-event-row/template.hbs
+++ b/app/components/pipeline-event-row/template.hbs
@@ -6,7 +6,7 @@
         <a href="{{event.pr.url}}">PR-{{event.prNum}}</a>
       {{else}}
         <a class="{{if (eq event.id lastSuccessful) "last-successful"}}" href="{{event.commit.url}}">#{{event.truncatedSha}}</a>
-        {{#if event.label}}{{event.label}}{{/if}}
+        {{#if event.label}}<div class="label">{{event.label}}</div>{{/if}}
       {{/if}}
     </div>
     <div class="date greyOut">Started {{event.createTimeWords}}</div>

--- a/app/components/pipeline-event-row/template.hbs
+++ b/app/components/pipeline-event-row/template.hbs
@@ -6,6 +6,7 @@
         <a href="{{event.pr.url}}">PR-{{event.prNum}}</a>
       {{else}}
         <a class="{{if (eq event.id lastSuccessful) "last-successful"}}" href="{{event.commit.url}}">#{{event.truncatedSha}}</a>
+        {{#if event.label}}{{event.label}}{{/if}}
       {{/if}}
     </div>
     <div class="date greyOut">Started {{event.createTimeWords}}</div>

--- a/app/components/pipeline-graph-nav/styles.scss
+++ b/app/components/pipeline-graph-nav/styles.scss
@@ -51,12 +51,12 @@
   }
 
   .col {
-    flex: 1 0 calc(100% / 7);
+    flex: 1 0 calc(100% / 8);
     padding-left: 10px;
     border-right: 1px solid $grey-500;
 
     &:nth-child(2) {
-      flex-basis: calc(100% / 7 * 2);
+      flex-basis: calc(100% / 8 * 2);
     }
 
     &:last-child {

--- a/app/components/pipeline-graph-nav/template.hbs
+++ b/app/components/pipeline-graph-nav/template.hbs
@@ -55,6 +55,12 @@
             <span class="title">Duration</span><br/>
             {{selectedEventObj.durationText}}
           </div>
+          {{#if selectedEventObj.label}}
+          <div class="col">
+            <span class="title">Label</span><br/>
+            {{selectedEventObj.label}}
+          </div>
+          {{/if}}
         </div>
       {{/unless}}
     </div>

--- a/app/event/model.js
+++ b/app/event/model.js
@@ -12,6 +12,7 @@ export default DS.Model.extend(ModelReloaderMixin, {
   createTime: DS.attr('date'),
   creator: DS.attr(),
   isComplete: DS.attr('boolean', { defaultValue: false }),
+  meta: DS.attr(),
   numBuilds: DS.attr('number', { defaultValue: 0 }),
   reloadWithoutNewBuilds: DS.attr('number', { defaultValue: 0 }),
   parentBuildId: DS.attr('number'),
@@ -61,6 +62,11 @@ export default DS.Model.extend(ModelReloaderMixin, {
   durationText: computed('duration', {
     get() {
       return humanizeDuration(get(this, 'duration'), { round: true, largest: 1 });
+    }
+  }),
+  label: computed('meta', {
+    get() {
+      return this.get('meta.label') || null;
     }
   }),
   truncatedMessage: computed('commit.message', {


### PR DESCRIPTION
## Context
It would be easier to rollback to a specific event if there was a more human-readable way to label/distinguish between events.

## Objective
This PR displays `meta.label` in the pipeline events page as "label". Defaults to showing nothing if the label does not exist.

In this example `meta.label` is set to `VERSION_1.2.3`:
<img width="1680" alt="Screen Shot 2019-04-03 at 4 26 04 PM" src="https://user-images.githubusercontent.com/3230529/55520226-1d35e100-5630-11e9-8a3a-1c7bd9895be4.png">


## Related links
Related to https://github.com/screwdriver-cd/screwdriver/issues/939

