### PR TITLE
fix: Use favicon for scheduler's avatar

### DIFF
--- a/app/components/user-link/template.hbs
+++ b/app/components/user-link/template.hbs
@@ -1,4 +1,8 @@
 <a href={{user.url}} title={{causeMessage}}>
-  <img src={{user.avatar}} alt="{{user.name}}'s avatar">
+  {{#if (eq user.username "sd:scheduler")}}
+    <img src="/favicon.ico" alt="Screwdriver scheduler's avatar">
+  {{else}}
+    <img src={{user.avatar}} alt="{{user.name}}'s avatar">
+  {{/if}}
   {{user.name}}
 </a>

--- a/tests/integration/components/user-link/component-test.js
+++ b/tests/integration/components/user-link/component-test.js
@@ -23,4 +23,21 @@ module('Integration | Component | user link', function(hooks) {
     assert.equal(find('img').src, 'http://example.com/u/batman/avatar');
     assert.dom('a').hasText('Bruce W');
   });
+
+  test('it renders scheduler', async function(assert) {
+    const userMock = {
+      username: 'sd:scheduler',
+      name: 'Screwdriver scheduler'
+    };
+
+    this.set('userMock', userMock);
+
+    await render(
+      hbs`{{user-link user=userMock causeMessage="Automatically started by scheduler"}}`
+    );
+
+    assert.equal(find('a').title, 'Automatically started by scheduler');
+    assert.ok(find('img').src.endsWith('/favicon.ico'));
+    assert.dom('a').hasText('Screwdriver scheduler');
+  });
 });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
A periodic build is started by Screwdriver scheduler.
However, Screwdriver scheduler has no avatar.
Because of this, a user-link of periodic build's detail page is broken.
![periodic_bug](https://user-images.githubusercontent.com/8113204/63011231-e071d480-bec2-11e9-8007-50f0046db995.png)
Therefore, I fixed to use favicon for an avatar when build user is scheduler.
<img width="337" alt="スクリーンショット 2019-08-14 18 42 01" src="https://user-images.githubusercontent.com/8113204/63011429-40687b00-bec3-11e9-88d0-408e2e223dec.png">

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
If a build user is scheduler, favicon is used for an src of user img.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
