### PR TITLE
feat(1091): add template popularity metrics to template details page

### DIFF
--- a/app/components/template-header/styles.scss
+++ b/app/components/template-header/styles.scss
@@ -25,6 +25,7 @@
   .template-stats {
     display: flex;
     justify-content: space-between;
+    margin-top: 20px;
     margin-bottom: 10px;
   }
 

--- a/app/components/template-header/styles.scss
+++ b/app/components/template-header/styles.scss
@@ -22,6 +22,21 @@
     margin-left: 10px;
   }
 
+  .template-stats {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 10px;
+  }
+
+  .template-version {
+    margin: 0;
+  }
+
+  .template-metrics {
+    font-size: 1.5em;
+    margin: 0;
+  }
+
   .trusted {
     fill: #16c047;
     height: 1em;

--- a/app/components/template-header/template.hbs
+++ b/app/components/template-header/template.hbs
@@ -21,8 +21,10 @@
     {{fa-icon "trash" title="Cannot delete template; pipeline could not be found."}}
   {{/if}}
 </h1>
-<h2>{{template.version}}</h2>
-<h2>Jobs: {{template.metrics.jobs.count}} | Builds: {{template.metrics.builds.count}}</h2>
+<div class="template-stats">
+  <h2 class="template-version">{{template.version}}</h2>
+  <div class="template-metrics">Usage - Jobs: {{template.metrics.jobs.count}} | Builds: {{template.metrics.builds.count}}</div>
+</div>
 <p>{{template.description}}</p>
   {{#if template.namespace}}
     <div class="template-details--item" id="template-namespace">

--- a/app/components/template-header/template.hbs
+++ b/app/components/template-header/template.hbs
@@ -22,6 +22,7 @@
   {{/if}}
 </h1>
 <h2>{{template.version}}</h2>
+<h2>Jobs: {{template.metrics.jobs.count}} | Builds: {{template.metrics.builds.count}}</h2>
 <p>{{template.description}}</p>
   {{#if template.namespace}}
     <div class="template-details--item" id="template-namespace">

--- a/app/template/service.js
+++ b/app/template/service.js
@@ -16,6 +16,13 @@ export default Service.extend({
 
     return this.fetchData(url).then(templatesFormatter);
   },
+  getOneTemplateWithMetrics(name) {
+    const url = `${ENV.APP.SDAPI_HOSTNAME}/${
+      ENV.APP.SDAPI_NAMESPACE
+    }/templates/${encodeURIComponent(name)}/metrics`;
+
+    return this.fetchData(url).then(templatesFormatter);
+  },
   getTemplateTags(namespace, name) {
     const fullName = `${namespace}/${name}`;
     const url =

--- a/app/templates/detail/controller.js
+++ b/app/templates/detail/controller.js
@@ -5,7 +5,7 @@ import { jwt_decode as decoder } from 'ember-cli-jwt-decode';
 const { alias } = computed;
 
 export default Controller.extend({
-  selectedVersion: null,
+  selectedVersion: computed.oneWay('model.versionOrTagFromUrl'),
   errorMessage: '',
   session: service(),
   template: service(),

--- a/app/templates/detail/controller.js
+++ b/app/templates/detail/controller.js
@@ -1,5 +1,5 @@
 import { inject as service } from '@ember/service';
-import { computed, observer } from '@ember/object';
+import { computed } from '@ember/object';
 import Controller from '@ember/controller';
 import { jwt_decode as decoder } from 'ember-cli-jwt-decode';
 const { alias } = computed;
@@ -45,11 +45,6 @@ export default Controller.extend({
 
       return this.templates.templateData.findBy('version', versionOrTagFromUrl);
     }
-  }),
-  // Set selected version to null whenever the list of templates changes
-  // eslint-disable-next-line ember/no-observers
-  modelObserver: observer('templates.templateData.[]', function modelObserver() {
-    this.set('selectedVersion', null);
   }),
   actions: {
     removeTemplate(name) {

--- a/app/templates/detail/route.js
+++ b/app/templates/detail/route.js
@@ -1,9 +1,8 @@
 import { inject as service } from '@ember/service';
 import RSVP from 'rsvp';
 import Route from '@ember/routing/route';
-import { get } from '@ember/object';
+import { get, set } from '@ember/object';
 import { compareVersions } from 'screwdriver-ui/helpers/compare-versions';
-import { set } from '@ember/object';
 
 export default Route.extend({
   template: service(),

--- a/app/templates/detail/route.js
+++ b/app/templates/detail/route.js
@@ -5,28 +5,52 @@ import { compareVersions } from 'screwdriver-ui/helpers/compare-versions';
 
 export default Route.extend({
   template: service(),
+  resultCache: Object(),
+  determineVersion(pVersion, verPayload, tagPayload) {
+    let version;
+
+    if (pVersion) {
+      const versionExists = verPayload.filter(t => t.version.startsWith(pVersion));
+      const tagExists = tagPayload.filter(t => t.tag === pVersion);
+
+      if (tagExists.length === 0 && versionExists.length === 0) {
+        this.transitionTo('/404');
+      }
+
+      if (versionExists.length > 0) {
+        // Sort commands by descending order
+        versionExists.sort((a, b) => compareVersions(b.version, a.version));
+        ({ version } = versionExists[0]);
+      }
+    }
+
+    return version || pVersion;
+  },
   model(params) {
+    this._super(...arguments);
+
+    if (this.resultCache.templateData) {
+      this.resultCache.versionOrTagFromUrl = this.determineVersion(
+        params.version,
+        this.resultCache.templateData,
+        this.resultCache.templateTagData
+      );
+
+      let newResult = {};
+
+      newResult.templateData = this.resultCache.templateData;
+      newResult.templateTagData = this.resultCache.templateTagData;
+      newResult.versionOrTagFromUrl = this.resultCache.versionOrTagFromUrl;
+
+      return newResult;
+    }
+
     return RSVP.all([
       this.template.getOneTemplateWithMetrics(`${params.namespace}/${params.name}`),
       this.template.getTemplateTags(params.namespace, params.name)
     ]).then(arr => {
       let [verPayload, tagPayload] = arr;
-      let version;
-
-      if (params.version) {
-        const versionExists = verPayload.filter(t => t.version.startsWith(params.version));
-        const tagExists = tagPayload.filter(t => t.tag === params.version);
-
-        if (tagExists.length === 0 && versionExists.length === 0) {
-          this.transitionTo('/404');
-        }
-
-        if (versionExists.length > 0) {
-          // Sort commands by descending order
-          versionExists.sort((a, b) => compareVersions(b.version, a.version));
-          ({ version } = versionExists[0]);
-        }
-      }
+      let version = this.determineVersion(params.version, verPayload, tagPayload);
 
       verPayload = verPayload.filter(t => t.namespace === params.namespace);
 
@@ -41,8 +65,10 @@ export default Route.extend({
       let result = {};
 
       result.templateData = verPayload;
-      result.versionOrTagFromUrl = version || params.version;
+      result.versionOrTagFromUrl = version;
       result.templateTagData = tagPayload;
+
+      this.resultCache = result;
 
       return result;
     });

--- a/app/templates/detail/route.js
+++ b/app/templates/detail/route.js
@@ -7,7 +7,7 @@ export default Route.extend({
   template: service(),
   model(params) {
     return RSVP.all([
-      this.template.getOneTemplate(`${params.namespace}/${params.name}`),
+      this.template.getOneTemplateWithMetrics(`${params.namespace}/${params.name}`),
       this.template.getTemplateTags(params.namespace, params.name)
     ]).then(arr => {
       let [verPayload, tagPayload] = arr;

--- a/app/templates/detail/route.js
+++ b/app/templates/detail/route.js
@@ -2,6 +2,7 @@ import { inject as service } from '@ember/service';
 import RSVP from 'rsvp';
 import Route from '@ember/routing/route';
 import { compareVersions } from 'screwdriver-ui/helpers/compare-versions';
+import { set } from '@ember/object';
 
 export default Route.extend({
   template: service(),
@@ -30,19 +31,15 @@ export default Route.extend({
     this._super(...arguments);
 
     if (this.resultCache.templateData) {
-      this.resultCache.versionOrTagFromUrl = this.determineVersion(
+      const versionOrTagFromUrl = this.determineVersion(
         params.version,
         this.resultCache.templateData,
         this.resultCache.templateTagData
       );
 
-      let newResult = {};
+      set(this.resultCache, 'versionOrTagFromUrl', versionOrTagFromUrl);
 
-      newResult.templateData = this.resultCache.templateData;
-      newResult.templateTagData = this.resultCache.templateTagData;
-      newResult.versionOrTagFromUrl = this.resultCache.versionOrTagFromUrl;
-
-      return newResult;
+      return this.resultCache;
     }
 
     return RSVP.all([

--- a/tests/unit/template/service-test.js
+++ b/tests/unit/template/service-test.js
@@ -76,6 +76,68 @@ module('Unit | Service | template', function(hooks) {
     });
   });
 
+  test('it fetches one set of template versions with metrics', function(assert) {
+    assert.expect(2);
+
+    server.get('http://localhost:8080/v4/templates/foo%2Fbar/metrics', () => [
+      200,
+      {
+        'Content-Type': 'application/json'
+      },
+      JSON.stringify([
+        {
+          id: 2,
+          namespace: 'foo',
+          name: 'bar',
+          version: '2.0.0',
+          createTime,
+          metrics: { jobs: { count: 7 }, builds: { count: 7 } }
+        },
+        {
+          id: 1,
+          namespace: 'foo',
+          name: 'bar',
+          version: '1.0.0',
+          createTime,
+          metrics: { jobs: { count: 3 }, builds: { count: 9 } }
+        }
+      ])
+    ]);
+
+    let service = this.owner.lookup('service:template');
+
+    assert.ok(service);
+
+    const t = service.getOneTemplateWithMetrics('foo/bar');
+
+    t.then(templates => {
+      /* eslint-disable max-len */
+      assert.deepEqual(templates, [
+        {
+          id: 2,
+          namespace: 'foo',
+          name: 'bar',
+          version: '2.0.0',
+          fullName: 'foo/bar',
+          createTime,
+          lastUpdated,
+          metrics: { jobs: { count: 7 }, builds: { count: 7 } }
+        },
+        {
+          id: 1,
+          namespace: 'foo',
+          name: 'bar',
+          version: '1.0.0',
+          fullName: 'foo/bar',
+          createTime,
+          lastUpdated,
+          metrics: { jobs: { count: 3 }, builds: { count: 9 } }
+        }
+      ]);
+      /* eslint-enable max-len */
+    });
+  });
+
   test('it fetches all templates', function(assert) {
     assert.expect(2);
 

--- a/tests/unit/templates/detail/route-test.js
+++ b/tests/unit/templates/detail/route-test.js
@@ -98,6 +98,7 @@ module('Unit | Route | templates/detail', function(hooks) {
       assert.equal(templates.templateData[0].name, 'baz');
       assert.equal(templates.versionOrTagFromUrl, undefined);
       assert.equal(templates.templateData[0].metrics.jobs.count, 1);
+      assert.equal(templates.templateData[0].metrics.builds.count, 3);
     });
   });
 
@@ -112,6 +113,7 @@ module('Unit | Route | templates/detail', function(hooks) {
       assert.equal(templates.templateData[0].name, 'baz');
       assert.equal(templates.versionOrTagFromUrl, '1.0.0');
       assert.equal(templates.templateData[3].metrics.jobs.count, 0);
+      assert.equal(templates.templateData[3].metrics.builds.count, 0);
     });
   });
 
@@ -126,6 +128,7 @@ module('Unit | Route | templates/detail', function(hooks) {
       assert.equal(templates.templateData[0].name, 'baz');
       assert.equal(templates.versionOrTagFromUrl, '1.1.0');
       assert.equal(templates.templateData[2].metrics.jobs.count, 7);
+      assert.equal(templates.templateData[2].metrics.builds.count, 9);
     });
   });
 
@@ -139,7 +142,8 @@ module('Unit | Route | templates/detail', function(hooks) {
       assert.equal(templates.templateData[0].namespace, 'foo');
       assert.equal(templates.templateData[0].name, 'baz');
       assert.equal(templates.versionOrTagFromUrl, 'stable');
-      assert.equal(templates.templateData[0].metrics.jobs.count, 1);
+      assert.equal(templates.templateData[4].metrics.jobs.count, 7);
+      assert.equal(templates.templateData[4].metrics.builds.count, 7);
     });
   });
 

--- a/tests/unit/templates/detail/route-test.js
+++ b/tests/unit/templates/detail/route-test.js
@@ -16,6 +16,59 @@ const templateServiceStub = Service.extend({
       { id: 5, name: 'baz', version: '1.0.0', namespace: 'bar' }
     ]);
   },
+  getOneTemplateWithMetrics() {
+    return resolve([
+      {
+        id: 4,
+        name: 'baz',
+        version: '3.0.0',
+        namespace: 'foo',
+        metrics: { jobs: { count: 1 }, builds: { count: 3 } }
+      },
+      {
+        id: 3,
+        name: 'baz',
+        version: '2.0.0',
+        namespace: 'foo',
+        metrics: { jobs: { count: 0 }, builds: { count: 0 } }
+      },
+      {
+        id: 2,
+        name: 'baz',
+        version: '1.1.0',
+        namespace: 'foo',
+        metrics: { jobs: { count: 7 }, builds: { count: 9 } }
+      },
+      {
+        id: 1,
+        name: 'baz',
+        version: '1.0.0',
+        namespace: 'foo',
+        metrics: { jobs: { count: 0 }, builds: { count: 0 } }
+      },
+      {
+        id: 7,
+        name: 'baz',
+        version: '3.0.0',
+        namespace: 'foo',
+        metrics: { jobs: { count: 7 }, builds: { count: 7 } }
+      },
+      {
+        id: 6,
+        name: 'baz',
+        version: '2.0.0',
+        namespace: 'bar',
+        metrics: { jobs: { count: 0 }, builds: { count: 0 } }
+      },
+      {
+        id: 5,
+        name: 'baz',
+        version: '1.0.0',
+        namespace: 'bar',
+        metrics: { jobs: { count: 1 }, builds: { count: 3 } }
+      }
+    ]);
+  },
   getTemplateTags(namespace, name) {
     return resolve([
       { id: 5, name, version: '3.0.0', tag: 'latest' },
@@ -40,10 +93,11 @@ module('Unit | Route | templates/detail', function(hooks) {
     assert.ok(route);
 
     return route.model({ namespace: 'foo', name: 'baz' }).then(templates => {
-      assert.equal(templates.templateData.length, 4);
+      assert.equal(templates.templateData.length, 5);
       assert.equal(templates.templateData[0].namespace, 'foo');
       assert.equal(templates.templateData[0].name, 'baz');
       assert.equal(templates.versionOrTagFromUrl, undefined);
+      assert.equal(templates.templateData[0].metrics.jobs.count, 1);
     });
   });
 
@@ -53,10 +107,11 @@ module('Unit | Route | templates/detail', function(hooks) {
     assert.ok(route);
 
     return route.model({ namespace: 'foo', name: 'baz', version: '1.0.0' }).then(templates => {
-      assert.equal(templates.templateData.length, 4);
+      assert.equal(templates.templateData.length, 5);
       assert.equal(templates.templateData[0].namespace, 'foo');
       assert.equal(templates.templateData[0].name, 'baz');
       assert.equal(templates.versionOrTagFromUrl, '1.0.0');
+      assert.equal(templates.templateData[3].metrics.jobs.count, 0);
     });
   });
 
@@ -66,10 +121,11 @@ module('Unit | Route | templates/detail', function(hooks) {
     assert.ok(route);
 
     return route.model({ namespace: 'foo', name: 'baz', version: '1' }).then(templates => {
-      assert.equal(templates.templateData.length, 4);
+      assert.equal(templates.templateData.length, 5);
       assert.equal(templates.templateData[0].namespace, 'foo');
       assert.equal(templates.templateData[0].name, 'baz');
       assert.equal(templates.versionOrTagFromUrl, '1.1.0');
+      assert.equal(templates.templateData[2].metrics.jobs.count, 7);
     });
   });
 
@@ -79,10 +135,11 @@ module('Unit | Route | templates/detail', function(hooks) {
     assert.ok(route);
 
     return route.model({ namespace: 'foo', name: 'baz', version: 'stable' }).then(templates => {
-      assert.equal(templates.templateData.length, 4);
+      assert.equal(templates.templateData.length, 5);
       assert.equal(templates.templateData[0].namespace, 'foo');
       assert.equal(templates.templateData[0].name, 'baz');
       assert.equal(templates.versionOrTagFromUrl, 'stable');
+      assert.equal(templates.templateData[0].metrics.jobs.count, 1);
     });
   });
 


### PR DESCRIPTION
## Context

We need to display template popularity metrics on the template details page.

Before:
![Screen Shot 2020-02-13 at 12 07 21 PM](https://user-images.githubusercontent.com/59983168/74474013-7f1ec400-4e59-11ea-836a-83414783f60c.png)

After:
![Screen Shot 2020-02-13 at 12 19 06 PM](https://user-images.githubusercontent.com/59983168/74474933-526bac00-4e5b-11ea-9c1e-b981fadb3f63.png)

## Objective

This PR adds template popularity metrics to the template details page. Additionally, it adds caching of template data so that when different template versions are selected on the template details page additional API calls are not made.

## References

https://github.com/screwdriver-cd/screwdriver/issues/1091

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
