### PR TITLE
fix(1710): Show external trigger remote pipeline link

### DIFF
--- a/app/components/pipeline-workflow/component.js
+++ b/app/components/pipeline-workflow/component.js
@@ -54,9 +54,9 @@ export default Component.extend({
   },
   actions: {
     graphClicked(job, mouseevent, sizes) {
-      const EXTERNAL_TRIGGER_REGEX = /^~sd@(\d+):([\w-]+)$/;
+      const EXTERNAL_TRIGGER_REGEX = /^~?sd@(\d+):([\w-]+)$/;
       const edges = get(this, 'directedGraph.edges');
-      const isTrigger = job ? /^~/.test(job.name) : false;
+      const isTrigger = job ? /^~?sd@/.test(job.name) : false;
       let isRootNode = true;
       let toolTipProperties = {};
 
@@ -110,7 +110,7 @@ export default Component.extend({
           const triggers = [];
 
           job.triggers.forEach(t => {
-            const downstreamTrigger = t.match(/^~sd@(\d+):([\w-]+)$/);
+            const downstreamTrigger = t.match(/^~?sd@(\d+):([\w-]+)$/);
 
             triggers.push({
               triggerName: t,


### PR DESCRIPTION
## Context

Now that users can use parallel fork join, the UI should link to the remote pipeline appropriately.

## Objective

This PR changes the remote pipeline to have a Go to remote pipeline tooltip.

Before:
<img width="600" alt="Screen Shot 2020-01-16 at 4 25 39 PM" src="https://user-images.githubusercontent.com/3230529/72574338-89ab6500-387d-11ea-8f07-c0aef457db1f.png">

After:
<img width="635" alt="Screen Shot 2020-01-16 at 4 25 31 PM" src="https://user-images.githubusercontent.com/3230529/72574344-8fa14600-387d-11ea-88fc-30c3dd5825cb.png">


## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/1710

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
