### PR TITLE
fix: correctly format utc time

### DIFF
--- a/app/components/build-log/template.hbs
+++ b/app/components/build-log/template.hbs
@@ -39,7 +39,7 @@
           {{#if (eq timeFormat "datetime")}}
             {{moment-format log.t "HH:mm:ss"}}
           {{else if (eq timeFormat "datetimeUTC")}}
-            {{moment-format log.t "HH:mm:ss" timeZone="UTC"}}
+            {{moment-format (utc log.t) "HH:mm:ss"}}
           {{else if (eq timeFormat "elapsedBuild")}}
             {{x-duration buildStartTime log.t precision="seconds"}}
           {{else if (eq timeFormat "elapsedStep")}}


### PR DESCRIPTION
## Context

https://github.com/screwdriver-cd/ui/pull/519 attempted to add utc time as a new format but it didn't actually work (time was still formatted in local format). This fixes that.

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
