### PR TITLE
fix(1718): allow user to set test and coverage url

### DIFF
--- a/app/components/build-banner/component.js
+++ b/app/components/build-banner/component.js
@@ -78,8 +78,8 @@ export default Component.extend({
     // override coverage info if set in build meta
     if (buildMeta && buildMeta.tests) {
       const { coverage, coverageUrl, results: tests, resultsUrl: testsUrl } = buildMeta.tests;
-      const regex = /^.+\/pipelines\/\d+\/builds\/\d+/;
-      const urlBase = window.location.href.match(regex);
+      const BUILD_URL_REGEX = /^.+\/pipelines\/\d+\/builds\/\d+/;
+      const buildUrl = window.location.href.match(BUILD_URL_REGEX);
       let coverageInfo = Object.assign({}, this.get('coverageInfo'));
 
       if (String(coverage).match(/^\d+$/)) {
@@ -87,8 +87,8 @@ export default Component.extend({
         coverageInfo.coverageUrl = '#';
       }
 
-      if (String(coverageUrl).match(/^(\/[^/]+)+$/) && urlBase) {
-        coverageInfo.coverageUrl = `${urlBase[0]}/artifacts${coverageUrl}`;
+      if (String(coverageUrl).match(/^(\/[^/]+)+$/) && buildUrl) {
+        coverageInfo.coverageUrl = `${buildUrl[0]}/artifacts${coverageUrl}`;
       }
 
       if (String(tests).match(/^\d+\/\d+$/)) {
@@ -96,8 +96,8 @@ export default Component.extend({
         coverageInfo.testsUrl = '#';
       }
 
-      if (String(testsUrl).match(/^(\/[^/]+)+$/) && urlBase) {
-        coverageInfo.testsUrl = `${urlBase[0]}/artifacts${testsUrl}`;
+      if (String(testsUrl).match(/^(\/[^/]+)+$/) && buildUrl) {
+        coverageInfo.testsUrl = `${buildUrl[0]}/artifacts${testsUrl}`;
       }
 
       this.set('coverageInfo', coverageInfo);

--- a/app/components/build-banner/component.js
+++ b/app/components/build-banner/component.js
@@ -77,18 +77,27 @@ export default Component.extend({
 
     // override coverage info if set in build meta
     if (buildMeta && buildMeta.tests) {
-      const coverage = String(buildMeta.tests.coverage);
-      const tests = String(buildMeta.tests.results);
-      let { coverageInfo } = this;
+      const { coverage, coverageUrl, results: tests, resultsUrl: testsUrl } = buildMeta.tests;
+      const regex = /^.+\/pipelines\/\d+\/builds\/\d+/;
+      const urlBase = window.location.href.match(regex);
+      let coverageInfo = Object.assign({}, this.get('coverageInfo'));
 
-      if (coverage.match(/^\d+$/)) {
+      if (String(coverage).match(/^\d+$/)) {
         coverageInfo.coverage = `${coverage}%`;
         coverageInfo.coverageUrl = '#';
       }
 
-      if (tests.match(/^\d+\/\d+$/)) {
+      if (String(coverageUrl).match(/^(\/[^/]+)+$/) && urlBase) {
+        coverageInfo.coverageUrl = `${urlBase[0]}/artifacts${coverageUrl}`;
+      }
+
+      if (String(tests).match(/^\d+\/\d+$/)) {
         coverageInfo.tests = tests;
         coverageInfo.testsUrl = '#';
+      }
+
+      if (String(testsUrl).match(/^(\/[^/]+)+$/) && urlBase) {
+        coverageInfo.testsUrl = `${urlBase[0]}/artifacts${testsUrl}`;
       }
 
       this.set('coverageInfo', coverageInfo);

--- a/tests/integration/components/build-banner/component-test.js
+++ b/tests/integration/components/build-banner/component-test.js
@@ -61,7 +61,9 @@ const buildMock = EmberObject.create({
 const buildMetaMock = {
   tests: {
     coverage: '100',
-    results: '10/10'
+    coverageUrl: '/coverage/666',
+    results: '10/10',
+    resultsUrl: '/results/666'
   }
 };
 
@@ -409,6 +411,13 @@ module('Integration | Component | build banner', function(hooks) {
       }
     ];
 
+    buildMetaMock.tests = {
+      coverage: '100',
+      coverageUrl: '/666',
+      results: '10/10',
+      resultsUrl: '/666'
+    };
+
     assert.expect(2);
     this.set('eventMock', eventMock);
     this.set('buildStepsMock', coverageStepsMock);
@@ -447,9 +456,12 @@ module('Integration | Component | build banner', function(hooks) {
 
     buildMetaMock.tests = {
       coverage: 'nonsense',
-      resulst: 'nonsense'
+      coverageUrl: 'nonsense',
+      results: 'nonsense',
+      resultsUrl: 'nonsense'
     };
-    assert.expect(2);
+
+    assert.expect(4);
     this.set('eventMock', eventMock);
     this.set('buildStepsMock', coverageStepsMock);
     this.set('buildMetaMock', buildMetaMock);
@@ -473,6 +485,8 @@ module('Integration | Component | build banner', function(hooks) {
     return settled().then(() => {
       assert.dom('.coverage .banner-value').hasText('98%');
       assert.dom('.tests .banner-value').hasText('7/10');
+      assert.dom('.coverage a').hasAttribute('href', 'http://example.com/coverage/123');
+      assert.dom('.tests a').hasAttribute('href', 'http://example.com/coverage/123');
     });
   });
 


### PR DESCRIPTION
## Context

Currently there's no way to set test and coverage urls even though we can set summary.

## Objective

Allow user to set test and coverage urls .

## References

https://github.com/screwdriver-cd/screwdriver/issues/1718

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
