### PR TITLE
fix: Pin to nginx:1.14.2-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:stable-alpine
+FROM nginx:1.14.2-alpine
 COPY nginx.conf /etc/nginx/nginx.conf
 WORKDIR /usr/share/nginx/html
 RUN set -x \


### PR DESCRIPTION
## Context
Nginx updated their `stable-alpine` Docker image 8 hours ago to use nginx 1.16 (https://github.com/nginxinc/docker-nginx/commit/9a052e07b2c283df9960375ee40be50c5c462a7e)

This breaks the UI
```
2019/04/24 19:04:58 [emerg] 1#1: module "/usr/lib/nginx/modules/ndk_http_module.so" version 1014002 instead of 1016000 in /etc/nginx/nginx.conf:1
nginx: [emerg] module "/usr/lib/nginx/modules/ndk_http_module.so" version 1014002 instead of 1016000 in /etc/nginx/nginx.conf:1
```

## Objective
This PR pins nginx to 1.14.2-alpine, which was the previous version before the update.

## Related links
nginx docker hub: https://hub.docker.com/_/nginx