### PR TITLE
fix(1903): split active step inside artifacts

### DIFF
--- a/app/pipeline/build/index/route.js
+++ b/app/pipeline/build/index/route.js
@@ -1,0 +1,14 @@
+import Route from '@ember/routing/route';
+
+export default Route.extend({
+  model() {
+    // return parent route model
+    return this.modelFor('pipeline.build');
+  },
+  actions: {
+    didTransition() {
+      // delegate to its parent route's didTranstion
+      return true;
+    }
+  }
+});

--- a/app/pipeline/build/route.js
+++ b/app/pipeline/build/route.js
@@ -44,18 +44,17 @@ export default Route.extend({
     set(model, 'userSelectedStepName', null);
   },
 
-  redirect(model, transition) {
-    if (transition.targetName !== 'pipeline.build.step') {
-      const name = getActiveStep(get(model, 'build.steps'));
+  goToActiveStep() {
+    const model = this.controller.get('model');
+    const name = getActiveStep(get(model, 'build.steps'));
 
-      if (name) {
-        this.transitionTo(
-          'pipeline.build.step',
-          model.pipeline.get('id'),
-          model.build.get('id'),
-          name
-        );
-      }
+    if (name) {
+      this.transitionTo(
+        'pipeline.build.step',
+        model.pipeline.get('id'),
+        model.build.get('id'),
+        name
+      );
     }
   },
 
@@ -65,6 +64,8 @@ export default Route.extend({
         selectedArtifact: '',
         activeTab: 'steps'
       });
+
+      this.goToActiveStep();
     }
   }
 });

--- a/app/router.js
+++ b/app/router.js
@@ -15,6 +15,7 @@ Router.map(function route() {
     this.route('events');
     this.route('secrets');
     this.route('build', { path: 'builds/:build_id' }, function stepsRoute() {
+      this.route('index', { path: '/' });
       this.route('step', { path: 'steps/:step_id' });
       this.route('artifacts', function artifactsRoute() {
         this.route('index', { path: '/' });

--- a/tests/unit/pipeline/build/route-test.js
+++ b/tests/unit/pipeline/build/route-test.js
@@ -39,7 +39,7 @@ module('Unit | Route | pipeline/build', function(hooks) {
     assert.ok(stub.calledWithExactly('pipeline', pipelineId), 'transition to pipeline');
   });
 
-  sinonTest('it redirects if not step route', function(assert) {
+  sinonTest('it should not redirect if not step route', function(assert) {
     const route = this.owner.lookup('route:pipeline/build');
     const stub = this.stub(route, 'transitionTo');
 
@@ -64,10 +64,6 @@ module('Unit | Route | pipeline/build', function(hooks) {
 
     route.redirect(model, transition);
 
-    assert.ok(stub.calledOnce, 'transitionTo was called once');
-    assert.ok(
-      stub.calledWithExactly('pipeline.build.step', pipelineId, buildId, 'error'),
-      'transition to build step page'
-    );
+    assert.ok(stub.notCalled, 'transitionTo was not called at all');
   });
 });

--- a/tests/unit/pipeline/build/route-test.js
+++ b/tests/unit/pipeline/build/route-test.js
@@ -39,7 +39,7 @@ module('Unit | Route | pipeline/build', function(hooks) {
     assert.ok(stub.calledWithExactly('pipeline', pipelineId), 'transition to pipeline');
   });
 
-  sinonTest('it should not redirect if not step route', function(assert) {
+  sinonTest('it should not call transitionTo when redirect', function(assert) {
     const route = this.owner.lookup('route:pipeline/build');
     const stub = this.stub(route, 'transitionTo');
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Current implementation is that when we land to artifacts route, it will redirect to `/pipeline/1/step/` route if we encountered failure step.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
This PR will prevent the redirection if users are on artifacts route.

## References
https://github.com/screwdriver-cd/screwdriver/issues/1903
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
