### PR TITLE
 fix: add admin UI to (un)mark template/command as "trusted"

### DIFF
--- a/app/command/service.js
+++ b/app/command/service.js
@@ -105,8 +105,41 @@ export default Service.extend({
             message = `${response.status} ${response.responseJSON.error}`;
           }
 
-          if (response.status === 401) {
+          if (response.status === 403) {
             message = 'You do not have the permissions to remove this command.';
+          }
+
+          return reject(message);
+        });
+    });
+  },
+  updateTrust(namespace, name, trusted) {
+    const url =
+      `${ENV.APP.SDAPI_HOSTNAME}/${ENV.APP.SDAPI_NAMESPACE}/commands/` +
+      `${encodeURIComponent(namespace)}/${encodeURIComponent(name)}/trusted`;
+    const ajaxConfig = {
+      method: 'PUT',
+      dataType: 'json',
+      url,
+      contentType: 'application/json',
+      crossDomain: true,
+      xhrFields: {
+        withCredentials: true
+      },
+      headers: {
+        Authorization: `Bearer ${get(this, 'session.data.authenticated.token')}`
+      },
+      data: JSON.stringify({ trusted })
+    };
+
+    return new EmberPromise((resolve, reject) => {
+      $.ajax(ajaxConfig)
+        .done(content => resolve(content))
+        .fail(response => {
+          let message = `${response.status} Request Failed`;
+
+          if (response.status === 401 || response.status === 403) {
+            message = 'You do not have the permissions to update this command.';
           }
 
           return reject(message);

--- a/app/commands/detail/controller.js
+++ b/app/commands/detail/controller.js
@@ -1,11 +1,13 @@
 import { computed, observer } from '@ember/object';
 import { inject as service } from '@ember/service';
 import Controller from '@ember/controller';
+import { jwt_decode as decoder } from 'ember-cli-jwt-decode';
 const { alias } = computed;
 
 export default Controller.extend({
   selectedVersion: null,
   errorMessage: '',
+  session: service(),
   command: service(),
   commands: alias('model'),
   reset() {
@@ -18,6 +20,11 @@ export default Controller.extend({
   }),
   trusted: computed('commands.[]', function computeTrusted() {
     return this.commands.some(c => c.trusted);
+  }),
+  isAdmin: computed(function isAdmin() {
+    const token = this.get('session.data.authenticated.token');
+
+    return (decoder(token).scope || []).includes('admin');
   }),
   versionCommand: computed('selectedVersion', 'commands.[]', {
     get() {
@@ -39,6 +46,14 @@ export default Controller.extend({
       return this.command
         .deleteCommands(namespace, name)
         .then(() => this.transitionToRoute('commands'), err => this.set('errorMessage', err));
+    },
+    updateTrust(namespace, name, toTrust) {
+      return (
+        this.isAdmin &&
+        this.command
+          .updateTrust(namespace, name, toTrust)
+          .catch(err => this.set('errorMessage', err))
+      );
     }
   }
 });

--- a/app/commands/detail/template.hbs
+++ b/app/commands/detail/template.hbs
@@ -1,6 +1,12 @@
 {{info-message message=errorMessage type="warning" icon="exclamation-triangle"}}
 
-{{command-header command=versionCommand trusted=trusted onRemoveCommand=(action "removeCommand")}}
+{{command-header
+  command=versionCommand
+  trusted=trusted
+  isAdmin=isAdmin
+  onUpdateTrust=(action "updateTrust")
+  onRemoveCommand=(action "removeCommand")
+}}
 
 {{command-format command=versionCommand}}
 

--- a/app/components/command-header/component.js
+++ b/app/components/command-header/component.js
@@ -31,6 +31,10 @@ export default Component.extend({
         this.set('commandToRemove', null);
         this.set('isRemoving', false);
       });
+    },
+    updateTrust(namespace, name, toTrust) {
+      this.set('trusted', toTrust);
+      this.onUpdateTrust(namespace, name, toTrust);
     }
   }
 });

--- a/app/components/command-header/styles.scss
+++ b/app/components/command-header/styles.scss
@@ -16,4 +16,14 @@
     width: 1em;
     vertical-align: middle;
   }
+
+  .x-toggle-component {
+    display: inline-flex;
+    font-size: 0.5em;
+    float: right;
+  }
+
+  .x-toggle-container {
+    font-size: 0.75rem;
+  }
 }

--- a/app/components/command-header/template.hbs
+++ b/app/components/command-header/template.hbs
@@ -7,6 +7,17 @@
   {{else}}
     {{fa-icon "code-fork" title="The pipeline for this command does not exist."}} {{fa-icon "trash" title="Cannot delete command; pipeline could not be found."}}
   {{/if}}
+  {{#if isAdmin}}
+    {{x-toggle
+      size="medium"
+      theme="light"
+      showLabels=true
+      value=trusted
+      offLabel=null
+      onLabel="Trust?"
+      onToggle=(action "updateTrust" command.namespace command.name)
+    }}
+  {{/if}}
 </h1>
 <h2>{{command.version}}</h2>
 <p>{{command.description}}</p>

--- a/app/components/template-header/component.js
+++ b/app/components/template-header/component.js
@@ -31,6 +31,10 @@ export default Component.extend({
         this.set('templateToRemove', null);
         this.set('isRemoving', false);
       });
+    },
+    updateTrust(fullName, toTrust) {
+      this.set('trusted', toTrust);
+      this.onUpdateTrust(fullName, toTrust);
     }
   }
 });

--- a/app/components/template-header/styles.scss
+++ b/app/components/template-header/styles.scss
@@ -28,4 +28,14 @@
     width: 1em;
     vertical-align: middle;
   }
+
+  .x-toggle-component {
+    display: inline-flex;
+    font-size: 0.5em;
+    float: right;
+  }
+
+  .x-toggle-container {
+    font-size: 0.75rem;
+  }
 }

--- a/app/components/template-header/template.hbs
+++ b/app/components/template-header/template.hbs
@@ -6,6 +6,17 @@
   {{else}}
     {{fa-icon "code-fork" title="The pipeline for this template does not exist."}} {{fa-icon "trash" title="Cannot delete template; pipeline could not be found."}}
   {{/if}}
+  {{#if isAdmin}}
+    {{x-toggle
+      size="medium"
+      theme="light"
+      showLabels=true
+      value=trusted
+      offLabel=null
+      onLabel="Trust?"
+      onToggle=(action "updateTrust" template.fullName)
+    }}
+  {{/if}}
 </h1>
 <h2>{{template.version}}</h2>
 <p>{{template.description}}</p>

--- a/app/template/service.js
+++ b/app/template/service.js
@@ -105,8 +105,41 @@ export default Service.extend({
             message = `${response.status} ${response.responseJSON.error}`;
           }
 
-          if (response.status === 401) {
+          if (response.status === 403) {
             message = 'You do not have the permissions to remove this template.';
+          }
+
+          return reject(message);
+        });
+    });
+  },
+  updateTrust(fullName, trusted) {
+    const url =
+      `${ENV.APP.SDAPI_HOSTNAME}/${ENV.APP.SDAPI_NAMESPACE}/templates/` +
+      `${encodeURIComponent(fullName)}/trusted`;
+    const ajaxConfig = {
+      method: 'PUT',
+      dataType: 'json',
+      url,
+      contentType: 'application/json',
+      crossDomain: true,
+      xhrFields: {
+        withCredentials: true
+      },
+      headers: {
+        Authorization: `Bearer ${get(this, 'session.data.authenticated.token')}`
+      },
+      data: JSON.stringify({ trusted })
+    };
+
+    return new EmberPromise((resolve, reject) => {
+      $.ajax(ajaxConfig)
+        .done(content => resolve(content))
+        .fail(response => {
+          let message = `${response.status} Request Failed`;
+
+          if (response.status === 401 || response.status === 403) {
+            message = 'You do not have the permissions to update this template.';
           }
 
           return reject(message);

--- a/app/templates/detail/controller.js
+++ b/app/templates/detail/controller.js
@@ -1,11 +1,13 @@
 import { inject as service } from '@ember/service';
 import { computed, observer } from '@ember/object';
 import Controller from '@ember/controller';
+import { jwt_decode as decoder } from 'ember-cli-jwt-decode';
 const { alias } = computed;
 
 export default Controller.extend({
   selectedVersion: null,
   errorMessage: '',
+  session: service(),
   template: service(),
   templates: alias('model'),
   reset() {
@@ -13,6 +15,11 @@ export default Controller.extend({
   },
   trusted: computed('templates.[]', function computeTrusted() {
     return this.templates.some(t => t.trusted);
+  }),
+  isAdmin: computed(function isAdmin() {
+    const token = this.get('session.data.authenticated.token');
+
+    return (decoder(token).scope || []).includes('admin');
   }),
   latest: computed('templates.[]', {
     get() {
@@ -39,6 +46,12 @@ export default Controller.extend({
       return this.template
         .deleteTemplates(name)
         .then(() => this.transitionToRoute('templates'), err => this.set('errorMessage', err));
+    },
+    updateTrust(fullName, toTrust) {
+      return (
+        this.isAdmin &&
+        this.template.updateTrust(fullName, toTrust).catch(err => this.set('errorMessage', err))
+      );
     }
   }
 });

--- a/app/templates/detail/template.hbs
+++ b/app/templates/detail/template.hbs
@@ -2,8 +2,10 @@
 
 {{template-header
   template=versionTemplate
-  onRemoveTemplate=(action "removeTemplate")
   trusted=trusted
+  isAdmin=isAdmin
+  onUpdateTrust=(action "updateTrust")
+  onRemoveTemplate=(action "removeTemplate")
 }}
 
 <h4>Contents:</h4>

--- a/package-lock.json
+++ b/package-lock.json
@@ -14197,9 +14197,9 @@
       }
     },
     "eslint-config-prettier": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-4.3.0.tgz",
-      "integrity": "sha512-sZwhSTHVVz78+kYD3t5pCWSYEdVSBR0PXnwjDRsUs8ytIrK8PLXw+6FKp8r3Z7rx4ZszdetWlXYKOHoUrrwPlA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-5.0.0.tgz",
+      "integrity": "sha512-c17Aqiz5e8LEqoc/QPmYnaxQFAHTx2KlCZBPxXXjEMmNchOLnV/7j0HoPZuC+rL/tDC9bazUYOKJW9bOhftI/w==",
       "dev": true,
       "requires": {
         "get-stdin": "^6.0.0"

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "ember-toggle": "^5.3.2",
     "ember-truth-helpers": "^2.1.0",
     "eslint": "^5.16.0",
-    "eslint-config-prettier": "^4.3.0",
+    "eslint-config-prettier": "^5.0.0",
     "eslint-config-screwdriver": "^4.0.0",
     "eslint-plugin-ember": "^6.5.1",
     "eslint-plugin-prettier": "^3.1.0",
@@ -123,7 +123,7 @@
     "lint-staged": "^8.1.7",
     "loader.js": "^4.7.0",
     "memoizerific": "^1.11.3",
-    "prettier": "^1.17.1",
+    "prettier": "^1.18.2",
     "qunit-dom": "^0.8.4",
     "sass": "^1.20.1"
   }

--- a/tests/integration/components/command-header/component-test.js
+++ b/tests/integration/components/command-header/component-test.js
@@ -40,7 +40,10 @@ module('Integration | Component | command header', function(hooks) {
     this.owner.register('service:store', storeStub);
 
     this.set('mock', COMMAND);
-    await render(hbs`{{command-header command=mock}}`);
+    this.set('trusted', false);
+    this.set('isAdmin', false);
+
+    await render(hbs`{{command-header command=mock trusted=trusted isAdmin=isAdmin}}`);
 
     assert.dom('h1').hasText('foo/bar');
     assert.dom('h2').hasText('1.0.0');
@@ -49,5 +52,11 @@ module('Integration | Component | command header', function(hooks) {
     assert.dom('ul li:first-child a').hasAttribute('href', 'mailto:test@example.com');
     assert.dom('h4').hasText('Usage:');
     assert.dom('pre').hasText('sd-cmd exec foo/bar@1.0.0');
+
+    this.set('trusted', true);
+    this.set('isAdmin', true);
+
+    assert.dom('svg').exists({ count: 1 });
+    assert.dom('.x-toggle-component').exists({ count: 1 });
   });
 });

--- a/tests/integration/components/template-header/component-test.js
+++ b/tests/integration/components/template-header/component-test.js
@@ -46,11 +46,13 @@ module('Integration | Component | template header', function(hooks) {
     });
 
     this.set('mock', TEMPLATE);
+    this.set('trusted', false);
+    this.set('isAdmin', false);
 
     this.owner.unregister('service:store');
     this.owner.register('service:store', storeStub);
 
-    await render(hbs`{{template-header template=mock}}`);
+    await render(hbs`{{template-header template=mock trusted=trusted isAdmin=isAdmin}}`);
 
     assert.dom('h1').hasText('foo/bar');
     assert.dom('h2').hasText('2.0.0');
@@ -64,5 +66,11 @@ module('Integration | Component | template header', function(hooks) {
     assert.dom('#template-tags').hasText('Tags: car armored');
     assert.dom('h4').hasText('Usage:');
     assert.dom('pre').hasText('jobs: main: template: foo/bar@2.0.0');
+
+    this.set('trusted', true);
+    this.set('isAdmin', true);
+
+    assert.dom('svg').exists({ count: 1 });
+    assert.dom('.x-toggle-component').exists({ count: 1 });
   });
 });

--- a/tests/unit/commands/detail/controller-test.js
+++ b/tests/unit/commands/detail/controller-test.js
@@ -2,11 +2,27 @@ import { resolve } from 'rsvp';
 import { A } from '@ember/array';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
 import Service from '@ember/service';
+
+const updateTrustStub = sinon.stub();
 
 const commandServiceStub = Service.extend({
   deleteCommands() {
     return resolve([204]);
+  },
+  updateTrust: updateTrustStub.resolves('123')
+});
+
+const sessionServiceMock = Service.extend({
+  isAuthenticated: true,
+  data: {
+    authenticated: {
+      // fake token for test, it has { username: apple } inside
+      // eslint-disable-next-line max-len
+      token:
+        'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImFwcGxlIiwic2NvcGUiOlsidXNlciIsImFkbWluIl0sImp0aSI6IjUwNTU0M2E1LTQ4Y2YtNDkwMi1hN2E5LWRmNDUyNTgxY2FjNCIsImlhdCI6MTUyMTU3MjAxOSwiZXhwIjoxNTIxNTc1NjE5fQ.85SkUix6FemFGM5SU6hJ1NzzI0fFS_9JxQw6Qt-Cnsc'
+    }
   }
 });
 
@@ -16,6 +32,7 @@ module('Unit | Controller | commands/detail', function(hooks) {
   // Specify the other units that are required for this test.
   // needs: ['controller:foo']
   hooks.beforeEach(function beforeEach() {
+    this.owner.register('service:session', sessionServiceMock);
     this.owner.register('service:command', commandServiceStub);
   });
 
@@ -99,5 +116,23 @@ module('Unit | Controller | commands/detail', function(hooks) {
     };
 
     controller.send('removeCommand', 'sample');
+  });
+
+  test('it handles command update', function(assert) {
+    let controller = this.owner.lookup('controller:commands/detail');
+    // eslint-disable-next-line new-cap
+    const arr = A([
+      { id: 3, name: 'sample', version: '3.0.0' },
+      { id: 2, name: 'sample', version: '2.0.0' },
+      { id: 1, name: 'sample', version: '1.0.0' }
+    ]);
+
+    controller.set('model', arr);
+
+    assert.ok(controller);
+    assert.ok(controller.get('isAdmin'));
+
+    controller.send('updateTrust', 'sample');
+    assert.ok(updateTrustStub.calledOnce);
   });
 });

--- a/tests/unit/templates/detail/controller-test.js
+++ b/tests/unit/templates/detail/controller-test.js
@@ -2,11 +2,27 @@ import { resolve } from 'rsvp';
 import { A } from '@ember/array';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
 import Service from '@ember/service';
+
+const updateTrustStub = sinon.stub();
 
 const templateServiceStub = Service.extend({
   deleteTemplates() {
     return resolve([204]);
+  },
+  updateTrust: updateTrustStub.resolves('123')
+});
+
+const sessionServiceMock = Service.extend({
+  isAuthenticated: true,
+  data: {
+    authenticated: {
+      // fake token for test, it has { username: apple } inside
+      // eslint-disable-next-line max-len
+      token:
+        'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImFwcGxlIiwic2NvcGUiOlsidXNlciIsImFkbWluIl0sImp0aSI6IjUwNTU0M2E1LTQ4Y2YtNDkwMi1hN2E5LWRmNDUyNTgxY2FjNCIsImlhdCI6MTUyMTU3MjAxOSwiZXhwIjoxNTIxNTc1NjE5fQ.85SkUix6FemFGM5SU6hJ1NzzI0fFS_9JxQw6Qt-Cnsc'
+    }
   }
 });
 
@@ -16,6 +32,7 @@ module('Unit | Controller | templates/detail', function(hooks) {
   // Specify the other units that are required for this test.
   // needs: ['controller:foo']
   hooks.beforeEach(function beforeEach() {
+    this.owner.register('service:session', sessionServiceMock);
     this.owner.register('service:template', templateServiceStub);
   });
 
@@ -99,5 +116,23 @@ module('Unit | Controller | templates/detail', function(hooks) {
     };
 
     controller.send('removeTemplate', 'sample');
+  });
+
+  test('it handles template update', function(assert) {
+    let controller = this.owner.lookup('controller:templates/detail');
+    // eslint-disable-next-line new-cap
+    const arr = A([
+      { id: 3, name: 'sample', version: '3.0.0' },
+      { id: 2, name: 'sample', version: '2.0.0' },
+      { id: 1, name: 'sample', version: '1.0.0' }
+    ]);
+
+    controller.set('model', arr);
+
+    assert.ok(controller);
+    assert.ok(controller.get('isAdmin'));
+
+    controller.send('updateTrust', 'sample');
+    assert.ok(updateTrustStub.calledOnce);
   });
 });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Screwdriver admins will need a UI to (un)mark template/command as `trusted`

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

This PR adds the required UI components

<img width="586" alt="Screen Shot 2019-06-21 at 4 19 09 AM" src="https://user-images.githubusercontent.com/1331106/59908925-82ea6b80-93dc-11e9-9d72-3cc574819644.png">
<img width="592" alt="Screen Shot 2019-06-21 at 4 18 57 AM" src="https://user-images.githubusercontent.com/1331106/59908917-7ebe4e00-93dc-11e9-82cd-ad9df3ff0a44.png">

- Not the prettiest UI but it's better than doing separate solo pipeline/manual script/direct sql
- While api endpoints require token with admin scope, UI does have the jwt with right privilege for admins. No need to acquire another token for this.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

https://github.com/screwdriver-cd/screwdriver/issues/1427

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
