### PR TITLE
feat: add query parameter for activeTab for artifacts and steps

### DIFF
--- a/app/components/build-step-collection/template.hbs
+++ b/app/components/build-step-collection/template.hbs
@@ -3,11 +3,11 @@
     {{#bs-tab customTabs=true as |tab|}}
       {{#bs-nav type="tabs" as |nav|}}
         {{#nav.item class="float-left"
-          active=(bs-eq tab.activeId "steps")
+          active=(bs-eq activeTab "steps")
           onClick=(action "changeActiveTabPane" "steps")}}
           <a href="#steps" role="tab" {{action tab.select "steps"}}>Steps</a>{{/nav.item}}
         {{#nav.item class="float-left"
-          active=(bs-eq tab.activeId "artifacts")
+          active=(bs-eq activeTab "artifacts")
           onClick=(action "changeActiveTabPane" "artifacts")}}
           <a href="#artifacts" role="tab" {{action tab.select "artifacts"}}>Artifacts</a>{{/nav.item}}
       {{/bs-nav}}

--- a/app/pipeline/build/controller.js
+++ b/app/pipeline/build/controller.js
@@ -20,6 +20,12 @@ export default Controller.extend({
   stepList: mapBy('build.steps', 'name'),
   isShowingModal: false,
   errorMessage: '',
+  activeTab: 'steps',
+  queryParams: [
+    {
+      activeTab: { type: 'string' }
+    }
+  ],
   prEvents: computed('model.{event.pr.url,pipeline.id}', {
     get() {
       if (this.get('model.event.type') === 'pr') {

--- a/app/pipeline/build/route.js
+++ b/app/pipeline/build/route.js
@@ -6,6 +6,12 @@ import { getActiveStep } from 'screwdriver-ui/utils/build';
 export default Route.extend({
   routeAfterAuthentication: 'pipeline.build',
 
+  queryParams: {
+    activeTab: {
+      as: 'tab'
+    }
+  },
+
   model(params) {
     this.set('pipeline', this.modelFor('pipeline').pipeline);
 

--- a/app/pipeline/build/template.hbs
+++ b/app/pipeline/build/template.hbs
@@ -45,6 +45,7 @@
     buildSteps=build.steps
     buildStart=build.startTime
     buildStats=build.stats
+    activeTab=activeTab
     changeBuildStep=(action "changeBuildStep")
   }}
 {{/if}}


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Users want to share which active tab they are actively viewing.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
This PR adds a `query parameter` to preserve what tab is currently `active`, so that users can share links 

`Steps`:  http://localhost:4200/pipelines/1/builds/2

![image](https://user-images.githubusercontent.com/15989893/61980745-7abdb700-afac-11e9-814d-5ee992fe4b1c.png)

Or 
`Artifacts`: http://localhost:4200/pipelines/1/builds/2?tab=artifacts

![image](https://user-images.githubusercontent.com/15989893/61980756-81e4c500-afac-11e9-816f-81897b253644.png)



## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->


## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
