### PR TITLE
feat: add Onboarding Guide

### DIFF
--- a/app/components/pipeline-create-form/styles.scss
+++ b/app/components/pipeline-create-form/styles.scss
@@ -104,3 +104,17 @@
     }
   }
 }
+
+.normal-weight {
+  font-weight: normal;
+}
+
+.templates-dropdown {
+  width: 50%;
+}
+
+#template-validate-results {
+  position: absolute;
+  left: 50%;
+  width: 85%;
+}

--- a/app/components/pipeline-create-form/template.hbs
+++ b/app/components/pipeline-create-form/template.hbs
@@ -1,7 +1,14 @@
 {{info-message message=errorMessage type="warning" icon="exclamation-triangle"}}
 
+
 <h1>Create Pipeline</h1>
-<p>Add a Git repository to Screwdriver by pasting your repository link below.<br>We accept both HTTPS and SSH URLs.</p>
+<div class="row">
+  <div class="col-xs-12 col-md-6">
+    <p>Add a Git repository to Screwdriver by pasting your repository link below.<br>We accept both HTTPS and SSH URLs.</p>
+  </div>
+  <div id="template-validate-results"></div>
+</div>
+
 <div>
   {{input
     class="text-input scm-url"
@@ -17,6 +24,53 @@
 <div>
   {{pipeline-rootdir hasRootDir=false updateRootDir=(action "updateRootDir")}}
 </div>
+
+<div>
+  {{input type="checkbox" checked=overrideScrewdriverYaml}}
+  <label class="normal-weight">
+    Create <span class="select-screwdriver-yaml">Screwdriver.yaml {{fa-icon "question-circle"}}
+    </span>
+  </label>
+
+  <div>
+  {{#if overrideScrewdriverYaml}}
+    <label class="normal-weight">Select from a
+      <span class="select-template">template {{fa-icon "question-circle"}}</span>
+    </label>
+
+    <div class="templates-dropdown">
+    {{#power-select
+      options=templates
+      selected=selectedTemplate
+      onchange=(action "selectTemplate")
+      searchField='name'
+      as |template| }}
+      {{template.name}}
+    {{/power-select}}
+    </div>
+
+    {{#if selectedTemplate}}
+      <div class="row">
+        <div class="col-xs-12 col-md-6">
+          {{validator-input yaml=(mut yaml)}}
+        </div>
+        {{#ember-wormhole to="template-validate-results"}}
+          <div class="col-xs-12 col-md-6">
+            {{validator-results results=results}}
+          </div>
+        {{/ember-wormhole}}
+      </div>
+    {{/if}}
+
+    <div class="tooltips">
+      {{#bs-tooltip placement="right" triggerElement=".select-template" renderInPlace=true delayHide="1000"}}
+        What are <a href="https://docs.screwdriver.cd/user-guide/templates">templates</a>?
+      {{/bs-tooltip}}
+    </div>
+  {{/if}}
+  </div>
+</div>
+
 <div>
   <button {{action "saveData"}} disabled={{isDisabled}} class="blue-button{{if isSaving " saving"}}">
     <div class="saving-loading">
@@ -25,4 +79,11 @@
     <div class="button-label">Create Pipeline</div>
   </button>
   {{#if isSaving}}{{fa-icon "spinner" spin=true}}{{/if}}
+</div>
+
+<div class="tooltips">
+  {{#bs-tooltip placement="right" triggerElement=".select-screwdriver-yaml" renderInPlace=true
+  delayHide="1000"}}
+    What is <a href="https://docs.screwdriver.cd/user-guide/configuration/">screwdriver.yaml</a>
+  {{/bs-tooltip}}
 </div>

--- a/app/components/pipeline-create-form/template.hbs
+++ b/app/components/pipeline-create-form/template.hbs
@@ -26,48 +26,43 @@
 </div>
 
 <div>
-  {{input type="checkbox" checked=overrideScrewdriverYaml}}
-  <label class="normal-weight">
-    Create <span class="select-screwdriver-yaml">Screwdriver.yaml {{fa-icon "question-circle"}}
-    </span>
-  </label>
+  {{input class="create-screwdriver-yaml" type="checkbox" checked=overrideScrewdriverYaml}}
+  <label class="normal-weight">Create <span class="select-screwdriver-yaml">Screwdriver.yaml {{fa-icon "question-circle"}}</span></label>
 
   <div>
-  {{#if overrideScrewdriverYaml}}
-    <label class="normal-weight">Select from a
-      <span class="select-template">template {{fa-icon "question-circle"}}</span>
-    </label>
+    {{#if overrideScrewdriverYaml}}
+      <label class="normal-weight">Select from a <span class="select-template">template {{fa-icon "question-circle"}}</span></label>
 
-    <div class="templates-dropdown">
-    {{#power-select
-      options=templates
-      selected=selectedTemplate
-      onchange=(action "selectTemplate")
-      searchField='name'
-      as |template| }}
-      {{template.name}}
-    {{/power-select}}
-    </div>
+      <div class="templates-dropdown">
+        {{#power-select
+          options=templates
+          selected=selectedTemplate
+          onchange=(action "selectTemplate")
+          searchField="name"
+          as |template| }}
+          {{template.name}}
+        {{/power-select}}
+      </div>
 
-    {{#if selectedTemplate}}
-      <div class="row">
-        <div class="col-xs-12 col-md-6">
-          {{validator-input yaml=(mut yaml)}}
-        </div>
-        {{#ember-wormhole to="template-validate-results"}}
+      {{#if selectedTemplate}}
+        <div class="row">
           <div class="col-xs-12 col-md-6">
-            {{validator-results results=results}}
+            {{validator-input yaml=(mut yaml)}}
           </div>
-        {{/ember-wormhole}}
+          {{#ember-wormhole to="template-validate-results"}}
+            <div class="col-xs-12 col-md-6">
+              {{validator-results results=results}}
+            </div>
+          {{/ember-wormhole}}
+        </div>
+      {{/if}}
+
+      <div class="tooltips">
+        {{#bs-tooltip placement="right" triggerElement=".select-template" renderInPlace=true delayHide="1000"}}
+          What are <a href="https://docs.screwdriver.cd/user-guide/templates">templates</a>?
+        {{/bs-tooltip}}
       </div>
     {{/if}}
-
-    <div class="tooltips">
-      {{#bs-tooltip placement="right" triggerElement=".select-template" renderInPlace=true delayHide="1000"}}
-        What are <a href="https://docs.screwdriver.cd/user-guide/templates">templates</a>?
-      {{/bs-tooltip}}
-    </div>
-  {{/if}}
   </div>
 </div>
 

--- a/app/components/quickstart-guide/component.js
+++ b/app/components/quickstart-guide/component.js
@@ -1,0 +1,15 @@
+import Component from '@ember/component';
+
+export default Component.extend({
+  isOpen: false,
+
+  actions: {
+    closeMenu() {
+      this.set('isOpen', false);
+    },
+
+    openMenu() {
+      this.set('isOpen', true);
+    }
+  }
+});

--- a/app/components/quickstart-guide/styles.scss
+++ b/app/components/quickstart-guide/styles.scss
@@ -75,16 +75,26 @@
 
         .section {
           display: flex;
-          flex-direction: column;
+          flex-direction: row;
           width: 100%;
         }
       }
     }
 
-    .header > .item > .section > .title,
-    .close-quickstart-guide {
+    .header > .item > .section > .title {
       width: 100%;
       font-size: 28px;
+      display: flex;
+
+      .text {
+        display: flex;
+      }
+
+      .close-quickstart-guide {
+        display: flex;
+        margin-left: auto;
+        margin-right: 10%;
+      }
     }
 
     .footer {

--- a/app/components/quickstart-guide/styles.scss
+++ b/app/components/quickstart-guide/styles.scss
@@ -1,0 +1,110 @@
+& {
+  .quickstart-guide-menu {
+    position: fixed;
+    color: #303030;
+    top: 60px;
+    right: 0;
+
+    .mini-menu-oval {
+      width: 36px;
+      height: 36px;
+      color: white;
+      background-color: #303030;
+      border-radius: 50%;
+      margin-right: -16px;
+
+      .mini-menu {
+        font-size: 16px;
+        top: 8px;
+        position: relative;
+        left: 5px;
+      }
+    }
+  }
+
+  .quickstart-guide {
+    position: fixed;
+    color: white;
+    background-color: #303030;
+
+    // cover header
+    // top: 0;
+    // does not cover header
+    top: 52px;
+
+    right: 0;
+    width: 33%;
+    height: 100%;
+
+    display: flex;
+    flex-direction: column;
+
+    &.menu-open {
+      transform: translate3d(0, 0, 0);
+      transition: all 0.5s ease 0s;
+    }
+
+    &.menu-close {
+      transform: translate3d(100%, 0px, 0px);
+      transition: all 0.5s ease 0s;
+    }
+
+    .header,
+    .content,
+    .footer {
+      display: flex;
+      flex-direction: column;
+      padding-bottom: 20px;
+
+      .item {
+        display: flex;
+        flex-direction: row;
+        order: 0;
+        flex: 0 1 auto;
+        align-self: auto;
+        align-items: center;
+        padding-bottom: 10px;
+
+        .icon {
+          display: flex;
+          width: 26px;
+          font-size: 26px;
+          margin-left: 14px;
+          margin-right: 14px;
+        }
+
+        .section {
+          display: flex;
+          flex-direction: column;
+          width: 100%;
+        }
+      }
+    }
+
+    .header > .item > .section > .title,
+    .close-quickstart-guide {
+      width: 100%;
+      font-size: 28px;
+    }
+
+    .footer {
+      align-items: center;
+      > .quickstart-doc-button {
+        display: flex;
+        background-color: #303030;
+        border-color: $sd-light-blue;
+        padding-top: 9px;
+        padding-bottom: 9px;
+        justify-content: center;
+        align-items: center;
+
+        width: 80%;
+
+        > span {
+          display: flex;
+          padding-right: 5px;
+        }
+      }
+    }
+  }
+}

--- a/app/components/quickstart-guide/styles.scss
+++ b/app/components/quickstart-guide/styles.scss
@@ -62,12 +62,14 @@
         order: 0;
         flex: 0 1 auto;
         align-self: auto;
-        align-items: center;
+        // enable to align in the middle
+        // align-items: center;
         padding-bottom: 10px;
 
         .icon {
           display: flex;
           width: 26px;
+          height: 20px;
           font-size: 26px;
           margin-left: 14px;
           margin-right: 14px;
@@ -77,6 +79,26 @@
           display: flex;
           flex-direction: row;
           width: 100%;
+
+          & > p {
+            .command-section {
+              background-color: #606060;
+              padding: 10px;
+
+              .command {
+                color: #c66a15;
+              }
+
+              .subcommand {
+                color: #72a526;
+              }
+
+              .argument {
+                color: #8ac5ed;
+                line-height: 1.85;
+              }
+            }
+          }
         }
       }
     }

--- a/app/components/quickstart-guide/template.hbs
+++ b/app/components/quickstart-guide/template.hbs
@@ -1,0 +1,79 @@
+{{#unless isOpen}}
+  <div class="quickstart-guide-menu" onclick={{action "openMenu"}}>
+    <div class="mini-menu-oval">
+      <div class="mini-menu">
+        {{fa-icon "power-off"}}
+      </div>
+    </div>
+  </div>
+{{/unless}}
+
+<div class="quickstart-guide {{if isOpen "menu-open" "menu-close"}}">
+  <div class="header">
+    <div class="item">
+      <div class="icon">
+        {{fa-icon "sign-in"}}
+      </div>
+      <div class="section">
+        <span class="title">Quickstart Guide</span>
+        <span class="close-quickstart-guide"
+            onclick={{action "closeMenu"}}>×</span>
+      </div>
+    </div>
+
+    <div class="item">
+      <div class="icon"></div>
+      <div class="section">
+        <span>This will cover how to build and deploy a sample app with Screwdriver</span>
+      </div>
+    </div>
+  </div>
+
+  <div class="content">
+    <div class="item">
+      <div class="icon">
+         <span class="badge">1</span>
+      </div>
+      <div class="section">
+        <span>Click on Create icon</span>
+      </div>
+    </div>
+
+    <div class="item">
+      <div class="icon">
+        <span class="badge">2</span>
+      </div>
+      <div class="section">
+        <span>Enter your repository link into the filed
+        </span>
+      </div>
+    </div>
+
+    <div class="item">
+      <div class="icon"></div>
+      <div class="section">
+        <p>
+          git clone git@github.com:screwdriver-cd/ui.git
+        </p>
+      </div>
+    </div>
+
+    <div class="item">
+      <div class="icon">
+        <span class="badge">3</span>
+      </div>
+      <div class="section">
+        <span>Now that you've created a pipeline. You should directed to your own pipeline page</span>
+      </div>
+    </div>
+
+  </div>
+
+  <div class="footer">
+    <button type="button" class="quickstart-doc-button">
+      <span>QuickStart Documentation</span>
+      {{fa-icon "share-square-o"}}
+    </button>
+  </div>
+
+</div>

--- a/app/components/quickstart-guide/template.hbs
+++ b/app/components/quickstart-guide/template.hbs
@@ -12,12 +12,14 @@
   <div class="header">
     <div class="item">
       <div class="icon">
-        {{fa-icon "sign-in"}}
+        {{fa-icon "power-off"}}
       </div>
       <div class="section">
-        <span class="title">Quickstart Guide</span>
+        <span class="title">
+          <span class="text">Quickstart Guide</span>
         <span class="close-quickstart-guide"
-            onclick={{action "closeMenu"}}>×</span>
+          onclick={{action "closeMenu"}}>×</span>
+        </span>
       </div>
     </div>
 

--- a/app/components/quickstart-guide/template.hbs
+++ b/app/components/quickstart-guide/template.hbs
@@ -17,8 +17,7 @@
       <div class="section">
         <span class="title">
           <span class="text">Quickstart Guide</span>
-        <span class="close-quickstart-guide"
-          onclick={{action "closeMenu"}}>×</span>
+          <span class="close-quickstart-guide" onclick={{action "closeMenu"}}>×</span>
         </span>
       </div>
     </div>
@@ -34,7 +33,7 @@
   <div class="content">
     <div class="item">
       <div class="icon">
-         <span class="badge">1</span>
+        <span class="badge">1</span>
       </div>
       <div class="section">
         <span>Click on the Create icon. (You will be redirected to login if you have not already.)</span>

--- a/app/components/quickstart-guide/template.hbs
+++ b/app/components/quickstart-guide/template.hbs
@@ -37,7 +37,7 @@
          <span class="badge">1</span>
       </div>
       <div class="section">
-        <span>Click on Create icon</span>
+        <span>Click on the Create icon. (You will be redirected to login if you have not already.)</span>
       </div>
     </div>
 
@@ -46,8 +46,7 @@
         <span class="badge">2</span>
       </div>
       <div class="section">
-        <span>Enter your repository link into the filed
-        </span>
+        <span>Enter your repository link into the field. SSH or HTTPS link is fine, with #&lt;YOUR_BRANCH_NAME&gt; immediately after.</span>
       </div>
     </div>
 
@@ -55,8 +54,21 @@
       <div class="icon"></div>
       <div class="section">
         <p>
-          git clone git@github.com:screwdriver-cd/ui.git
+          <div class="command-section">
+            <div>
+              <span class="argument">
+                git clone git@github.com:screwdriver-cd/ui.git
+              </span>
+            </div>
+          </div>
         </p>
+      </div>
+    </div>
+
+    <div class="item">
+      <div class="icon"></div>
+      <div class="section">
+        <span>If no BRANCH_NAME is provided, it will default to the master branch. Click Use this repository to confirm and then click Create Pipeline.</span>
       </div>
     </div>
 
@@ -65,9 +77,33 @@
         <span class="badge">3</span>
       </div>
       <div class="section">
-        <span>Now that you've created a pipeline. You should directed to your own pipeline page</span>
+        <span>Now that you’ve created a pipeline, you should be directed to your new pipeline page. Click the Start button to start your build.</span>
       </div>
     </div>
+
+    <div class="item">
+      <div class="icon"></div>
+      <div class="section">
+        <p>
+          <div>
+            <div class="command-section">
+              <div>
+                <span>$</span>
+                <span class="command">git</span>
+                <span class="subcommand">clone</span>
+                <span class="argument">git@github.com:&lt;YOUR_USERNAME_HERE&gt;/quickstart-generic.git</span>
+              </div>
+              <div>
+                <span>$</span>
+                <span class="command">cd</span>
+                <span class="subcommand">quickstart-generic/</span>
+              </div>
+            </div>
+          </div>
+        </p>
+      </div>
+    </div>
+
 
   </div>
 

--- a/app/create/controller.js
+++ b/app/create/controller.js
@@ -5,7 +5,8 @@ import Controller from '@ember/controller';
 export default Controller.extend({
   isSaving: false,
   errorMessage: '',
-
+  // showQuickStartGuide: true,
+  showQuickStartGuide: false,
   actions: {
     createPipeline({ scmUrl, rootDir }) {
       let payload = { checkoutUrl: scmUrl, rootDir };

--- a/app/create/controller.js
+++ b/app/create/controller.js
@@ -5,8 +5,8 @@ import Controller from '@ember/controller';
 export default Controller.extend({
   isSaving: false,
   errorMessage: '',
-  // showQuickStartGuide: true,
   showQuickStartGuide: false,
+  templates: [],
   actions: {
     createPipeline({ scmUrl, rootDir }) {
       let payload = { checkoutUrl: scmUrl, rootDir };

--- a/app/create/route.js
+++ b/app/create/route.js
@@ -1,7 +1,23 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+import { hash } from 'rsvp';
 
 export default Route.extend(AuthenticatedRouteMixin, {
   titleToken: 'Create Pipeline',
-  routeAfterAuthentication: 'create'
+  routeAfterAuthentication: 'create',
+  shuttle: service(),
+
+  model() {
+    return hash({
+      templates: this.shuttle.fetchAllTemplates()
+    });
+  },
+
+  setupController(controller, model) {
+    this._super(...arguments);
+    const trustedTemplates = model.templates.filter(t => t.trusted === true);
+
+    controller.set('templates', trustedTemplates);
+  }
 });

--- a/app/create/template.hbs
+++ b/app/create/template.hbs
@@ -3,4 +3,10 @@
   errorMessage=errorMessage
   onCreatePipeline=(action "createPipeline")
 }}
+
+
+{{quickstart-guide
+  isOpen=showQuickStartGuide}}
+
+
 {{outlet}}

--- a/app/create/template.hbs
+++ b/app/create/template.hbs
@@ -2,11 +2,10 @@
   isSaving=isSaving
   errorMessage=errorMessage
   onCreatePipeline=(action "createPipeline")
+  templates=templates
 }}
-
 
 {{quickstart-guide
   isOpen=showQuickStartGuide}}
-
 
 {{outlet}}

--- a/app/shuttle/service.js
+++ b/app/shuttle/service.js
@@ -52,6 +52,10 @@ export default Service.extend({
       requestType = 'raw';
     }
 
+    if (requestType === 'get') {
+      requestType = 'request';
+    }
+
     const uri = `${baseHost}${url}`;
 
     const options = Object.assign({}, this.ajaxOptions(), {
@@ -77,5 +81,13 @@ export default Service.extend({
     const raw = true;
 
     return this.fetchFromApi(method, url, data, raw);
+  },
+
+  fetchAllTemplates() {
+    const method = 'get';
+    const url = `/templates`;
+    const data = { sortBy: 'createTime', sort: 'descending', compact: true };
+
+    return this.fetchFromApi(method, url, data);
   }
 });

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -171,3 +171,5 @@ body {
   font-family: Helvetica, Arial, sans-serif;
   font-weight: $weight-normal;
 }
+
+@import 'ember-power-select';

--- a/app/validator/controller.js
+++ b/app/validator/controller.js
@@ -36,3 +36,5 @@ export default Controller.extend({
     debounce(this, getResults, 250);
   })
 });
+
+export { getResults };

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-modal-dialog": "^3.0.0-beta.4",
     "ember-moment": "^7.8.1",
+    "ember-power-select": "^2.3.4",
     "ember-promise-helpers": "^1.0.9",
     "ember-qunit": "^4.5.1",
     "ember-resolver": "^5.3.0",

--- a/tests/acceptance/create-page-test.js
+++ b/tests/acceptance/create-page-test.js
@@ -69,6 +69,10 @@ module('Acceptance | create', function(hooks) {
       JSON.stringify([])
     ]);
 
+    server.get('http://localhost:8080/v4/templates', () => {
+      return [200, { 'Content-Type': 'application/json' }, JSON.stringify([])];
+    });
+
     await authenticateSession({ token: 'faketoken' });
     await visit('/create');
 
@@ -120,6 +124,10 @@ module('Acceptance | create', function(hooks) {
       JSON.stringify([])
     ]);
 
+    server.get('http://localhost:8080/v4/templates', () => {
+      return [200, { 'Content-Type': 'application/json' }, JSON.stringify([])];
+    });
+
     await authenticateSession({ token: 'faketoken' });
     await visit('/create');
 
@@ -142,6 +150,9 @@ module('Acceptance | create', function(hooks) {
         message: 'something conflicting'
       })
     ]);
+    server.get('http://localhost:8080/v4/templates', () => {
+      return [200, { 'Content-Type': 'application/json' }, JSON.stringify([])];
+    });
 
     await authenticateSession({ token: 'faketoken' });
     await visit('/create');
@@ -152,5 +163,64 @@ module('Acceptance | create', function(hooks) {
     await click('button.blue-button');
     assert.equal(currentURL(), '/create');
     assert.dom('.alert > span').hasText('something conflicting');
+  });
+
+  test('Create Screwdriver.yaml', async function(assert) {
+    server.post('http://localhost:8080/v4/pipelines', () => [
+      409,
+      { 'Content-Type': 'application/json' },
+      JSON.stringify({
+        statusCode: 409,
+        error: 'Conflict',
+        message: 'something conflicting'
+      })
+    ]);
+
+    server.get('http://localhost:8080/v4/templates', () => {
+      return [200, { 'Content-Type': 'application/json' }, JSON.stringify([])];
+    });
+
+    await authenticateSession({ token: 'faketoken' });
+    await visit('/create');
+
+    await fillIn('.text-input', 'git@github.com:foo/bar.git');
+    await triggerEvent('.text-input', 'keyup');
+    await click('input.create-screwdriver-yaml');
+
+    assert.dom('.select-template').hasText('template');
+    assert.dom('.templates-dropdown').exists();
+    assert.dom('.ace_editor').exists();
+    assert.dom('#template-validate-results').exists();
+  });
+
+  test('Quick start guide', async function(assert) {
+    server.post('http://localhost:8080/v4/pipelines', () => [
+      409,
+      { 'Content-Type': 'application/json' },
+      JSON.stringify({
+        statusCode: 409,
+        error: 'Conflict',
+        message: 'something conflicting'
+      })
+    ]);
+
+    server.get('http://localhost:8080/v4/templates', () => {
+      return [200, { 'Content-Type': 'application/json' }, JSON.stringify([])];
+    });
+
+    await authenticateSession({ token: 'faketoken' });
+    await visit('/create');
+    await fillIn('.text-input', 'git@github.com:foo/bar.git');
+    await triggerEvent('.text-input', 'keyup');
+
+    // default toggle button is closed
+    assert.dom('.quickstart-guide-menu').exists();
+    assert.dom('.quickstart-guide.menu-open').doesNotExist();
+    assert.dom('.quickstart-guide.menu-close').exists();
+
+    await click('.quickstart-guide-menu');
+    // after click toggle-button, menu now is open
+    assert.dom('.quickstart-guide.menu-open').exists();
+    assert.dom('.quickstart-guide.menu-close').doesNotExist();
   });
 });

--- a/tests/integration/components/quickstart-guide/component-test.js
+++ b/tests/integration/components/quickstart-guide/component-test.js
@@ -1,0 +1,23 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | quickstart-guide', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders open', async function(assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`{{quickstart-guide isOpen=true}}`);
+    assert.dom('.quickstart-guide.menu-open').exists();
+    assert.dom('.quickstart-guide.menu-close').doesNotExist();
+  });
+
+  test('it renders close', async function(assert) {
+    await render(hbs`{{quickstart-guide isOpen=false}}`);
+    assert.dom('.quickstart-guide.menu-open').doesNotExist();
+    assert.dom('.quickstart-guide.menu-close').exists();
+  });
+});


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Add an quickstart guide on create pipeline page.

After I took a look at 
- https://prismjs.com
- https://craig.is/making/rainbows

I decided its easier to implement the simple color syntax myself.

It supports `command`, `subcommand` `argument`, simple enough :P 


> -- TESTS PENDING --

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Trying to make things easier for both first time users and experienced screwdriver users

Screenshot: 
![image](https://user-images.githubusercontent.com/15989893/77685313-8b1d9b80-6f58-11ea-8e3a-dbf01ce24eda.png)

Gif: 
![2020-03-26_12-05-53 (2)](https://user-images.githubusercontent.com/15989893/77686619-79d58e80-6f5a-11ea-9faa-6948015d234d.gif)

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

Introduced: 
- [Ember power select](https://2-x.ember-power-select.com/docs/how-to-use-it/)

Also took advantage of using: 
- https://yapplabs.github.io/ember-wormhole/

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
