### PR TITLE
fix: show rootDir if exists on collection view

### DIFF
--- a/app/components/collection-view/component.js
+++ b/app/components/collection-view/component.js
@@ -40,14 +40,17 @@ export default Component.extend({
       if (this.get('collection.pipelines')) {
         return this.get('collection.pipelines').map(pipeline => {
           const scm = scmService.getScm(pipeline.scmContext);
+          const { id, scmRepo, workflow, lastBuilds, prs } = pipeline;
+          const { branch, rootDir } = scmRepo;
           const ret = {
-            id: pipeline.id,
-            scmRepo: pipeline.scmRepo,
+            id,
+            scmRepo,
+            branch: rootDir ? `${branch}#${rootDir}` : branch,
             scm: scm.displayName,
             scmIcon: scm.iconType,
-            workflow: pipeline.workflow,
-            lastBuilds: pipeline.lastBuilds,
-            prs: pipeline.prs
+            workflow,
+            lastBuilds,
+            prs
           };
 
           if (pipeline.lastBuilds && pipeline.lastBuilds.length) {

--- a/app/components/collection-view/template.hbs
+++ b/app/components/collection-view/template.hbs
@@ -65,7 +65,7 @@
             <td class="app-id">
               {{#highlight-terms query}}{{#link-to "pipeline" pipeline.id}}{{pipeline.scmRepo.name}}{{/link-to}}{{/highlight-terms}}
             </td>
-            <td class="branch">{{fa-icon "code-fork"}}{{pipeline.scmRepo.branch}}</td>
+            <td class="branch">{{fa-icon "code-fork"}}{{pipeline.branch}}</td>
             <td class="account">{{fa-icon pipeline.scmIcon}} {{pipeline.scm}}</td>
             <td class="health">
               {{fa-icon pipeline.lastBuildIcon class=pipeline.lastBuildStatusColor}}

--- a/tests/integration/components/collection-view/component-test.js
+++ b/tests/integration/components/collection-view/component-test.js
@@ -91,7 +91,7 @@ module('Integration | Component | collection view', function(hooks) {
         },
         {
           id: 4,
-          scmUri: 'github.com:54321879:master',
+          scmUri: 'github.com:54321879:master:lib',
           createTime: '2017-01-05T00:55:46.775Z',
           admins: {
             username: true
@@ -100,7 +100,8 @@ module('Integration | Component | collection view', function(hooks) {
           scmRepo: {
             name: 'screwdriver-cd/zzz',
             branch: 'master',
-            url: 'https://github.com/screwdriver-cd/zzz/tree/master'
+            url: 'https://github.com/screwdriver-cd/zzz/tree/master',
+            rootDir: 'lib'
           },
           scmContext: 'bitbucket:bitbucket.org',
           annotations: {},
@@ -142,6 +143,14 @@ module('Integration | Component | collection view', function(hooks) {
     assert.dom(appIdEls[1]).hasText('screwdriver-cd/screwdriver');
     assert.dom(appIdEls[2]).hasText('screwdriver-cd/ui');
     assert.dom(appIdEls[3]).hasText('screwdriver-cd/zzz');
+
+    // The pipelines are sorted in alphabetical order by default by the component
+    const branchEls = findAll('td.branch');
+
+    assert.dom(branchEls[0]).hasText('master');
+    assert.dom(branchEls[1]).hasText('master');
+    assert.dom(branchEls[2]).hasText('master');
+    assert.dom(branchEls[3]).hasText('master#lib');
 
     // The models pipeline has scm display names
     const accountEls = findAll('td.account');


### PR DESCRIPTION
The collection view is not using the pipeline model, the collection object itself contains a list of pipelines. This PR will add rootDir to branch if it exists.

Related to: https://github.com/screwdriver-cd/screwdriver/issues/1455