### PR TITLE
feat: implement artifacts preview for screwdriver UI

### DIFF
--- a/app/components/artifact-preview/component.js
+++ b/app/components/artifact-preview/component.js
@@ -1,0 +1,51 @@
+import Component from '@ember/component';
+import $ from 'jquery';
+
+export default Component.extend({
+  iframeUrl: undefined,
+
+  iframeId: undefined,
+
+  init() {
+    this._super(...arguments);
+    const iframeId = `${this.elementId}-iframe`;
+
+    this.set('iframeId', iframeId);
+  },
+
+  handleMessageSendFromIframe(e) {
+    const { href } = e.data;
+
+    if (!this.get('isDestroyed') && !this.get('isDestroying') && href) {
+      this.set('iframeUrl', href);
+    }
+  },
+
+  handleMessageSendToIframe() {
+    const { iframeId } = this;
+
+    $(`#${this.iframeId}`).on('load', (/* e */) => {
+      const currentIframe = document.getElementById(iframeId).contentWindow;
+
+      currentIframe.postMessage(
+        {
+          state: 'ready'
+        },
+        '*'
+      );
+    });
+  },
+
+  didInsertElement() {
+    window.addEventListener('message', this.handleMessageSendFromIframe.bind(this));
+    this.handleMessageSendToIframe();
+  },
+
+  actions: {
+    download() {
+      const downloadLink = this.iframeUrl.replace('type=preview', 'type=download');
+
+      window.open(downloadLink, '_blank');
+    }
+  }
+});

--- a/app/components/artifact-preview/template.hbs
+++ b/app/components/artifact-preview/template.hbs
@@ -1,0 +1,15 @@
+<div>
+  {{#bs-button
+    type="primary"
+    icon="glyphicon glyphicon-download"
+    onClick=(action "download")
+  }}Download
+  {{/bs-button}}
+  <iframe
+    id={{iframeId}}
+    src={{iframeUrl}}
+    width="100%"
+    height="625px">
+    <h4>Alternative content for browsers which do not support iframe.</h4>
+  </iframe>
+</div>

--- a/app/components/artifact-tree/component.js
+++ b/app/components/artifact-tree/component.js
@@ -16,11 +16,13 @@ const typesOptions = {
 };
 
 export default Component.extend({
+  iframeUrl: undefined,
   artifact: service('build-artifact'),
   classNames: ['artifact-tree'],
   classNameBindings: ['buildStatus'],
   typesOptions,
   plugins: 'types',
+  isModalOpen: false,
   treedata: computed('buildStatus', 'buildId', {
     get() {
       const { buildStatus } = this;
@@ -34,13 +36,41 @@ export default Component.extend({
       });
     }
   }),
-  actions: {
-    handleJstreeEventDidChange(data) {
-      if (data.node) {
-        let { href } = data.node.a_attr;
 
-        if (href !== '#') {
-          window.open(`${href}?download=true`, '_blank');
+  download(href) {
+    window.open(`${href}?type=download`, '_blank');
+  },
+
+  actions: {
+    handleClose() {
+      this.set('isModalOpen', false);
+    },
+
+    handleDownload() {
+      this.download(this.href);
+    },
+
+    handleJstreeEventDidChange(data = {}) {
+      const { node, instance } = data;
+
+      if (node) {
+        const {
+          type,
+          a_attr: { href }
+        } = node;
+
+        if (type === 'directory') {
+          instance.toggle_node(node);
+
+          return;
+        }
+
+        if (type === 'file') {
+          this.setProperties({
+            href,
+            iframeUrl: `${href}?type=preview`,
+            isModalOpen: true
+          });
         }
       }
     }

--- a/app/components/artifact-tree/component.js
+++ b/app/components/artifact-tree/component.js
@@ -16,7 +16,7 @@ const typesOptions = {
 };
 
 export default Component.extend({
-  iframeUrl: undefined,
+  iframeUrl: '',
   artifact: service('build-artifact'),
   classNames: ['artifact-tree'],
   classNameBindings: ['buildStatus'],

--- a/app/components/build-step-collection/component.js
+++ b/app/components/build-step-collection/component.js
@@ -1,10 +1,13 @@
 import Component from '@ember/component';
-import { filter, mapBy } from '@ember/object/computed';
+import { filter, mapBy, equal } from '@ember/object/computed';
 import { set, computed } from '@ember/object';
 import { inject as service } from '@ember/service';
 
 export default Component.extend({
+  iframeUrl: '',
   router: service(),
+  activeTab: 'steps',
+  isArtifacts: equal('activeTab', 'artifacts'),
   classNames: ['build-step-collection', 'row'],
   stepNames: mapBy('buildSteps', 'name'),
   setupSteps: filter('stepNames', item => /^sd-setup/.test(item)),
@@ -50,6 +53,9 @@ export default Component.extend({
     },
     toggleTeardown() {
       set(this, 'teardownCollapsed', !this.teardownCollapsed);
+    },
+    changeActiveTabPane(activeTab) {
+      this.set('activeTab', activeTab);
     }
   }
 });

--- a/app/components/build-step-collection/template.hbs
+++ b/app/components/build-step-collection/template.hbs
@@ -1,84 +1,109 @@
 <div class="row">
-  <div class="col-xs-3 step-list">
-    <h3>Steps</h3>
-    <a class="step-toggle" onClick={{action "toggleSetup"}}>
-      {{#if setupCollapsed}}
-        {{fa-icon "chevron-right"}}
-      {{else}}
-        {{fa-icon "chevron-down"}}
-      {{/if}}
-      Setup
-    </a>
-    {{#bs-collapse collapsed=setupCollapsed}}
-      <ul class="setup indent">
-        {{#each setupSteps as |step|}}
-          {{#with (get-step-data buildSteps step) as |s|}}
-            {{build-step-item
-              selectedStep=selectedStep
-              stepName=s.name
-              stepStart=s.startTime
-              stepEnd=s.endTime
-              stepCode=s.code
-              onClick=(action changeBuildStep)
-            }}
-          {{/with}}
-        {{/each}}
-      </ul>
-    {{/bs-collapse}}
-    <div class="user-steps">
-      <ul>
-        {{#each userSteps as |step|}}
-          {{#with (get-step-data buildSteps step) as |s|}}
-            {{build-step-item
-              selectedStep=selectedStep
-              stepName=s.name
-              stepStart=s.startTime
-              stepEnd=s.endTime
-              stepCode=s.code
-              onClick=(action changeBuildStep)
-            }}
-          {{/with}}
-        {{/each}}
-      </ul>
-    </div>
-    <a class="step-toggle" onClick={{action "toggleTeardown"}}>
-      {{#if teardownCollapsed}}
-        {{fa-icon "chevron-right"}}
-      {{else}}
-        {{fa-icon "chevron-down"}}
-      {{/if}}
-      Teardown
-    </a>
-    {{#bs-collapse collapsed=teardownCollapsed}}
-      <ul class="teardown indent">
-        {{#each teardownSteps as |step|}}
-          {{#with (get-step-data buildSteps step) as |s|}}
-            {{build-step-item
-              selectedStep=selectedStep
-              stepName=s.name
-              stepStart=s.startTime
-              stepEnd=s.endTime
-              stepCode=s.code
-              onClick=(action changeBuildStep)
-            }}
-          {{/with}}
-        {{/each}}
-      </ul>
-    {{/bs-collapse}}
-    <hr>
-    {{artifact-tree buildStatus=buildStatus buildId=buildId}}
+  <div class="col-xs-3 step-list no-padding column-tabs-view partial-view">
+    {{#bs-tab customTabs=true as |tab|}}
+      {{#bs-nav type="tabs" as |nav|}}
+        {{#nav.item class="float-left"
+          active=(bs-eq tab.activeId "steps")
+          onClick=(action "changeActiveTabPane" "steps")}}
+          <a href="#steps" role="tab" {{action tab.select "steps"}}>Steps</a>{{/nav.item}}
+        {{#nav.item class="float-left"
+          active=(bs-eq tab.activeId "artifacts")
+          onClick=(action "changeActiveTabPane" "artifacts")}}
+          <a href="#artifacts" role="tab" {{action tab.select "artifacts"}}>Afifacts</a>{{/nav.item}}
+      {{/bs-nav}}
+
+      <div class="tab-content">
+        {{#tab.pane id="steps" title="Steps"}}
+          <h3>Steps</h3>
+          <a class="step-toggle" onClick={{action "toggleSetup"}}>
+            {{#if setupCollapsed}}
+              {{fa-icon "chevron-right"}}
+            {{else}}
+              {{fa-icon "chevron-down"}}
+            {{/if}}
+            Setup
+          </a>
+          {{#bs-collapse collapsed=setupCollapsed}}
+            <ul class="setup indent">
+              {{#each setupSteps as |step|}}
+                {{#with (get-step-data buildSteps step) as |s|}}
+                  {{build-step-item
+                    selectedStep=selectedStep
+                    stepName=s.name
+                    stepStart=s.startTime
+                    stepEnd=s.endTime
+                    stepCode=s.code
+                    onClick=(action changeBuildStep)
+                  }}
+                {{/with}}
+              {{/each}}
+            </ul>
+          {{/bs-collapse}}
+          <div class="user-steps">
+            <ul>
+              {{#each userSteps as |step|}}
+                {{#with (get-step-data buildSteps step) as |s|}}
+                  {{build-step-item
+                    selectedStep=selectedStep
+                    stepName=s.name
+                    stepStart=s.startTime
+                    stepEnd=s.endTime
+                    stepCode=s.code
+                    onClick=(action changeBuildStep)
+                  }}
+                {{/with}}
+              {{/each}}
+            </ul>
+          </div>
+          <a class="step-toggle" onClick={{action "toggleTeardown"}}>
+            {{#if teardownCollapsed}}
+              {{fa-icon "chevron-right"}}
+            {{else}}
+              {{fa-icon "chevron-down"}}
+            {{/if}}
+            Teardown
+          </a>
+          {{#bs-collapse collapsed=teardownCollapsed}}
+            <ul class="teardown indent">
+              {{#each teardownSteps as |step|}}
+                {{#with (get-step-data buildSteps step) as |s|}}
+                  {{build-step-item
+                    selectedStep=selectedStep
+                    stepName=s.name
+                    stepStart=s.startTime
+                    stepEnd=s.endTime
+                    stepCode=s.code
+                    onClick=(action changeBuildStep)
+                  }}
+                {{/with}}
+              {{/each}}
+            </ul>
+          {{/bs-collapse}}
+        {{/tab.pane}}
+        {{#tab.pane id="artifacts" title="Artifacts"}}
+          {{artifact-tree
+            buildStatus=buildStatus
+            buildId=buildId
+            iframeUrl=iframeUrl}}
+        {{/tab.pane}}
+      </div>
+    {{/bs-tab}}
   </div>
   <div class="col-xs-9">
-    {{build-log
-      stepName=selectedStep
-      totalLine=(get-step-data buildSteps selectedStep "lines")
-      buildId=buildId
-      stepStartTime=(get-step-data buildSteps selectedStep "startTime")
-      stepEndTime=(get-step-data buildSteps selectedStep "endTime")
-      buildStartTime=buildStart
-      buildStats=buildStats
-      buildStatus=buildStatus
-    }}
+    {{#if (and isArtifacts iframeUrl)}}
+      {{artifact-preview iframeUrl=iframeUrl}}
+    {{else}}
+      {{build-log
+        stepName=selectedStep
+        totalLine=(get-step-data buildSteps selectedStep "lines")
+        buildId=buildId
+        stepStartTime=(get-step-data buildSteps selectedStep "startTime")
+        stepEndTime=(get-step-data buildSteps selectedStep "endTime")
+        buildStartTime=buildStart
+        buildStats=buildStats
+        buildStatus=buildStatus
+      }}
+    {{/if}}
   </div>
 </div>
 

--- a/app/components/build-step-collection/template.hbs
+++ b/app/components/build-step-collection/template.hbs
@@ -9,7 +9,7 @@
         {{#nav.item class="float-left"
           active=(bs-eq tab.activeId "artifacts")
           onClick=(action "changeActiveTabPane" "artifacts")}}
-          <a href="#artifacts" role="tab" {{action tab.select "artifacts"}}>Afifacts</a>{{/nav.item}}
+          <a href="#artifacts" role="tab" {{action tab.select "artifacts"}}>Artifacts</a>{{/nav.item}}
       {{/bs-nav}}
 
       <div class="tab-content">

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -144,6 +144,10 @@ a {
       text-align: center;
       border-bottom: 2px solid $grey-400;
 
+      &.float-left {
+        float: left;
+      }
+
       & > a {
         &,
         &:hover {

--- a/config/environment.js
+++ b/config/environment.js
@@ -11,6 +11,7 @@ module.exports = environment => {
         // Glimmer [ember] and ACE Editor [validator] add styles to elements at run time, this makes it impossible to precalculate all possible shas for inline styles
         "'unsafe-inline'"
       ],
+      'frame-src': ["'self'"],
       'connect-src': ["'self'"],
       // JSTree web worker
       'worker-src': ['blob:'],
@@ -105,6 +106,8 @@ module.exports = environment => {
 
   ENV.contentSecurityPolicy['connect-src'].push(ENV.APP.SDAPI_HOSTNAME);
   ENV.contentSecurityPolicy['connect-src'].push(ENV.APP.SDSTORE_HOSTNAME);
+  ENV.contentSecurityPolicy['frame-src'].push(ENV.APP.SDAPI_HOSTNAME);
+  ENV.contentSecurityPolicy['frame-src'].push(ENV.APP.SDSTORE_HOSTNAME);
 
   return ENV;
 };

--- a/config/environment.js
+++ b/config/environment.js
@@ -11,6 +11,7 @@ module.exports = environment => {
         // Glimmer [ember] and ACE Editor [validator] add styles to elements at run time, this makes it impossible to precalculate all possible shas for inline styles
         "'unsafe-inline'"
       ],
+      'manifest-src': ["'self'"],
       'frame-src': ["'self'"],
       'connect-src': ["'self'"],
       // JSTree web worker

--- a/tests/integration/components/artifact-preview/component-test.js
+++ b/tests/integration/components/artifact-preview/component-test.js
@@ -1,0 +1,18 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | artifact-preview', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`{{artifact-preview}}`);
+    assert
+      .dom('iframe')
+      .includesText('Alternative content for browsers which do not support iframe');
+  });
+});

--- a/tests/integration/components/build-step-collection/component-test.js
+++ b/tests/integration/components/build-step-collection/component-test.js
@@ -43,9 +43,12 @@ module('Integration | Component | build step collection', function(hooks) {
       buildStart=null
     }}`);
 
+    assert.dom('.step-list .nav-tabs li:nth-of-type(1) a').hasText('Steps');
+    assert.dom('.step-list .nav-tabs li:nth-of-type(2) a').hasText('Artifacts');
+
     assert.dom('h3').hasText('Steps');
-    assert.dom('.step-list a:nth-of-type(1)').hasText('Setup');
-    assert.dom('.step-list a:nth-of-type(2)').hasText('Teardown');
+    assert.dom('.step-list .tab-content a:nth-of-type(1)').hasText('Setup');
+    assert.dom('.step-list .tab-content a:nth-of-type(2)').hasText('Teardown');
     assert.dom('.setup-spinner').doesNotExist();
 
     await render(hbs`{{#build-step-collection


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
This PR implemented previewing artifacts feature by loading content from iframe. Such mechanism can keep the `html` in a sandboxed isolated environment, and not pollute the parent frame.
 

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

This feature allows UI to have preview functionality, to see what artifacts being generated prior downloading such file. i.e. html or any browser viewable items. 

See screenshot

![image](https://user-images.githubusercontent.com/15989893/61499476-2dbe5d00-a97c-11e9-8009-6dbc2334e309.png)


## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

UI: https://github.com/screwdriver-cd/ui/pull/465
Backend: https://github.com/screwdriver-cd/screwdriver/pull/1703
Store: https://github.com/screwdriver-cd/store/pull/88

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
