### PR TITLE
fix(1891): Correctly handle the startsWith of the version

### DIFF
--- a/app/commands/detail/route.js
+++ b/app/commands/detail/route.js
@@ -15,7 +15,9 @@ export default Route.extend({
       let version;
 
       if (params.version) {
-        const versionExists = verPayload.filter(t => t.version.startsWith(params.version));
+        const versionExists = verPayload.filter(t =>
+          t.version.concat('.').startsWith(params.version.concat('.'))
+        );
         const tagExists = tagPayload.filter(c => c.tag === params.version);
 
         if (tagExists.length === 0 && versionExists.length === 0) {

--- a/app/templates/detail/route.js
+++ b/app/templates/detail/route.js
@@ -11,7 +11,9 @@ export default Route.extend({
     let version;
 
     if (pVersion) {
-      const versionExists = verPayload.filter(t => t.version.startsWith(pVersion));
+      const versionExists = verPayload.filter(t =>
+        t.version.concat('.').startsWith(pVersion.concat('.'))
+      );
       const tagExists = tagPayload.filter(t => t.tag === pVersion);
 
       if (tagExists.length === 0 && versionExists.length === 0) {

--- a/tests/unit/commands/detail/router-test.js
+++ b/tests/unit/commands/detail/router-test.js
@@ -7,7 +7,7 @@ import sinonTest from 'ember-sinon-qunit/test-support/test';
 const commandServiceStub = Service.extend({
   getOneCommand(namespace, name) {
     return resolve([
-      { id: 4, namespace, name, version: '3.0.0' },
+      { id: 4, namespace, name, version: '10.0.0' },
       { id: 3, namespace, name, version: '2.0.0' },
       { id: 2, namespace, name, version: '1.1.0' },
       { id: 1, namespace, name, version: '1.0.0' }
@@ -15,7 +15,7 @@ const commandServiceStub = Service.extend({
   },
   getCommandTags(namespace, name) {
     return resolve([
-      { id: 4, namespace, name, version: '3.0.0', tag: 'latest' },
+      { id: 4, namespace, name, version: '10.0.0', tag: 'latest' },
       { id: 3, namespace, name, version: '2.0.0', tag: 'stable' },
       { id: 2, namespace, name, version: '1.1.0' },
       { id: 1, namespace, name, version: '1.0.0' }

--- a/tests/unit/templates/detail/route-test.js
+++ b/tests/unit/templates/detail/route-test.js
@@ -7,11 +7,11 @@ import sinonTest from 'ember-sinon-qunit/test-support/test';
 const templateServiceStub = Service.extend({
   getOneTemplate() {
     return resolve([
-      { id: 4, name: 'baz', version: '3.0.0', namespace: 'foo' },
+      { id: 4, name: 'baz', version: '10.0.0', namespace: 'foo' },
       { id: 3, name: 'baz', version: '2.0.0', namespace: 'foo' },
       { id: 2, name: 'baz', version: '1.1.0', namespace: 'foo' },
       { id: 1, name: 'baz', version: '1.0.0', namespace: 'foo' },
-      { id: 7, name: 'baz', version: '3.0.0', namespace: 'bar' },
+      { id: 7, name: 'baz', version: '10.0.0', namespace: 'bar' },
       { id: 6, name: 'baz', version: '2.0.0', namespace: 'bar' },
       { id: 5, name: 'baz', version: '1.0.0', namespace: 'bar' }
     ]);
@@ -21,7 +21,7 @@ const templateServiceStub = Service.extend({
       {
         id: 4,
         name: 'baz',
-        version: '3.0.0',
+        version: '10.0.0',
         namespace: 'foo',
         metrics: { jobs: { count: 1 }, builds: { count: 3 } }
       },
@@ -49,8 +49,8 @@ const templateServiceStub = Service.extend({
       {
         id: 7,
         name: 'baz',
-        version: '3.0.0',
-        namespace: 'foo',
+        version: '10.0.0',
+        namespace: 'bar',
         metrics: { jobs: { count: 7 }, builds: { count: 7 } }
       },
       {
@@ -71,8 +71,8 @@ const templateServiceStub = Service.extend({
   },
   getTemplateTags(namespace, name) {
     return resolve([
-      { id: 5, name, version: '3.0.0', tag: 'latest' },
-      { id: 6, name, version: '3.0.0', tag: 'stable' },
+      { id: 5, name, version: '10.0.0', tag: 'latest' },
+      { id: 6, name, version: '10.0.0', tag: 'stable' },
       { id: 7, name, version: '2.0.0', tag: 'meeseeks' }
     ]);
   }
@@ -100,7 +100,7 @@ module('Unit | Route | templates/detail', function(hooks) {
     );
 
     return route.model({ namespace: 'foo', name: 'baz' }).then(templates => {
-      assert.equal(templates.templateData.length, 5);
+      assert.equal(templates.templateData.length, 4);
       assert.equal(templates.templateData[0].namespace, 'foo');
       assert.equal(templates.templateData[0].name, 'baz');
       assert.equal(templates.versionOrTagFromUrl, undefined);
@@ -123,7 +123,7 @@ module('Unit | Route | templates/detail', function(hooks) {
     );
 
     return route.model({ namespace: 'foo', name: 'baz', version: '1.0.0' }).then(templates => {
-      assert.equal(templates.templateData.length, 5);
+      assert.equal(templates.templateData.length, 4);
       assert.equal(templates.templateData[0].namespace, 'foo');
       assert.equal(templates.templateData[0].name, 'baz');
       assert.equal(templates.versionOrTagFromUrl, '1.0.0');
@@ -138,7 +138,7 @@ module('Unit | Route | templates/detail', function(hooks) {
     assert.ok(route);
 
     return route.model({ namespace: 'foo', name: 'baz', version: '1' }).then(templates => {
-      assert.equal(templates.templateData.length, 5);
+      assert.equal(templates.templateData.length, 4);
       assert.equal(templates.templateData[0].namespace, 'foo');
       assert.equal(templates.templateData[0].name, 'baz');
       assert.equal(templates.versionOrTagFromUrl, '1.1.0');
@@ -161,12 +161,12 @@ module('Unit | Route | templates/detail', function(hooks) {
     );
 
     return route.model({ namespace: 'foo', name: 'baz', version: 'stable' }).then(templates => {
-      assert.equal(templates.templateData.length, 5);
+      assert.equal(templates.templateData.length, 4);
       assert.equal(templates.templateData[0].namespace, 'foo');
       assert.equal(templates.templateData[0].name, 'baz');
       assert.equal(templates.versionOrTagFromUrl, 'stable');
-      assert.equal(templates.templateData[4].metrics.jobs.count, 7);
-      assert.equal(templates.templateData[4].metrics.builds.count, 7);
+      assert.equal(templates.templateData[3].metrics.jobs.count, 0);
+      assert.equal(templates.templateData[3].metrics.builds.count, 0);
     });
   });
 


### PR DESCRIPTION
## Objective
This PR modifies the following issue.
https://github.com/screwdriver-cd/screwdriver/issues/1891

Modify the API as shown below. Correct the UI to the same behavior.
https://github.com/screwdriver-cd/models/pull/439

About the order in which to merge the API and UI, there is no dependency.

## References
https://github.com/screwdriver-cd/screwdriver/issues/1891

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
