### PR TITLE
fix: Reverse eventsInfo array because of pipeline model change

### DIFF
--- a/app/components/collection-view/component.js
+++ b/app/components/collection-view/component.js
@@ -171,7 +171,7 @@ export default Component.extend({
           };
 
           if (metrics && metrics.length) {
-            const lastEvent = metrics.get('lastObject');
+            const lastEvent = metrics.get('firstObject');
             const lastEventStartTime = new Date(lastEvent.createTime);
             const lastEventStartYear = lastEventStartTime.getFullYear();
             const lastEventStartMonth = (lastEventStartTime.getMonth() + 1)

--- a/app/components/events-thumbnail/component.js
+++ b/app/components/events-thumbnail/component.js
@@ -41,7 +41,7 @@ export default Component.extend({
     // Fixed number of bars
     if (this.events.length < MAX_NUM_EVENTS_SHOWN) {
       this.events = [
-        ...this.events,
+        ...this.events.reverse(),
         ...new Array(MAX_NUM_EVENTS_SHOWN - totalNumberOfEvents).fill({
           duration: 0,
           statusColor: 'build-empty'

--- a/tests/integration/components/collection-view/component-test.js
+++ b/tests/integration/components/collection-view/component-test.js
@@ -168,18 +168,6 @@ const mockCollections = [
 const mockMetricsMap = EmberObject.create({
   1: [
     {
-      status: 'SUCCESS',
-      duration: 23173
-    },
-    {
-      status: 'SUCCESS',
-      duration: 20011
-    },
-    {
-      status: 'FAILURE',
-      duration: 39234
-    },
-    {
       creatTime: 'Tue Oct 01 2019 15:55:52 GMT-0700 (Pacific Daylight Time)',
       status: 'FAILURE',
       duration: 42718,
@@ -190,6 +178,18 @@ const mockMetricsMap = EmberObject.create({
         url:
           'https://github.com/screwdriver-cd/screwdriver/commit/9af92ba97483213119dd4b57d7cc903405d199ea'
       }
+    },
+    {
+      status: 'SUCCESS',
+      duration: 23173
+    },
+    {
+      status: 'SUCCESS',
+      duration: 20011
+    },
+    {
+      status: 'FAILURE',
+      duration: 39234
     }
   ],
   2: [],

--- a/tests/integration/components/events-thumbnail/component-test.js
+++ b/tests/integration/components/events-thumbnail/component-test.js
@@ -31,10 +31,10 @@ module('Integration | Component | events thumbnail', function(hooks) {
     const rect1 = $('svg rect:nth-of-type(1)');
     const rect2 = $('svg rect:nth-of-type(2)');
 
-    assert.equal(rect1.css('fill'), BUILD_SUCCESS_COLOR);
-    assert.equal(rect1.css('height'), '20px');
-    assert.equal(rect2.css('fill'), BUILD_FAILURE_COLOR);
-    assert.equal(rect2.css('height'), '40px');
+    assert.equal(rect1.css('fill'), BUILD_FAILURE_COLOR);
+    assert.equal(rect1.css('height'), '40px');
+    assert.equal(rect2.css('fill'), BUILD_SUCCESS_COLOR);
+    assert.equal(rect2.css('height'), '20px');
     assert.equal($('svg rect:nth-of-type(3)').css('fill'), BUILD_EMPTY_COLOR);
   });
 });


### PR DESCRIPTION
## Context
Events-thumbnail components show outdated events info because of an API bug. Now the API is fixed, we need to make corresponding changes for the UI.

## Objective
Make events-thumbnail show latest events info.

## References
[screwdriver feat(947)](https://github.com/screwdriver-cd/ui/pull/480)

## License
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
