### PR TITLE
try internal k8s api for deployment

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -54,7 +54,7 @@ jobs:
       DOCKER_REPO: screwdrivercd/ui
       K8S_CONTAINER: screwdriver-ui
       K8S_IMAGE: screwdrivercd/ui
-      K8S_HOST: api.ossd.k8s.screwdriver.cd
+      K8S_HOST: kubernetes
       K8S_DEPLOYMENT: sdui-beta
       SD_UI: beta.cd.screwdriver.cd
     secrets:
@@ -75,7 +75,7 @@ jobs:
       DOCKER_REPO: screwdrivercd/ui
       K8S_CONTAINER: screwdriver-ui
       K8S_IMAGE: screwdrivercd/ui
-      K8S_HOST: api.ossd.k8s.screwdriver.cd
+      K8S_HOST: kubernetes
       K8S_DEPLOYMENT: sdui
       SD_UI: cd.screwdriver.cd
     secrets:


### PR DESCRIPTION
## Context
We need to limit k8s api access not opening it to the whole internet.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
