### PR TITLE
feat: show template and commands in validator

### DIFF
--- a/app/components/validator-job/component.js
+++ b/app/components/validator-job/component.js
@@ -42,14 +42,14 @@ export default Component.extend({
       const commands = this.steps;
       const regex = /sd-cmd\s+exec\s+([\w-]+\/[\w-]+)/g;
       let sdCommands = [];
-      let matchRes;
 
       if (commands === []) {
         return [];
       }
 
       commands.forEach(c => {
-        matchRes = regex.exec(c.command);
+        let matchRes = regex.exec(c.command);
+
         while (matchRes !== null) {
           if (!sdCommands.includes(matchRes[1])) {
             sdCommands.push(matchRes[1]);

--- a/app/components/validator-job/component.js
+++ b/app/components/validator-job/component.js
@@ -5,6 +5,11 @@ export default Component.extend({
   classNameBindings: ['hasParseError', 'collapsible'],
   isOpen: true,
   collapsible: true,
+  getTemplateName: computed('job', {
+    get() {
+      return this.get('job.environment.SD_TEMPLATE_FULLNAME');
+    }
+  }),
   hasParseError: computed('job', {
     get() {
       return this.get('job.commands.0.name') === 'config-parse-error';
@@ -30,6 +35,30 @@ export default Component.extend({
       }
 
       return [];
+    }
+  }),
+  sdCommands: computed('job', {
+    get() {
+      const commands = this.steps;
+      const regex = /sd-cmd\s+exec\s+([\w-]+\/[\w-]+)/g;
+      let sdCommands = [];
+      let matchRes;
+
+      if (commands === []) {
+        return [];
+      }
+
+      commands.forEach(c => {
+        matchRes = regex.exec(c.command);
+        while (matchRes !== null) {
+          if (!sdCommands.includes(matchRes[1])) {
+            sdCommands.push(matchRes[1]);
+          }
+          matchRes = regex.exec(c.command);
+        }
+      });
+
+      return sdCommands;
     }
   }),
   actions: {

--- a/app/components/validator-job/template.hbs
+++ b/app/components/validator-job/template.hbs
@@ -1,5 +1,5 @@
 {{#if collapsible}}
-  <h4 class="job" {{action "nameClick"}}>{{fa-icon (if isOpen "minus-square" "plus-square")}} {{name}}{{#if index }}.{{index}}{{/if}}</h4>
+  <h4 class="job" {{action "nameClick"}}>{{fa-icon (if isOpen "minus-square" "plus-square")}} {{name}}{{#if index }}.{{index}}{{/if}}</h4>{{#if getTemplateName}}<h4>This job uses <a href="/templates/{{getTemplateName}}">{{getTemplateName}}</a> template.</h4>{{/if}}
 {{/if}}
 {{#if template.description}}
   <div class="template-description" title="This is the description of the template">
@@ -107,6 +107,18 @@
             </div>
           </div>
         </li>
+      {{else}}
+        <li>None defined</li>
+      {{/each-in}}
+    </ul>
+  </span>
+</div>
+<div class="sd-commands" title="These are the sd-commands that will be executed in the job.">
+  <span class="label">Sd-commands:</span>
+  <span class="value">
+    <ul>
+      {{#each-in sdCommands as |index value|}}
+        <li><span class="name"><a href="/commands/{{value}}">{{value}}</a></span></li>
       {{else}}
         <li>None defined</li>
       {{/each-in}}

--- a/app/components/validator-job/template.hbs
+++ b/app/components/validator-job/template.hbs
@@ -114,7 +114,7 @@
   </span>
 </div>
 <div class="sd-commands" title="These are the sd-commands that will be executed in the job.">
-  <span class="label">Sd-commands:</span>
+  <span class="label">Commands:</span>
   <span class="value">
     <ul>
       {{#each-in sdCommands as |index value|}}

--- a/tests/integration/components/validator-job/component-test.js
+++ b/tests/integration/components/validator-job/component-test.js
@@ -244,8 +244,9 @@ module('Integration | Component | validator job', function(hooks) {
     this.set('jobMock', {
       image: 'int-test:1',
       commands: [
-        { name: 'step1', command: 'echo hello' },
-        { name: 'step2', command: 'sd-cmd exec foo/bar@0.0.1 foobar' }
+        { name: 'step1', command: 'sd-cmd exec bar/foo@latest' },
+        { name: 'step2', command: 'sd-cmd exec foo/bar@0.0.1 foobar' },
+        { name: 'step3', command: 'sd-cmd exec bar/foo@stable' }
       ],
       secrets: [],
       environment: {},
@@ -257,8 +258,10 @@ module('Integration | Component | validator job', function(hooks) {
 
     assert.dom('h4').hasText('int-test');
     assert.dom('.sd-commands .label').hasText('Commands:');
-    assert.dom('.sd-commands ul li').hasText('foo/bar');
-    assert.dom('.sd-commands ul li a').hasAttribute('href', '/commands/foo/bar');
+    assert.dom('.sd-commands ul li:nth-of-type(1)').hasText('bar/foo');
+    assert.dom('.sd-commands ul li:nth-of-type(1) a').hasAttribute('href', '/commands/bar/foo');
+    assert.dom('.sd-commands ul li:nth-of-type(2)').hasText('foo/bar');
+    assert.dom('.sd-commands ul li:nth-of-type(2) a').hasAttribute('href', '/commands/foo/bar');
   });
 
   test('it renders without a collapsible heading', async function(assert) {

--- a/tests/integration/components/validator-job/component-test.js
+++ b/tests/integration/components/validator-job/component-test.js
@@ -139,6 +139,23 @@ module('Integration | Component | validator job', function(hooks) {
     assert.dom('.sourcePaths ul li').hasText('None defined');
   });
 
+  test('it renders template name', async function(assert) {
+    this.set('jobMock', {
+      image: 'int-test:1',
+      steps: [{ step1: 'echo hello' }, { step2: 'echo goodby' }],
+      secrets: [],
+      environment: { SD_TEMPLATE_FULLNAME: 'foo/bar' },
+      settings: {},
+      annotations: {}
+    });
+
+    await render(hbs`{{validator-job name="int-test" index=0 job=jobMock}}`);
+
+    assert.dom('h4:nth-of-type(1)').hasText('int-test');
+    assert.dom('h4:nth-of-type(2)').hasText('This job uses foo/bar template.');
+    assert.dom('h4:nth-of-type(2) a').hasAttribute('href', '/templates/foo/bar');
+  });
+
   test('it renders when there are no steps or commands', async function(assert) {
     this.set('jobMock', {
       image: 'int-test:1',
@@ -221,6 +238,27 @@ module('Integration | Component | validator job', function(hooks) {
     assert.dom('.sourcePaths .label').hasText('Source Paths:');
     assert.dom('.sourcePaths .value ul li:first-child').hasText('README.md');
     assert.dom('.sourcePaths .value ul li:last-child').hasText('src/folder/');
+  });
+
+  test('it renders sd-commands', async function(assert) {
+    this.set('jobMock', {
+      image: 'int-test:1',
+      commands: [
+        { name: 'step1', command: 'echo hello' },
+        { name: 'step2', command: 'sd-cmd exec foo/bar@0.0.1 foobar' }
+      ],
+      secrets: [],
+      environment: {},
+      settings: {},
+      annotations: {}
+    });
+
+    await render(hbs`{{validator-job name="int-test" index=0 job=jobMock}}`);
+
+    assert.dom('h4').hasText('int-test');
+    assert.dom('.sd-commands .label').hasText('Sd-commands:');
+    assert.dom('.sd-commands ul li').hasText('foo/bar');
+    assert.dom('.sd-commands ul li a').hasAttribute('href', '/commands/foo/bar');
   });
 
   test('it renders without a collapsible heading', async function(assert) {

--- a/tests/integration/components/validator-job/component-test.js
+++ b/tests/integration/components/validator-job/component-test.js
@@ -256,7 +256,7 @@ module('Integration | Component | validator job', function(hooks) {
     await render(hbs`{{validator-job name="int-test" index=0 job=jobMock}}`);
 
     assert.dom('h4').hasText('int-test');
-    assert.dom('.sd-commands .label').hasText('Sd-commands:');
+    assert.dom('.sd-commands .label').hasText('Commands:');
     assert.dom('.sd-commands ul li').hasText('foo/bar');
     assert.dom('.sd-commands ul li a').hasAttribute('href', '/commands/foo/bar');
   });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
We want to know what templates and commands are used in a job when using validator or visiting template details page.
Therefore, I added templates and commands link on the result of validation and template details page.

validator
<img width="1323" alt="スクリーンショット 2019-08-01 13 55 53" src="https://user-images.githubusercontent.com/8113204/62266732-72f68a80-b464-11e9-9d0c-4b0dfd363bd7.png">

template details
<img width="655" alt="スクリーンショット 2019-08-01 13 57 19" src="https://user-images.githubusercontent.com/8113204/62266744-7be75c00-b464-11e9-8f27-e23c8c69b665.png">

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
If `SD_TEMPLATE_FULLNAME` env exists, a job uses template.
So I add link to template on job details.

And, validator searches all commands with regex `sd-cmd\s+exec\s+([\w-]+\/[\w-]+)` to find executed sd-cmd.
If sd-cmd is executed in a job, I add link to all executed sd-cmd on job details.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
