### PR TITLE
feat(1285): Can stop all builds in a selected event

### DIFF
--- a/app/components/pipeline-graph-nav/styles.scss
+++ b/app/components/pipeline-graph-nav/styles.scss
@@ -11,6 +11,24 @@
     line-height: 33px;
   }
 
+  .btn.event__stop {
+    float: right;
+    border: 1px solid $sd-aborted;
+    background-color: #fff;
+    color: $sd-aborted;
+    width: 100px;
+    font-size: 14px;
+    border-radius: 2px;
+    padding: 5px 10px;
+    font-weight: $weight-normal;
+
+    &:hover,
+    &.active:hover {
+      border-color: #ccc;
+      color: $grey-800;
+    }
+  }
+
   .btn {
     border-radius: 3px;
     padding: 5px 10px;

--- a/app/components/pipeline-graph-nav/template.hbs
+++ b/app/components/pipeline-graph-nav/template.hbs
@@ -61,6 +61,11 @@
             {{selectedEventObj.label}}
           </div>
           {{/if}}
+          {{#if selectedEventObj.isRunning}}
+          <div class="col">
+            {{#bs-button onClick=(action stopEvent) class="event__stop" title="Stop all builds for this event"}}Stop{{/bs-button}}
+          </div>
+          {{/if}}
         </div>
       {{/unless}}
     </div>

--- a/app/components/pipeline-start/template.hbs
+++ b/app/components/pipeline-start/template.hbs
@@ -1,1 +1,1 @@
-<button {{action "startBuild"}} class="start-button">Start{{#if prNum}} PR-{{prNum}}{{/if}}</button>
+<button {{action "startBuild"}} class="start-button" title="Start a new event from latest commit">Start{{#if prNum}} PR-{{prNum}}{{/if}}</button>

--- a/app/event-stop/service.js
+++ b/app/event-stop/service.js
@@ -1,0 +1,32 @@
+import $ from 'jquery';
+import { Promise as EmberPromise } from 'rsvp';
+import Service, { inject as service } from '@ember/service';
+import { get } from '@ember/object';
+import ENV from 'screwdriver-ui/config/environment';
+
+export default Service.extend({
+  session: service('session'),
+
+  /**
+   * Stop all running builds or builds about to run in a single event
+   * @method stopBuilds
+   * @param   {Number}  eventId    ID of event
+   * @return  {Promise}            Resolve nothing if success otherwise reject with error message
+   */
+  stopBuilds(eventId) {
+    const url = `${ENV.APP.SDAPI_HOSTNAME}/${ENV.APP.SDAPI_NAMESPACE}` +
+      `/events/${eventId}/stop`;
+
+    return new EmberPromise((resolve, reject) => {
+      $.ajax({
+        url,
+        type: 'PUT',
+        headers: {
+          Authorization: `Bearer ${get(this, 'session.data.authenticated.token')}`
+        }
+      })
+        .done(() => resolve())
+        .fail(jqXHR => reject(JSON.parse(jqXHR.responseText).message));
+    });
+  }
+});

--- a/app/pipeline/events/controller.js
+++ b/app/pipeline/events/controller.js
@@ -10,6 +10,7 @@ import { isPRJob } from 'screwdriver-ui/utils/build';
 
 export default Controller.extend(ModelReloaderMixin, {
   session: service(),
+  stop: service('event-stop'),
   init() {
     this._super(...arguments);
     this.startReloading();
@@ -293,6 +294,13 @@ export default Controller.extend(ModelReloaderMixin, {
       }
 
       return new Promise.Resolve();
+    },
+    stopEvent() {
+      const event = get(this, 'selectedEventObj');
+      const eventId = get(event, 'id');
+
+      return this.get('stop').stopBuilds(eventId)
+        .catch(e => this.set('errorMessage', Array.isArray(e.errors) ? e.errors[0].detail : ''));
     },
     startPRBuild(prNum, jobs) {
       this.set('isShowingModal', true);

--- a/app/pipeline/events/template.hbs
+++ b/app/pipeline/events/template.hbs
@@ -17,6 +17,7 @@
       startMainBuild=(action "startMainBuild")
       startPRBuild=(action "startPRBuild")
       prGroups=pullRequestGroups
+      stopEvent=(action "stopEvent")
     }}
 
     {{pipeline-workflow

--- a/tests/unit/event-stop/service-test.js
+++ b/tests/unit/event-stop/service-test.js
@@ -1,0 +1,63 @@
+import { moduleFor, test } from 'ember-qunit';
+import Pretender from 'pretender';
+let server;
+
+const stop = () => {
+  server.put('http://localhost:8080/v4/events/1/stop', () => [200]);
+};
+
+const stopFailed = () => {
+  server.put('http://localhost:8080/v4/events/1/stop', () => [500,
+    { 'Content-Type': 'application/json' },
+    JSON.stringify({
+      statusCode: 500,
+      message: 'internal server error'
+    })
+  ]);
+};
+
+moduleFor('service:event-stop', 'Unit | Service | event-stop', {
+  // Specify the other units that are required for this test.
+  needs: ['service:session'],
+
+  beforeEach() {
+    server = new Pretender();
+  },
+
+  afterEach() {
+    server.shutdown();
+  }
+});
+
+test('it exists', function (assert) {
+  const service = this.subject();
+
+  assert.ok(service);
+});
+
+test('it makes a call to stop all builds in an event', function (assert) {
+  assert.expect(1);
+  stop();
+  const service = this.subject();
+  const e = service.stopBuilds(1);
+
+  e.then(() => {
+    const [request] = server.handledRequests;
+
+    assert.equal(request.url, 'http://localhost:8080/v4/events/1/stop');
+  });
+});
+
+test('it fails to stop all builds in an event with error message ', function (assert) {
+  assert.expect(2);
+  stopFailed();
+  const service = this.subject();
+  const e = service.stopBuilds(1);
+
+  e.catch((error) => {
+    assert.equal(error, 'internal server error');
+    const [request] = server.handledRequests;
+
+    assert.equal(request.url, 'http://localhost:8080/v4/events/1/stop');
+  });
+});

--- a/tests/unit/pipeline/events/controller-test.js
+++ b/tests/unit/pipeline/events/controller-test.js
@@ -22,7 +22,7 @@ let server;
 moduleFor('controller:pipeline/events', 'Unit | Controller | pipeline/events', {
   // Specify the other units that are required for this test.
   // eslint-disable-next-line max-len
-  needs: ['model:build', 'model:event', 'adapter:application', 'service:session', 'serializer:build', 'serializer:event'],
+  needs: ['model:build', 'model:event', 'adapter:application', 'service:session', 'service:event-stop', 'serializer:build', 'serializer:event'],
   beforeEach() {
     server = new Pretender();
     this.register('service:session', sessionServiceMock);


### PR DESCRIPTION
## Context

It can be annoying for users to have to manually stop each build in an event. It would be nice if they could stop all running/queued/blocked builds with one click or API call.

## Objective

This PR adds a Stop button to the main pipeline event graph so a user can stop all running builds with one click. The button only shows if there are builds running.

Example:
![Screen Shot 2019-04-19 at 3 54 47 PM](https://user-images.githubusercontent.com/3230529/56447914-0cd46600-62c0-11e9-97db-4ff37433d90c.png)

On hover it will show a text hint:
![Screen Shot 2019-04-19 at 3 54 57 PM](https://user-images.githubusercontent.com/3230529/56447912-0a720c00-62c0-11e9-8763-883a527bfb36.png)


## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/1285