### PR TITLE
fix: Display a detail page with just the major version

### DIFF
--- a/app/commands/detail/route.js
+++ b/app/commands/detail/route.js
@@ -1,6 +1,7 @@
 import { inject as service } from '@ember/service';
 import RSVP from 'rsvp';
 import Route from '@ember/routing/route';
+import { compareVersions } from 'screwdriver-ui/helpers/compare-versions';
 
 export default Route.extend({
   command: service(),
@@ -22,25 +23,7 @@ export default Route.extend({
 
         if (versionExists.length > 0) {
           // Sort commands by descending order
-          versionExists.sort((a, b) => {
-            const as = a.version.split('.');
-            const bs = b.version.split('.');
-            let ai;
-            let bi;
-            let limit = Math.max(as.length, bs.length);
-
-            while (limit) {
-              limit -= 1;
-              ai = parseInt(as.shift() || 0, 10);
-              bi = parseInt(bs.shift() || 0, 10);
-              if (ai !== bi) {
-                break;
-              }
-            }
-
-            return ai > bi;
-          });
-
+          versionExists.sort((a, b) => compareVersions(b.version, a.version));
           ({ version } = versionExists[0]);
         }
       }

--- a/app/commands/detail/route.js
+++ b/app/commands/detail/route.js
@@ -10,13 +10,38 @@ export default Route.extend({
       this.command.getCommandTags(params.namespace, params.name)
     ]).then(arr => {
       const [verPayload, tagPayload] = arr;
+      let version;
 
       if (params.version) {
-        const versionExists = verPayload.filter(t => t.version === params.version);
+        const versionExists = verPayload.filter(t => t.version.startsWith(params.version));
         const tagExists = tagPayload.filter(c => c.tag === params.version);
 
         if (tagExists.length === 0 && versionExists.length === 0) {
           this.transitionTo('/404');
+        }
+
+        if (versionExists.length > 0) {
+          // Sort commands by descending order
+          versionExists.sort((a, b) => {
+            const as = a.version.split('.');
+            const bs = b.version.split('.');
+            let ai;
+            let bi;
+            let limit = Math.max(as.length, bs.length);
+
+            while (limit) {
+              limit -= 1;
+              ai = parseInt(as.shift() || 0, 10);
+              bi = parseInt(bs.shift() || 0, 10);
+              if (ai !== bi) {
+                break;
+              }
+            }
+
+            return ai > bi;
+          });
+
+          ({ version } = versionExists[0]);
         }
       }
 
@@ -31,7 +56,7 @@ export default Route.extend({
       let result = {};
 
       result.commandData = verPayload;
-      result.versionOrTagFromUrl = params.version;
+      result.versionOrTagFromUrl = version || params.version;
       result.commandTagData = tagPayload;
 
       return result;

--- a/app/helpers/compare-versions.js
+++ b/app/helpers/compare-versions.js
@@ -1,0 +1,31 @@
+import { helper } from '@ember/component/helper';
+
+/**
+ * Compare version strings to find greater, equal or lesser
+ * @param  {String}  v1  version
+ * @param  {String}  v2  version
+ * @return {Number} greater, equal, lesser
+ */
+export function compareVersions(v1, v2) {
+  const s1 = v1.split('.');
+  const s2 = v2.split('.');
+  let i1;
+  let i2;
+  let limit = Math.max(s1.length, s2.length);
+
+  while (limit) {
+    limit -= 1;
+    i1 = parseInt(s1.shift() || 0, 10);
+    i2 = parseInt(s2.shift() || 0, 10);
+    if (i1 !== i2) {
+      break;
+    }
+  }
+
+  if (i1 > i2) return 1;
+  if (i1 < i2) return -1;
+
+  return 0;
+}
+
+export default helper(compareVersions);

--- a/app/templates/detail/route.js
+++ b/app/templates/detail/route.js
@@ -10,13 +10,38 @@ export default Route.extend({
       this.template.getTemplateTags(params.namespace, params.name)
     ]).then(arr => {
       let [verPayload, tagPayload] = arr;
+      let version;
 
       if (params.version) {
-        const versionExists = verPayload.filter(t => t.version === params.version);
+        const versionExists = verPayload.filter(t => t.version.startsWith(params.version));
         const tagExists = tagPayload.filter(t => t.tag === params.version);
 
         if (tagExists.length === 0 && versionExists.length === 0) {
           this.transitionTo('/404');
+        }
+
+        if (versionExists.length > 0) {
+          // Sort commands by descending order
+          versionExists.sort((a, b) => {
+            const as = a.version.split('.');
+            const bs = b.version.split('.');
+            let ai;
+            let bi;
+            let limit = Math.max(as.length, bs.length);
+
+            while (limit) {
+              limit -= 1;
+              ai = parseInt(as.shift() || 0, 10);
+              bi = parseInt(bs.shift() || 0, 10);
+              if (ai !== bi) {
+                break;
+              }
+            }
+
+            return ai > bi;
+          });
+
+          ({ version } = versionExists[0]);
         }
       }
 
@@ -33,7 +58,7 @@ export default Route.extend({
       let result = {};
 
       result.templateData = verPayload;
-      result.versionOrTagFromUrl = params.version;
+      result.versionOrTagFromUrl = version || params.version;
       result.templateTagData = tagPayload;
 
       return result;

--- a/app/templates/detail/route.js
+++ b/app/templates/detail/route.js
@@ -1,6 +1,7 @@
 import { inject as service } from '@ember/service';
 import RSVP from 'rsvp';
 import Route from '@ember/routing/route';
+import { compareVersions } from 'screwdriver-ui/helpers/compare-versions';
 
 export default Route.extend({
   template: service(),
@@ -22,25 +23,7 @@ export default Route.extend({
 
         if (versionExists.length > 0) {
           // Sort commands by descending order
-          versionExists.sort((a, b) => {
-            const as = a.version.split('.');
-            const bs = b.version.split('.');
-            let ai;
-            let bi;
-            let limit = Math.max(as.length, bs.length);
-
-            while (limit) {
-              limit -= 1;
-              ai = parseInt(as.shift() || 0, 10);
-              bi = parseInt(bs.shift() || 0, 10);
-              if (ai !== bi) {
-                break;
-              }
-            }
-
-            return ai > bi;
-          });
-
+          versionExists.sort((a, b) => compareVersions(b.version, a.version));
           ({ version } = versionExists[0]);
         }
       }

--- a/tests/unit/commands/detail/router-test.js
+++ b/tests/unit/commands/detail/router-test.js
@@ -7,15 +7,17 @@ import sinonTest from 'ember-sinon-qunit/test-support/test';
 const commandServiceStub = Service.extend({
   getOneCommand(namespace, name) {
     return resolve([
-      { id: 3, namespace, name, version: '3.0.0' },
-      { id: 2, namespace, name, version: '2.0.0' },
+      { id: 4, namespace, name, version: '3.0.0' },
+      { id: 3, namespace, name, version: '2.0.0' },
+      { id: 2, namespace, name, version: '1.1.0' },
       { id: 1, namespace, name, version: '1.0.0' }
     ]);
   },
   getCommandTags(namespace, name) {
     return resolve([
-      { id: 3, namespace, name, version: '3.0.0', tag: 'latest' },
-      { id: 2, namespace, name, version: '2.0.0', tag: 'stable' },
+      { id: 4, namespace, name, version: '3.0.0', tag: 'latest' },
+      { id: 3, namespace, name, version: '2.0.0', tag: 'stable' },
+      { id: 2, namespace, name, version: '1.1.0' },
       { id: 1, namespace, name, version: '1.0.0' }
     ]);
   }
@@ -49,10 +51,23 @@ module('Unit | Route | commands/detail', function(hooks) {
     assert.ok(route);
 
     return route.model({ namespace: 'foo', name: 'baz', version: '1.0.0' }).then(commands => {
-      assert.equal(commands.commandData.length, 3);
+      assert.equal(commands.commandData.length, 4);
       assert.equal(commands.commandData[0].namespace, 'foo');
       assert.equal(commands.commandData[0].name, 'baz');
       assert.equal(commands.versionOrTagFromUrl, '1.0.0');
+    });
+  });
+
+  test('it asks for the list of commands for a given name and exist version of according to ember', function(assert) {
+    let route = this.owner.lookup('route:commands/detail');
+
+    assert.ok(route);
+
+    return route.model({ namespace: 'foo', name: 'baz', version: '1' }).then(commands => {
+      assert.equal(commands.commandData.length, 4);
+      assert.equal(commands.commandData[0].namespace, 'foo');
+      assert.equal(commands.commandData[0].name, 'baz');
+      assert.equal(commands.versionOrTagFromUrl, '1.1.0');
     });
   });
 
@@ -62,7 +77,7 @@ module('Unit | Route | commands/detail', function(hooks) {
     assert.ok(route);
 
     return route.model({ namespace: 'foo', name: 'baz', version: 'stable' }).then(commands => {
-      assert.equal(commands.commandData.length, 3);
+      assert.equal(commands.commandData.length, 4);
       assert.equal(commands.commandData[0].namespace, 'foo');
       assert.equal(commands.commandData[0].name, 'baz');
       assert.equal(commands.versionOrTagFromUrl, 'stable');

--- a/tests/unit/helpers/compare-versions-test.js
+++ b/tests/unit/helpers/compare-versions-test.js
@@ -1,0 +1,40 @@
+import { compareVersions } from 'screwdriver-ui/helpers/compare-versions';
+import { module, test } from 'qunit';
+
+module('Unit | Helper | compare versions', function() {
+  test('it works', function(assert) {
+    assert.equal(compareVersions('2.0.0', '1.0.0'), 1);
+    assert.equal(compareVersions('0.2.0', '0.1.0'), 1);
+    assert.equal(compareVersions('0.0.2', '0.0.1'), 1);
+    assert.equal(compareVersions('2.0.0', '2.0.0'), 0);
+    assert.equal(compareVersions('0.2.0', '0.2.0'), 0);
+    assert.equal(compareVersions('0.0.2', '0.0.2'), 0);
+    assert.equal(compareVersions('1.0.0', '2.0.0'), -1);
+    assert.equal(compareVersions('0.1.0', '0.2.0'), -1);
+    assert.equal(compareVersions('0.0.1', '0.0.2'), -1);
+    assert.equal(compareVersions('2.0.0', '1.0'), 1);
+    assert.equal(compareVersions('0.0.8', '0.3'), -1);
+    assert.equal(compareVersions('0.3.0', '0.3'), 0);
+    assert.equal(compareVersions('2.0.0', '1'), 1);
+    assert.equal(compareVersions('0.0.3', '1'), -1);
+    assert.equal(compareVersions('2.0.0', '2'), 0);
+    assert.equal(compareVersions('2.3', '1.6.0'), 1);
+    assert.equal(compareVersions('2.1', '2.1.3'), -1);
+    assert.equal(compareVersions('2.0', '2.0.0'), 0);
+    assert.equal(compareVersions('2.8', '2.4'), 1);
+    assert.equal(compareVersions('2.3', '4.7'), -1);
+    assert.equal(compareVersions('0.3', '0.3'), 0);
+    assert.equal(compareVersions('2.0', '1'), 1);
+    assert.equal(compareVersions('2.59', '3'), -1);
+    assert.equal(compareVersions('2.0', '2'), 0);
+    assert.equal(compareVersions('2', '1.8.3'), 1);
+    assert.equal(compareVersions('2', '5.1.1'), -1);
+    assert.equal(compareVersions('2', '2.0.0'), 0);
+    assert.equal(compareVersions('2', '1.8'), 1);
+    assert.equal(compareVersions('2', '5.1'), -1);
+    assert.equal(compareVersions('2', '2.0'), 0);
+    assert.equal(compareVersions('2', '1'), 1);
+    assert.equal(compareVersions('2', '3'), -1);
+    assert.equal(compareVersions('2', '2'), 0);
+  });
+});

--- a/tests/unit/templates/detail/route-test.js
+++ b/tests/unit/templates/detail/route-test.js
@@ -7,12 +7,13 @@ import sinonTest from 'ember-sinon-qunit/test-support/test';
 const templateServiceStub = Service.extend({
   getOneTemplate() {
     return resolve([
-      { id: 3, name: 'baz', version: '3.0.0', namespace: 'foo' },
-      { id: 2, name: 'baz', version: '2.0.0', namespace: 'foo' },
+      { id: 4, name: 'baz', version: '3.0.0', namespace: 'foo' },
+      { id: 3, name: 'baz', version: '2.0.0', namespace: 'foo' },
+      { id: 2, name: 'baz', version: '1.1.0', namespace: 'foo' },
       { id: 1, name: 'baz', version: '1.0.0', namespace: 'foo' },
-      { id: 6, name: 'baz', version: '3.0.0', namespace: 'bar' },
-      { id: 5, name: 'baz', version: '2.0.0', namespace: 'bar' },
-      { id: 4, name: 'baz', version: '1.0.0', namespace: 'bar' }
+      { id: 7, name: 'baz', version: '3.0.0', namespace: 'bar' },
+      { id: 6, name: 'baz', version: '2.0.0', namespace: 'bar' },
+      { id: 5, name: 'baz', version: '1.0.0', namespace: 'bar' }
     ]);
   },
   getTemplateTags(namespace, name) {
@@ -39,7 +40,7 @@ module('Unit | Route | templates/detail', function(hooks) {
     assert.ok(route);
 
     return route.model({ namespace: 'foo', name: 'baz' }).then(templates => {
-      assert.equal(templates.templateData.length, 3);
+      assert.equal(templates.templateData.length, 4);
       assert.equal(templates.templateData[0].namespace, 'foo');
       assert.equal(templates.templateData[0].name, 'baz');
       assert.equal(templates.versionOrTagFromUrl, undefined);
@@ -52,10 +53,23 @@ module('Unit | Route | templates/detail', function(hooks) {
     assert.ok(route);
 
     return route.model({ namespace: 'foo', name: 'baz', version: '1.0.0' }).then(templates => {
-      assert.equal(templates.templateData.length, 3);
+      assert.equal(templates.templateData.length, 4);
       assert.equal(templates.templateData[0].namespace, 'foo');
       assert.equal(templates.templateData[0].name, 'baz');
       assert.equal(templates.versionOrTagFromUrl, '1.0.0');
+    });
+  });
+
+  test('it asks for the list of templates for a given name and exist version of according to ember', function(assert) {
+    let route = this.owner.lookup('route:templates/detail');
+
+    assert.ok(route);
+
+    return route.model({ namespace: 'foo', name: 'baz', version: '1' }).then(templates => {
+      assert.equal(templates.templateData.length, 4);
+      assert.equal(templates.templateData[0].namespace, 'foo');
+      assert.equal(templates.templateData[0].name, 'baz');
+      assert.equal(templates.versionOrTagFromUrl, '1.1.0');
     });
   });
 
@@ -65,7 +79,7 @@ module('Unit | Route | templates/detail', function(hooks) {
     assert.ok(route);
 
     return route.model({ namespace: 'foo', name: 'baz', version: 'stable' }).then(templates => {
-      assert.equal(templates.templateData.length, 3);
+      assert.equal(templates.templateData.length, 4);
       assert.equal(templates.templateData[0].namespace, 'foo');
       assert.equal(templates.templateData[0].name, 'baz');
       assert.equal(templates.versionOrTagFromUrl, 'stable');


### PR DESCRIPTION
## Context
My screwdriver.cd has a `common/jq` command.
<img width="200" alt="common:jq" src="https://user-images.githubusercontent.com/24538326/71248155-8cd63280-235d-11ea-8208-2bf00aed98bb.png">

For example, if I input the following in the validator form, the list of Commands displays `common/jq@1.5`.
<img width="500" alt="validator" src="https://user-images.githubusercontent.com/24538326/71247995-3537c700-235d-11ea-8f13-6579d2ab1628.png">

Clicking on the `common/jq@1.5` link will display the not found page.
<img width="200" alt="404" src="https://user-images.githubusercontent.com/24538326/71248294-d3c42800-235d-11ea-9879-65e56c4d06fe.png">

## Objective
Even if only the major version is specified, the command details page can be accessed. And I fixed the same for templates page.
<img width="300" alt="fix" src="https://user-images.githubusercontent.com/24538326/71248447-34536500-235e-11ea-81aa-d435a11042dc.png">

## References
https://github.com/screwdriver-cd/ui/pull/479
https://github.com/screwdriver-cd/ui/pull/504

I fixed based on this.
https://github.com/screwdriver-cd/models/blob/b88a006b832cfafa96f1114b1149055cc108f1b7/lib/commandFactory.js#L136-L153

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
