### PR TITLE
fix(1651): Allow admins to delete templates and commands with no pipelines

### DIFF
--- a/app/components/command-header/template.hbs
+++ b/app/components/command-header/template.hbs
@@ -3,11 +3,11 @@
   {{command.namespace}}/{{command.name}}
   {{#if scmUrl}}
     <a href={{scmUrl}}>{{fa-icon "code-fork" title="Source code"}}</a>
-    <a href="#" {{action "setCommandToRemove" command}} class="remove">{{fa-icon "trash" title="Delete command"}}</a>
   {{else}}
-    {{fa-icon "code-fork" title="The pipeline for this command does not exist."}} {{fa-icon "trash" title="Cannot delete command; pipeline could not be found."}}
+    {{fa-icon "code-fork" title="The pipeline for this command does not exist."}}
   {{/if}}
   {{#if isAdmin}}
+    <a href="#" {{action "setCommandToRemove" command}} class="remove">{{fa-icon "trash" title="Delete command"}}</a>
     {{x-toggle
       size="medium"
       theme="light"
@@ -17,6 +17,8 @@
       onLabel="Trust?"
       onToggle=(action "updateTrust" command.namespace command.name)
     }}
+  {{else}}
+    {{fa-icon "trash" title="Cannot delete command; pipeline could not be found."}}
   {{/if}}
 </h1>
 <h2>{{command.version}}</h2>

--- a/app/components/template-header/template.hbs
+++ b/app/components/template-header/template.hbs
@@ -2,11 +2,12 @@
   {{#if trusted}}<span title="Trusted">{{inline-svg "trusted" class="trusted"}}</span>{{/if}}
   {{template.fullName}}
   {{#if scmUrl}}
-    <a href={{scmUrl}}>{{fa-icon "code-fork" title="Source code"}}</a> <a href="#" {{action "setTemplateToRemove" template}} class="remove">{{fa-icon "trash" title="Delete template"}}</a>
+    <a href={{scmUrl}}>{{fa-icon "code-fork" title="Source code"}}</a>
   {{else}}
-    {{fa-icon "code-fork" title="The pipeline for this template does not exist."}} {{fa-icon "trash" title="Cannot delete template; pipeline could not be found."}}
+    {{fa-icon "code-fork" title="The pipeline for this template does not exist."}}
   {{/if}}
   {{#if isAdmin}}
+    <a href="#" {{action "setTemplateToRemove" template}} class="remove">{{fa-icon "trash" title="Delete template"}}</a>
     {{x-toggle
       size="medium"
       theme="light"
@@ -16,6 +17,8 @@
       onLabel="Trust?"
       onToggle=(action "updateTrust" template.fullName)
     }}
+  {{else}}
+    {{fa-icon "trash" title="Cannot delete template; pipeline could not be found."}}
   {{/if}}
 </h1>
 <h2>{{template.version}}</h2>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1644,7 +1644,7 @@
     "@glimmer/resolver": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/@glimmer/resolver/-/resolver-0.4.3.tgz",
-      "integrity": "sha512-UhX6vlZbWRMq6pCquSC3wfWLM9kO0PhQPD1dZ3XnyZkmsvEE94Cq+EncA9JalUuevKoJrfUFRvrZ0xaz+yar3g==",
+      "integrity": "sha1-sbquXDKRtGIQAsz414cEZgl+hB0=",
       "dev": true,
       "requires": {
         "@glimmer/di": "^0.2.0"
@@ -4464,7 +4464,7 @@
     "broccoli-templater": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/broccoli-templater/-/broccoli-templater-2.0.2.tgz",
-      "integrity": "sha512-71KpNkc7WmbEokTQpGcbGzZjUIY1NSVa3GB++KFKAfx5SZPUozCOsBlSTwxcv8TLoCAqbBnsX5AQPgg6vJ2l9g==",
+      "integrity": "sha1-KFqJIHHAs61evCddnos0ZeLRINY=",
       "dev": true,
       "requires": {
         "broccoli-plugin": "^1.3.1",
@@ -4736,7 +4736,7 @@
     "caniuse-api": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
-      "integrity": "sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==",
+      "integrity": "sha1-Xk2Q4idJYdRikZl99Znj7QCO5MA=",
       "dev": true,
       "requires": {
         "browserslist": "^4.0.0",
@@ -5135,7 +5135,7 @@
     "common-tags": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
-      "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==",
+      "integrity": "sha1-jjFT5ULUo56bEFVENK+q+YlWqTc=",
       "dev": true
     },
     "compare-versions": {
@@ -8516,7 +8516,7 @@
     "ember-cli-test-loader": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ember-cli-test-loader/-/ember-cli-test-loader-2.2.0.tgz",
-      "integrity": "sha512-mlSXX9SciIRwGkFTX6XGyJYp4ry6oCFZRxh5jJ7VH8UXLTNx2ZACtDTwaWtNhYrWXgKyiDUvmD8enD56aePWRA==",
+      "integrity": "sha1-P7jV0TV+RGDT8KCS9Tdecbb3wkM=",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^6.8.1"
@@ -10907,7 +10907,7 @@
     "ember-ignore-children-helper": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ember-ignore-children-helper/-/ember-ignore-children-helper-1.0.1.tgz",
-      "integrity": "sha512-AgKkrvd1/hIBWdLn42gITlweVsALUGPYF9fMpQ2IDqp7QnRmtO8ocRbZEmMddPDWY9Xu7W5qO2f35rbD7OSpYw==",
+      "integrity": "sha1-98SqF6+5xWheHU3Nthx7E4ynzcM=",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^6.8.2"
@@ -13508,7 +13508,7 @@
     "ember-runtime-enumerable-includes-polyfill": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ember-runtime-enumerable-includes-polyfill/-/ember-runtime-enumerable-includes-polyfill-2.1.0.tgz",
-      "integrity": "sha512-au18iI8VbEDYn3jLFZzETnKN5ciPgCUxMRucEP3jkq7qZ6sE0FVKpWMPY/h9tTND3VOBJt6fgPpEBJoJVCUudg==",
+      "integrity": "sha1-3G1KAoRx5KzDUN/SoUmHT7IJE/U=",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^6.9.0",
@@ -15625,7 +15625,7 @@
     "fastboot-transform": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/fastboot-transform/-/fastboot-transform-0.1.3.tgz",
-      "integrity": "sha512-6otygPIJw1ARp1jJb+6KVO56iKBjhO+5x59RSC9qiZTbZRrv+HZAuP00KD3s+nWMvcFDemtdkugki9DNFTTwCQ==",
+      "integrity": "sha1-feoLEXWUr9h3K6psmwkZZE5/fc0=",
       "dev": true,
       "requires": {
         "broccoli-stew": "^1.5.0",
@@ -17687,7 +17687,7 @@
     },
     "lines-and-columns": {
       "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
       "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
       "dev": true
     },


### PR DESCRIPTION
## Context

Sometimes the pipeline is removed before people get a change to delete the template/command. Even if the pipeline doesn't exist, a Screwdriver admin should be able to remove the template/command through the UI.

## Objective

This PR always shows the trash icon on the template/command pages. The backend should be able to handle the case where a pipeline doesn't exist but the user is a Screwdriver admin gracefully: https://github.com/screwdriver-cd/screwdriver/blob/master/plugins/templates/index.js#L39-L41

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/1651

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
