### PR TITLE
Fix hover text: "template" => "command"

### DIFF
--- a/app/components/command-header/template.hbs
+++ b/app/components/command-header/template.hbs
@@ -3,7 +3,7 @@
   {{command.namespace}}/{{command.name}}
   {{#if scmUrl}}
     <a href={{scmUrl}}>{{fa-icon "code-fork" title="Source code"}}</a>
-    <a href="#" {{action "setCommandToRemove" command}} class="remove">{{fa-icon "trash" title="Delete template"}}</a>
+    <a href="#" {{action "setCommandToRemove" command}} class="remove">{{fa-icon "trash" title="Delete command"}}</a>
   {{else}}
     {{fa-icon "code-fork" title="The pipeline for this command does not exist."}} {{fa-icon "trash" title="Cannot delete command; pipeline could not be found."}}
   {{/if}}


### PR DESCRIPTION
## Context

When hovering over the delete icon for a command, it says "delete template" instead of "delete command".
![image](https://user-images.githubusercontent.com/1390277/62080517-7268b480-b216-11e9-8885-cdfc018c76a9.png)

## Objective
Fix above typo

## References
N/A

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
