### PR TITLE
fix: Fix regex for finding trigger

### DIFF
--- a/app/components/pipeline-workflow/component.js
+++ b/app/components/pipeline-workflow/component.js
@@ -56,7 +56,7 @@ export default Component.extend({
     graphClicked(job, mouseevent, sizes) {
       const EXTERNAL_TRIGGER_REGEX = /^~?sd@(\d+):([\w-]+)$/;
       const edges = get(this, 'directedGraph.edges');
-      const isTrigger = job ? /^~?sd@/.test(job.name) : false;
+      const isTrigger = job ? /(^~)|(^~?sd@)/.test(job.name) : false;
       let isRootNode = true;
       let toolTipProperties = {};
 

--- a/tests/integration/components/pipeline-workflow/component-test.js
+++ b/tests/integration/components/pipeline-workflow/component-test.js
@@ -12,20 +12,24 @@ const GRAPH = {
     { name: '~commit' },
     { id: 1, name: 'main' },
     { id: 2, name: 'batman' },
-    { id: 3, name: 'robin' }
+    { id: 3, name: 'robin' },
+    { id: 4, name: 'sd@123:main' },
+    { id: 5, name: 'deploy' }
   ],
   edges: [
     { src: '~pr', dest: 'main' },
     { src: '~commit', dest: 'main' },
     { src: 'main', dest: 'batman' },
-    { src: 'batman', dest: 'robin' }
+    { src: 'batman', dest: 'robin' },
+    { src: 'robin', dest: 'sd@123:main' }
   ]
 };
 
 const BUILDS = [
   { jobId: 1, id: 4, status: 'SUCCESS' },
   { jobId: 2, id: 5, status: 'SUCCESS' },
-  { jobId: 3, id: 6, status: 'FAILURE' }
+  { jobId: 3, id: 6, status: 'SUCCESS' },
+  { jobId: 5, id: 8, status: 'FAILURE' }
 ];
 
 module('Integration | Component | pipeline workflow', function(hooks) {
@@ -41,12 +45,12 @@ module('Integration | Component | pipeline workflow', function(hooks) {
         causeMessage: 'test'
       }),
       'graph',
-      EmberObject.create({})
+      EmberObject.create(GRAPH)
     );
 
     await render(hbs`{{pipeline-workflow selectedEventObj=obj graph=graph}}`);
 
-    assert.dom('.graph-node').exists({ count: 5 });
+    assert.dom('.graph-node').exists({ count: 7 });
     assert.dom('.workflow-tooltip').exists({ count: 1 });
   });
 


### PR DESCRIPTION
## Context

Changing the trigger matching regex broke logic for downstream trigger rendering.

## Objective

This PR fixes the trigger matching regex to look for job names that start with `~` or `sd@`.

<img width="721" alt="Screen Shot 2020-01-23 at 11 55 56 AM" src="https://user-images.githubusercontent.com/3230529/73018897-56198f00-3dd7-11ea-83b6-730c81cd9264.png">

## References

Related to https://github.com/screwdriver-cd/ui/pull/516

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
