### PR TITLE
fix(1833): event view does not convey context which triggered it

### DIFF
--- a/app/components/build-banner/template.hbs
+++ b/app/components/build-banner/template.hbs
@@ -49,8 +49,8 @@
     <span class="banner-label">Create Time</span>
   </li>
   <li class="user">
-    <span class="banner-value">{{user-link user=event.creator causeMessage=event.causeMessage}}</span>
-    <span class="banner-label">User</span>
+    <span class="banner-value">{{user-link user=event.commit.author causeMessage=event.causeMessage}}</span>
+    <span class="banner-label">Committer</span>
   </li>
   {{#if coverageStep}}
     <li class="coverage">

--- a/app/components/pipeline-event-row/component.js
+++ b/app/components/pipeline-event-row/component.js
@@ -54,7 +54,7 @@ export default Component.extend({
 
   externalBuild: computed('event.{causeMessage,startFrom}', {
     get() {
-      // need to use underscores here because they used for link-to
+      // using underscore because router.js doesn't pick up camelcase
       /* eslint-disable camelcase */
       const build_id = this.get('event.causeMessage').match(/\d+$/)[0];
       const pipeline_id = this.get('event.startFrom').match(/^~sd@(\d+):[\w-]+$/)[1];

--- a/app/components/pipeline-event-row/component.js
+++ b/app/components/pipeline-event-row/component.js
@@ -37,6 +37,33 @@ export default Component.extend({
     }
   }),
 
+  isExternalTrigger: computed('event.startFrom', {
+    get() {
+      return this.get('event.startFrom').match(/^~sd@(\d+):([\w-]+)$/);
+    }
+  }),
+
+  isCommiterDifferent: computed('isExternalTrigger', 'event.{creator.name,commit.author.name}', {
+    get() {
+      const creatorName = this.get('event.creator.name');
+      const authorName = this.get('event.commit.author.name');
+
+      return this.get('isExternalTrigger') || creatorName !== authorName;
+    }
+  }),
+
+  externalBuild: computed('event.{causeMessage,startFrom}', {
+    get() {
+      // need to use underscores here because they used for link-to
+      /* eslint-disable camelcase */
+      const build_id = this.get('event.causeMessage').match(/\d+$/)[0];
+      const pipeline_id = this.get('event.startFrom').match(/^~sd@(\d+):[\w-]+$/)[1];
+      /* eslint-enable camelcase */
+
+      return { build_id, pipeline_id };
+    }
+  }),
+
   actions: {
     clickRow() {
       const fn = get(this, 'eventClick');

--- a/app/components/pipeline-event-row/template.hbs
+++ b/app/components/pipeline-event-row/template.hbs
@@ -11,7 +11,22 @@
     </div>
     <div class="date greyOut">Started {{event.createTimeWords}}</div>
     <span class="message" title={{event.commit.message}}>{{event.truncatedMessage}}</span>
-    <div class="by"><a href={{event.creator.url}}>{{event.creator.name}}</a></div>
+    <div class="by">
+      {{#if isCommiterDifferent}}
+        <span>Committed by: </span>
+        <a href={{event.commit.author.url}}>{{event.commit.author.name}}</a>
+        <br>
+        <span> Started by: </span>
+        {{#if isExternalTrigger}}
+          {{#link-to "pipeline.build" externalBuild.pipeline_id externalBuild.build_id}}External Trigger{{/link-to}}
+        {{else}}
+          <a href={{event.creator.url}}>{{event.creator.name}}</a>
+        {{/if}}
+      {{else}}
+        <span>Started and committed by: </span>
+        <a href={{event.creator.url}}>{{event.creator.name}}</a>
+      {{/if}}
+    </div>
     {{#if (and (is-fulfilled event.builds) isShowGraph)}}
       <div class="workflow">
         {{workflow-graph-d3

--- a/app/components/pipeline-graph-nav/template.hbs
+++ b/app/components/pipeline-graph-nav/template.hbs
@@ -58,8 +58,8 @@
           <span class="status">{{fa-icon icon fixedWidth=true}} {{selectedEventObj.status}}</span>
         </div>
         <div class="col">
-          <span class="title">User</span><br>
-          <a href={{selectedEventObj.creator.url}}>{{selectedEventObj.creator.name}}</a>
+          <span class="title">Committer</span><br>
+          <a href={{selectedEventObj.commit.author.url}}>{{selectedEventObj.commit.author.name}}</a>
         </div>
         <div class="col">
           <span class="title">Start Date</span><br>

--- a/tests/integration/components/pipeline-graph-nav/component-test.js
+++ b/tests/integration/components/pipeline-graph-nav/component-test.js
@@ -8,7 +8,13 @@ module('Integration | Component | pipeline graph nav', function(hooks) {
   setupRenderingTest(hooks);
 
   test('it renders', async function(assert) {
-    set(this, 'obj', { truncatedSha: 'abc123', status: 'SUCCESS', creator: { name: 'anonymous' } });
+    set(this, 'obj', {
+      truncatedSha: 'abc123',
+      status: 'SUCCESS',
+      commit: {
+        author: { name: 'anonymous' }
+      }
+    });
     set(this, 'selected', 2);
     set(this, 'startBuild', () => {
       assert.ok(true);
@@ -64,7 +70,7 @@ module('Integration | Component | pipeline graph nav', function(hooks) {
         .eq(3)
         .text()
         .trim(),
-      'User'
+      'Committer'
     );
     assert.equal(
       $columnTitles


### PR DESCRIPTION
## Context

Currently ui displays creator user name rather than commit author user name. Most of time both are the same, when event is create by another build, UI displays previous build's author rather than sd-builtbot. This lead to user confusion due to ambiguity. 

## Objective

UI now displays both committer and event creator, and in event panel correctly labels `committer` rather than `user`. And in case of event triggered by external pipeline, creator
will now link to according external build

Before:
<img width="404" alt="Screen Shot 2019-11-12 at 3 19 08 PM" src="https://user-images.githubusercontent.com/55161078/68719035-d31ac380-055f-11ea-8f7e-bdca8e2bb83f.png">
After:
1.when event is trigger by external pipeline
<img width="402" alt="Screen Shot 2019-11-12 at 3 17 18 PM" src="https://user-images.githubusercontent.com/55161078/68719054-e0d04900-055f-11ea-99d3-2f80c27d8043.png">
2.when creator and committer is the same
<img width="403" alt="Screen Shot 2019-11-12 at 3 13 50 PM" src="https://user-images.githubusercontent.com/55161078/68719059-e62d9380-055f-11ea-8a2f-77be6d864b6e.png">
3.when creator and committer is different
<img width="404" alt="Screen Shot 2019-11-12 at 3 16 34 PM" src="https://user-images.githubusercontent.com/55161078/68719076-eded3800-055f-11ea-94c6-4947fff6cc5e.png">


## References

https://github.com/screwdriver-cd/screwdriver/issues/1790

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
