### PR TITLE
fix: change word from move-to to copy-to and fix metrics error bubbling up

### DIFF
--- a/app/components/collection-view/template.hbs
+++ b/app/components/collection-view/template.hbs
@@ -27,7 +27,7 @@
 
       <BsModal
         @class="add-pipeline-modal"
-        @open={{showAddPipelineModal}} 
+        @open={{showAddPipelineModal}}
         @onHidden={{action "toggleAddPipelineModal"}}
       as |modal|>
         <modal.header>
@@ -56,17 +56,17 @@
         </modal.header>
         <modal.body>
           <BsForm @formLayout="vertical" as |form|>
-            <form.element 
-              @controlType="text" 
-              @label="Name" 
-              @placeholder="Screwdriver CI/CD" 
+            <form.element
+              @controlType="text"
+              @label="Name"
+              @placeholder="Screwdriver CI/CD"
               @value={{collection.name}}
               @onChange={{action "updateCollectionName"}}
             />
-            <form.element 
-              @controlType="textarea" 
-              @label="Description" 
-              @placeholder="Collection Description" 
+            <form.element
+              @controlType="textarea"
+              @label="Description"
+              @placeholder="Collection Description"
               @value={{collection.description}}
               @onChange={{action "updateCollectionDescription"}}
             />
@@ -99,7 +99,7 @@
                 collections=collections
                 addMultipleToCollection=(action "addMultipleToCollection")
                 buttonClass="operation-button"
-                buttonText="Move To"
+                buttonText="Copy To"
             }}
           {{/if}}
           <BsButton class="cancel-organize-button" onclick={{action "resetView"}}>Cancel</BsButton>
@@ -182,5 +182,5 @@
         {{/each}}
       </div>
     {{/if}}
-  {{/if}}  
+  {{/if}}
 </div>

--- a/app/components/collection-view/template.hbs
+++ b/app/components/collection-view/template.hbs
@@ -95,7 +95,7 @@
             <span>{{selectedPipelines.length}}&nbsp;&nbsp;Selected</span>
             <BsButton class="operation-button" onclick={{action "removeSelectedPipelines"}}>Remove</BsButton>
             {{collection-dropdown
-                class="move-pipeline"
+                class="copy-pipeline"
                 collections=collections
                 addMultipleToCollection=(action "addMultipleToCollection")
                 buttonClass="operation-button"

--- a/app/dashboard/show/route.js
+++ b/app/dashboard/show/route.js
@@ -1,24 +1,19 @@
 import RSVP from 'rsvp';
 import Route from '@ember/routing/route';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
-
 const MAX_NUM_EVENTS_SHOWN = 20;
 
 export default Route.extend(AuthenticatedRouteMixin, {
   model(params) {
     return this.store.findRecord('collection', params.collection_id).then(collection => {
       return RSVP.hash({
-        metricsMap: RSVP.hash(
-          (collection.pipelineIds || []).reduce((oldMap, pipelineId) => {
-            oldMap[pipelineId] = this.store.query('metric', {
-              pipelineId,
-              page: 1,
-              count: MAX_NUM_EVENTS_SHOWN
-            });
-
-            return oldMap;
-          }, {})
-        ),
+        metricsMap: collection.pipelineIds.map(pipelineId => {
+          return this.store.query('metric', {
+            pipelineId,
+            page: 1,
+            count: MAX_NUM_EVENTS_SHOWN
+          });
+        }),
         collection,
         collections: this.store.findAll('collection').catch(() => [])
       });

--- a/tests/integration/components/collection-view/component-test.js
+++ b/tests/integration/components/collection-view/component-test.js
@@ -902,8 +902,8 @@ module('Integration | Component | collection view', function(hooks) {
     await click(checkboxes[1]);
 
     // remove these selected pipelines
-    await click('.move-pipeline button');
-    await click('.move-pipeline .dropdown-menu li:nth-of-type(2) span');
+    await click('.copy-pipeline button');
+    await click('.copy-pipeline .dropdown-menu li:nth-of-type(2) span');
   });
 
   test('it moves multiple pipelines to another collection in list mode', async function(assert) {
@@ -940,8 +940,8 @@ module('Integration | Component | collection view', function(hooks) {
     await click(checkboxes[1]);
 
     // remove these selected pipelines
-    await click('.move-pipeline button');
-    await click('.move-pipeline .dropdown-menu li:nth-of-type(2) span');
+    await click('.copy-pipeline button');
+    await click('.copy-pipeline .dropdown-menu li:nth-of-type(2) span');
   });
 
   test('it fails to move multiple pipelines to another collection in card mode', async function(assert) {
@@ -975,8 +975,8 @@ module('Integration | Component | collection view', function(hooks) {
     await click(checkboxes[1]);
 
     // remove these selected pipelines
-    await click('.move-pipeline button');
-    await click('.move-pipeline .dropdown-menu li:nth-of-type(2) span');
+    await click('.copy-pipeline button');
+    await click('.copy-pipeline .dropdown-menu li:nth-of-type(2) span');
 
     // assert the error message is correct
     assert
@@ -1018,8 +1018,8 @@ module('Integration | Component | collection view', function(hooks) {
     await click(checkboxes[1]);
 
     // remove these selected pipelines
-    await click('.move-pipeline button');
-    await click('.move-pipeline .dropdown-menu li:nth-of-type(2) span');
+    await click('.copy-pipeline button');
+    await click('.copy-pipeline .dropdown-menu li:nth-of-type(2) span');
   });
 
   test('it searches and adds pipelines into the collection', async function(assert) {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

1) Label `Move To` actually keeps the original pipeline inside the original collection, which should be. We need to change the label from `Move To` to `Copy To`.

2) Metrics fetch no longer exist pipelineId will result to 404 pages.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

This PR Changes the label from `Move To` to `Copy To`

Before: 

![image](https://user-images.githubusercontent.com/15989893/67060028-2c820500-f110-11e9-9bbe-adb859d78f23.png)

After:
![image](https://user-images.githubusercontent.com/15989893/67060037-373c9a00-f110-11e9-8a8e-2150edf3ab91.png)

2)  While it still shows errors, but this time the errors are caught by Ember.RSVP, instead of bubbling up, and will not 404 pages
![image](https://user-images.githubusercontent.com/15989893/67059963-f3499500-f10f-11e9-8a40-22379d7da8e5.png)


## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
