### PR TITLE
fix(1383): Keep selecting the last viewed collection

### DIFF
--- a/app/components/collection-view/component.js
+++ b/app/components/collection-view/component.js
@@ -155,6 +155,10 @@ export default Component.extend({
 
       const getSha = sha => sha.substring(0, 7);
 
+      let viewingId = this.get('collection.id');
+
+      this.session.set('lastViewedCollectionId', viewingId);
+
       if (this.get('collection.pipelines')) {
         return this.get('collection.pipelines').map(pipeline => {
           const scm = scmService.getScm(pipeline.scmContext);

--- a/app/home/route.js
+++ b/app/home/route.js
@@ -18,7 +18,13 @@ export default Route.extend(AuthenticatedRouteMixin, {
             const defaultCollection = collections.find(collection => collection.type === 'default');
             const routeId = defaultCollection.id;
 
-            this.replaceWith(`/dashboards/${routeId}`);
+            let lastViewedCollectionId = get(this, 'session.lastViewedCollectionId');
+
+            if (lastViewedCollectionId) {
+              this.replaceWith(`/dashboards/${lastViewedCollectionId}`);
+            } else {
+              this.replaceWith(`/dashboards/${routeId}`);
+            }
           }
         })
         .catch(() => {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Fixed issue https://github.com/screwdriver-cd/screwdriver/issues/1383

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
This PR is to keep last viewed collection. When a user back to collection screen, the last viewed collection is shown.

The collection id data is deleted if a user reload browser on other screen than collections, and I cannot find the way to keep after reloading. 

However, it might be enough to solve this issue.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/1383

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
