### PR TITLE
fix(1910):Remove default pipelines from 'Add to Collection' list

### DIFF
--- a/app/components/collection-dropdown/component.js
+++ b/app/components/collection-dropdown/component.js
@@ -1,13 +1,22 @@
 import Component from '@ember/component';
+import { computed } from '@ember/object';
 
 export default Component.extend({
   classNames: ['collection-dropdown'],
   showCollectionModal: false,
+  collections: null,
   addCollectionError: null,
   addCollectionSuccess: null,
   pipeline: null,
   buttonText: undefined,
   buttonClass: undefined,
+  filteredCollections: computed('collections', {
+    get() {
+      const { collections } = this;
+
+      return collections.filter(collection => collection.type !== 'default');
+    }
+  }),
   actions: {
     openModal() {
       this.set('showCollectionModal', true);

--- a/app/components/collection-dropdown/component.js
+++ b/app/components/collection-dropdown/component.js
@@ -1,21 +1,16 @@
 import Component from '@ember/component';
-import { computed } from '@ember/object';
+import { filter } from '@ember/object/computed';
 
 export default Component.extend({
   classNames: ['collection-dropdown'],
   showCollectionModal: false,
-  collections: null,
   addCollectionError: null,
   addCollectionSuccess: null,
   pipeline: null,
   buttonText: undefined,
   buttonClass: undefined,
-  filteredCollections: computed('collections', {
-    get() {
-      const { collections } = this;
-
-      return collections.filter(collection => collection.type !== 'default');
-    }
+  filteredCollections: filter('collections.[]', function isNormalCollection(collection) {
+    return collection.type !== 'default';
   }),
   actions: {
     openModal() {

--- a/app/components/collection-dropdown/component.js
+++ b/app/components/collection-dropdown/component.js
@@ -9,7 +9,7 @@ export default Component.extend({
   pipeline: null,
   buttonText: undefined,
   buttonClass: undefined,
-  filteredCollections: filter('collections.[]', function isNormalCollection(collection) {
+  normalCollections: filter('collections.[]', function isNormalCollection(collection) {
     return collection.type !== 'default';
   }),
   actions: {

--- a/app/components/collection-dropdown/template.hbs
+++ b/app/components/collection-dropdown/template.hbs
@@ -15,7 +15,7 @@
     {{/dd.button}}
   {{/if}}
   {{#dd.menu align="right" class="dropdown" as |menu|}}
-    {{#each collections as |collection|}}
+    {{#each filteredCollections as |collection|}}
       {{#menu.item}}
         <span onclick={{action "addToCollection" collection}}>
           {{collection.name}}
@@ -29,7 +29,7 @@
     </li>
   {{/dd.menu}}
 {{/bs-dropdown}}
-{{collection-modal 
+{{collection-modal
   showModal=showCollectionModal
   addNewCollection=addNewCollection
   addToCollection=(action "addToCollection")}}

--- a/app/components/collection-dropdown/template.hbs
+++ b/app/components/collection-dropdown/template.hbs
@@ -15,7 +15,7 @@
     {{/dd.button}}
   {{/if}}
   {{#dd.menu align="right" class="dropdown" as |menu|}}
-    {{#each filteredCollections as |collection|}}
+    {{#each normalCollections as |collection|}}
       {{#menu.item}}
         <span onclick={{action "addToCollection" collection}}>
           {{collection.name}}

--- a/tests/integration/components/collection-dropdown/component-test.js
+++ b/tests/integration/components/collection-dropdown/component-test.js
@@ -41,6 +41,46 @@ module('Integration | Component | collection add button', function(hooks) {
     assert.dom('.dropdown-menu > li:nth-child(2)').hasText('CREATE');
   });
 
+  test('it does not render default collection', async function(assert) {
+    const collections = [
+      EmberObject.create({
+        id: 1,
+        name: 'collection1',
+        description: 'description1',
+        pipelineIds: [2, 3],
+        type: 'default'
+      }),
+      EmberObject.create({
+        id: 2,
+        name: 'collection2',
+        description: 'description2',
+        pipelineIds: []
+      })
+    ];
+
+    this.set('collections', collections);
+    this.set('pipeline', { id: 1 });
+    this.set('onAddToCollection', true);
+
+    await render(hbs`{{collection-dropdown
+      collections=collections
+      pipeline=pipeline
+      onAddToCollection=onAddToCollection
+    }}`);
+
+    // the button should be there
+    assert.dom('.dropdown-toggle').exists({ count: 1 });
+
+    await click('.dropdown-toggle');
+
+    // there should be two list items ('collection2' and 'CREATE')
+    assert.dom('.dropdown-menu > li').exists({ count: 2 });
+
+    // Validate that list items exist
+    assert.dom('.dropdown-menu > li:nth-child(1)').hasText('collection2');
+    assert.dom('.dropdown-menu > li:nth-child(2)').hasText('CREATE');
+  });
+
   test('it adds a pipeline to a collection', async function(assert) {
     assert.expect(2);
 

--- a/tests/integration/components/collection-dropdown/component-test.js
+++ b/tests/integration/components/collection-dropdown/component-test.js
@@ -42,6 +42,8 @@ module('Integration | Component | collection add button', function(hooks) {
   });
 
   test('it does not render default collection', async function(assert) {
+    assert.expect(4);
+
     const collections = [
       EmberObject.create({
         id: 1,

--- a/tests/integration/components/collection-view/component-test.js
+++ b/tests/integration/components/collection-view/component-test.js
@@ -151,7 +151,7 @@ const mockCollections = [
     id: 1,
     name: 'My Pipelines',
     description: 'Default Collection',
-    type: 'default',
+    type: 'normal',
     pipelineIds: [1, 2, 3, 4],
     userId: 1
   },
@@ -221,8 +221,8 @@ module('Integration | Component | collection view', function(hooks) {
     injectScmServiceStub(this);
 
     await render(hbs`
-      {{collection-view 
-        collection=collection 
+      {{collection-view
+        collection=collection
         collections=collections
         metricsMap=metricsMap
       }}`);
@@ -277,7 +277,7 @@ module('Integration | Component | collection view', function(hooks) {
     injectScmServiceStub(this);
 
     await render(hbs`
-      {{collection-view 
+      {{collection-view
         collection=collection
         collections=collections
         metricsMap=metricsMap
@@ -345,7 +345,7 @@ module('Integration | Component | collection view', function(hooks) {
     injectScmServiceStub(this);
 
     await render(hbs`
-      {{collection-view 
+      {{collection-view
         collection=collection
         collections=collections
         metricsMap=metricsMap
@@ -361,7 +361,7 @@ module('Integration | Component | collection view', function(hooks) {
     injectScmServiceStub(this);
 
     await render(hbs`
-      {{collection-view 
+      {{collection-view
         collection=collection
         collections=collections
         metricsMap=metricsMap
@@ -403,7 +403,7 @@ module('Integration | Component | collection view', function(hooks) {
     injectScmServiceStub(this);
 
     await render(hbs`
-      {{collection-view 
+      {{collection-view
         collection=collection
         collections=collections
         metricsMap=metricsMap
@@ -439,7 +439,7 @@ module('Integration | Component | collection view', function(hooks) {
     injectScmServiceStub(this);
 
     await render(hbs`
-      {{collection-view 
+      {{collection-view
         collection=collection
         collections=collections
         metricsMap=metricsMap

--- a/tests/integration/components/collection-view/component-test.js
+++ b/tests/integration/components/collection-view/component-test.js
@@ -151,7 +151,7 @@ const mockCollections = [
     id: 1,
     name: 'My Pipelines',
     description: 'Default Collection',
-    type: 'normal',
+    type: 'default',
     pipelineIds: [1, 2, 3, 4],
     userId: 1
   },
@@ -162,6 +162,14 @@ const mockCollections = [
     type: 'normal',
     userId: 1,
     pipelineIds: []
+  },
+  {
+    id: 3,
+    name: 'My Pipelines',
+    description: 'Collection2',
+    type: 'normal',
+    pipelineIds: [1, 2, 3, 4],
+    userId: 1
   }
 ];
 
@@ -874,9 +882,11 @@ module('Integration | Component | collection view', function(hooks) {
   });
 
   test('it moves multiple pipelines to another collection in card mode', async function(assert) {
+    assert.expect(2);
+
     const addMultipleToCollectionMock = (pipelineIds, collectionId) => {
       assert.deepEqual(pipelineIds, [3, 1]);
-      assert.strictEqual(collectionId, 2);
+      assert.strictEqual(collectionId, 3);
 
       return resolve();
     };
@@ -909,9 +919,11 @@ module('Integration | Component | collection view', function(hooks) {
   });
 
   test('it moves multiple pipelines to another collection in list mode', async function(assert) {
+    assert.expect(2);
+
     const addMultipleToCollectionMock = (pipelineIds, collectionId) => {
       assert.deepEqual(pipelineIds, [3, 1]);
-      assert.strictEqual(collectionId, 2);
+      assert.strictEqual(collectionId, 3);
 
       return resolve();
     };
@@ -947,9 +959,11 @@ module('Integration | Component | collection view', function(hooks) {
   });
 
   test('it fails to move multiple pipelines to another collection in card mode', async function(assert) {
+    assert.expect(3);
+
     const addMultipleToCollectionMock = (pipelineIds, collectionId) => {
       assert.deepEqual(pipelineIds, [3, 1]);
-      assert.strictEqual(collectionId, 2);
+      assert.strictEqual(collectionId, 3);
 
       return reject();
     };
@@ -983,13 +997,15 @@ module('Integration | Component | collection view', function(hooks) {
     // assert the error message is correct
     assert
       .dom('.alert-warning > span')
-      .hasText(`Could not add Pipeline to Collection ${mockEmptyCollection.name}`);
+      .hasText('Could not add Pipeline to Collection My Pipelines');
   });
 
   test('it fails to move multiple pipelines to another collection in list mode', async function(assert) {
+    assert.expect(2);
+
     const addMultipleToCollectionMock = (pipelineIds, collectionId) => {
       assert.deepEqual(pipelineIds, [3, 1]);
-      assert.strictEqual(collectionId, 2);
+      assert.strictEqual(collectionId, 3);
 
       return reject();
     };


### PR DESCRIPTION
## Context

When trying to add a pipeline to a collection, the default collection (My Pipelines) shows up as an option. When trying to click that option, I get an error Could not add Pipeline to `My Pipelines`.

## Objective

Since users should not be allowed to modify the default collection, that option should not show up to the Add to Collection list.

## References

https://github.com/screwdriver-cd/screwdriver/issues/1910

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
