### PR TITLE
fix: click previous step when running build

### DIFF
--- a/app/pipeline/build/artifacts/route.js
+++ b/app/pipeline/build/artifacts/route.js
@@ -9,9 +9,6 @@ export default Route.extend({
   actions: {
     didTransition() {
       this.controllerFor('pipeline.build').set('activeTab', 'artifacts');
-
-      // NOT delegate to its parent route's didTranstion
-      return false;
     }
   }
 });

--- a/app/pipeline/build/index/route.js
+++ b/app/pipeline/build/index/route.js
@@ -7,8 +7,10 @@ export default Route.extend({
   },
   actions: {
     didTransition() {
-      // delegate to its parent route's didTranstion
-      return true;
+      this.controllerFor('pipeline.build').setProperties({
+        selectedArtifact: '',
+        activeTab: 'steps'
+      });
     }
   }
 });

--- a/app/pipeline/build/route.js
+++ b/app/pipeline/build/route.js
@@ -58,14 +58,17 @@ export default Route.extend({
     }
   },
 
-  actions: {
-    didTransition() {
-      this.controller.setProperties({
-        selectedArtifact: '',
-        activeTab: 'steps'
-      });
+  redirect(model /* , transition */) {
+    console.log('redirect called');
+    const name = getActiveStep(get(model, 'build.steps'));
 
-      this.goToActiveStep();
+    if (name) {
+      this.transitionTo(
+        'pipeline.build.step',
+        model.pipeline.get('id'),
+        model.build.get('id'),
+        name
+      );
     }
   }
 });

--- a/app/pipeline/build/route.js
+++ b/app/pipeline/build/route.js
@@ -59,7 +59,6 @@ export default Route.extend({
   },
 
   redirect(model /* , transition */) {
-    console.log('redirect called');
     const name = getActiveStep(get(model, 'build.steps'));
 
     if (name) {

--- a/app/pipeline/build/step/route.js
+++ b/app/pipeline/build/step/route.js
@@ -22,8 +22,10 @@ export default Route.extend({
 
   actions: {
     didTransition() {
-      // delegate to its parent route's didTranstion
-      return true;
+      this.controllerFor('pipeline.build').setProperties({
+        selectedArtifact: '',
+        activeTab: 'steps'
+      });
     }
   }
 });

--- a/tests/unit/pipeline/build/route-test.js
+++ b/tests/unit/pipeline/build/route-test.js
@@ -39,7 +39,7 @@ module('Unit | Route | pipeline/build', function(hooks) {
     assert.ok(stub.calledWithExactly('pipeline', pipelineId), 'transition to pipeline');
   });
 
-  sinonTest('it should not call transitionTo when redirect', function(assert) {
+  sinonTest('it redirects if not step route', function(assert) {
     const route = this.owner.lookup('route:pipeline/build');
     const stub = this.stub(route, 'transitionTo');
 
@@ -64,6 +64,10 @@ module('Unit | Route | pipeline/build', function(hooks) {
 
     route.redirect(model, transition);
 
-    assert.ok(stub.notCalled, 'transitionTo was not called at all');
+    assert.ok(stub.calledOnce, 'transitionTo was called once');
+    assert.ok(
+      stub.calledWithExactly('pipeline.build.step', pipelineId, buildId, 'error'),
+      'transition to build step page'
+    );
   });
 });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Currently, a ui bug was introduced by pr https://github.com/screwdriver-cd/ui/pull/517

https://github.com/screwdriver-cd/ui/pull/517/files#diff-0a13691fa8d703678c66fb99133a59fbL47

It causes users click on previous steps will always redirect to most active step.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

This is not desired behavior, and this PR fixes it by using (reverting) `redirect` in parent route instead of using `didTransition` action hook.


## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
