### PR TITLE
fix(1963): fix redirect route to step route on all build route redirections

### DIFF
--- a/app/pipeline/build/route.js
+++ b/app/pipeline/build/route.js
@@ -58,16 +58,18 @@ export default Route.extend({
     }
   },
 
-  redirect(model /* , transition */) {
-    const name = getActiveStep(get(model, 'build.steps'));
+  redirect(model, transition) {
+    if (['pipeline.build.step', 'pipeline.build.index'].includes(transition.targetName)) {
+      const name = getActiveStep(get(model, 'build.steps'));
 
-    if (name) {
-      this.transitionTo(
-        'pipeline.build.step',
-        model.pipeline.get('id'),
-        model.build.get('id'),
-        name
-      );
+      if (name) {
+        this.transitionTo(
+          'pipeline.build.step',
+          model.pipeline.get('id'),
+          model.build.get('id'),
+          name
+        );
+      }
     }
   }
 });

--- a/tests/unit/pipeline/build/route-test.js
+++ b/tests/unit/pipeline/build/route-test.js
@@ -2,6 +2,7 @@ import EmberObject from '@ember/object';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinonTest from 'ember-sinon-qunit/test-support/test';
+import { getActiveStep } from 'screwdriver-ui/utils/build';
 
 module('Unit | Route | pipeline/build', function(hooks) {
   setupTest(hooks);
@@ -69,5 +70,31 @@ module('Unit | Route | pipeline/build', function(hooks) {
       stub.calledWithExactly('pipeline.build.step', pipelineId, buildId, 'error'),
       'transition to build step page'
     );
+  });
+
+  sinonTest('it redirects will NOT redirect if on artifacts route', function(assert) {
+    const route = this.owner.lookup('route:pipeline/build');
+    const spy = this.spy(getActiveStep);
+
+    const buildId = 345;
+    const pipelineId = 123;
+    const model = {
+      pipeline: {
+        get: type => (type === 'id' ? pipelineId : null)
+      },
+      build: {
+        get: type => (type === 'id' ? buildId : null),
+        steps: []
+      }
+    };
+    let transition = { targetName: 'pipeline.build.artifacts.details' };
+
+    route.redirect(model, transition);
+    assert.ok(spy.notCalled, 'redirect was not called');
+
+    transition = { targetName: 'pipeline.build.artifacts.index' };
+
+    route.redirect(model, transition);
+    assert.ok(spy.notCalled, 'redirect was not called');
   });
 });

--- a/tests/unit/pipeline/build/route-test.js
+++ b/tests/unit/pipeline/build/route-test.js
@@ -73,9 +73,9 @@ module('Unit | Route | pipeline/build', function(hooks) {
   });
 
   sinonTest('it redirects will NOT redirect if on artifacts route', function(assert) {
+    assert.expect(2);
     const route = this.owner.lookup('route:pipeline/build');
     const spy = this.spy(getActiveStep);
-
     const buildId = 345;
     const pipelineId = 123;
     const model = {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

If users visit a failed build with artifacts link directly, then users should not be redirected to the failed step of the build.

Please see issue: https://github.com/screwdriver-cd/screwdriver/issues/1963

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

This PR adds check only redirect to step route for 'pipeline.build.step', 'pipeline.build.index', which will NOT redirect users when their intention is to visit the artifacts directly.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
issue: https://github.com/screwdriver-cd/screwdriver/issues/1963
FYI: 
I always refer to this doc :) 
Ember Route: https://alexdiliberto.com/posts/ember-route-hooks-a-complete-look/

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
