### PR TITLE
fix(1656): Add word-wrap property

### DIFF
--- a/app/components/build-banner/styles.scss
+++ b/app/components/build-banner/styles.scss
@@ -49,6 +49,7 @@ li {
 
 .job-name {
   border-left-width: 3px;
+  word-wrap: break-word;
 
   .banner-value {
     font-weight: $weight-bold;


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

The build page shows long job name in a header inappropriately.
To fix this bug, I added a `word-wrap` property to css.
before:
<img width="353" src="https://user-images.githubusercontent.com/1608595/58526809-44adc200-820b-11e9-9479-8b515e3d1740.png">
after:
<img width="353" alt="スクリーンショット 2019-12-26 10 19 30" src="https://user-images.githubusercontent.com/8113204/71452529-3d628d00-27c9-11ea-96b1-9791cfd8fbf6.png">


## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Added `word-wrap: break-word;` property to css.


## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/1656

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
