### PR TITLE
fix(1685): Fix SKIPPED status

### DIFF
--- a/app/event/model.js
+++ b/app/event/model.js
@@ -195,12 +195,17 @@ export default DS.Model.extend(ModelReloaderMixin, {
 
   modelToReload: 'builds',
   reloadTimeout: ENV.APP.EVENT_RELOAD_TIMER,
-  isSkipped: computed('commit.message', 'type', {
+  isSkipped: computed('commit.message', 'type', 'numBuilds', {
     get() {
       if (get(this, 'type') === 'pr') {
         return false;
       }
       const msg = get(this, 'commit.message');
+      const numBuilds = get(this, 'numBuilds');
+
+      if (numBuilds !== 0) {
+        return false;
+      }
 
       return msg ? msg.match(/\[(skip ci|ci skip)\]/) : false;
     }

--- a/tests/unit/event/model-test.js
+++ b/tests/unit/event/model-test.js
@@ -139,6 +139,25 @@ module('Unit | Model | event', function(hooks) {
     assert.notOk(isSkipped);
   });
 
+  test('it is not skipped when it has builds', async function(assert) {
+    const build = this.owner
+      .lookup('service:store')
+      .createRecord('build', { jobId: 1, status: 'RUNNING' });
+    const model = this.owner.lookup('service:store').createRecord('event');
+
+    run(() => {
+      model.set('commit', { message: '[skip ci] skip ci build.' });
+      model.set('type', 'pipeline');
+      model.set('builds', [build]);
+    });
+
+    await settled();
+
+    const isSkipped = get(model, 'isSkipped');
+
+    assert.notOk(isSkipped);
+  });
+
   test('it is RUNNING when there are no builds', async function(assert) {
     const model = run(() => this.owner.lookup('service:store').createRecord('event'));
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
When starting build from `skip ci` event, the new event status still SKIPPED.
It should be the new status of new builds.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
`isSkipped` is false when an event has builds.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
screwdriver-cd/screwdriver#1685


## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
