### PR TITLE
fix(1977): The pipeline admin deletes template/command

### DIFF
--- a/app/components/command-header/template.hbs
+++ b/app/components/command-header/template.hbs
@@ -6,8 +6,8 @@
   {{else}}
     {{fa-icon "code-fork" title="The pipeline for this command does not exist."}}
   {{/if}}
+  <a href="#" {{action "setCommandToRemove" command}} class="remove">{{fa-icon "trash" title="Delete command"}}</a>
   {{#if isAdmin}}
-    <a href="#" {{action "setCommandToRemove" command}} class="remove">{{fa-icon "trash" title="Delete command"}}</a>
     {{x-toggle
       size="medium"
       theme="light"
@@ -17,8 +17,6 @@
       onLabel="Trust?"
       onToggle=(action "updateTrust" command.namespace command.name)
     }}
-  {{else}}
-    {{fa-icon "trash" title="Cannot delete command; pipeline could not be found."}}
   {{/if}}
 </h1>
 <h2>{{command.version}}</h2>

--- a/app/components/command-header/template.hbs
+++ b/app/components/command-header/template.hbs
@@ -6,8 +6,8 @@
   {{else}}
     {{fa-icon "code-fork" title="The pipeline for this command does not exist."}}
   {{/if}}
-  <a href="#" {{action "setCommandToRemove" command}} class="remove">{{fa-icon "trash" title="Delete command"}}</a>
   {{#if isAdmin}}
+    <a href="#" {{action "setCommandToRemove" command}} class="remove">{{fa-icon "trash" title="Delete command"}}</a>
     {{x-toggle
       size="medium"
       theme="light"
@@ -17,6 +17,12 @@
       onLabel="Trust?"
       onToggle=(action "updateTrust" command.namespace command.name)
     }}
+  {{else}}
+    {{#if scmUrl}}
+      <a href="#" {{action "setCommandToRemove" command}} class="remove">{{fa-icon "trash" title="Delete command"}}</a>
+    {{else}}
+      {{fa-icon "trash" title="Cannot delete command; pipeline could not be found."}}
+    {{/if}}
   {{/if}}
 </h1>
 <h2>{{command.version}}</h2>

--- a/app/components/template-header/template.hbs
+++ b/app/components/template-header/template.hbs
@@ -6,8 +6,8 @@
   {{else}}
     {{fa-icon "code-fork" title="The pipeline for this template does not exist."}}
   {{/if}}
+  <a href="#" {{action "setTemplateToRemove" template}} class="remove">{{fa-icon "trash" title="Delete template"}}</a>
   {{#if isAdmin}}
-    <a href="#" {{action "setTemplateToRemove" template}} class="remove">{{fa-icon "trash" title="Delete template"}}</a>
     {{x-toggle
       size="medium"
       theme="light"
@@ -17,8 +17,6 @@
       onLabel="Trust?"
       onToggle=(action "updateTrust" template.fullName)
     }}
-  {{else}}
-    {{fa-icon "trash" title="Cannot delete template; pipeline could not be found."}}
   {{/if}}
 </h1>
 <div class="template-stats">

--- a/app/components/template-header/template.hbs
+++ b/app/components/template-header/template.hbs
@@ -6,8 +6,8 @@
   {{else}}
     {{fa-icon "code-fork" title="The pipeline for this template does not exist."}}
   {{/if}}
-  <a href="#" {{action "setTemplateToRemove" template}} class="remove">{{fa-icon "trash" title="Delete template"}}</a>
   {{#if isAdmin}}
+    <a href="#" {{action "setTemplateToRemove" template}} class="remove">{{fa-icon "trash" title="Delete template"}}</a>
     {{x-toggle
       size="medium"
       theme="light"
@@ -17,6 +17,12 @@
       onLabel="Trust?"
       onToggle=(action "updateTrust" template.fullName)
     }}
+  {{else}}
+    {{#if scmUrl}}
+      <a href="#" {{action "setTemplateToRemove" template}} class="remove">{{fa-icon "trash" title="Delete template"}}</a>
+    {{else}}
+      {{fa-icon "trash" title="Cannot delete template; pipeline could not be found."}}
+    {{/if}}
   {{/if}}
 </h1>
 <div class="template-stats">


### PR DESCRIPTION
## Context
I fix [issue](https://github.com/screwdriver-cd/screwdriver/issues/1977).
Currently, template / command can only be deleted by cluster admin.
It is inconvenient because the admin of the template/command cannot be deleted.
Therefore, I modify it so that the pipeline admin can  be deleted.

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
Modify non-cluster admins can click on the trash icon.
If anyone other than the cluster admin and the pipeline admin tries to delete, an err message will be displayed.

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/screwdriver/issues/1977
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
