### PR TITLE
fix: fill bottom space.

### DIFF
--- a/app/components/build-log/styles.scss
+++ b/app/components/build-log/styles.scss
@@ -3,6 +3,7 @@
   border-radius: 5px;
   color: $grey-100;
   padding: 0 15px 10px;
+  height: 100%;
 }
 
 .row {

--- a/app/components/build-step-collection/template.hbs
+++ b/app/components/build-step-collection/template.hbs
@@ -90,7 +90,7 @@
       </div>
     {{/bs-tab}}
   </div>
-  <div class="col-xs-9">
+  <div class="col-xs-9 partial-view">
     {{#if (and isArtifacts iframeUrl)}}
       {{artifact-preview iframeUrl=iframeUrl}}
     {{else}}


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Currently, the space under the build log is not constant. It depends on the window size.
<img width="1295" alt="add_space1" src="https://user-images.githubusercontent.com/8113204/77712579-8b30a080-7017-11ea-98a4-4a8c836c06d1.png">
<img width="1680" alt="add_space2" src="https://user-images.githubusercontent.com/8113204/77712591-9257ae80-7017-11ea-807c-a93dfdc8f46c.png">

I fix it to fill the build log to the bottom.

before:
<img width="1680" alt="mosa2" src="https://user-images.githubusercontent.com/8113204/77712839-5244fb80-7018-11ea-94cd-a3a9dc22ee28.png">

after:
<img width="1680" alt="after" src="https://user-images.githubusercontent.com/8113204/77712867-5a04a000-7018-11ea-8d8a-b3695a34b97e.png">


## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Fill the build log to the bottom.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
