### PR TITLE
fix: Reverse events when the number of fetched events is 20

### DIFF
--- a/app/components/events-thumbnail/component.js
+++ b/app/components/events-thumbnail/component.js
@@ -38,17 +38,18 @@ export default Component.extend({
     // Add padding to the svg element so that it stays symmetrical
     svg.style('padding', `0 ${paddingLeft} 0 ${paddingRight}`);
 
+    // Reverse the events array so the lastest event is at the end
+    this.events.reverse();
+
     // Fixed number of bars
     if (this.events.length < MAX_NUM_EVENTS_SHOWN) {
       this.events = [
-        ...this.events.reverse(),
+        ...this.events,
         ...new Array(MAX_NUM_EVENTS_SHOWN - totalNumberOfEvents).fill({
           duration: 0,
           statusColor: 'build-empty'
         })
       ];
-    } else {
-      this.events = this.events.slice(0, MAX_NUM_EVENTS_SHOWN);
     }
 
     const bars = svg


### PR DESCRIPTION
## Context
In last pull request, only when the number of fetched events is less than 20 will the events array be reversed, which is causing issues.
![image](https://user-images.githubusercontent.com/23255780/67875828-261e6080-faf4-11e9-9c56-54012a36ffde.png)


## Objective
Make events-thumbnail show events in the correct order in any situation.

## References
[fix 495](https://github.com/screwdriver-cd/ui/pull/495)

## License
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
