### PR TITLE
[Refactor] Refactor string space into keyCode 32

### DIFF
--- a/app/components/app-header/template.hbs
+++ b/app/components/app-header/template.hbs
@@ -7,7 +7,7 @@
     {{#navbar.nav classNames="navbar-nav navbar-left" as |nav|}}
       {{#if showCollections}}
         {{#nav.item}}
-          {{#link-to "dashboard" class="icon"}}
+          {{#link-to "home" class="icon"}}
             <span>Collections</span>
           {{/link-to}}
         {{/nav.item}}

--- a/tests/integration/components/pipeline-options/component-test.js
+++ b/tests/integration/components/pipeline-options/component-test.js
@@ -107,7 +107,7 @@ module('Integration | Component | pipeline options', function(hooks) {
     assert.dom('.root-dir').doesNotExist();
 
     await fillIn('.scm-url', scm);
-    await triggerKeyEvent('.text-input', 'keyup', 'SPACE');
+    await triggerKeyEvent('.text-input', 'keyup', 32);
 
     assert.dom('.scm-url').hasValue(scm);
 
@@ -144,7 +144,7 @@ module('Integration | Component | pipeline options', function(hooks) {
     await fillIn('.scm-url', scm);
     await click('.checkbox-input');
     await fillIn('.root-dir', root);
-    await triggerKeyEvent('.scm-url', 'keyup', 'SPACE');
+    await triggerKeyEvent('.scm-url', 'keyup', 32);
 
     assert.dom('.scm-url').hasValue(scm);
     assert.dom('.root-dir').hasValue(root);

--- a/tests/integration/components/pipeline-secret-settings/component-test.js
+++ b/tests/integration/components/pipeline-secret-settings/component-test.js
@@ -50,28 +50,28 @@ module('Integration | Component | pipeline secret settings', function(hooks) {
 
     // disabled when no value
     await fillIn('.key input', 'SECRET_KEY');
-    await triggerKeyEvent('.key input', 'keyup', 'ENTER');
+    await triggerKeyEvent('.key input', 'keyup', 13);
 
     assert.dom('tfoot button').isDisabled();
 
     // disabled when no key
     await fillIn('.key input', '');
-    await triggerKeyEvent('.key input', 'keyup', 'ENTER');
+    await triggerKeyEvent('.key input', 'keyup', 13);
 
     await fillIn('.pass input', 'SECRET_VAL');
-    await triggerKeyEvent('.pass input', 'keyup', 'ENTER');
+    await triggerKeyEvent('.pass input', 'keyup', 13);
 
     assert.dom('tfoot button').isDisabled();
 
     // enabled when both present
     await fillIn('.key input', 'SECRET_KEY');
-    await triggerKeyEvent('.key input', 'keyup', 'ENTER');
+    await triggerKeyEvent('.key input', 'keyup', 13);
 
     assert.dom('tfoot button').isNotDisabled();
 
     // disabled again when no key
     await fillIn('.key input', '');
-    await triggerKeyEvent('.key input', 'keyup', 'ENTER');
+    await triggerKeyEvent('.key input', 'keyup', 13);
 
     assert.dom('tfoot button').isDisabled();
   });
@@ -90,10 +90,10 @@ module('Integration | Component | pipeline secret settings', function(hooks) {
     );
 
     await fillIn('.key input', 'SECRET_KEY');
-    await triggerKeyEvent('.key input', 'keyup', 'ENTER');
+    await triggerKeyEvent('.key input', 'keyup', 13);
 
     await fillIn('.pass input', 'SECRET_VAL');
-    await triggerKeyEvent('.pass input', 'keyup', 'ENTER');
+    await triggerKeyEvent('.pass input', 'keyup', 13);
 
     await click('tfoot button');
 
@@ -115,10 +115,10 @@ module('Integration | Component | pipeline secret settings', function(hooks) {
     );
 
     await fillIn('.key input', '0banana');
-    await triggerKeyEvent('.key input', 'keyup', 'ENTER');
+    await triggerKeyEvent('.key input', 'keyup', 13);
 
     await fillIn('.pass input', '0value');
-    await triggerKeyEvent('.pass input', 'keyup', 'ENTER');
+    await triggerKeyEvent('.pass input', 'keyup', 13);
 
     await click('tfoot button');
 

--- a/tests/integration/components/secret-view/component-test.js
+++ b/tests/integration/components/secret-view/component-test.js
@@ -33,13 +33,13 @@ module('Integration | Component | secret view', function(hooks) {
 
     // button value changes when user types a new value
     await fillIn('.pass input', 'banana');
-    await triggerKeyEvent('.pass input', 'keyup', 'ENTER');
+    await triggerKeyEvent('.pass input', 'keyup', 13);
 
     assert.dom('button').hasText('Update');
 
     // button value changes when user types a new value
     await fillIn('.pass input', '');
-    await triggerKeyEvent('.pass input', 'keyup', 'ENTER');
+    await triggerKeyEvent('.pass input', 'keyup', 13);
     assert.dom('button').hasText('Delete');
 
     // button value changes when user click the checkbox
@@ -127,7 +127,7 @@ module('Integration | Component | secret view', function(hooks) {
     await render(hbs`{{secret-view secret=mockSecret pipeline=mockPipeline}}`);
 
     await fillIn('.pass input', 'banana');
-    await triggerKeyEvent('.pass input', 'keyup', 'ENTER');
+    await triggerKeyEvent('.pass input', 'keyup', 13);
 
     await click('.allow input');
     await click('button');
@@ -182,7 +182,7 @@ module('Integration | Component | secret view', function(hooks) {
       onCreateSecret=(action externalAction)}}`);
 
     await fillIn('.pass input', 'apple');
-    await triggerKeyEvent('.pass input', 'keyup', 'ENTER');
+    await triggerKeyEvent('.pass input', 'keyup', 13);
 
     await click('button');
   });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Code refactoring

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

1. Refactor string `SPACE` into keyCode `32`
2. Refactor string `ENTER` into keyCode `13`
3. Replace `collection` route in the header and use `home` route instead

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
