### PR TITLE
fix: buildLog component set property when component is destroyed

### DIFF
--- a/app/components/build-log/component.js
+++ b/app/components/build-log/component.js
@@ -296,7 +296,12 @@ export default Component.extend({
    * @param {boolean} fetchMax
    */
   getLogs(fetchMax = false) {
-    if (!this.isFetching && this.shouldLoad) {
+    if (
+      !this.get('isDestroyed') &&
+      !this.get('isDestroying') &&
+      !this.isFetching &&
+      this.shouldLoad
+    ) {
       const { buildId, stepName, totalLine } = this;
       const started = !!this.stepStartTime;
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

This is kind annoying when UI faces racing condition: when component is getting destroyed while setting property in the component. See screenshot:

![image](https://user-images.githubusercontent.com/15989893/75516588-b04ad880-59b1-11ea-9ffb-d91b0c866d98.png)

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Add `!this.get('isDestroyed') && !this.get('isDestroying')` to ensure component is present. 

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
See other reference: 
1) [Cannot update watchers for model after it has been destroyed · Issue #5387 · emberjs/data](https://github.com/emberjs/data/issues/5387)
2) Ember Component Property: [isDestroyed](https://api.emberjs.com/ember/3.16/classes/Component/properties/isDestroyed?anchor=isDestroyed)

I'm actually thinking we should integrate with [ember-concurrency](http://ember-concurrency.com) slowly. 

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
