### PR TITLE
fix: pipeline controller.js

### DIFF
--- a/app/pipeline/controller.js
+++ b/app/pipeline/controller.js
@@ -12,7 +12,7 @@ export default Controller.extend({
       const { pipelineIds } = collection;
 
       if (!pipelineIds.includes(pipelineId)) {
-        pipelineIds.push(pipelineId);
+        collection.set('pipelineIds', [...pipelineIds, pipelineId]);
       }
 
       return collection.save();

--- a/tests/unit/pipeline/controller-test.js
+++ b/tests/unit/pipeline/controller-test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import EmberObject from '@ember/object';
 
 module('Unit | Controller | pipeline', function(hooks) {
   setupTest(hooks);
@@ -8,12 +9,12 @@ module('Unit | Controller | pipeline', function(hooks) {
     assert.expect(1);
     let controller = this.owner.lookup('controller:pipeline');
     let pipelineId = 1;
-    let collection = {
+    let collection = EmberObject.create({
       pipelineIds: [],
       save() {
         assert.equal(this.pipelineIds.length, 1, 'Collection now has 1 pipelineId');
       }
-    };
+    });
 
     controller.send('addToCollection', pipelineId, collection);
   });
@@ -22,12 +23,12 @@ module('Unit | Controller | pipeline', function(hooks) {
     assert.expect(1);
     let controller = this.owner.lookup('controller:pipeline');
     let pipelineId = 1;
-    let collection = {
+    let collection = EmberObject.create({
       pipelineIds: [1],
       save() {
         assert.equal(this.pipelineIds.length, 1, 'Collection now has 1 uniq pipelineId');
       }
-    };
+    });
 
     controller.send('addToCollection', pipelineId, collection);
   });
@@ -36,12 +37,12 @@ module('Unit | Controller | pipeline', function(hooks) {
     assert.expect(1);
     let controller = this.owner.lookup('controller:pipeline');
     let pipelineId = 2;
-    let collection = {
+    let collection = EmberObject.create({
       pipelineIds: [1],
       save() {
         assert.equal(this.pipelineIds.length, 2, 'Collection now has 2 pipelineId');
       }
-    };
+    });
 
     controller.send('addToCollection', pipelineId, collection);
   });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
We must use `set` to notify that Ember this attribute is dirty in 
```javascript
if (!pipelineIds.includes(pipelineId)) {
      collection.set('pipelineIds', [...pipelineIds, pipelineId]);
}
```

Since this method 👇  is missing `this._super(...arguments);` and does some manual `isDirty` checks.

https://github.com/screwdriver-cd/ui/blob/c95d6d6d333e3d8b2aeaccbe8e2ba12cd9c7ea18/app/collection/serializer.js#L10-L17

Otherwise, current 👆  will send `PUT` empty object

![image](https://user-images.githubusercontent.com/15989893/67926824-4988f000-fb74-11e9-885d-6731ef88b759.png)


## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
This PR fixed that so we can add pipeline to collection from pipeline detail's page
![image](https://user-images.githubusercontent.com/15989893/67926704-ef882a80-fb73-11e9-8cda-154c3302221d.png)

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
