### PR TITLE
fix: properly display workflow that has sd-external job as parallel join jobs

### DIFF
--- a/app/components/workflow-graph-d3/component.js
+++ b/app/components/workflow-graph-d3/component.js
@@ -29,7 +29,18 @@ export default Component.extend({
           edges: []
         });
         let graph = showDownstreamTriggers ? completeGraph : workflowGraph;
-        const endNodes = graph.nodes.filter(node => node.name.startsWith('sd@'));
+
+        // only remove node if it is not a source node
+        const endNodes = graph.nodes.filter(node => {
+          if (node.name.startsWith('sd@')) {
+            // check if an edge has this node as source
+            if (graph.edges.filter(edge => edge.src === node.name).length <= 0) {
+              return true;
+            }
+          }
+
+          return false;
+        });
 
         // remove duplicate dangling trigger jobs from graph
         if (endNodes.length) {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

The previous PR: https://github.com/screwdriver-cd/ui/pull/520 will remove parallel joined jobs

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
This PR will only remove jobs that name starts with `'sd@'`, and is not a `src`(source) node of an edge.

The previous implementation will remove nodes bluntly based on the name of `'sd@'`

## References

Expected:

![image](https://user-images.githubusercontent.com/15989893/73805681-35a8e780-477c-11ea-92b2-d52ad9a1d9ef.png)

![image](https://user-images.githubusercontent.com/15989893/73806112-6e958c00-477d-11ea-8f35-afcb7b8b12b3.png)

![image](https://user-images.githubusercontent.com/15989893/73805765-6d179400-477c-11ea-9424-7a852582afb7.png)

![image](https://user-images.githubusercontent.com/15989893/73805730-58d39700-477c-11ea-8516-10fc4a4ce7d4.png)

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->
2 sample pipelines:

- https://cd.screwdriver.cd/pipelines/4074/events
- https://cd.screwdriver.cd/pipelines/3983/events

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
