### PR TITLE
fix: remove version display column on templates & commands table

### DIFF
--- a/app/components/command-versions/template.hbs
+++ b/app/components/command-versions/template.hbs
@@ -2,7 +2,7 @@
 <ul>
   {{#each commands.commandData as |c|}}
     <li>
-      <a href="/commands/{{c.namespace}}/{{c.name}}/{{c.version}}"><span class="version">{{c.version}}{{#if c.tag}} - {{c.tag}}{{/if}}</span></a>{{#if c.lastUpdated}} {{c.lastUpdated}}{{/if}}
+      {{#link-to "commands.detail" c.namespace c.name c.version}}<span class="version">{{c.version}}{{#if c.tag}} - {{c.tag}}{{/if}}</span>{{/link-to}}{{#if c.lastUpdated}} {{c.lastUpdated}}{{/if}}
     </li>
   {{/each}}
 </ul>

--- a/app/components/tc-collection-linker/template.hbs
+++ b/app/components/tc-collection-linker/template.hbs
@@ -1,5 +1,5 @@
 {{#if (eq column.label "Name")}}
-  {{#link-to extra.routes.detail row.content.namespace value row.content.version}}{{#if row.content.trusted}}<span title="Trusted">{{inline-svg "trusted" class="trusted"}}</span>{{/if}}<span class="name">{{value}}</span>{{/link-to}}
+  <a href="/{{extra.routes.prefix}}/{{row.content.namespace}}/{{value}}">{{#if row.content.trusted}}<span title="Trusted">{{inline-svg "trusted" class="trusted"}}</span>{{/if}}<span class="name">{{value}}</span></a>
 {{else if (eq column.label "Namespace")}}
   {{#link-to extra.routes.namespace value}}<span class="namespace">{{value}}</span>{{/link-to}}
 {{/if}}

--- a/app/components/tc-collection-list/component.js
+++ b/app/components/tc-collection-list/component.js
@@ -132,15 +132,7 @@ export default Component.extend({
       label: 'Updated',
       valuePath: 'lastUpdated',
       resizable: true,
-      width: '10%',
-      minResizeWidth: 100
-    },
-    {
-      label: 'Version',
-      sortable: false,
-      valuePath: 'version',
-      resizable: true,
-      width: '10%',
+      width: '15%',
       minResizeWidth: 100
     },
     {
@@ -148,7 +140,7 @@ export default Component.extend({
       sortable: true,
       valuePath: 'maintainer',
       resizable: true,
-      width: '15%',
+      width: '20%',
       minResizeWidth: 150
     }
   ]),

--- a/app/components/template-versions/template.hbs
+++ b/app/components/template-versions/template.hbs
@@ -2,7 +2,7 @@
 <ul>
   {{#each templates.templateData as |t|}}
     <li>
-      <a href="/templates/{{t.namespace}}/{{t.name}}/{{t.version}}"><span class="version">{{t.version}}{{#if t.tag}} - {{t.tag}}{{/if}}</span></a>{{#if t.lastUpdated}} {{t.lastUpdated}}{{/if}}
+      {{#link-to "templates.detail" t.namespace t.name t.version}}<span class="version">{{t.version}}{{#if t.tag}} - {{t.tag}}{{/if}}</span>{{/link-to}}{{#if t.lastUpdated}} {{t.lastUpdated}}{{/if}}
     </li>
   {{/each}}
 </ul>

--- a/tests/integration/components/command-versions/component-test.js
+++ b/tests/integration/components/command-versions/component-test.js
@@ -34,6 +34,8 @@ module('Integration | Component | command versions', function(hooks) {
   test('Links of version exist', async function(assert) {
     assert.expect(10);
 
+    this.owner.setupRouter();
+
     this.set('mock', COMMANDS);
     this.actions.mockAction = function(ver) {
       assert.equal(ver, '1.0.0');

--- a/tests/integration/components/tc-collection-list/component-test.js
+++ b/tests/integration/components/tc-collection-list/component-test.js
@@ -47,8 +47,8 @@ module('Integration | Component | tc collection list', function(hooks) {
     assert
       .dom('header h4 a')
       .hasAttribute('href', 'http://docs.screwdriver.cd/user-guide/collection');
-    assert.dom('.collection-list-table th').exists({ count: 6 });
-    assert.dom('.collection-list-table .lt-body td').exists({ count: 12 });
+    assert.dom('.collection-list-table th').exists({ count: 5 });
+    assert.dom('.collection-list-table .lt-body td').exists({ count: 10 });
   });
 
   test('it renders with filter namespace', async function(assert) {
@@ -68,7 +68,7 @@ module('Integration | Component | tc collection list', function(hooks) {
     assert
       .dom('header h4 a')
       .hasAttribute('href', 'http://docs.screwdriver.cd/user-guide/collection');
-    assert.dom('.collection-list-table th').exists({ count: 6 });
-    assert.dom('.collection-list-table .lt-body td').exists({ count: 6 });
+    assert.dom('.collection-list-table th').exists({ count: 5 });
+    assert.dom('.collection-list-table .lt-body td').exists({ count: 5 });
   });
 });

--- a/tests/integration/components/template-versions/component-test.js
+++ b/tests/integration/components/template-versions/component-test.js
@@ -34,6 +34,8 @@ module('Integration | Component | template versions', function(hooks) {
   test('it handles clicks on versions', async function(assert) {
     assert.expect(10);
 
+    this.owner.setupRouter();
+
     this.set('mock', TEMPLATES);
     this.actions.mockAction = function(ver) {
       assert.equal(ver, '1.0.0');


### PR DESCRIPTION
## Context

There is complication with aggregate group query related to `version` text on templates and commands. Remove it entirely until the data part is figured out.

## Objective

1. On templates and commands pages, clicking on name on the table row reload and navigate to `/{templates|commands}/{namespace}/{name}` route which is now pointing to the latest version implicitly
2. the version links on the detail page will do client side navigation instead of hard-core reload
3. fix tests

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
