### PR TITLE
fix(1950): refactor fetchLogs api call

### DIFF
--- a/app/build-logs/service.js
+++ b/app/build-logs/service.js
@@ -1,11 +1,10 @@
-import $ from 'jquery';
 import { Promise as EmberPromise } from 'rsvp';
 import Service, { inject as service } from '@ember/service';
-import ENV from 'screwdriver-ui/config/environment';
 import { get, set } from '@ember/object';
 
 export default Service.extend({
   session: service(),
+  shuttle: service(),
   cache: Object.create(null),
   blobKeys: [],
   /**
@@ -31,9 +30,6 @@ export default Service.extend({
     let lines = [];
     let done = false;
     const inProgress = sortOrder === 'ascending';
-    const url =
-      `${ENV.APP.SDAPI_HOSTNAME}/${ENV.APP.SDAPI_NAMESPACE}` +
-      `/builds/${buildId}/steps/${stepName}/logs`;
 
     return new EmberPromise((resolve, reject) => {
       if (!this.get('session.isAuthenticated')) {
@@ -42,25 +38,24 @@ export default Service.extend({
 
       // convert jquery's ajax promises to a real promise
       return (
-        $.ajax({
-          url,
-          data: {
-            from: logNumber,
-            pages: pageSize,
-            sort: sortOrder
-          },
-          headers: {
-            Authorization: `Bearer ${this.session.get('data.authenticated.token')}`
-          }
-        })
-          .done((data, textStatus, jqXHR) => {
-            if (Array.isArray(data)) {
-              lines = data;
+        this.shuttle
+          .fetchLogs({
+            buildId,
+            stepName,
+            logNumber,
+            pageSize,
+            sortOrder
+          })
+          .then(result => {
+            const { response, jqXHR } = result;
+
+            if (Array.isArray(response)) {
+              lines = response;
             }
             done = started && jqXHR.getResponseHeader('x-more-data') === 'false';
           })
           // always resolve something
-          .always(() => {
+          .finally(() => {
             this.setCache(buildId, stepName, { done });
 
             if (lines.length) {

--- a/app/build-logs/service.js
+++ b/app/build-logs/service.js
@@ -54,6 +54,7 @@ export default Service.extend({
             }
             done = started && jqXHR.getResponseHeader('x-more-data') === 'false';
           })
+          .catch(() => [])
           // always resolve something
           .finally(() => {
             this.setCache(buildId, stepName, { done });

--- a/app/shuttle/service.js
+++ b/app/shuttle/service.js
@@ -2,17 +2,13 @@ import { computed } from '@ember/object';
 import Service, { inject as service } from '@ember/service';
 import ENV from 'screwdriver-ui/config/environment';
 
-const ALLOWED_METHODS = {
-  get: 'request',
-  request: 'request',
-  post: 'post',
-  put: 'put',
-  patch: 'patch',
-  delete: 'del',
-  del: 'del',
-  raw: 'raw'
-};
-
+/**
+ * Screwdriver Shuttle Service
+ * Only certain methods are allowed: get, request, post, put, patch, del, raw
+ * Ember Ajax API: https://github.com/ember-cli/ember-ajax
+ * @namespace
+ * @return
+ */
 export default Service.extend({
   ajax: service(),
 
@@ -44,31 +40,26 @@ export default Service.extend({
 
   fetchFrom(host = 'store', method = 'get', url, data = {}, raw = false) {
     let baseHost = this.apiHost;
-    let actualMethod = method.toLowerCase();
 
     if (host === 'store') {
       baseHost = this.storeHost;
     }
 
-    const options = this.ajaxOptions();
+    let optionsType = method.toUpperCase();
+    let requestType = method.toLowerCase();
 
     if (raw) {
-      actualMethod = 'raw';
+      requestType = 'raw';
     }
 
-    const httpMethod = ALLOWED_METHODS[actualMethod];
+    const uri = `${baseHost}${url}`;
 
-    if (httpMethod === 'post') {
-      options.data = JSON.stringify(data);
-    }
+    const options = Object.assign({}, this.ajaxOptions(), {
+      data,
+      type: optionsType
+    });
 
-    let uri = `${baseHost}/${url}`;
-
-    if (url.startsWith('/')) {
-      uri = `${baseHost}${url}`;
-    }
-
-    return this.get('ajax')[httpMethod](uri, options);
+    return this.get('ajax')[requestType](uri, options);
   },
 
   fetchFromApi(method = 'get', url, data, raw = false) {

--- a/config/environment.js
+++ b/config/environment.js
@@ -49,7 +49,7 @@ module.exports = environment => {
       SLACK_URL: 'http://slack.screwdriver.cd',
       BUILD_RELOAD_TIMER: 5000, // 5 seconds
       EVENT_RELOAD_TIMER: 60000, // 1 minute
-      LOG_RELOAD_TIMER: 1000,
+      LOG_RELOAD_TIMER: 3000,
       NUM_EVENTS_LISTED: 5,
       NUM_PIPELINES_LISTED: 50,
       MAX_LOG_LINES: 1000,

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -2,7 +2,7 @@ cache:
   pipeline: [ ~/.npm ]
 
 shared:
-  image: node:10
+  image: node:12
 
 jobs:
   main:

--- a/tests/unit/build-logs/service-test.js
+++ b/tests/unit/build-logs/service-test.js
@@ -2,6 +2,8 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import Service from '@ember/service';
 import Pretender from 'pretender';
+import Ember from 'ember';
+
 let server;
 const now = Date.now();
 
@@ -170,17 +172,22 @@ module('Unit | Service | build logs', function(hooks) {
     assert.expect(3);
     badLogs();
     const service = this.owner.lookup('service:build-logs');
-    const { lines, done } = await service.fetchLogs(serviceConfig);
 
-    assert.notOk(done);
-    assert.equal(lines.length, 0);
+    try {
+      const { lines, done } = await service.fetchLogs(serviceConfig);
 
-    const [request] = server.handledRequests;
+      assert.notOk(done);
+      assert.equal(lines.length, 0);
 
-    assert.equal(
-      request.url,
-      'http://localhost:8080/v4/builds/1/steps/banana/logs?from=0&pages=10&sort=ascending'
-    );
+      const [request] = server.handledRequests;
+
+      assert.equal(
+        request.url,
+        'http://localhost:8080/v4/builds/1/steps/banana/logs?from=0&pages=10&sort=ascending'
+      );
+    } catch (err) {
+      Ember.Logger.error('err', err);
+    }
   });
 
   test('it handles fetching multiple pages', async function(assert) {

--- a/tests/unit/shuttle/service-test.js
+++ b/tests/unit/shuttle/service-test.js
@@ -1,0 +1,55 @@
+import { module, test } from 'qunit';
+import Pretender from 'pretender';
+import ENV from 'screwdriver-ui/config/environment';
+import { setupTest } from 'ember-qunit';
+
+let server;
+
+module('Unit | Service | shuttle', function(hooks) {
+  setupTest(hooks);
+
+  // Specify the other units that are required for this test.
+  // needs: ['service:foo']
+  hooks.beforeEach(function() {
+    server = new Pretender();
+  });
+
+  hooks.afterEach(function() {
+    server.shutdown();
+  });
+
+  test('fetchLogs payload', function(assert) {
+    assert.expect(2);
+    let service = this.owner.lookup('service:shuttle');
+
+    server.get(`${ENV.APP.SDAPI_HOSTNAME}/v4/builds/170338/steps/step6/logs`, () => [
+      200,
+      {
+        'Content-Type': 'application/json',
+        'x-more-data': false
+      },
+      JSON.stringify([
+        { t: 1581116848342, m: '$ sleep 5 && echo ok', n: 0 },
+        { t: 1581116853344, m: 'ok', n: 1 },
+        { t: 1581116853344, m: '', n: 2 }
+      ])
+    ]);
+
+    service
+      .fetchLogs({
+        buildId: 170338,
+        stepName: 'step6',
+        logNumber: 0,
+        pageSize: 10,
+        sortOrder: 'ascending'
+      })
+      .then(result => {
+        assert.equal(result.payload.length, 3, 'should have 3 logs');
+        assert.equal(
+          result.jqXHR.getResponseHeader('x-more-data'),
+          'false',
+          'no more logs, logs completed'
+        );
+      });
+  });
+});


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Minor UI optimization

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
- increase `LOG_RELOAD_TIMER` from `1` to `3`s
- refactored `fetchLog` to `shuttle` api service
- add tests for `shuttle` service

- upgrade to `node:12` for https://github.com/screwdriver-cd/screwdriver/issues/1722

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
Issue: https://github.com/screwdriver-cd/screwdriver/issues/1950

Ember Data / Ember Ajax / Ember Fetch proposal
https://gist.github.com/tomdale/203ea125acd0be8b5f1f

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
