### PR TITLE
fix(1604): sorting order when toggle triggers on the UI

### DIFF
--- a/app/pipeline/serializer.js
+++ b/app/pipeline/serializer.js
@@ -2,6 +2,27 @@ import { assign } from '@ember/polyfills';
 import DS from 'ember-data';
 
 export default DS.RESTSerializer.extend({
+  normalizeResponse(store, typeClass, payload, id, requestType) {
+    console.log('===== pipeline normalizeResponse');
+    const { pipeline } = payload;
+
+    if (pipeline.workflowGraph) {
+      // sorting on the dest should be enough
+      pipeline.workflowGraph.edges.sort(({ dest: a }, { dest: b }) => {
+        if (a < b) {
+          return -1;
+        }
+        if (a > b) {
+          return 1;
+        }
+
+        return 0;
+      });
+    }
+
+    return this._super(store, typeClass, payload, id, requestType);
+  },
+
   /**
    * Override the serializeIntoHash
    * See http://emberjs.com/api/data/classes/DS.RESTSerializer.html#method_serializeIntoHash

--- a/app/pipeline/serializer.js
+++ b/app/pipeline/serializer.js
@@ -3,10 +3,9 @@ import DS from 'ember-data';
 
 export default DS.RESTSerializer.extend({
   normalizeResponse(store, typeClass, payload, id, requestType) {
-    console.log('===== pipeline normalizeResponse');
     const { pipeline } = payload;
 
-    if (pipeline.workflowGraph) {
+    if (pipeline && pipeline.workflowGraph) {
       // sorting on the dest should be enough
       pipeline.workflowGraph.edges.sort(({ dest: a }, { dest: b }) => {
         if (a < b) {

--- a/tests/unit/pipeline/serializer-test.js
+++ b/tests/unit/pipeline/serializer-test.js
@@ -4,6 +4,90 @@ import { setupTest } from 'ember-qunit';
 import { settled } from '@ember/test-helpers';
 import Pretender from 'pretender';
 let server;
+const pipelinePayload = {
+  id: 3,
+  name: 'adong/sd-sorting-jobs',
+  scmUri: 'github.com:242007195:master',
+  scmContext: 'github:github.com',
+  scmRepo: {
+    branch: 'master',
+    name: 'adong/sd-sorting-jobs',
+    url: 'https://github.com/adong/sd-sorting-jobs/tree/master',
+    rootDir: ''
+  },
+  createTime: '2020-02-20T22:52:36.978Z',
+  admins: {
+    adong: true
+  },
+  workflowGraph: {
+    nodes: [
+      {
+        name: '~pr'
+      },
+      {
+        name: '~commit'
+      },
+      {
+        name: 'main',
+        id: 34
+      },
+      {
+        name: 'fan1',
+        id: 35
+      },
+      {
+        name: 'fan2',
+        id: 36
+      },
+      {
+        name: 'fan10',
+        id: 37
+      }
+    ],
+    edges: [
+      {
+        src: '~pr',
+        dest: 'main'
+      },
+      {
+        src: '~commit',
+        dest: 'main'
+      },
+      {
+        src: 'main',
+        dest: 'fan1'
+      },
+      {
+        src: 'main',
+        dest: 'fan2'
+      },
+      {
+        src: 'main',
+        dest: 'fan10'
+      }
+    ]
+  },
+  annotations: {},
+  lastEventId: 49,
+  prChain: false,
+  parameters: {},
+  links: {
+    events: 'events',
+    jobs: 'jobs',
+    secrets: 'secrets',
+    tokens: 'tokens',
+    metrics: 'metrics'
+  }
+};
+const getPipeline = () => {
+  server.get('http://localhost:8080/v4/pipelines/3', () => [
+    200,
+    {
+      'Content-Type': 'application/json'
+    },
+    JSON.stringify(pipelinePayload)
+  ]);
+};
 
 module('Unit | Serializer | pipeline', function(hooks) {
   setupTest(hooks);
@@ -49,5 +133,50 @@ module('Unit | Serializer | pipeline', function(hooks) {
         rootDir: ''
       });
     });
+  });
+
+  test('it has workflow edges sorted alphabetically via normalize', function(assert) {
+    assert.expect(3);
+    getPipeline();
+
+    const alphabeticalSortedOrder = [
+      {
+        src: 'main',
+        dest: 'fan1'
+      },
+      {
+        src: 'main',
+        dest: 'fan10'
+      },
+      {
+        src: 'main',
+        dest: 'fan2'
+      },
+      {
+        src: '~pr',
+        dest: 'main'
+      },
+      {
+        src: '~commit',
+        dest: 'main'
+      }
+    ];
+
+    return this.owner
+      .lookup('service:store')
+      .findRecord('pipeline', 3)
+      .then(pipeline => {
+        assert.equal(pipeline.workflowGraph.edges.length, 5, 'has 5 edges');
+        assert.deepEqual(
+          pipeline.workflowGraph.edges,
+          alphabeticalSortedOrder,
+          'edges order is sorted'
+        );
+        assert.notDeepEqual(
+          pipeline.workflowGraph.edges,
+          pipelinePayload.workflowGraph.edges,
+          'payload and response edges order is not the same'
+        );
+      });
   });
 });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
https://github.com/screwdriver-cd/screwdriver/issues/1604


## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

https://github.com/screwdriver-cd/ui/blame/66dce078f0052b8a2b91d12b1fe4d9980fc81654/app/event/serializer.js 

This PR fixes sorting order on `show/hide triggers`. 

Please see screenshot: 

Before: 
![before](https://user-images.githubusercontent.com/15989893/74995365-891a6700-5405-11ea-93b7-5bd9b889fa22.gif)

After:
![after](https://user-images.githubusercontent.com/15989893/74995356-83248600-5405-11ea-93c0-89be42570499.gif)

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
Related 
Issues: 
1) https://github.com/screwdriver-cd/screwdriver/issues/1359

PRs: 
1) https://github.com/screwdriver-cd/ui/pull/399


## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
