### PR TITLE
fix(1391): Fix update user token

### DIFF
--- a/app/components/token-view/component.js
+++ b/app/components/token-view/component.js
@@ -21,7 +21,7 @@ export default Component.extend({
     this.set('newDescription', this.get('token.description') || '');
   },
   actions: {
-    modifyToken() {
+    modifyToken(pipelineId) {
       const token = this.get('token');
 
       if (this.get('buttonAction') === 'Delete') {
@@ -31,13 +31,23 @@ export default Component.extend({
         token.set('description', this.get('newDescription'));
         this.get('setIsSaving')(true);
 
-        token.save({ adapterOptions: { pipelineId: this.get('pipelineId') } })
-          .then(() => {
-            this.get('setIsSaving')(false);
-          })
-          .catch((error) => {
-            this.get('setErrorMessage')(error.errors[0].detail);
-          });
+        if (pipelineId) {
+          token.save({ adapterOptions: { pipelineId } })
+            .then(() => {
+              this.get('setIsSaving')(false);
+            })
+            .catch((error) => {
+              this.get('setErrorMessage')(error.errors[0].detail);
+            });
+        } else {
+          token.save()
+            .then(() => {
+              this.get('setIsSaving')(false);
+            })
+            .catch((error) => {
+              this.get('setErrorMessage')(error.errors[0].detail);
+            });
+        }
       }
     },
     refresh() {

--- a/app/components/token-view/template.hbs
+++ b/app/components/token-view/template.hbs
@@ -3,5 +3,5 @@
 <td class="last-used">{{#if token.lastUsed}}{{moment-from-now token.lastUsed}}{{else}}Never used{{/if}}</td>
 <td class="actions">
   <button {{action "refresh"}}>Refresh</button>
-  <button {{action "modifyToken"}} class={{buttonAction}}>{{buttonAction}}</button>
+  <button {{action "modifyToken" pipelineId}} class={{buttonAction}}>{{buttonAction}}</button>
 </td>


### PR DESCRIPTION
## Context
Currently, pipeline token and user token operations use the same template, and updating the token from either page is hardcoded to hit the same endpoint `/v4/pipelines/:pipelineId/tokens/:tokenId`.

## Objective
This PR passes in `pipelineId` to the `modifyToken` function to help determine which endpoint to PUT to: `/v4/pipelines/:pipelineId/tokens/:tokenId` or `/v4/tokens/:tokenId`.

## Related links
Related to https://github.com/screwdriver-cd/screwdriver/issues/1391