### PR TITLE
feat(1685): Improve skip ci event view

### DIFF
--- a/app/components/pipeline-event-row/component.js
+++ b/app/components/pipeline-event-row/component.js
@@ -16,9 +16,9 @@ export default Component.extend({
   }),
   isShowGraph: computed('event.{workflowGraph,isSkipped}', {
     get() {
-      const { workflowGraph, isSkipped } = getProperties(this, 'event.workflowGraph', 'event.isSkipped');
+      const eventProperties = getProperties(this, 'event.workflowGraph', 'event.isSkipped');
 
-      return workflowGraph && !isSkipped;
+      return eventProperties['event.workflowGraph'] && !eventProperties['event.isSkipped'];
     }
   }),
   actions: {

--- a/app/components/pipeline-event-row/component.js
+++ b/app/components/pipeline-event-row/component.js
@@ -14,6 +14,14 @@ export default Component.extend({
       return statusIcon(this.get('event.status'), true);
     }
   }),
+  isShowGraph: computed('event.{workflowGraph,isSkipped}', {
+    get() {
+      const workflowGraph = get(this, 'event.workflowGraph');
+      const isSkipped = get(this, 'event.isSkipped');
+
+      return workflowGraph && !isSkipped;
+    }
+  }),
   actions: {
     clickRow() {
       const fn = get(this, 'eventClick');

--- a/app/components/pipeline-event-row/component.js
+++ b/app/components/pipeline-event-row/component.js
@@ -1,5 +1,5 @@
 import Component from '@ember/component';
-import { computed, get } from '@ember/object';
+import { computed, get, getProperties } from '@ember/object';
 import { statusIcon } from 'screwdriver-ui/utils/build';
 
 export default Component.extend({
@@ -16,8 +16,7 @@ export default Component.extend({
   }),
   isShowGraph: computed('event.{workflowGraph,isSkipped}', {
     get() {
-      const workflowGraph = get(this, 'event.workflowGraph');
-      const isSkipped = get(this, 'event.isSkipped');
+      const { workflowGraph, isSkipped } = getProperties(this, 'event.workflowGraph', 'event.isSkipped');
 
       return workflowGraph && !isSkipped;
     }

--- a/app/components/pipeline-event-row/template.hbs
+++ b/app/components/pipeline-event-row/template.hbs
@@ -13,7 +13,7 @@
     <span class="message" title={{event.commit.message}}>{{event.truncatedMessage}}</span>
     <div class="by"><a href={{event.creator.url}}>{{event.creator.name}}</a></div>
     <div class="workflow">
-      {{#if (and (is-fulfilled event.builds) event.workflowGraph (not event.isSkipped))}}
+      {{#if (and (is-fulfilled event.builds) isShowGraph)}}
         {{workflow-graph-d3
           builds=event.builds
           workflowGraph=event.workflowGraph

--- a/app/components/pipeline-event-row/template.hbs
+++ b/app/components/pipeline-event-row/template.hbs
@@ -13,7 +13,7 @@
     <span class="message" title={{event.commit.message}}>{{event.truncatedMessage}}</span>
     <div class="by"><a href={{event.creator.url}}>{{event.creator.name}}</a></div>
     <div class="workflow">
-      {{#if (and (is-fulfilled event.builds) event.workflowGraph)}}
+      {{#if (and (is-fulfilled event.builds) event.workflowGraph (not event.isSkipped))}}
         {{workflow-graph-d3
           builds=event.builds
           workflowGraph=event.workflowGraph

--- a/app/components/pipeline-workflow/template.hbs
+++ b/app/components/pipeline-workflow/template.hbs
@@ -23,6 +23,7 @@
       startFrom=selectedEventObj.startFrom
       causeMessage=selectedEventObj.causeMessage
       graphClicked=(action "graphClicked")
+      isSkipped=selectedEventObj.isSkipped
     }}
       {{workflow-tooltip
         tooltipData=tooltipData

--- a/app/components/workflow-graph-d3/component.js
+++ b/app/components/workflow-graph-d3/component.js
@@ -150,14 +150,20 @@ export default Component.extend({
     // Calculate the start/end point of a line
     const calcPos = (pos, spacer) => (pos + 1) * ICON_SIZE + (pos * spacer - ICON_SIZE / 2);
 
+    const isSkipped = getWithDefault(this, 'isSkipped', false);
+
     // edges
     svg
       .selectAll('link')
       .data(data.edges)
       .enter()
       .append('path')
-      .attr('class', d => `graph-edge ${d.status ? `build-${d.status.toLowerCase()}` : ''}`)
-      .attr('stroke-dasharray', d => (!d.status ? 5 : 500))
+      .attr('class', d =>
+        isSkipped
+          ? 'graph-edge build-skipped'
+          : `graph-edge ${d.status ? `build-${d.status.toLowerCase()}` : ''}`
+      )
+      .attr('stroke-dasharray', d => (!d.status || isSkipped ? 5 : 500))
       .attr('stroke-width', 2)
       .attr('fill', 'transparent')
       .attr('d', d => {
@@ -186,11 +192,23 @@ export default Component.extend({
       // for each element in data array - do the following
       // create a group element to animate
       .append('g')
-      .attr('class', d => `graph-node${d.status ? ` build-${d.status.toLowerCase()}` : ''}`)
+      .attr('class', d => {
+        if (isSkipped && d.status === 'STARTED_FROM') {
+          return 'graph-node build-skipped';
+        }
+
+        return `graph-node${d.status ? ` build-${d.status.toLowerCase()}` : ''}`;
+      })
       .attr('data-job', d => d.name)
       // create the icon graphic
       .insert('text')
-      .text(d => icon(d.status))
+      .text(d => {
+        if (isSkipped && d.status === 'STARTED_FROM') {
+          return icon('SKIPPED');
+        }
+
+        return icon(d.status);
+      })
       .attr('font-size', `${ICON_SIZE}px`)
       .style('text-anchor', 'middle')
       .attr('x', d => calcXCenter(d.pos.x))

--- a/app/components/workflow-graph-d3/styles.scss
+++ b/app/components/workflow-graph-d3/styles.scss
@@ -65,7 +65,9 @@ g {
 
   &.build-running,
   &.build-queued,
-  &.build-blocked {
+  &.build-blocked,
+  // TODO: Replace skipped property if necessary.
+  &.build-skipped {
     fill: $sd-queued;
 
     &:hover {

--- a/app/event/model.js
+++ b/app/event/model.js
@@ -1,5 +1,5 @@
 import { computed, observer, get, set } from '@ember/object';
-import { sort, not } from '@ember/object/computed';
+import { sort } from '@ember/object/computed';
 import DS from 'ember-data';
 import ENV from 'screwdriver-ui/config/environment';
 import ModelReloaderMixin from 'screwdriver-ui/mixins/model-reloader';
@@ -29,7 +29,17 @@ export default DS.Model.extend(ModelReloaderMixin, {
 
   builds: DS.hasMany('build'),
 
-  isRunning: not('isComplete'),
+  isRunning: computed('isComplete', 'isSkipped', {
+    get() {
+      let isRunning = true;
+
+      if (get(this, 'isComplete') || get(this, 'isSkipped')) {
+        isRunning = false;
+      }
+
+      return isRunning;
+    }
+  }),
   buildsSorted: sort('builds', (a, b) => parseInt(a.id, 10) - parseInt(b.id, 10)),
   createTimeWords: computed('createTime', 'duration', {
     get() {
@@ -87,7 +97,7 @@ export default DS.Model.extend(ModelReloaderMixin, {
   }),
   // eslint-disable-next-line ember/no-observers
   statusObserver: observer('builds.@each.status', 'isComplete', function statusObserver() {
-    if (this.isSaving) {
+    if (this.isSaving || get(this, 'isSkipped')) {
       return;
     }
 
@@ -185,9 +195,24 @@ export default DS.Model.extend(ModelReloaderMixin, {
 
   modelToReload: 'builds',
   reloadTimeout: ENV.APP.EVENT_RELOAD_TIMER,
+  isSkipped: computed('commit.message', 'type', {
+    get() {
+      if (get(this, 'type') === 'pr') {
+        return false;
+      }
+      const msg = get(this, 'commit.message');
+
+      return msg ? msg.match(/\[(skip ci|ci skip)\]/) : false;
+    }
+  }),
 
   // Reload builds only if the event is still running
   shouldReload() {
     return get(this, 'isRunning');
+  },
+  init() {
+    if (get(this, 'isSkipped')) {
+      set(this, 'status', 'SKIPPED');
+    }
   }
 });

--- a/app/event/model.js
+++ b/app/event/model.js
@@ -33,7 +33,7 @@ export default DS.Model.extend(ModelReloaderMixin, {
     get() {
       let isRunning = true;
 
-      if (get(this, 'isComplete') || get(this, 'isSkipped')) {
+      if (this.isComplete || this.isSkipped) {
         isRunning = false;
       }
 
@@ -97,7 +97,7 @@ export default DS.Model.extend(ModelReloaderMixin, {
   }),
   // eslint-disable-next-line ember/no-observers
   statusObserver: observer('builds.@each.status', 'isComplete', function statusObserver() {
-    if (this.isSaving || get(this, 'isSkipped')) {
+    if (this.isSaving || this.isSkipped) {
       return;
     }
 

--- a/app/event/model.js
+++ b/app/event/model.js
@@ -211,6 +211,7 @@ export default DS.Model.extend(ModelReloaderMixin, {
     return get(this, 'isRunning');
   },
   init() {
+    this._super(...arguments);
     if (get(this, 'isSkipped')) {
       set(this, 'status', 'SKIPPED');
     }

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -94,7 +94,9 @@ $weight-bold: 600;
 .RUNNING,
 .QUEUED,
 .BLOCKED,
-.CREATED {
+.CREATED,
+// TODO: Replace skipped property if necessary.
+.SKIPPED {
   .status .fa {
     color: $sd-running;
   }

--- a/app/utils/build.js
+++ b/app/utils/build.js
@@ -43,6 +43,10 @@ const statusIcon = (status, isLight) => {
     case 'ABORTED':
       icon = `times-circle${isLight ? '-o' : ''}`;
       break;
+    case 'SKIPPED':
+      // TODO: Replace skipped property if necessary.
+      icon = 'exclamation-circle';
+      break;
     default:
       icon = 'circle-o';
       break;

--- a/app/utils/graph-tools.js
+++ b/app/utils/graph-tools.js
@@ -14,7 +14,9 @@ const STATUS_MAP = {
   UNSTABLE: { icon: '\ue909' },
   BLOCKED: { icon: '\ue908' },
   COLLAPSED: { icon: '\ue908' },
-  FROZEN: { icon: '\ue910' }
+  FROZEN: { icon: '\ue910' },
+  // TODO: Replace skipped property if necessary.
+  SKIPPED: { icon: '\ue909' }
 };
 const edgeSrcBranchRegExp = new RegExp('^~(pr|commit):/(.+)/$');
 const triggerBranchRegExp = new RegExp('^~(pr|commit):(.+)$');

--- a/tests/integration/components/pipeline-event-row/component-test.js
+++ b/tests/integration/components/pipeline-event-row/component-test.js
@@ -83,6 +83,7 @@ module('Integration | Component | pipeline event row', function(hooks) {
 
     const eventMock = EmberObject.create(
       assign(copy(event, true), {
+        id: 4,
         startFrom: '~pr',
         type: 'pr',
         pr: {
@@ -94,7 +95,7 @@ module('Integration | Component | pipeline event row', function(hooks) {
 
     this.set('event', eventMock);
 
-    await render(hbs`{{pipeline-event-row event=event selectedEvent=3 lastSuccessful=3}}`);
+    await render(hbs`{{pipeline-event-row event=event selectedEvent=4 lastSuccessful=3}}`);
 
     assert.dom('.SUCCESS').exists({ count: 1 });
     assert.dom('.status .fa-check-circle-o').exists({ count: 1 });
@@ -103,6 +104,34 @@ module('Integration | Component | pipeline event row', function(hooks) {
     assert.dom('svg').exists({ count: 1 });
     assert.dom('.graph-node').exists({ count: 4 });
     assert.dom('.graph-edge').exists({ count: 3 });
+    assert.dom('.by').hasText('batman');
+    assert.dom('.date').hasText('Started now');
+  });
+
+  test('it does not render graph when skipped event', async function(assert) {
+    this.actions.eventClick = () => {
+      assert.ok(true);
+    };
+
+    const eventMock = EmberObject.create(
+      assign(copy(event, true), {
+        status: 'SKIPPED',
+        commit: {
+          url: '#',
+          message: '[skip ci] skip ci build.'
+        },
+        truncatedMessage: '[skip ci] skip ci build.'
+      })
+    );
+
+    this.set('event', eventMock);
+
+    await render(hbs`{{pipeline-event-row event=event selectedEvent=3 lastSuccessful=3}}`);
+
+    assert.dom('.SKIPPED').exists({ count: 1 });
+    assert.dom('.status .fa-exclamation-circle').exists({ count: 1 });
+    assert.dom('.commit').hasText('#abc123');
+    assert.dom('.message').hasText('[skip ci] skip ci build.');
     assert.dom('.by').hasText('batman');
     assert.dom('.date').hasText('Started now');
   });

--- a/tests/integration/components/pipeline-graph-nav/component-test.js
+++ b/tests/integration/components/pipeline-graph-nav/component-test.js
@@ -177,6 +177,44 @@ module('Integration | Component | pipeline graph nav', function(hooks) {
     assert.dom('.row button').exists({ count: 2 });
   });
 
+  test('it renders when selectedEvent is a skipped event', async function(assert) {
+    set(this, 'obj', {
+      truncatedSha: 'abc123',
+      status: 'SKIPPED',
+      commit: { message: '[skip ci] skip ci build.' },
+      creator: { name: 'anonymous' },
+      type: 'pipeline'
+    });
+    set(this, 'selected', 2);
+    set(this, 'startBuild', () => {
+      assert.ok(true);
+    });
+    set(this, 'currentEventType', 'pipeline');
+    set(this, 'showDownstreamTriggers', false);
+    set(this, 'setDownstreamTrigger', () => {
+      assert.ok(true);
+    });
+
+    await render(hbs`{{pipeline-graph-nav
+      mostRecent=3
+      lastSuccessful=2
+      selectedEvent=2
+      selectedEventObj=obj
+      selected=selected
+      startMainBuild=startBuild
+      startPRBuild=startBuild
+      graphType=currentEventType
+      showDownstreamTriggers=showDownstreamTriggers
+      setDownstreamTrigger=setDownstreamTrigger
+    }}`);
+
+    assert.dom('.row strong').hasText('Pipeline');
+    assert.dom('.row button').exists({ count: 3 });
+    assert.dom('.SKIPPED').exists({ count: 1 });
+    assert.dom('.btn-group').hasText('Most Recent Last Successful Aggregate');
+    assert.dom('.x-toggle-component').includesText('Show triggers');
+  });
+
   test('it handles toggling triggers', async function(assert) {
     assert.expect(2);
     set(this, 'obj', { truncatedSha: 'abc123' });

--- a/tests/unit/event/model-test.js
+++ b/tests/unit/event/model-test.js
@@ -109,6 +109,36 @@ module('Unit | Model | event', function(hooks) {
     assert.ok(isComplete);
   });
 
+  test('it is skipped when commit massage contains skip ci', async function(assert) {
+    const model = this.owner.lookup('service:store').createRecord('event');
+
+    run(() => {
+      model.set('commit', { message: '[skip ci] skip ci build.' });
+      model.set('type', 'pipeline');
+    });
+
+    await settled();
+
+    const isSkipped = get(model, 'isSkipped');
+
+    assert.ok(isSkipped);
+  });
+
+  test('it is not skipped when commit type is pr', async function(assert) {
+    const model = this.owner.lookup('service:store').createRecord('event');
+
+    run(() => {
+      model.set('commit', { message: '[skip ci] skip ci build.' });
+      model.set('type', 'pr');
+    });
+
+    await settled();
+
+    const isSkipped = get(model, 'isSkipped');
+
+    assert.notOk(isSkipped);
+  });
+
   test('it is RUNNING when there are no builds', async function(assert) {
     const model = run(() => this.owner.lookup('service:store').createRecord('event'));
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
`skip ci` events' view is hard to recognize on UI.
So I improved skip ci events' view.

1. Build status becomes SKIPPED
1. Pipeline graph shows only skipped icon
1. Events list item also shows skipped icon
<img width="883" alt="スクリーンショット 2019-07-12 17 53 31" src="https://user-images.githubusercontent.com/8113204/61115749-168bf500-a4ce-11e9-999c-53dbf2f1fcee.png">
<img width="422" alt="スクリーンショット 2019-07-12 17 53 42" src="https://user-images.githubusercontent.com/8113204/61115764-1db30300-a4ce-11e9-8dac-8ae8dd79dd5e.png">

Temporary, I used stable status icon and running icon color for skip status.
If you have more better icon and color, feel free to change icon and color.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
* Add `SKIPPED` status.
* Add `isSkipped` property to event model, and fix some property.
* Does not render workflow-graph in event-row when event status is skipped.
* Only render skipped icon in workflow-graph when event status is skipped.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/1685

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
