### PR TITLE
fix(1790): handle undefined and incorrect startFrom

### DIFF
--- a/app/components/pipeline-event-row/component.js
+++ b/app/components/pipeline-event-row/component.js
@@ -39,7 +39,15 @@ export default Component.extend({
 
   isExternalTrigger: computed('event.startFrom', {
     get() {
-      return this.get('event.startFrom').match(/^~sd@(\d+):([\w-]+)$/);
+      const startFrom = this.get('event.startFrom');
+      const pipelineId = this.get('event.pipelineId');
+      let isExternal = false;
+
+      if (startFrom && startFrom.match(/^~sd@(\d+):([\w-]+)$/)) {
+        isExternal = Number(startFrom.match(/^~sd@(\d+):([\w-]+)$/)[1]) !== pipelineId;
+      }
+
+      return isExternal;
     }
   }),
 
@@ -56,11 +64,14 @@ export default Component.extend({
     get() {
       // using underscore because router.js doesn't pick up camelcase
       /* eslint-disable camelcase */
-      const pipeline_id = this.get('event.startFrom').match(/^~sd@(\d+):[\w-]+$/)[1];
-      let build_id = this.get('event.causeMessage').match(/\d+$/);
+      let pipeline_id = this.get('event.startFrom').match(/^~sd@(\d+):[\w-]+$/);
+      let build_id = this.get('event.causeMessage').match(/\s(\d+)$/);
 
       if (build_id) {
-        build_id = build_id[0];
+        build_id = build_id[1];
+      }
+      if (pipeline_id) {
+        pipeline_id = pipeline_id[1];
       }
       /* eslint-enable camelcase */
 

--- a/tests/integration/components/pipeline-event-row/component-test.js
+++ b/tests/integration/components/pipeline-event-row/component-test.js
@@ -172,6 +172,59 @@ module('Integration | Component | pipeline event row', function(hooks) {
     assert.dom('.date').hasText('Started now');
   });
 
+  test('it render when event is trigger by same pipeline', async function(assert) {
+    assert.expect(9);
+    this.actions.eventClick = () => {
+      assert.ok(true);
+    };
+
+    const eventMock = EmberObject.create(
+      assign(copy(event, true), {
+        causeMessage: 'Triggered from API Deploy pipeline',
+        startFrom: '~sd@456:test',
+        pipelineId: 456
+      })
+    );
+
+    this.set('event', eventMock);
+
+    await render(hbs`{{pipeline-event-row event=event selectedEvent=3 lastSuccessful=3}}`);
+
+    assert.dom('.SUCCESS').exists({ count: 1 });
+    assert.dom('.status .fa-check-circle-o').exists({ count: 1 });
+    assert.dom('.commit').hasText('#abc123');
+    assert.dom('.message').hasText('this was a test');
+    assert.dom('svg').exists({ count: 1 });
+    assert.dom('.graph-node').exists({ count: 4 });
+    assert.dom('.graph-edge').exists({ count: 3 });
+    assert.dom('.by').hasText('Started and committed by: batman');
+    assert.dom('.date').hasText('Started now');
+  });
+
+  test('it render when startFrom is missing', async function(assert) {
+    assert.expect(6);
+    this.actions.eventClick = () => {
+      assert.ok(true);
+    };
+
+    const eventMock = EmberObject.create(
+      assign(copy(event, true), {
+        startFrom: undefined
+      })
+    );
+
+    this.set('event', eventMock);
+
+    await render(hbs`{{pipeline-event-row event=event selectedEvent=3 lastSuccessful=3}}`);
+
+    assert.dom('.SUCCESS').exists({ count: 1 });
+    assert.dom('.status .fa-check-circle-o').exists({ count: 1 });
+    assert.dom('.commit').hasText('#abc123');
+    assert.dom('.message').hasText('this was a test');
+    assert.dom('.by').hasText('Started and committed by: batman');
+    assert.dom('.date').hasText('Started now');
+  });
+
   test('it does not render graph when skipped event', async function(assert) {
     this.actions.eventClick = () => {
       assert.ok(true);


### PR DESCRIPTION
## Context

In previous pr I enhanced event view, but there are builds with incorrect/undefined startFrom.
Causing UI to break.

## Objective

Handle incorrect/undefined startFrom

## References

https://github.com/screwdriver-cd/screwdriver/issues/1790

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
