### PR TITLE
feat: Enable URL with specific version or tag of commands or templates

### DIFF
--- a/app/commands/detail/controller.js
+++ b/app/commands/detail/controller.js
@@ -38,10 +38,10 @@ export default Controller.extend({
         return this.commands.commandData.findBy('version', version);
       }
 
-      let exsistTag = commandTagData.filter(t => t.tag === versionOrTagFromUrl);
+      let tagExists = commandTagData.filter(t => t.tag === versionOrTagFromUrl);
 
-      if (exsistTag.length > 0) {
-        return this.commands.commandData.findBy('version', exsistTag[0].version);
+      if (tagExists.length > 0) {
+        return this.commands.commandData.findBy('version', tagExists[0].version);
       }
 
       return this.commands.commandData.findBy('version', versionOrTagFromUrl);

--- a/app/commands/detail/route.js
+++ b/app/commands/detail/route.js
@@ -12,10 +12,10 @@ export default Route.extend({
       const [verPayload, tagPayload] = arr;
 
       if (params.version) {
-        const exsistVersion = verPayload.filter(t => t.version === params.version);
-        const exsistTag = tagPayload.filter(c => c.tag === params.version);
+        const versionExists = verPayload.filter(t => t.version === params.version);
+        const tagExists = tagPayload.filter(c => c.tag === params.version);
 
-        if (exsistTag.length === 0 && exsistVersion.length === 0) {
+        if (tagExists.length === 0 && versionExists.length === 0) {
           this.transitionTo('/404');
         }
       }

--- a/app/commands/detail/route.js
+++ b/app/commands/detail/route.js
@@ -11,6 +11,15 @@ export default Route.extend({
     ]).then(arr => {
       const [verPayload, tagPayload] = arr;
 
+      if (params.version) {
+        const exsistVersion = verPayload.filter(t => t.version === params.version);
+        const exsistTag = tagPayload.filter(c => c.tag === params.version);
+
+        if (exsistTag.length === 0 && exsistVersion.length === 0) {
+          this.transitionTo('/404');
+        }
+      }
+
       tagPayload.forEach(tagObj => {
         const taggedVerObj = verPayload.find(verObj => verObj.version === tagObj.version);
 
@@ -19,7 +28,13 @@ export default Route.extend({
         }
       });
 
-      return verPayload;
+      let result = {};
+
+      result.commandData = verPayload;
+      result.versionOrTagFromUrl = params.version;
+      result.commandTagData = tagPayload;
+
+      return result;
     });
   },
   setupController(controller, model) {

--- a/app/commands/detail/template.hbs
+++ b/app/commands/detail/template.hbs
@@ -10,6 +10,6 @@
 
 {{command-format command=versionCommand}}
 
-{{command-versions commands=commands changeVersion=(action "changeVersion")}}
+{{command-versions commands=commands}}
 
 {{outlet}}

--- a/app/components/command-versions/template.hbs
+++ b/app/components/command-versions/template.hbs
@@ -1,6 +1,8 @@
 <h4>Versions:</h4>
 <ul>
-  {{#each commands as |c|}}
-    <li><span {{action changeVersion c.version on="click"}} class="version">{{c.version}}{{#if c.tag}} - {{c.tag}}{{/if}}</span>{{#if c.lastUpdated}} {{c.lastUpdated}}{{/if}}</li>
+  {{#each commands.commandData as |c|}}
+    <li>
+      <a href={{c.version}}><span class="version">{{c.version}}{{#if c.tag}} - {{c.tag}}{{/if}}</span></a>{{#if c.lastUpdated}} {{c.lastUpdated}}{{/if}}
+    </li>
   {{/each}}
 </ul>

--- a/app/components/tc-collection-linker/template.hbs
+++ b/app/components/tc-collection-linker/template.hbs
@@ -1,5 +1,5 @@
 {{#if (eq column.label "Name")}}
-  {{#link-to extra.routes.detail row.content.namespace value}}{{#if row.content.trusted}}<span title="Trusted">{{inline-svg "trusted" class="trusted"}}</span>{{/if}}<span class="name">{{value}}</span>{{/link-to}}
+  {{#link-to extra.routes.detail row.content.namespace value row.content.version}}{{#if row.content.trusted}}<span title="Trusted">{{inline-svg "trusted" class="trusted"}}</span>{{/if}}<span class="name">{{value}}</span>{{/link-to}}
 {{else if (eq column.label "Namespace")}}
   {{#link-to extra.routes.namespace value}}<span class="namespace">{{value}}</span>{{/link-to}}
 {{/if}}

--- a/app/components/template-versions/template.hbs
+++ b/app/components/template-versions/template.hbs
@@ -1,8 +1,8 @@
 <h4>Versions:</h4>
 <ul>
-  {{#each templates as |t|}}
+  {{#each templates.templateData as |t|}}
     <li>
-      <span {{action changeVersion t.version on="click"}} class="version">{{t.version}}{{#if t.tag}} - {{t.tag}}{{/if}}</span>{{#if t.lastUpdated}} {{t.lastUpdated}}{{/if}}
+      <a href={{t.version}}><span class="version">{{t.version}}{{#if t.tag}} - {{t.tag}}{{/if}}</span></a>{{#if t.lastUpdated}} {{t.lastUpdated}}{{/if}}
     </li>
   {{/each}}
 </ul>

--- a/app/router.js
+++ b/app/router.js
@@ -37,10 +37,12 @@ Router.map(function route() {
   this.route('templates', function templatesRoute() {
     this.route('namespace', { path: '/:namespace' });
     this.route('detail', { path: '/:namespace/:name' });
+    this.route('detail', { path: '/:namespace/:name/:version' });
   });
   this.route('commands', function commandsRoute() {
     this.route('namespace', { path: '/:namespace' });
     this.route('detail', { path: '/:namespace/:name' });
+    this.route('detail', { path: '/:namespace/:name/:version' });
   });
   this.route('404', { path: '/*path' });
 });

--- a/app/templates/detail/controller.js
+++ b/app/templates/detail/controller.js
@@ -37,10 +37,10 @@ export default Controller.extend({
         return this.templates.templateData.findBy('version', version);
       }
 
-      let exsistTag = templateTagData.filter(t => t.tag === versionOrTagFromUrl);
+      let tagExists = templateTagData.filter(t => t.tag === versionOrTagFromUrl);
 
-      if (exsistTag.length > 0) {
-        return this.templates.templateData.findBy('version', exsistTag[0].version);
+      if (tagExists.length > 0) {
+        return this.templates.templateData.findBy('version', tagExists[0].version);
       }
 
       return this.templates.templateData.findBy('version', versionOrTagFromUrl);

--- a/app/templates/detail/controller.js
+++ b/app/templates/detail/controller.js
@@ -13,35 +13,45 @@ export default Controller.extend({
   reset() {
     this.set('errorMessage', '');
   },
-  trusted: computed('templates.[]', function computeTrusted() {
-    return this.templates.some(t => t.trusted);
+  trusted: computed('templates.templateData.[]', function computeTrusted() {
+    return this.templates.templateData.some(t => t.trusted);
   }),
   isAdmin: computed(function isAdmin() {
     const token = this.get('session.data.authenticated.token');
 
     return (decoder(token).scope || []).includes('admin');
   }),
-  latest: computed('templates.[]', {
+  latest: computed('templates.templateData.[]', {
     get() {
-      return this.templates[0];
+      return this.templates.templateData[0];
     }
   }),
-  versionTemplate: computed('selectedVersion', 'templates.[]', {
+  versionTemplate: computed('selectedVersion', 'templates.templateData.[]', {
     get() {
       const version = this.selectedVersion || this.get('latest.version');
 
-      return this.templates.findBy('version', version);
+      let { versionOrTagFromUrl } = this.templates;
+      let { templateTagData } = this.templates;
+
+      if (versionOrTagFromUrl === undefined) {
+        return this.templates.templateData.findBy('version', version);
+      }
+
+      let exsistTag = templateTagData.filter(t => t.tag === versionOrTagFromUrl);
+
+      if (exsistTag.length > 0) {
+        return this.templates.templateData.findBy('version', exsistTag[0].version);
+      }
+
+      return this.templates.templateData.findBy('version', versionOrTagFromUrl);
     }
   }),
   // Set selected version to null whenever the list of templates changes
   // eslint-disable-next-line ember/no-observers
-  modelObserver: observer('templates.[]', function modelObserver() {
+  modelObserver: observer('templates.templateData.[]', function modelObserver() {
     this.set('selectedVersion', null);
   }),
   actions: {
-    changeVersion(version) {
-      this.set('selectedVersion', version);
-    },
     removeTemplate(name) {
       return this.template
         .deleteTemplates(name)

--- a/app/templates/detail/route.js
+++ b/app/templates/detail/route.js
@@ -11,6 +11,15 @@ export default Route.extend({
     ]).then(arr => {
       let [verPayload, tagPayload] = arr;
 
+      if (params.version) {
+        const exsistVersion = verPayload.filter(t => t.version === params.version);
+        const exsistTag = tagPayload.filter(t => t.tag === params.version);
+
+        if (exsistTag.length === 0 && exsistVersion.length === 0) {
+          this.transitionTo('/404');
+        }
+      }
+
       verPayload = verPayload.filter(t => t.namespace === params.namespace);
 
       tagPayload.forEach(tagObj => {
@@ -21,7 +30,13 @@ export default Route.extend({
         }
       });
 
-      return verPayload;
+      let result = {};
+
+      result.templateData = verPayload;
+      result.versionOrTagFromUrl = params.version;
+      result.templateTagData = tagPayload;
+
+      return result;
     });
   },
   setupController(controller, model) {

--- a/app/templates/detail/route.js
+++ b/app/templates/detail/route.js
@@ -12,10 +12,10 @@ export default Route.extend({
       let [verPayload, tagPayload] = arr;
 
       if (params.version) {
-        const exsistVersion = verPayload.filter(t => t.version === params.version);
-        const exsistTag = tagPayload.filter(t => t.tag === params.version);
+        const versionExists = verPayload.filter(t => t.version === params.version);
+        const tagExists = tagPayload.filter(t => t.tag === params.version);
 
-        if (exsistTag.length === 0 && exsistVersion.length === 0) {
+        if (tagExists.length === 0 && versionExists.length === 0) {
           this.transitionTo('/404');
         }
       }

--- a/app/templates/detail/template.hbs
+++ b/app/templates/detail/template.hbs
@@ -11,6 +11,6 @@
 <h4>Contents:</h4>
 {{validator-job name=versionTemplate.fullName job=versionTemplate.config template=versionTemplate collapsible=false}}
 
-{{template-versions templates=templates changeVersion=(action "changeVersion")}}
+{{template-versions templates=templates}}
 
 {{outlet}}

--- a/tests/integration/components/command-versions/component-test.js
+++ b/tests/integration/components/command-versions/component-test.js
@@ -1,13 +1,15 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, click } from '@ember/test-helpers';
+import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-const COMMANDS = [
-  { version: '3.0.0', tag: 'latest stable' },
-  { version: '2.0.0', tag: 'meeseeks' },
-  { version: '1.0.0' }
-];
+const COMMANDS = {
+  commandData: [
+    { version: '3.0.0', tag: 'latest stable' },
+    { version: '2.0.0', tag: 'meeseeks' },
+    { version: '1.0.0' }
+  ]
+};
 
 module('Integration | Component | command versions', function(hooks) {
   setupRenderingTest(hooks);
@@ -21,7 +23,7 @@ module('Integration | Component | command versions', function(hooks) {
     this.set('mock', COMMANDS);
     this.actions.mockAction = function() {};
 
-    await render(hbs`{{command-versions commands=mock changeVersion=(action "mockAction")}}`);
+    await render(hbs`{{command-versions commands=mock}}`);
 
     assert.dom('h4').hasText('Versions:');
     assert.dom('ul li:first-child').hasText('3.0.0 - latest stable');
@@ -29,21 +31,27 @@ module('Integration | Component | command versions', function(hooks) {
     assert.dom('ul li:last-child').hasText('1.0.0');
   });
 
-  test('it handles clicks on versions', async function(assert) {
-    assert.expect(5);
+  test('Links of version exist', async function(assert) {
+    assert.expect(10);
 
     this.set('mock', COMMANDS);
     this.actions.mockAction = function(ver) {
       assert.equal(ver, '1.0.0');
     };
 
-    await render(hbs`{{command-versions commands=mock changeVersion=(action "mockAction")}}`);
+    await render(hbs`{{command-versions commands=mock }}`);
 
     assert.dom('h4').hasText('Versions:');
     assert.dom('ul li:first-child').hasText('3.0.0 - latest stable');
     assert.dom('ul li:nth-child(2)').hasText('2.0.0 - meeseeks');
     assert.dom('ul li:last-child').hasText('1.0.0');
 
-    await click('ul li:last-child span');
+    assert.dom('ul li:first-child a').hasAttribute('href');
+    assert.dom('ul li:nth-child(2) a').hasAttribute('href');
+    assert.dom('ul li:last-child a').hasAttribute('href');
+
+    assert.dom('ul li:first-child a[href]').hasText('3.0.0 - latest stable');
+    assert.dom('ul li:nth-child(2) a[href]').hasText('2.0.0 - meeseeks');
+    assert.dom('ul li:last-child a[href]').hasText('1.0.0');
   });
 });

--- a/tests/integration/components/template-versions/component-test.js
+++ b/tests/integration/components/template-versions/component-test.js
@@ -1,13 +1,15 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, click } from '@ember/test-helpers';
+import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-const TEMPLATES = [
-  { version: '3.0.0', tag: 'latest stable' },
-  { version: '2.0.0', tag: 'meeseeks' },
-  { version: '1.0.0' }
-];
+const TEMPLATES = {
+  templateData: [
+    { version: '3.0.0', tag: 'latest stable' },
+    { version: '2.0.0', tag: 'meeseeks' },
+    { version: '1.0.0' }
+  ]
+};
 
 module('Integration | Component | template versions', function(hooks) {
   setupRenderingTest(hooks);
@@ -21,7 +23,7 @@ module('Integration | Component | template versions', function(hooks) {
     this.set('mock', TEMPLATES);
     this.actions.mockAction = function() {};
 
-    await render(hbs`{{template-versions templates=mock changeVersion=(action "mockAction")}}`);
+    await render(hbs`{{template-versions templates=mock}}`);
 
     assert.dom('h4').hasText('Versions:');
     assert.dom('ul li:first-child').hasText('3.0.0 - latest stable');
@@ -30,20 +32,18 @@ module('Integration | Component | template versions', function(hooks) {
   });
 
   test('it handles clicks on versions', async function(assert) {
-    assert.expect(5);
+    assert.expect(4);
 
     this.set('mock', TEMPLATES);
     this.actions.mockAction = function(ver) {
       assert.equal(ver, '1.0.0');
     };
 
-    await render(hbs`{{template-versions templates=mock changeVersion=(action "mockAction")}}`);
+    await render(hbs`{{template-versions templates=mock}}`);
 
     assert.dom('h4').hasText('Versions:');
     assert.dom('ul li:first-child').hasText('3.0.0 - latest stable');
     assert.dom('ul li:nth-child(2)').hasText('2.0.0 - meeseeks');
     assert.dom('ul li:last-child').hasText('1.0.0');
-
-    await click('ul li:last-child span');
   });
 });

--- a/tests/unit/commands/detail/controller-test.js
+++ b/tests/unit/commands/detail/controller-test.js
@@ -39,14 +39,19 @@ module('Unit | Controller | commands/detail', function(hooks) {
   test('it parses model properly', function(assert) {
     let controller = this.owner.lookup('controller:commands/detail');
 
-    controller.set('model', [
-      { id: 3, version: '3.0.0', trusted: true },
-      { id: 2, version: '2.0.0' },
-      { id: 1, version: '1.0.0' }
-    ]);
+    controller.set('model', {
+      commandData: [
+        { id: 3, version: '3.0.0', trusted: true },
+        { id: 2, version: '2.0.0' },
+        { id: 1, version: '1.0.0' }
+      ],
+      commandTagData: [
+        { id: 2, version: '2.0.0', tag: 'latest' },
+        { id: 1, version: '1.0.0', tag: 'stable' }
+      ]
+    });
 
     assert.ok(controller);
-
     assert.equal(controller.get('selectedVersion'), null);
     assert.equal(controller.get('latest.id'), 3);
     assert.equal(controller.get('versionCommand.id'), 3);
@@ -56,30 +61,34 @@ module('Unit | Controller | commands/detail', function(hooks) {
   test('it handles version changes', function(assert) {
     let controller = this.owner.lookup('controller:commands/detail');
 
-    controller.set('model', [
-      { id: 3, version: '3.0.0' },
-      { id: 2, version: '2.0.0' },
-      { id: 1, version: '1.0.0' }
-    ]);
+    controller.set('model', {
+      commandData: [
+        { id: 3, version: '3.0.0', trusted: true },
+        { id: 2, version: '2.0.0' },
+        { id: 1, version: '1.0.0' }
+      ],
+      commandTagData: [
+        { id: 2, version: '2.0.0', tag: 'latest' },
+        { id: 1, version: '1.0.0', tag: 'stable' }
+      ]
+    });
 
     assert.ok(controller);
     assert.equal(controller.get('selectedVersion'), null);
     assert.equal(controller.get('latest.id'), 3);
     assert.equal(controller.get('versionCommand.id'), 3);
-    controller.send('changeVersion', '1.0.0');
-    assert.equal(controller.get('selectedVersion'), '1.0.0');
-    assert.equal(controller.get('versionCommand.id'), 1);
-    assert.equal(controller.get('latest.id'), 3);
   });
 
   test('it handles model changes', function(assert) {
     let controller = this.owner.lookup('controller:commands/detail');
     // eslint-disable-next-line new-cap
-    const arr = A([
-      { id: 3, version: '3.0.0' },
-      { id: 2, version: '2.0.0' },
-      { id: 1, version: '1.0.0' }
-    ]);
+    const arr = A({
+      commandData: [
+        { id: 3, version: '3.0.0' },
+        { id: 2, version: '2.0.0' },
+        { id: 1, version: '1.0.0' }
+      ]
+    });
 
     controller.set('model', arr);
 
@@ -88,11 +97,7 @@ module('Unit | Controller | commands/detail', function(hooks) {
     assert.equal(controller.get('versionCommand.id'), 3);
     assert.equal(controller.get('latest.id'), 3);
 
-    controller.send('changeVersion', '1.0.0');
-    assert.equal(controller.get('selectedVersion'), '1.0.0');
-    assert.equal(controller.get('versionCommand.id'), 1);
-
-    arr.unshiftObject({ id: 4, version: '4.0.0' });
+    arr.commandData.unshiftObject({ id: 4, version: '4.0.0' });
     assert.equal(controller.get('selectedVersion'), null);
     assert.equal(controller.get('versionCommand.id'), 4);
     assert.equal(controller.get('latest.id'), 4);
@@ -101,11 +106,13 @@ module('Unit | Controller | commands/detail', function(hooks) {
   test('it handles command deletion', function(assert) {
     let controller = this.owner.lookup('controller:commands/detail');
     // eslint-disable-next-line new-cap
-    const arr = A([
-      { id: 3, name: 'sample', version: '3.0.0' },
-      { id: 2, name: 'sample', version: '2.0.0' },
-      { id: 1, name: 'sample', version: '1.0.0' }
-    ]);
+    const arr = A({
+      commandData: [
+        { id: 3, name: 'sample', version: '3.0.0' },
+        { id: 2, name: 'sample', version: '2.0.0' },
+        { id: 1, name: 'sample', version: '1.0.0' }
+      ]
+    });
 
     controller.set('model', arr);
 
@@ -121,11 +128,13 @@ module('Unit | Controller | commands/detail', function(hooks) {
   test('it handles command update', function(assert) {
     let controller = this.owner.lookup('controller:commands/detail');
     // eslint-disable-next-line new-cap
-    const arr = A([
-      { id: 3, name: 'sample', version: '3.0.0' },
-      { id: 2, name: 'sample', version: '2.0.0' },
-      { id: 1, name: 'sample', version: '1.0.0' }
-    ]);
+    const arr = A({
+      commandData: [
+        { id: 3, name: 'sample', version: '3.0.0' },
+        { id: 2, name: 'sample', version: '2.0.0' },
+        { id: 1, name: 'sample', version: '1.0.0' }
+      ]
+    });
 
     controller.set('model', arr);
 
@@ -134,5 +143,105 @@ module('Unit | Controller | commands/detail', function(hooks) {
 
     controller.send('updateTrust', 'sample');
     assert.ok(updateTrustStub.calledOnce);
+  });
+
+  test('it handles undefined tag or version', function(assert) {
+    let controller = this.owner.lookup('controller:commands/detail');
+
+    controller.set('model', {
+      commandData: [
+        { id: 3, version: '3.0.0', trusted: true },
+        { id: 2, version: '2.0.0' },
+        { id: 1, version: '1.0.0' }
+      ],
+      commandTagData: [
+        { id: 2, version: '3.0.0', tag: 'latest' },
+        { id: 1, version: '1.0.0', tag: 'stable' }
+      ],
+      versionOrTagFromUrl: undefined
+    });
+
+    assert.ok(controller);
+    assert.equal(controller.get('versionCommand.version'), '3.0.0');
+  });
+
+  test('it handles a version that is exist', function(assert) {
+    let controller = this.owner.lookup('controller:commands/detail');
+
+    controller.set('model', {
+      commandData: [
+        { id: 3, version: '3.0.0', trusted: true },
+        { id: 2, version: '2.0.0' },
+        { id: 1, version: '1.0.0' }
+      ],
+      commandTagData: [
+        { id: 2, version: '3.0.0', tag: 'latest' },
+        { id: 1, version: '1.0.0', tag: 'stable' }
+      ],
+      versionOrTagFromUrl: '2.0.0'
+    });
+
+    assert.ok(controller);
+    assert.equal(controller.get('versionCommand.version'), '2.0.0');
+  });
+
+  test('it handles a tag that is exist', function(assert) {
+    let controller = this.owner.lookup('controller:commands/detail');
+
+    controller.set('model', {
+      commandData: [
+        { id: 3, version: '3.0.0', trusted: true },
+        { id: 2, version: '2.0.0' },
+        { id: 1, version: '1.0.0' }
+      ],
+      commandTagData: [
+        { id: 2, version: '3.0.0', tag: 'latest' },
+        { id: 1, version: '1.0.0', tag: 'stable' }
+      ],
+      versionOrTagFromUrl: 'stable'
+    });
+
+    assert.ok(controller);
+    assert.equal(controller.get('versionCommand.version'), '1.0.0');
+  });
+
+  test('it handles a version that is not exist', function(assert) {
+    let controller = this.owner.lookup('controller:commands/detail');
+
+    controller.set('model', {
+      commandData: [
+        { id: 3, version: '3.0.0', trusted: true },
+        { id: 2, version: '2.0.0' },
+        { id: 1, version: '1.0.0' }
+      ],
+      commandTagData: [
+        { id: 2, version: '3.0.0', tag: 'latest' },
+        { id: 1, version: '1.0.0', tag: 'stable' }
+      ],
+      versionOrTagFromUrl: '9.9.9'
+    });
+
+    assert.ok(controller);
+    assert.equal(controller.get('versionCommand.version'), undefined);
+  });
+
+  test('it handles a tag that is not exist', function(assert) {
+    let controller = this.owner.lookup('controller:commands/detail');
+
+    controller.set('model', {
+      commandData: [
+        { id: 3, version: '3.0.0', trusted: true },
+        { id: 2, version: '2.0.0' },
+        { id: 1, version: '1.0.0' }
+      ],
+      commandTagData: [
+        { id: 2, version: '3.0.0', tag: 'latest' },
+        { id: 1, version: '1.0.0', tag: 'stable' }
+      ],
+      versionOrTagFromUrl: 'foo'
+    });
+
+    assert.ok(controller);
+    assert.equal(controller.get('versionCommand.version'), undefined);
   });
 });

--- a/tests/unit/template/service-test.js
+++ b/tests/unit/template/service-test.js
@@ -55,19 +55,19 @@ module('Unit | Service | template', function(hooks) {
       assert.deepEqual(templates, [
         {
           id: 2,
-          fullName: 'foo/bar',
           namespace: 'foo',
           name: 'bar',
           version: '2.0.0',
+          fullName: 'foo/bar',
           createTime,
           lastUpdated
         },
         {
           id: 1,
-          fullName: 'foo/bar',
           namespace: 'foo',
           name: 'bar',
           version: '1.0.0',
+          fullName: 'foo/bar',
           createTime,
           lastUpdated
         }


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->


When the version is clicked on the template/command details screen, the content is rewritten by javascript. Since there is no link to the details screen of each version, they cannot be shared. So instead of rewriting content we changed for a link to each template and command.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
The version of the template/command details screen is changed to `href` like below.

#### Precondition
```
command: [
  {id:1, namespace:'foo', name:'bar', version:'1.0.0'}
  {id:2, namespace:'foo', name:'bar', version:'2.0.0 - latest'}
]  
```
#### Behavior
1. `/foo/bar`
 - It shows the screen of `latest (2.0.0)`
2. `/foo/bar/1.0.0`
 - It shows the screen of `1.0.0`
3. `/foo/bar/latest`
 - It shows the screen of `latest (2.0.0)`
4. `/foo/bar/9.9.9` or `/foo/bar/nonexisttag`
 - It shows the screen of `404`
## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
