### PR TITLE
fix(1925): support branch names with number sign

### DIFF
--- a/app/components/pipeline-header/template.hbs
+++ b/app/components/pipeline-header/template.hbs
@@ -5,7 +5,7 @@
   {{info-message message=addCollectionSuccess type="success" icon="check"}}
 {{/if}}
 {{#link-to "pipeline" pipeline.id}}<h1>{{pipeline.appId}}</h1>{{/link-to}}
-<a href={{pipeline.hubUrl}} class="branch">{{fa-icon "code-fork"}} {{pipeline.branch}}</a>
+<a href={{branch-url-encode pipeline.hubUrl}} class="branch">{{fa-icon "code-fork"}} {{pipeline.branch}}</a>
 <span class="scm">{{fa-icon scmContext.scmIcon}} {{scmContext.scm}}</span>
 {{#if pipeline.configPipelineId}}
   {{fa-icon "cog"}} {{#link-to "pipeline" pipeline.configPipelineId}}Parent Pipeline{{/link-to}}

--- a/app/helpers/branch-url-encode.js
+++ b/app/helpers/branch-url-encode.js
@@ -1,0 +1,17 @@
+import { helper } from '@ember/component/helper';
+
+/**
+ * Encode name of branch in url for number sign
+ * @method branchUrlEncode
+ * @param  {Array}     url      url
+ * @return {String}             encoded url
+ */
+export function branchUrlEncode([url]) {
+  if (!url) {
+    return url;
+  }
+
+  return url.replace(/#/g, '%23');
+}
+
+export default helper(branchUrlEncode);

--- a/tests/integration/helpers/branch-url-encode-test.js
+++ b/tests/integration/helpers/branch-url-encode-test.js
@@ -6,7 +6,7 @@ import hbs from 'htmlbars-inline-precompile';
 module('helper:branch-url-encode', function(hooks) {
   setupRenderingTest(hooks);
 
-  test('it renders a duration given two parsable times in HH:mm:ss format', async function(assert) {
+  test('it renders a encoded url of branch name including #', async function(assert) {
     this.set('url', 'https://github/org/repo/tree/branch#hash');
 
     await render(hbs`{{branch-url-encode url}}`);

--- a/tests/integration/helpers/branch-url-encode-test.js
+++ b/tests/integration/helpers/branch-url-encode-test.js
@@ -1,0 +1,22 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('helper:branch-url-encode', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders a duration given two parsable times in HH:mm:ss format', async function(assert) {
+    this.set('url', 'https://github/org/repo/tree/branch#hash');
+
+    await render(hbs`{{branch-url-encode url}}`);
+
+    assert.dom(this.element).hasText('https://github/org/repo/tree/branch%23hash');
+
+    this.set('url', null);
+
+    await render(hbs`{{branch-url-encode url}}`);
+
+    assert.dom(this.element).hasText('');
+  });
+});


### PR DESCRIPTION
## Context
This PR is for this Issue.
https://github.com/screwdriver-cd/screwdriver/issues/1925

Number sign of the branch name must be encoded to `%23`.

**Current**
<img width="400" src="https://user-images.githubusercontent.com/24538326/73235808-47feb080-41d3-11ea-9069-4f1b66ff7a64.png">

**After**
<img width="400" src="https://user-images.githubusercontent.com/24538326/73235825-5a78ea00-41d3-11ea-9596-478510e5971d.png">
Link to below page.
<img width="400" src="https://user-images.githubusercontent.com/24538326/73235844-6b296000-41d3-11ea-89fd-a2c96b023210.png">

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
