### PR TITLE
fix: invert check for normal collection

### DIFF
--- a/app/components/collections-flyout/component.js
+++ b/app/components/collections-flyout/component.js
@@ -24,8 +24,7 @@ export default Component.extend({
   orderedCollections: computed('collections.[]', {
     get() {
       let defaultCollection;
-      const 
-      Collections = this.collections.filter(collection => {
+      const normalCollections = this.collections.filter(collection => {
         if (collection.type === 'default') {
           defaultCollection = collection;
         }

--- a/app/components/collections-flyout/component.js
+++ b/app/components/collections-flyout/component.js
@@ -24,12 +24,13 @@ export default Component.extend({
   orderedCollections: computed('collections.[]', {
     get() {
       let defaultCollection;
-      const normalCollections = this.collections.filter(collection => {
+      const 
+      Collections = this.collections.filter(collection => {
         if (collection.type === 'default') {
           defaultCollection = collection;
         }
 
-        return collection.type === 'normal';
+        return collection.type !== 'default';
       });
 
       return defaultCollection ? [defaultCollection, ...normalCollections] : normalCollections;


### PR DESCRIPTION
## Context

Collections which were created prior to adding collection type are not showing up in UI

## Objective

Invert the check for normal collection

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
