### PR TITLE
fix: unchecking "My source directory is not at the checkout root" 

### DIFF
--- a/app/components/pipeline-options/component.js
+++ b/app/components/pipeline-options/component.js
@@ -14,6 +14,7 @@ export default Component.extend({
   errorMessage: '',
   scmUrl: '',
   rootDir: '',
+  hasRootDir: false,
   // Removing a pipeline
   isRemoving: false,
   isShowingModal: false,
@@ -49,7 +50,10 @@ export default Component.extend({
     );
 
     if (this.get('pipeline.scmRepo.rootDir')) {
-      this.set('rootDir', this.get('pipeline.scmRepo.rootDir'));
+      this.setProperties({
+        rootDir: this.get('pipeline.scmRepo.rootDir'),
+        hasRootDir: true
+      });
     }
   },
   actions: {
@@ -70,10 +74,16 @@ export default Component.extend({
       this.set('rootDir', val.trim());
     },
     updatePipeline() {
-      this.onUpdatePipeline({
-        scmUrl: this.scmUrl,
-        rootDir: this.rootDir
-      });
+      const { scmUrl, rootDir, hasRootDir } = this;
+      const pipelineConfig = {
+        scmUrl,
+        rootDir: ''
+      };
+
+      if (hasRootDir) {
+        pipelineConfig.rootDir = rootDir;
+      }
+      this.onUpdatePipeline(pipelineConfig);
     },
     toggleJob(jobId, user, name, stillActive) {
       const status = stillActive ? 'ENABLED' : 'DISABLED';

--- a/app/components/pipeline-options/template.hbs
+++ b/app/components/pipeline-options/template.hbs
@@ -22,7 +22,7 @@
                     value=scmUrl
                   }}
                 </div>
-                {{pipeline-rootdir hasRootDir=(if this.rootDir true false) rootDir=this.rootDir updateRootDir=(action "updateRootDir")}}
+                {{pipeline-rootdir hasRootDir=hasRootDir rootDir=this.rootDir updateRootDir=(action "updateRootDir")}}
               </div>
             </div>
             <div class="row">


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
If you just uncheck the checkbox but without zeroing out the text box, it still uses that value as the folder.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
This PR fixes that, and will only send `rootDir` if is `checked`
## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
