### PR TITLE
Fix pr detach job

### DIFF
--- a/app/pipeline/events/controller.js
+++ b/app/pipeline/events/controller.js
@@ -260,11 +260,17 @@ export default Controller.extend(ModelReloaderMixin, {
 
       const event = this.selectedEventObj;
       const parentEventId = get(event, 'id');
-      const startFrom = get(job, 'name');
       const pipelineId = get(this, 'pipeline.id');
       const token = get(this, 'session.data.authenticated.token');
       const user = get(decoder(token), 'username');
       const causeMessage = `Manually started by ${user}`;
+      const prNum = get(event, 'prNum');
+      let startFrom = get(job, 'name');
+
+      if (prNum) {
+        // PR-<num>: prefix is needed, if it is a PR event.
+        startFrom = `PR-${prNum}:${startFrom}`;
+      }
       const newEvent = this.store.createRecord('event', {
         buildId,
         pipelineId,

--- a/tests/unit/pipeline/events/controller-test.js
+++ b/tests/unit/pipeline/events/controller-test.js
@@ -189,11 +189,13 @@ module('Unit | Controller | pipeline/events', function(hooks) {
       });
 
       controller.set(
-        'pr',
+        'pipeline',
         EmberObject.create({
           id: '1234'
         })
       );
+
+      controller.set('activeTab', 'pulls');
 
       controller.set('reload', () => {
         assert.ok(true);
@@ -209,6 +211,7 @@ module('Unit | Controller | pipeline/events', function(hooks) {
         assert.equal(path, 'pipeline/1234/pulls');
       };
 
+      assert.notOk(controller.get('isShowingModal'));
       controller.send('startDetachedBuild', { buildId: '123', name: 'deploy' });
       assert.ok(controller.get('isShowingModal'));
     });


### PR DESCRIPTION
## Context
When choose pull request event and start non-existed job (gray color job), new event is not executed as pull request job. 
Its better to create new PR event, when start job from PR event.

## Objective
When start detached job from PR event, the value of startFrom has prefix of `PR-<num>:`.

Even start job which trigger from commit build has `PR-<num>:` in pull request tab, `startFrom` has pr prefix. When execute these jobs, user got 404.I think it makes the PR event more secure.

## How to reproduce the problem
1. Open PR. 
<img width="1405" alt="スクリーンショット 2019-05-20 21 17 30" src="https://user-images.githubusercontent.com/4645011/58021405-c33c9c80-7b45-11e9-92ba-35b2756a53e8.png">

2. Exec job from chain2 PR.
<img width="1419" alt="スクリーンショット 2019-05-20 21 20 17" src="https://user-images.githubusercontent.com/4645011/58021423-d3ed1280-7b45-11e9-82db-e78c55c2d0aa.png">

3. Exec chain1 PR, then the new event was created in event tab.
<img width="1432" alt="スクリーンショット 2019-05-20 21 20 40" src="https://user-images.githubusercontent.com/4645011/58021436-e1a29800-7b45-11e9-971b-23ac675bee73.png">
