### PR TITLE
fix: route from pipeline/build page to any route will redirect within timeout

### DIFF
--- a/app/pipeline/build/controller.js
+++ b/app/pipeline/build/controller.js
@@ -9,6 +9,7 @@ import ENV from 'screwdriver-ui/config/environment';
 import { getActiveStep } from 'screwdriver-ui/utils/build';
 
 export default Controller.extend({
+  router: service(),
   prEventsService: service('pr-events'),
   session: service('session'),
   loading: false,
@@ -127,6 +128,12 @@ export default Controller.extend({
   },
 
   changeBuildStep(name) {
+    const currentRouteName = this.router.currentRoute.name;
+
+    if (!['pipeline.build.step', 'pipeline.build.index'].includes(currentRouteName)) {
+      return;
+    }
+
     const build = this.get('build');
     const pipelineId = this.get('pipeline.id');
     let activeStep;

--- a/app/pipeline/build/controller.js
+++ b/app/pipeline/build/controller.js
@@ -104,13 +104,12 @@ export default Controller.extend({
 
     // reload again in a little bit if queued
     if (!this.loading) {
-      if (status === 'QUEUED' || status === 'RUNNING') {
+      if (['QUEUED', 'RUNNING'].includes(status)) {
         later(
           this,
           () => {
             if (!build.get('isDeleted') && !this.loading) {
               this.set('loading', true);
-
               build.reload().then(() => {
                 this.set('loading', false);
                 throttle(this, 'reloadBuild', timeout);
@@ -128,7 +127,7 @@ export default Controller.extend({
   },
 
   changeBuildStep(name) {
-    const currentRouteName = this.router.currentRoute.name;
+    const currentRouteName = this.getWithDefault('router.currentRoute.name', '');
 
     if (!['pipeline.build.step', 'pipeline.build.index'].includes(currentRouteName)) {
       return;


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

We had a PR: https://github.com/screwdriver-cd/ui/pull/528

That increased the reload time from `1s` to `3s`:
https://github.com/screwdriver-cd/ui/pull/528/files#diff-695693c5dabaffb064bde5b060195ff7L52

Which effects `timeout` here 
https://github.com/screwdriver-cd/ui/blob/1b8b32deb80a2c1744d1d61ff28de910d94a12c1/app/pipeline/build/controller.js#L116-L123

Cause UI to behave that: if users are on pipeline/build page, and go back to any route. Within the timeout period, users will be redirected back. This behavior was not intended, and was not visible when the timeout was set to `1s`. 

But this undesired behavior is visible now, and we need to address it. Hence this PR. Credits to @klu909 who spotted this. 

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

This will only trigger `changeBuildStep` if it's from the desired routes, such as `'pipeline.build.step', 'pipeline.build.index'`. All other routes will not trigger build. 

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

[Ember Router Service](https://api.emberjs.com/ember/3.12/classes/RouterService/properties/currentRoute?anchor=currentRoute)
## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
