### PR TITLE
fix: add cause message to override during freezeWindow

### DIFF
--- a/app/components/pipeline-workflow/component.js
+++ b/app/components/pipeline-workflow/component.js
@@ -41,9 +41,11 @@ export default Component.extend({
     this._super(...arguments);
     setProperties(this, {
       builds: [],
-      showDownstreamTriggers: false
+      showDownstreamTriggers: false,
+      reason: 'Please enter reason'
     });
   },
+
   didUpdateAttrs() {
     this._super(...arguments);
     // hide graph tooltip when event changes

--- a/app/components/pipeline-workflow/component.js
+++ b/app/components/pipeline-workflow/component.js
@@ -144,15 +144,19 @@ export default Component.extend({
       return false;
     },
     confirmStartBuild() {
-      set(this, 'isShowingModal', true);
-      set(this, 'showTooltip', false);
+      setProperties(this, {
+        isShowingModal: true,
+        showTooltip: false
+      });
     },
     cancelStartBuild() {
       set(this, 'isShowingModal', false);
     },
     startDetachedBuild(options) {
       set(this, 'isShowingModal', false);
-      this.startDetachedBuild(get(this, 'tooltipData.job'), options);
+      this.startDetachedBuild(get(this, 'tooltipData.job'), options).then(() => {
+        this.set('reason', '');
+      });
     }
   }
 });

--- a/app/components/pipeline-workflow/component.js
+++ b/app/components/pipeline-workflow/component.js
@@ -35,6 +35,7 @@ export default Component.extend({
       return graph;
     }
   }),
+
   displayRestartButton: alias('authenticated'),
 
   init() {
@@ -42,7 +43,7 @@ export default Component.extend({
     setProperties(this, {
       builds: [],
       showDownstreamTriggers: false,
-      reason: 'Please enter reason'
+      reason: ''
     });
   },
 

--- a/app/components/pipeline-workflow/component.js
+++ b/app/components/pipeline-workflow/component.js
@@ -39,8 +39,10 @@ export default Component.extend({
 
   init() {
     this._super(...arguments);
-    set(this, 'builds', []);
-    set(this, 'showDownstreamTriggers', false);
+    setProperties(this, {
+      builds: [],
+      showDownstreamTriggers: false
+    });
   },
   didUpdateAttrs() {
     this._super(...arguments);
@@ -145,9 +147,9 @@ export default Component.extend({
     cancelStartBuild() {
       set(this, 'isShowingModal', false);
     },
-    startDetachedBuild(parameters) {
+    startDetachedBuild(options) {
       set(this, 'isShowingModal', false);
-      this.startDetachedBuild(get(this, 'tooltipData.job'), parameters);
+      this.startDetachedBuild(get(this, 'tooltipData.job'), options);
     }
   }
 });

--- a/app/components/pipeline-workflow/template.hbs
+++ b/app/components/pipeline-workflow/template.hbs
@@ -30,19 +30,32 @@
         Job: <code>{{tooltipData.job.name}}</code><br>
         Commit:<a href={{selectedEventObj.commit.url}}><code>{{selectedEventObj.truncatedMessage}}</code>({{selectedEventObj.truncatedSha}})</a>
       </p>
-      {{#if (get-length tooltipData.selectedEvent.meta.parameters)}}
+      {{#if (eq tooltipData.job.status "FROZEN")}}
+        <form>
+          <label class="checkbox-inline">Reason:{{input type="text" value=reason}}</label>
+        </form>
+        <div class="row non-parameters-build">
+          <div class="col-xs-6">
+            <button class="d-button is-primary" {{action "startDetachedBuild" (hash reason=reason)}}>Yes</button>
+          </div>
+          <div class="col-xs-6 right">
+            <button class="d-button is-secondary" {{action "cancelStartBuild"}}>No</button>
+          </div>
+        </div>
+      {{else if (get-length tooltipData.selectedEvent.meta.parameters)}}
         {{#pipeline-parameterized-build
           buildParameters=tooltipData.selectedEvent.meta.parameters
           as |parameterizedBuild| }}
           <div class="row">
             <div class="col-xs-6">
-              <button class="d-button is-primary" {{action "startDetachedBuild" parameterizedBuild.parameters}}>Yes</button>
+              <button class="d-button is-primary" {{action "startDetachedBuild" (hash parameters=parameterizedBuild.parameters)}}>Yes</button>
             </div>
             <div class="col-xs-6 right">
               <button class="d-button is-secondary" {{action "cancelStartBuild"}}>No</button>
             </div>
           </div>
         {{/pipeline-parameterized-build}}
+
       {{else}}
         <div class="row non-parameters-build">
           <div class="col-xs-6">

--- a/app/components/pipeline-workflow/template.hbs
+++ b/app/components/pipeline-workflow/template.hbs
@@ -31,17 +31,47 @@
         Commit:<a href={{selectedEventObj.commit.url}}><code>{{selectedEventObj.truncatedMessage}}</code>({{selectedEventObj.truncatedSha}})</a>
       </p>
       {{#if (eq tooltipData.job.status "FROZEN")}}
-        <form>
-          <label class="checkbox-inline">Reason:{{input type="text" value=reason}}</label>
-        </form>
-        <div class="row non-parameters-build">
-          <div class="col-xs-6">
-            <button class="d-button is-primary" {{action "startDetachedBuild" (hash reason=reason)}}>Yes</button>
+        {{#if (get-length tooltipData.selectedEvent.meta.parameters)}}
+          {{#pipeline-parameterized-build
+            buildParameters=tooltipData.selectedEvent.meta.parameters
+            as |parameterizedBuild| }}
+            <div class="form-group form-horizontal">
+              <label class="control-label col-md-4">Reason:</label>
+              <div class="col-md-8">
+                {{input class="form-control" type="text" value=reason
+                  placeholder="Please enter reason"}}
+              </div>
+            </div>
+            <div class="row">
+              <div class="col-xs-6">
+                <button class="d-button is-primary"
+                {{action "startDetachedBuild" (hash reason=reason
+                parameters=parameterizedBuild.parameters)}}>
+                  Yes
+                </button>
+              </div>
+              <div class="col-xs-6 right">
+                <button class="d-button is-secondary" {{action "cancelStartBuild"}}>No</button>
+              </div>
+            </div>
+          {{/pipeline-parameterized-build}}
+        {{else}}
+          <div class="form-group form-horizontal">
+            <label class="control-label col-md-4">Reason:</label>
+            <div class="col-md-8">
+              {{input class="form-control" type="text" value=reason
+                placeholder="Please enter reason"}}
+            </div>
           </div>
-          <div class="col-xs-6 right">
-            <button class="d-button is-secondary" {{action "cancelStartBuild"}}>No</button>
+          <div class="row non-parameters-build">
+            <div class="col-xs-6">
+              <button class="d-button is-primary" {{action "startDetachedBuild" (hash reason=reason)}}>Yes</button>
+            </div>
+            <div class="col-xs-6 right">
+              <button class="d-button is-secondary" {{action "cancelStartBuild"}}>No</button>
+            </div>
           </div>
-        </div>
+        {{/if}}
       {{else if (get-length tooltipData.selectedEvent.meta.parameters)}}
         {{#pipeline-parameterized-build
           buildParameters=tooltipData.selectedEvent.meta.parameters
@@ -55,7 +85,6 @@
             </div>
           </div>
         {{/pipeline-parameterized-build}}
-
       {{else}}
         <div class="row non-parameters-build">
           <div class="col-xs-6">

--- a/app/components/pipeline-workflow/template.hbs
+++ b/app/components/pipeline-workflow/template.hbs
@@ -45,6 +45,7 @@
             <div class="row">
               <div class="col-xs-6">
                 <button class="d-button is-primary"
+                disabled={{eq (get-length reason) 0}}
                 {{action "startDetachedBuild" (hash reason=reason
                 parameters=parameterizedBuild.parameters)}}>
                   Yes
@@ -65,7 +66,8 @@
           </div>
           <div class="row non-parameters-build">
             <div class="col-xs-6">
-              <button class="d-button is-primary" {{action "startDetachedBuild" (hash reason=reason)}}>Yes</button>
+              <button class="d-button is-primary" disabled={{eq (get-length reason) 0}}
+              {{action "startDetachedBuild" (hash reason=reason)}}>Yes</button>
             </div>
             <div class="col-xs-6 right">
               <button class="d-button is-secondary" {{action "cancelStartBuild"}}>No</button>

--- a/app/components/pipeline-workflow/template.hbs
+++ b/app/components/pipeline-workflow/template.hbs
@@ -67,7 +67,9 @@
           <div class="row non-parameters-build">
             <div class="col-xs-6">
               <button class="d-button is-primary" disabled={{eq (get-length reason) 0}}
-              {{action "startDetachedBuild" (hash reason=reason)}}>Yes</button>
+              {{action "startDetachedBuild" (hash reason=reason)}}>
+                Yes
+              </button>
             </div>
             <div class="col-xs-6 right">
               <button class="d-button is-secondary" {{action "cancelStartBuild"}}>No</button>

--- a/app/pipeline/events/controller.js
+++ b/app/pipeline/events/controller.js
@@ -277,9 +277,10 @@ export default Controller.extend(ModelReloaderMixin, {
           this.set('errorMessage', Array.isArray(e.errors) ? e.errors[0].detail : '');
         });
     },
-    startDetachedBuild(job, parameters) {
+    startDetachedBuild(job, options = {}) {
       const buildId = get(job, 'buildId');
       let parentBuildId = null;
+      const { parameters, reason } = options;
 
       if (buildId) {
         const build = this.store.peekRecord('build', buildId);
@@ -292,7 +293,7 @@ export default Controller.extend(ModelReloaderMixin, {
       const pipelineId = get(this, 'pipeline.id');
       const token = get(this, 'session.data.authenticated.token');
       const user = get(decoder(token), 'username');
-      const causeMessage = `Manually started by ${user}`;
+      const causeMessage = reason || `Manually started by ${user}`;
       const prNum = get(event, 'prNum');
       let startFrom = get(job, 'name');
 

--- a/app/pipeline/events/controller.js
+++ b/app/pipeline/events/controller.js
@@ -293,9 +293,13 @@ export default Controller.extend(ModelReloaderMixin, {
       const pipelineId = get(this, 'pipeline.id');
       const token = get(this, 'session.data.authenticated.token');
       const user = get(decoder(token), 'username');
-      const causeMessage = reason || `Manually started by ${user}`;
+      let causeMessage = `Manually started by ${user}`;
       const prNum = get(event, 'prNum');
       let startFrom = get(job, 'name');
+
+      if (reason) {
+        causeMessage = `[force start]${reason}`;
+      }
 
       if (prNum) {
         // PR-<num>: prefix is needed, if it is a PR event.

--- a/app/pipeline/events/route.js
+++ b/app/pipeline/events/route.js
@@ -24,7 +24,7 @@ export default Route.extend({
         count: ENV.APP.NUM_EVENTS_LISTED
       }),
       triggers: this.triggerService.getDownstreamTriggers(this.get('pipeline.id'))
-    });
+    }).catch(() => {});
   },
   actions: {
     refreshModel: function refreshModel() {

--- a/app/pipeline/events/route.js
+++ b/app/pipeline/events/route.js
@@ -24,7 +24,7 @@ export default Route.extend({
         count: ENV.APP.NUM_EVENTS_LISTED
       }),
       triggers: this.triggerService.getDownstreamTriggers(this.get('pipeline.id'))
-    }).catch(() => {});
+    });
   },
   actions: {
     refreshModel: function refreshModel() {

--- a/tests/mock/frozenBuild.js
+++ b/tests/mock/frozenBuild.js
@@ -1,0 +1,83 @@
+const frozenBuild = {
+  buildId: null,
+  causeMessage: 'Manually started by adong',
+  commit: {
+    author: {
+      avatar: 'https://avatars3.githubusercontent.com/u/15989893?v=4',
+      name: 'Alan',
+      username: 'adong',
+      url: 'https://github.com/adong'
+    },
+    committer: {
+      avatar: 'https://avatars3.githubusercontent.com/u/19864447?v=4',
+      name: 'GitHub Web Flow',
+      username: 'web-flow',
+      url: 'https://github.com/web-flow'
+    },
+    message: 'Change freezeWindow from nov(11) to dec(12)',
+    url: 'https://github.com/adong/sd-dummy-job/commit/28fe2cc0b60fde5880c4dc838e4b83ab45aac91f'
+  },
+  createTime: '2019-12-03T00:30:37.043Z',
+  creator: {
+    avatar: 'https://avatars3.githubusercontent.com/u/15989893?v=4',
+    name: 'Alan',
+    username: 'adong',
+    url: 'https://github.com/adong'
+  },
+  isComplete: true,
+  meta: {
+    parameters: {
+      p1: {
+        value: 'p1'
+      }
+    }
+  },
+  numBuilds: 1,
+  reloadWithoutNewBuilds: 11,
+  parentBuildId: null,
+  parentEventId: 50,
+  pipelineId: '1',
+  pr: {},
+  prNum: null,
+  sha: '28fe2cc0b60fde5880c4dc838e4b83ab45aac91f',
+  startFrom: 'mainFreeze',
+  status: 'FROZEN',
+  type: 'pipeline',
+  workflowGraph: {
+    nodes: [
+      {
+        name: '~pr'
+      },
+      {
+        name: '~commit'
+      },
+      {
+        id: 6,
+        status: 'SUCCESS',
+        name: 'main'
+      },
+      {
+        id: 7,
+        status: 'FROZEN',
+        name: 'mainFreeze'
+      }
+    ],
+    edges: [
+      {
+        src: '~pr',
+        dest: 'main'
+      },
+      {
+        src: '~commit',
+        dest: 'main'
+      },
+      {
+        src: 'main',
+        dest: 'mainFreeze'
+      }
+    ]
+  },
+  builds: []
+};
+
+export { frozenBuild as default };


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
UI work for PR: https://github.com/screwdriver-cd/data-schema/pull/360

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
This allows users to give reason (to override causeMessage) to `force start` during the `freezeWindow` period. 
## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
![image](https://user-images.githubusercontent.com/15989893/70172068-d13ab080-1684-11ea-8366-dae3da4a4d2f.png)

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
