### PR TITLE
fix: fix build log display

### DIFF
--- a/app/components/build-log/styles.scss
+++ b/app/components/build-log/styles.scss
@@ -34,7 +34,7 @@
 }
 
 .wrap {
-  height: auto;
+  max-height: 100vh;
   overflow-y: auto;
   transform: translateZ(0);
 }

--- a/app/components/build-log/styles.scss
+++ b/app/components/build-log/styles.scss
@@ -5,6 +5,7 @@
   padding: 0 15px 10px;
   height: 100%;
   display: grid;
+  grid-template-rows: auto 1fr;
 }
 
 .row {

--- a/app/components/build-log/styles.scss
+++ b/app/components/build-log/styles.scss
@@ -4,6 +4,7 @@
   color: $grey-100;
   padding: 0 15px 10px;
   height: 100%;
+  display: grid;
 }
 
 .row {
@@ -32,7 +33,7 @@
 }
 
 .wrap {
-  height: 70vh;
+  height: auto;
   overflow-y: auto;
   transform: translateZ(0);
 }


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Because `.wrap`'s height is `vh70`, bottom space of build log still remain like below.
<img width="1680" alt="bottom_space" src="https://user-images.githubusercontent.com/8113204/77888254-e88e5100-72a6-11ea-9344-203ed7376341.png">

Fill the build log to the bottom.

After:
<img width="1680" alt="after_space" src="https://user-images.githubusercontent.com/8113204/77888502-58044080-72a7-11ea-9e7c-5943b8f3d0ac.png">


## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Fill the build log to the bottom.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
#541 

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
