### PR TITLE
fix: do not fetch job/builds unless it's for PR

### DIFF
--- a/app/components/pipeline-graph-nav/component.js
+++ b/app/components/pipeline-graph-nav/component.js
@@ -24,10 +24,6 @@ export default Component.extend({
         { label: 'Last Successful', value: this.lastSuccessful }
       ];
 
-      if (!this.isPR) {
-        options.push({ label: 'Aggregate', value: 'aggregate' });
-      }
-
       return options;
     }
   }),

--- a/app/components/pipeline-graph-nav/template.hbs
+++ b/app/components/pipeline-graph-nav/template.hbs
@@ -40,45 +40,43 @@
 {{#if selectedEventObj}}
   <div class="row {{selectedEventObj.status}}">
     <div class="col-xs-12">
-      {{#unless (eq selected "aggregate")}}
-        <div class="event-info">
-          <div class="col">
-            <span class="title">Commit</span><br>
-            <a href={{selectedEventObj.commit.url}}>#{{selectedEventObj.truncatedSha}}</a>
-          </div>
-          <div class="col">
-            <span class="title">Message</span><br>
-            <span title={{selectedEventObj.commit.message}}>{{selectedEventObj.truncatedMessage}}</span>
-          </div>
-          <div class="col">
-            <span class="title">Status</span><br>
-            <span class="status">{{fa-icon icon fixedWidth=true}} {{selectedEventObj.status}}</span>
-          </div>
-          <div class="col">
-            <span class="title">User</span><br>
-            <a href={{selectedEventObj.creator.url}}>{{selectedEventObj.creator.name}}</a>
-          </div>
-          <div class="col">
-            <span class="title">Start Time</span><br>
-            {{selectedEventObj.createTimeWords}}
-          </div>
-          <div class="col">
-            <span class="title">Duration</span><br>
-            {{selectedEventObj.durationText}}
-          </div>
-          {{#if selectedEventObj.label}}
-            <div class="col">
-              <span class="title">Label</span><br>
-              {{selectedEventObj.label}}
-            </div>
-          {{/if}}
-          {{#if selectedEventObj.isRunning}}
-            <div class="col">
-              {{#bs-button onClick=(action stopEvent) class="event__stop" title="Stop all builds for this event"}}Stop{{/bs-button}}
-            </div>
-          {{/if}}
+      <div class="event-info">
+        <div class="col">
+          <span class="title">Commit</span><br>
+          <a href={{selectedEventObj.commit.url}}>#{{selectedEventObj.truncatedSha}}</a>
         </div>
-      {{/unless}}
+        <div class="col">
+          <span class="title">Message</span><br>
+          <span title={{selectedEventObj.commit.message}}>{{selectedEventObj.truncatedMessage}}</span>
+        </div>
+        <div class="col">
+          <span class="title">Status</span><br>
+          <span class="status">{{fa-icon icon fixedWidth=true}} {{selectedEventObj.status}}</span>
+        </div>
+        <div class="col">
+          <span class="title">User</span><br>
+          <a href={{selectedEventObj.creator.url}}>{{selectedEventObj.creator.name}}</a>
+        </div>
+        <div class="col">
+          <span class="title">Start Time</span><br>
+          {{selectedEventObj.createTimeWords}}
+        </div>
+        <div class="col">
+          <span class="title">Duration</span><br>
+          {{selectedEventObj.durationText}}
+        </div>
+        {{#if selectedEventObj.label}}
+          <div class="col">
+            <span class="title">Label</span><br>
+            {{selectedEventObj.label}}
+          </div>
+        {{/if}}
+        {{#if selectedEventObj.isRunning}}
+          <div class="col">
+            {{#bs-button onClick=(action stopEvent) class="event__stop" title="Stop all builds for this event"}}Stop{{/bs-button}}
+          </div>
+        {{/if}}
+      </div>
     </div>
   </div>
 {{/if}}

--- a/app/components/pipeline-workflow/component.js
+++ b/app/components/pipeline-workflow/component.js
@@ -28,15 +28,11 @@ export default Component.extend({
         // push the job id into the graph
         if (node) {
           node.id = get(j, 'id');
-          fetchBuilds.push(get(j, 'builds'));
         }
       });
 
       return all(fetchBuilds).then(() => {
         const builds = [];
-
-        // preload the "last build" data for each job for the graph to consume
-        jobs.forEach(j => builds.push(get(j, 'lastBuild')));
 
         // set values to consume from templates
         set(this, 'builds', builds);

--- a/app/components/pipeline-workflow/component.js
+++ b/app/components/pipeline-workflow/component.js
@@ -1,7 +1,7 @@
 import { alias } from '@ember/object/computed';
 import Component from '@ember/component';
 import { get, computed, set, setProperties } from '@ember/object';
-import { all, reject } from 'rsvp';
+import { reject } from 'rsvp';
 import { isRoot } from 'screwdriver-ui/utils/graph-tools';
 import { isActiveBuild } from 'screwdriver-ui/utils/build';
 
@@ -12,7 +12,6 @@ export default Component.extend({
   graph: computed('workflowGraph', 'completeWorkflowGraph', 'showDownstreamTriggers', {
     get() {
       const { jobs } = this;
-      const fetchBuilds = [];
       const graph = this.showDownstreamTriggers ? this.completeWorkflowGraph : this.workflowGraph;
 
       // Hack to make page display stuff when a workflow is not provided
@@ -31,15 +30,9 @@ export default Component.extend({
         }
       });
 
-      return all(fetchBuilds).then(() => {
-        const builds = [];
+      set(this, 'directedGraph', graph);
 
-        // set values to consume from templates
-        set(this, 'builds', builds);
-        set(this, 'directedGraph', graph);
-
-        return graph;
-      });
+      return graph;
     }
   }),
   displayRestartButton: alias('authenticated'),

--- a/app/components/pipeline-workflow/component.js
+++ b/app/components/pipeline-workflow/component.js
@@ -51,12 +51,14 @@ export default Component.extend({
     graphClicked(job, mouseevent, sizes) {
       const EXTERNAL_TRIGGER_REGEX = /^~sd@(\d+):([\w-]+)$/;
       const edges = get(this, 'directedGraph.edges');
-      let isRootNode = true;
       const isTrigger = job ? /^~/.test(job.name) : false;
+      let isRootNode = true;
       let toolTipProperties = {};
 
       // Find root nodes to determine position of tooltip
       if (job && edges && !/^~/.test(job.name)) {
+        const selectedEvent = get(this, 'selectedEventObj');
+
         toolTipProperties = {
           showTooltip: true,
           // detached jobs should show tooltip on the left
@@ -65,7 +67,8 @@ export default Component.extend({
             displayStop: isActiveBuild(job.status),
             job,
             mouseevent,
-            sizes
+            sizes,
+            selectedEvent
           }
         };
         isRootNode = isRoot(edges, job.name);

--- a/app/components/pipeline-workflow/template.hbs
+++ b/app/components/pipeline-workflow/template.hbs
@@ -1,59 +1,43 @@
-{{#if (and (eq selected "aggregate") (is-fulfilled graph))}}
+{{#if (is-fulfilled selectedEventObj.builds)}}
   {{#workflow-graph-d3
     completeWorkflowGraph=completeWorkflowGraph
-    workflowGraph=directedGraph
-    builds=builds
+    showDownstreamTriggers=showDownstreamTriggers
+    builds=selectedEventObj.builds
     jobs=jobs
+    workflowGraph=selectedEventObj.workflowGraph
+    startFrom=selectedEventObj.startFrom
+    causeMessage=selectedEventObj.causeMessage
     graphClicked=(action "graphClicked")
+    isSkipped=selectedEventObj.isSkipped
   }}
     {{workflow-tooltip
       tooltipData=tooltipData
-      displayRestartButton=false
+      displayRestartButton=displayRestartButton
+      stopBuild=stopBuild
       showTooltip=showTooltip
+      showTooltipPosition=showTooltipPosition
+      confirmStartBuild=(action "confirmStartBuild")
     }}
   {{/workflow-graph-d3}}
-{{else}}
-  {{#if (is-fulfilled selectedEventObj.builds)}}
-    {{#workflow-graph-d3
-      completeWorkflowGraph=completeWorkflowGraph
-      showDownstreamTriggers=showDownstreamTriggers
-      builds=selectedEventObj.builds
-      jobs=jobs
-      workflowGraph=selectedEventObj.workflowGraph
-      startFrom=selectedEventObj.startFrom
-      causeMessage=selectedEventObj.causeMessage
-      graphClicked=(action "graphClicked")
-      isSkipped=selectedEventObj.isSkipped
+  {{#if isShowingModal}}
+    {{#modal-dialog
+      targetAttachment="center"
+      translucentOverlay=true
+      containerClass="detached-confirm-dialog"
     }}
-      {{workflow-tooltip
-        tooltipData=tooltipData
-        displayRestartButton=displayRestartButton
-        stopBuild=stopBuild
-        showTooltip=showTooltip
-        showTooltipPosition=showTooltipPosition
-        confirmStartBuild=(action "confirmStartBuild")
-      }}
-    {{/workflow-graph-d3}}
-    {{#if isShowingModal}}
-      {{#modal-dialog
-        targetAttachment="center"
-        translucentOverlay=true
-        containerClass="detached-confirm-dialog"
-      }}
-        <h3>Are you sure?</h3>
-        <p>
-          You are about to start the job <code>{{tooltipData.job.name}}</code> in a new event with the same
-          context of the selected event for sha <code>#{{selectedEventObj.truncatedSha}}</code>
-        </p>
-        <div class="row">
-          <div class="col-xs-6">
-            <button class="d-button is-primary" {{action "startDetachedBuild"}}>Yes</button>
-          </div>
-          <div class="col-xs-6 right">
-            <button class="d-button is-secondary" {{action "cancelStartBuild"}}>No</button>
-          </div>
+      <h3>Are you sure?</h3>
+      <p>
+        You are about to start the job <code>{{tooltipData.job.name}}</code> in a new event with the same
+        context of the selected event for sha <code>#{{selectedEventObj.truncatedSha}}</code>
+      </p>
+      <div class="row">
+        <div class="col-xs-6">
+          <button class="d-button is-primary" {{action "startDetachedBuild"}}>Yes</button>
         </div>
-      {{/modal-dialog}}
-    {{/if}}
+        <div class="col-xs-6 right">
+          <button class="d-button is-secondary" {{action "cancelStartBuild"}}>No</button>
+        </div>
+      </div>
+    {{/modal-dialog}}
   {{/if}}
 {{/if}}

--- a/app/components/pipeline-workflow/template.hbs
+++ b/app/components/pipeline-workflow/template.hbs
@@ -1,4 +1,4 @@
-{{#if (is-fulfilled selectedEventObj.builds)}}
+{{#if (and (is-fulfilled selectedEventObj.builds) (is-fulfilled graph))}}
   {{#workflow-graph-d3
     completeWorkflowGraph=completeWorkflowGraph
     showDownstreamTriggers=showDownstreamTriggers

--- a/app/components/workflow-tooltip/component.js
+++ b/app/components/workflow-tooltip/component.js
@@ -24,10 +24,5 @@ export default Component.extend({
         left
       });
     }
-  },
-  actions: {
-    stopBuild() {
-      this.stopBuild(get(this, 'tooltipData.job'));
-    }
   }
 });

--- a/app/components/workflow-tooltip/template.hbs
+++ b/app/components/workflow-tooltip/template.hbs
@@ -18,7 +18,7 @@
       {{/if}}
     {{/if}}
     {{#if tooltipData.displayStop}}
-      <a {{action stopBuild tooltipData.job}}>Stop build</a>
+      <a {{action stopBuild tooltipData.selectedEvent tooltipData.job}}>Stop build</a>
     {{/if}}
   {{/if}}
   {{yield}}

--- a/app/job/model.js
+++ b/app/job/model.js
@@ -1,11 +1,10 @@
-import EmberObject, { computed } from '@ember/object';
+import { computed } from '@ember/object';
 import { equal, match } from '@ember/object/computed';
-import ModelReloaderMixin from 'screwdriver-ui/mixins/model-reloader';
 import DS from 'ember-data';
 import ENV from 'screwdriver-ui/config/environment';
 import { isActiveBuild } from 'screwdriver-ui/utils/build';
 
-export default DS.Model.extend(ModelReloaderMixin, {
+export default DS.Model.extend({
   pipelineId: DS.attr('string'),
   name: DS.attr('string'),
   isPR: match('name', /^PR-/),
@@ -42,25 +41,10 @@ export default DS.Model.extend(ModelReloaderMixin, {
   permutations: DS.attr(),
   builds: DS.hasMany('build', { async: true }),
   isDisabled: equal('state', 'DISABLED'),
-  lastBuild: computed('builds', {
-    get() {
-      const { builds } = this;
-
-      if (builds.length === 0) {
-        return EmberObject.create();
-      }
-
-      return builds.objectAt(0);
-    }
-  }),
   modelToReload: 'builds',
   reloadTimeout: ENV.APP.EVENT_RELOAD_TIMER,
   // Reload builds only if the pr job build is still running
   shouldReload() {
     return this.isPR && this.builds.any(b => isActiveBuild(b.get('status'), b.get('endTime')));
-  },
-  init() {
-    this._super(...arguments);
-    this.startReloading();
   }
 });

--- a/app/pipeline/events/controller.js
+++ b/app/pipeline/events/controller.js
@@ -320,7 +320,7 @@ export default Controller.extend(ModelReloaderMixin, {
           this.set('errorMessage', Array.isArray(e.errors) ? e.errors[0].detail : '');
         });
     },
-    stopBuild(job) {
+    stopBuild(event, job) {
       const buildId = get(job, 'buildId');
       let build;
 
@@ -330,7 +330,7 @@ export default Controller.extend(ModelReloaderMixin, {
 
         return build
           .save()
-          .then(() => job.hasMany('builds').reload())
+          .then(() => event.hasMany('builds').reload())
           .catch(e => this.set('errorMessage', Array.isArray(e.errors) ? e.errors[0].detail : ''));
       }
 

--- a/app/pipeline/events/controller.js
+++ b/app/pipeline/events/controller.js
@@ -165,10 +165,6 @@ export default Controller.extend(ModelReloaderMixin, {
     get() {
       const selected = this.selectedEvent;
 
-      if (selected === 'aggregate') {
-        return null;
-      }
-
       return this.events.find(e => get(e, 'id') === selected);
     }
   }),

--- a/tests/integration/components/pipeline-graph-nav/component-test.js
+++ b/tests/integration/components/pipeline-graph-nav/component-test.js
@@ -33,7 +33,7 @@ module('Integration | Component | pipeline graph nav', function(hooks) {
     }}`);
 
     assert.dom('.row strong').hasText('Pipeline');
-    assert.dom('.row button').exists({ count: 3 });
+    assert.dom('.row button').exists({ count: 2 });
 
     const $columnTitles = this.$('.event-info .title');
     const $links = this.$('.event-info a');
@@ -209,7 +209,7 @@ module('Integration | Component | pipeline graph nav', function(hooks) {
     }}`);
 
     assert.dom('.row strong').hasText('Pipeline');
-    assert.dom('.row button').exists({ count: 3 });
+    assert.dom('.row button').exists({ count: 2 });
     assert.dom('.SKIPPED').exists({ count: 1 });
     assert.dom('.btn-group').hasText('Most Recent Last Successful Aggregate');
     assert.dom('.x-toggle-component').includesText('Show triggers');

--- a/tests/integration/components/pipeline-graph-nav/component-test.js
+++ b/tests/integration/components/pipeline-graph-nav/component-test.js
@@ -98,7 +98,7 @@ module('Integration | Component | pipeline graph nav', function(hooks) {
 
     assert.dom('.SUCCESS').exists({ count: 1 });
 
-    assert.dom('.btn-group').hasText('Most Recent Last Successful Aggregate');
+    assert.dom('.btn-group').hasText('Most Recent Last Successful');
 
     assert.dom('.x-toggle-component').includesText('Show triggers');
   });
@@ -211,7 +211,7 @@ module('Integration | Component | pipeline graph nav', function(hooks) {
     assert.dom('.row strong').hasText('Pipeline');
     assert.dom('.row button').exists({ count: 2 });
     assert.dom('.SKIPPED').exists({ count: 1 });
-    assert.dom('.btn-group').hasText('Most Recent Last Successful Aggregate');
+    assert.dom('.btn-group').hasText('Most Recent Last Successful');
     assert.dom('.x-toggle-component').includesText('Show triggers');
   });
 

--- a/tests/integration/components/pipeline-workflow/component-test.js
+++ b/tests/integration/components/pipeline-workflow/component-test.js
@@ -30,31 +30,6 @@ const BUILDS = [
 module('Integration | Component | pipeline workflow', function(hooks) {
   setupRenderingTest(hooks);
 
-  test('it renders an aggregate', async function(assert) {
-    const jobs = ['main', 'batman', 'robin'].map(name => {
-      const j = {
-        name,
-        isDisabled: false,
-        lastBuild: EmberObject.create({
-          id: 12345,
-          status: 'SUCCESS',
-          sha: 'abcd1234'
-        })
-      };
-
-      return EmberObject.create(j);
-    });
-
-    this.set('jobsMock', jobs);
-    this.set('graph', GRAPH);
-    this.set('selected', 'aggregate');
-
-    await render(hbs`{{pipeline-workflow workflowGraph=graph jobs=jobsMock selected=selected}}`);
-
-    assert.dom('.graph-node').exists({ count: 5 });
-    assert.dom('.workflow-tooltip').exists({ count: 1 });
-  });
-
   test('it renders an event', async function(assert) {
     this.set('selected', 1);
     this.set(

--- a/tests/integration/components/pipeline-workflow/component-test.js
+++ b/tests/integration/components/pipeline-workflow/component-test.js
@@ -38,10 +38,10 @@ module('Integration | Component | pipeline workflow', function(hooks) {
         workflowGraph: GRAPH,
         startFrom: '~commit',
         causeMessage: 'test'
-      })
+      }),
+      'graph',
+      EmberObject.create({})
     );
-
-    this.set('graph', EmberObject.create({}));
 
     await render(hbs`{{pipeline-workflow selectedEventObj=obj graph=graph}}`);
 

--- a/tests/integration/components/pipeline-workflow/component-test.js
+++ b/tests/integration/components/pipeline-workflow/component-test.js
@@ -31,7 +31,6 @@ module('Integration | Component | pipeline workflow', function(hooks) {
   setupRenderingTest(hooks);
 
   test('it renders an event', async function(assert) {
-    this.set('selected', 1);
     this.set(
       'obj',
       EmberObject.create({
@@ -42,7 +41,9 @@ module('Integration | Component | pipeline workflow', function(hooks) {
       })
     );
 
-    await render(hbs`{{pipeline-workflow selectedEventObj=obj selected=selected}}`);
+    this.set('graph', EmberObject.create({}));
+
+    await render(hbs`{{pipeline-workflow selectedEventObj=obj graph=graph}}`);
 
     assert.dom('.graph-node').exists({ count: 5 });
     assert.dom('.workflow-tooltip').exists({ count: 1 });

--- a/tests/unit/pipeline/events/controller-test.js
+++ b/tests/unit/pipeline/events/controller-test.js
@@ -245,9 +245,13 @@ module('Unit | Controller | pipeline/events', function(hooks) {
     const controller = this.owner.lookup('controller:pipeline/events');
 
     const job = {
-      hasMany: () => ({ reload: () => assert.ok(true) }),
       buildId: '123',
       name: 'deploy'
+    };
+
+    const event = {
+      hasMany: () => ({ reload: () => assert.ok(true) }),
+      id: '123'
     };
 
     run(() => {
@@ -270,7 +274,7 @@ module('Unit | Controller | pipeline/events', function(hooks) {
       build.set('status', 'ABORTED');
       build.save();
 
-      controller.send('stopBuild', job);
+      controller.send('stopBuild', event, job);
     });
 
     await settled();


### PR DESCRIPTION
## Context

UI is making calls to ` /jobs/:jobID/builds` end point for all jobs of a pipeline. This is causing serious performance issues  for pipelines with large build history. There is no reason for UI to make this call, except for fetching PR build data, since there is no API available to fetch details of a PR.

## Objective

Reduce job -> builds API call
1. Remove all references of `job.builds` unless in PR job context. 
1. Remove auto reload of job model.
1. Remove aggregate view

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
