### PR TITLE
fix: ui patching when buildId is undefined for unconventional causeMessage

### DIFF
--- a/app/components/pipeline-event-row/component.js
+++ b/app/components/pipeline-event-row/component.js
@@ -56,8 +56,12 @@ export default Component.extend({
     get() {
       // using underscore because router.js doesn't pick up camelcase
       /* eslint-disable camelcase */
-      const build_id = this.get('event.causeMessage').match(/\d+$/)[0];
       const pipeline_id = this.get('event.startFrom').match(/^~sd@(\d+):[\w-]+$/)[1];
+      let build_id = this.get('event.causeMessage').match(/\d+$/);
+
+      if (build_id) {
+        build_id = build_id[0];
+      }
       /* eslint-enable camelcase */
 
       return { build_id, pipeline_id };

--- a/app/components/pipeline-event-row/template.hbs
+++ b/app/components/pipeline-event-row/template.hbs
@@ -16,9 +16,13 @@
         <span>Committed by: </span>
         <a href={{event.commit.author.url}}>{{event.commit.author.name}}</a>
         <br>
-        <span> Started by: </span>
+        <span>Started by: </span>
         {{#if isExternalTrigger}}
-          {{#link-to "pipeline.build" externalBuild.pipeline_id externalBuild.build_id}}External Trigger{{/link-to}}
+          {{#if externalBuild.build_id}}
+            {{#link-to "pipeline.build" externalBuild.pipeline_id externalBuild.build_id}}External Trigger{{/link-to}}
+          {{else}}
+            {{#link-to "pipeline" externalBuild.pipeline_id}}External Trigger{{/link-to}}
+          {{/if}}
         {{else}}
           <a href={{event.creator.url}}>{{event.creator.name}}</a>
         {{/if}}


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
This PR fixing a runtime exception, and breaks the UI back button.

## Objective
This PR fix exactly that by adding check to `buildId` when using `{{link-to}}`, if `buildId` exists, it would route to pipeline with given build, otherwise will default to pipeline with given `pipelineId`

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
