### PR TITLE
feat(1516): Enable stopping a build from pipeline events graph

### DIFF
--- a/app/components/pipeline-workflow/component.js
+++ b/app/components/pipeline-workflow/component.js
@@ -2,6 +2,7 @@ import Component from '@ember/component';
 import { get, computed, set, setProperties } from '@ember/object';
 import { all, reject } from 'rsvp';
 import { isRoot } from 'screwdriver-ui/utils/graph-tools';
+import { isActiveBuild } from 'screwdriver-ui/utils/build';
 
 export default Component.extend({
   classNames: ['pipelineWorkflow'],
@@ -97,6 +98,7 @@ export default Component.extend({
         // detached jobs should show tooltip on the left
         showTooltipPosition: isRootNode ? 'left' : 'center',
         tooltipData: {
+          displayStop: isActiveBuild(job.status),
           job,
           mouseevent,
           sizes

--- a/app/components/pipeline-workflow/template.hbs
+++ b/app/components/pipeline-workflow/template.hbs
@@ -24,6 +24,7 @@
     {{workflow-tooltip
       tooltipData=tooltipData
       displayRestartButton=displayRestartButton
+      stopBuild=stopBuild
       showTooltip=showTooltip
       showTooltipPosition=showTooltipPosition
       confirmStartBuild=(action "confirmStartBuild")

--- a/app/components/workflow-tooltip/component.js
+++ b/app/components/workflow-tooltip/component.js
@@ -24,5 +24,10 @@ export default Component.extend({
         left
       });
     }
+  },
+  actions: {
+    stopBuild() {
+      get(this, 'stopBuild')(get(this, 'tooltipData.job'));
+    }
   }
 });

--- a/app/components/workflow-tooltip/template.hbs
+++ b/app/components/workflow-tooltip/template.hbs
@@ -12,6 +12,9 @@
         <a {{action confirmStartBuild}}>Start pipeline from here</a>
       {{/if}}
     {{/if}}
+    {{#if tooltipData.displayStop}}
+      <a {{action stopBuild tooltipData.job}}>Stop build</a>
+    {{/if}}
   {{/if}}
   {{yield}}
 </div>

--- a/app/pipeline/events/controller.js
+++ b/app/pipeline/events/controller.js
@@ -277,6 +277,20 @@ export default Controller.extend(ModelReloaderMixin, {
         this.set('errorMessage', Array.isArray(e.errors) ? e.errors[0].detail : '');
       });
     },
+    stopBuild(job) {
+      const buildId = get(job, 'buildId');
+      let build;
+
+      if (buildId) {
+        build = this.store.peekRecord('build', buildId);
+        build.set('status', 'ABORTED');
+
+        return build.save()
+          .catch(e => this.set('errorMessage', Array.isArray(e.errors) ? e.errors[0].detail : ''));
+      }
+
+      return new Promise.Resolve();
+    },
     startPRBuild(prNum, jobs) {
       this.set('isShowingModal', true);
       const user = get(decoder(this.get('session.data.authenticated.token')), 'username');

--- a/app/pipeline/events/template.hbs
+++ b/app/pipeline/events/template.hbs
@@ -25,6 +25,7 @@
       selectedEventObj=selectedEventObj
       selected=selected
       startDetachedBuild=(action "startDetachedBuild")
+      stopBuild=(action "stopBuild")
       authenticated=session.isAuthenticated
     }}
   </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -3208,7 +3208,7 @@
     "broccoli-flatiron": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/broccoli-flatiron/-/broccoli-flatiron-0.1.3.tgz",
-      "integrity": "sha1-/HvY+vfbQp7XGZkzqi7H74So2UM=",
+      "integrity": "sha512-dD/4ck+LKOLTBzFlxP2zX7fhWt1TFMVR/88b9/wd8LkAHUyAzWs1vBah94ObSvajYGZ7ic+XvMXw+OhmvdlYoQ==",
       "dev": true,
       "requires": {
         "broccoli-plugin": "^1.3.0",
@@ -15561,7 +15561,7 @@
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk=",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true
     },
     "scss-tokenizer": {


### PR DESCRIPTION
## Context
It would be nice if users could stop a build from the pipeline events graph.

## Objective
This PR displays the "Stop Build" option if a build is active.
It also stops the build when the option is clicked.

<img width="590" alt="Screen Shot 2019-04-05 at 12 03 38 PM" src="https://user-images.githubusercontent.com/3230529/55650626-20011500-579b-11e9-9310-c254ea4b0cab.png">

<img width="691" alt="Screen Shot 2019-04-05 at 12 07 58 PM" src="https://user-images.githubusercontent.com/3230529/55650771-79694400-579b-11e9-9aae-d0ca715f9fb4.png">

## Related links
Related to https://github.com/screwdriver-cd/screwdriver/issues/1516