### PR TITLE
fix(1725): Allow for <a> in banner

### DIFF
--- a/app/components/nav-banner/template.hbs
+++ b/app/components/nav-banner/template.hbs
@@ -4,7 +4,7 @@
       {{fa-icon
         (if (eq banner.type "info") "info-circle" "exclamation-triangle")
       }}
-      <span>{{banner.message}}</span>
+      <span>{{{banner.message}}}</span>
     {{/bs-alert}}
   </div>
 {{/each}}

--- a/app/components/nav-banner/template.hbs
+++ b/app/components/nav-banner/template.hbs
@@ -4,7 +4,7 @@
       {{fa-icon
         (if (eq banner.type "info") "info-circle" "exclamation-triangle")
       }}
-      {{！template-lint-disable no-triple-curlies}}
+      {{! template-lint-disable no-triple-curlies }}
       <span>{{{banner.message}}}</span>
     {{/bs-alert}}
   </div>

--- a/app/components/nav-banner/template.hbs
+++ b/app/components/nav-banner/template.hbs
@@ -4,6 +4,7 @@
       {{fa-icon
         (if (eq banner.type "info") "info-circle" "exclamation-triangle")
       }}
+      {{！template-lint-disable no-triple-curlies}}
       <span>{{{banner.message}}}</span>
     {{/bs-alert}}
   </div>


### PR DESCRIPTION
## Context

Sometimes it can be useful to add links in the banner message.

## Objective

This PR allows for links in the banner message.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/1725

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
