### PR TITLE
feat: update restart modal sentences

### DIFF
--- a/app/components/pipeline-workflow/template.hbs
+++ b/app/components/pipeline-workflow/template.hbs
@@ -42,8 +42,8 @@
       }}
         <h3>Are you sure?</h3>
         <p>
-          You are about to start the job <code>{{tooltipData.job.name}}</code> in a new event with the same
-          context of the selected event for sha <code>#{{selectedEventObj.truncatedSha}}</code>
+          Job: <code>{{tooltipData.job.name}}</code><br>
+          Commit:<a href={{selectedEventObj.commit.url}}><code>{{selectedEventObj.commit.message}}</code>({{selectedEventObj.truncatedSha}})</a> 
         </p>
         <div class="row">
           <div class="col-xs-6">

--- a/app/components/pipeline-workflow/template.hbs
+++ b/app/components/pipeline-workflow/template.hbs
@@ -25,10 +25,10 @@
       translucentOverlay=true
       containerClass="detached-confirm-dialog"
     }}
-      <h3>Are you sure?</h3>
+      <h3>Are you sure to start?</h3>
       <p>
         Job: <code>{{tooltipData.job.name}}</code><br>
-        Commit:<a href={{selectedEventObj.commit.url}}><code>{{selectedEventObj.commit.message}}</code>({{selectedEventObj.truncatedSha}})</a> 
+        Commit:<a href={{selectedEventObj.commit.url}}><code>{{selectedEventObj.truncatedMessage}}</code>({{selectedEventObj.truncatedSha}})</a> 
       </p>
       <div class="row">
         <div class="col-xs-6">


### PR DESCRIPTION
## Context
Sometime user get confused when the job's sha is not the pipeline's branch. It happen when user set  branch specific job such as `requires: [~commi, ~commit:developnt]`.

I try to make it easy to understand what kind job user will start.

## Objective
Add commit message and able to jump commit change page.

before:
<img width="338" alt="スクリーンショット 2019-09-09 12 10 16" src="https://user-images.githubusercontent.com/4645011/64501072-d2b14280-d2fa-11e9-9e1b-9e08c0b1d23d.png">


after:
<img width="346" alt="スクリーンショット 2019-09-09 12 01 31" src="https://user-images.githubusercontent.com/4645011/64500791-99c49e00-d2f9-11e9-811c-65b4fbbcc68e.png">

## reference
related https://github.com/screwdriver-cd/screwdriver/issues/1706

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
