### PR TITLE
fix: default pipeline

### DIFF
--- a/app/collection/model.js
+++ b/app/collection/model.js
@@ -3,6 +3,7 @@ import DS from 'ember-data';
 export default DS.Model.extend({
   name: DS.attr('string'),
   description: DS.attr('string'),
+  type: DS.attr('string'),
   pipelineIds: DS.attr(),
   pipelines: DS.attr()
 });

--- a/app/components/collections-flyout/template.hbs
+++ b/app/components/collections-flyout/template.hbs
@@ -16,14 +16,16 @@
       {{#link-to "dashboard.show" collection.id invokeAction="changeCollectionDisplayed"}}
         {{collection.name}}
       {{/link-to}}
-      {{#if showDeleteButtons}}
-        <button
-          class="collection-wrapper__delete"
-          onclick={{action "setCollectionToDelete" collection}}
-        >
-          {{fa-icon "trash" title="Delete collection" size="md"}}
-        </button>
-      {{/if}}
+      {{#unless (eq collection.type "default")}}
+        {{#if showDeleteButtons}}
+          <button
+            class="collection-wrapper__delete"
+            onclick={{action "setCollectionToDelete" collection}}
+          >
+            {{fa-icon "trash" title="Delete collection" size="md"}}
+          </button>
+        {{/if}}
+      {{/unless}}
     </div>
   {{else}}
     <p class="no-collections-text">Please create a collection.</p>


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
To avoid confusion for users that they cannot delete default pipeline (`My Pipelines`), knowing that API will drop if the collection `type` attribute is `default`.


## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Remove delete option to default pipeline

## References

Before: 
![image](https://user-images.githubusercontent.com/15989893/64745041-12268d00-d4bb-11e9-97a9-3e9f26496e42.png)

After:
![image](https://user-images.githubusercontent.com/15989893/64745033-0935bb80-d4bb-11e9-9b73-4509499e0817.png)

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
