### PR TITLE
fix(build metrics): live with a visual cue

### DIFF
--- a/app/components/pipeline-nav/styles.scss
+++ b/app/components/pipeline-nav/styles.scss
@@ -25,3 +25,20 @@
     color: $grey-800;
   }
 }
+
+.beta-feature {
+  position: relative;
+
+  &:after {
+    content: 'Beta';
+    color: #fff;
+    background: #ff4444;
+    font-size: 0.65em;
+    position: absolute;
+    line-height: 1;
+    top: -1em;
+    right: -1em;
+    padding: 3px 5px;
+    border-radius: 5px;
+  }
+}

--- a/app/components/pipeline-nav/template.hbs
+++ b/app/components/pipeline-nav/template.hbs
@@ -5,6 +5,5 @@
   {{#nav.item}}{{#nav.link-to "pipeline.events"}}Events{{/nav.link-to}}{{/nav.item}}
   {{#nav.item}}{{#nav.link-to "pipeline.secrets"}}Secrets{{/nav.link-to}}{{/nav.item}}
   {{#nav.item}}{{#nav.link-to "pipeline.options"}}Options{{/nav.link-to}}{{/nav.item}}
-  {{!-- uncomment the following to expose metrics tab --}}
-  {{!-- {{#nav.item}}{{#nav.link-to "pipeline.metrics"}}Metrics{{/nav.link-to}}{{/nav.item}} --}}
+  {{#nav.item}}{{#nav.link-to "pipeline.metrics" class="beta-feature"}}Metrics{{/nav.link-to}}{{/nav.item}}
 {{/bs-nav}}

--- a/tests/integration/components/pipeline-nav/component-test.js
+++ b/tests/integration/components/pipeline-nav/component-test.js
@@ -18,7 +18,7 @@ test('it renders without child pipelines tab', function (assert) {
 
   this.render(hbs`{{pipeline-nav pipeline=pipelineMock}}`);
 
-  assert.equal(this.$('a').text().trim(), 'EventsSecretsOptions');
+  assert.equal(this.$('a').text().trim(), 'EventsSecretsOptionsMetrics');
 });
 
 test('it renders with child pipelines tab', function (assert) {
@@ -36,5 +36,5 @@ test('it renders with child pipelines tab', function (assert) {
 
   this.render(hbs`{{pipeline-nav pipeline=pipelineMock}}`);
 
-  assert.equal(this.$('a').text().trim(), 'Child PipelinesEventsSecretsOptions');
+  assert.equal(this.$('a').text().trim(), 'Child PipelinesEventsSecretsOptionsMetrics');
 });


### PR DESCRIPTION
live showing the 4th tab on pipeline page, plus a little visual cue

<img width="381" alt="Screen Shot 2019-04-10 at 1 45 38 PM" src="https://user-images.githubusercontent.com/1331106/55901256-fc710c80-5b96-11e9-82d3-34995bde28dd.png">

