### PR TITLE
Add UTC time as a log format option.

### DIFF
--- a/app/components/build-log/component.js
+++ b/app/components/build-log/component.js
@@ -5,7 +5,7 @@ import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import ENV from 'screwdriver-ui/config/environment';
 
-const timeTypes = ['datetime', 'elapsedBuild', 'elapsedStep'];
+const timeTypes = ['datetime', 'datetimeUTC', 'elapsedBuild', 'elapsedStep'];
 
 export default Component.extend({
   logService: service('build-logs'),

--- a/app/components/build-log/template.hbs
+++ b/app/components/build-log/template.hbs
@@ -5,6 +5,8 @@
         <span class="time" onClick={{action "toggleTimeDisplay"}}>
           {{#if (eq timeFormat "datetime")}}
             Local Timestamp
+          {{else if (eq timeFormat "datetimeUTC")}}
+            UTC Timestamp
           {{else if (eq timeFormat "elapsedBuild")}}
             Since build started
           {{else if (eq timeFormat "elapsedStep")}}
@@ -36,6 +38,8 @@
         <span class="time" onClick={{action "toggleTimeDisplay"}}>
           {{#if (eq timeFormat "datetime")}}
             {{moment-format log.t "HH:mm:ss"}}
+          {{else if (eq timeFormat "datetimeUTC")}}
+            {{moment-format log.t "HH:mm:ss" timeZone="UTC"}}
           {{else if (eq timeFormat "elapsedBuild")}}
             {{x-duration buildStartTime log.t precision="seconds"}}
           {{else if (eq timeFormat "elapsedStep")}}


### PR DESCRIPTION
## Context

It's often useful to see the time in UTC instead of local time.

## Objective
Adds another item in the rotation when clicking through the various timestamp formats to show the event time in UTC.

## References

https://github.com/stefanpenner/ember-moment#common-optional-named-arguments

```
timeZone | An optional String time zone, defaults to moment.timeZone (the default time zone)
```

## Tests
I don't see a great way to test this. Can the UI be started up with static data or do I need to set up a complete local cluster to verify this change?

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
