### PR TITLE
fix: bug of version link in template/command detail page

### DIFF
--- a/app/components/command-versions/template.hbs
+++ b/app/components/command-versions/template.hbs
@@ -2,7 +2,7 @@
 <ul>
   {{#each commands.commandData as |c|}}
     <li>
-      <a href={{c.version}}><span class="version">{{c.version}}{{#if c.tag}} - {{c.tag}}{{/if}}</span></a>{{#if c.lastUpdated}} {{c.lastUpdated}}{{/if}}
+      <a href="/commands/{{c.namespace}}/{{c.name}}/{{c.version}}"><span class="version">{{c.version}}{{#if c.tag}} - {{c.tag}}{{/if}}</span></a>{{#if c.lastUpdated}} {{c.lastUpdated}}{{/if}}
     </li>
   {{/each}}
 </ul>

--- a/app/components/template-versions/template.hbs
+++ b/app/components/template-versions/template.hbs
@@ -2,7 +2,7 @@
 <ul>
   {{#each templates.templateData as |t|}}
     <li>
-      <a href={{t.version}}><span class="version">{{t.version}}{{#if t.tag}} - {{t.tag}}{{/if}}</span></a>{{#if t.lastUpdated}} {{t.lastUpdated}}{{/if}}
+      <a href="/templates/{{t.namespace}}/{{t.name}}/{{t.version}}"><span class="version">{{t.version}}{{#if t.tag}} - {{t.tag}}{{/if}}</span></a>{{#if t.lastUpdated}} {{t.lastUpdated}}{{/if}}
     </li>
   {{/each}}
 </ul>

--- a/tests/integration/components/command-versions/component-test.js
+++ b/tests/integration/components/command-versions/component-test.js
@@ -5,9 +5,9 @@ import hbs from 'htmlbars-inline-precompile';
 
 const COMMANDS = {
   commandData: [
-    { version: '3.0.0', tag: 'latest stable' },
-    { version: '2.0.0', tag: 'meeseeks' },
-    { version: '1.0.0' }
+    { namespace: 'boo', name: 'baz', version: '3.0.0', tag: 'latest stable' },
+    { namespace: 'boo', name: 'baz', version: '2.0.0', tag: 'meeseeks' },
+    { namespace: 'boo', name: 'baz', version: '1.0.0' }
   ]
 };
 
@@ -46,9 +46,9 @@ module('Integration | Component | command versions', function(hooks) {
     assert.dom('ul li:nth-child(2)').hasText('2.0.0 - meeseeks');
     assert.dom('ul li:last-child').hasText('1.0.0');
 
-    assert.dom('ul li:first-child a').hasAttribute('href');
-    assert.dom('ul li:nth-child(2) a').hasAttribute('href');
-    assert.dom('ul li:last-child a').hasAttribute('href');
+    assert.dom('ul li:first-child a').hasAttribute('href', '/commands/boo/baz/3.0.0');
+    assert.dom('ul li:nth-child(2) a').hasAttribute('href', '/commands/boo/baz/2.0.0');
+    assert.dom('ul li:last-child a').hasAttribute('href', '/commands/boo/baz/1.0.0');
 
     assert.dom('ul li:first-child a[href]').hasText('3.0.0 - latest stable');
     assert.dom('ul li:nth-child(2) a[href]').hasText('2.0.0 - meeseeks');

--- a/tests/integration/components/template-versions/component-test.js
+++ b/tests/integration/components/template-versions/component-test.js
@@ -5,9 +5,9 @@ import hbs from 'htmlbars-inline-precompile';
 
 const TEMPLATES = {
   templateData: [
-    { version: '3.0.0', tag: 'latest stable' },
-    { version: '2.0.0', tag: 'meeseeks' },
-    { version: '1.0.0' }
+    { namespace: 'boo', name: 'baz', version: '3.0.0', tag: 'latest stable' },
+    { namespace: 'boo', name: 'baz', version: '2.0.0', tag: 'meeseeks' },
+    { namespace: 'boo', name: 'baz', version: '1.0.0' }
   ]
 };
 
@@ -32,7 +32,7 @@ module('Integration | Component | template versions', function(hooks) {
   });
 
   test('it handles clicks on versions', async function(assert) {
-    assert.expect(4);
+    assert.expect(10);
 
     this.set('mock', TEMPLATES);
     this.actions.mockAction = function(ver) {
@@ -45,5 +45,13 @@ module('Integration | Component | template versions', function(hooks) {
     assert.dom('ul li:first-child').hasText('3.0.0 - latest stable');
     assert.dom('ul li:nth-child(2)').hasText('2.0.0 - meeseeks');
     assert.dom('ul li:last-child').hasText('1.0.0');
+
+    assert.dom('ul li:first-child a').hasAttribute('href', '/templates/boo/baz/3.0.0');
+    assert.dom('ul li:nth-child(2) a').hasAttribute('href', '/templates/boo/baz/2.0.0');
+    assert.dom('ul li:last-child a').hasAttribute('href', '/templates/boo/baz/1.0.0');
+
+    assert.dom('ul li:first-child a[href]').hasText('3.0.0 - latest stable');
+    assert.dom('ul li:nth-child(2) a[href]').hasText('2.0.0 - meeseeks');
+    assert.dom('ul li:last-child a[href]').hasText('1.0.0');
   });
 });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
In the case of 
* /template/namespace/name 
* /command/namespace/name 

When accessing, the screen became white like below.

<img width="1436" alt="スクリーンショット 2019-09-24 15 21 33" src="https://user-images.githubusercontent.com/17828065/65486323-1b622180-dedf-11e9-8577-21397920e0df.png">

This PR fixes the problem.

## Objective
This PR changes the link fullpath.

<!-- What does this PR fix? What intentional changes will this PR make? -->
 
## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
