### PR TITLE
make timestamps non-selectable

### DIFF
--- a/app/components/build-log/styles.scss
+++ b/app/components/build-log/styles.scss
@@ -52,6 +52,7 @@
     display: inline-block;
     vertical-align: top;
     width: 70px;
+    user-select: none;
   }
 
   .content {


### PR DESCRIPTION
## Context

Copying multiple lines from a log is really annoying to do in a readable way because the timestamps are selectable.

## Objective

by making the timestamps unselectable highlighting allows you to get just the useful information

## References
_  | Screenshot
------------ | -------------
Before | ![Screen Shot 2019-07-23 at 1 10 13 PM](https://user-images.githubusercontent.com/333260/61732501-bad22f00-ad4b-11e9-83e2-84ec540aaba9.png)
After | ![Screen Shot 2019-07-23 at 1 10 24 PM](https://user-images.githubusercontent.com/333260/61732519-c1f93d00-ad4b-11e9-9da3-25134ad50180.png)

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
