### PR TITLE
fix(1383): Keep collection ID in localStorage

### DIFF
--- a/app/components/collection-view/component.js
+++ b/app/components/collection-view/component.js
@@ -157,7 +157,7 @@ export default Component.extend({
 
       let viewingId = this.get('collection.id');
 
-      this.session.set('lastViewedCollectionId', viewingId);
+      localStorage.setItem('lastViewedCollectionId', viewingId);
 
       if (this.get('collection.pipelines')) {
         return this.get('collection.pipelines').map(pipeline => {

--- a/app/home/route.js
+++ b/app/home/route.js
@@ -18,7 +18,7 @@ export default Route.extend(AuthenticatedRouteMixin, {
             const defaultCollection = collections.find(collection => collection.type === 'default');
             const routeId = defaultCollection.id;
 
-            let lastViewedCollectionId = get(this, 'session.lastViewedCollectionId');
+            let lastViewedCollectionId = localStorage.getItem('lastViewedCollectionId');
 
             if (lastViewedCollectionId) {
               this.replaceWith(`/dashboards/${lastViewedCollectionId}`);

--- a/tests/acceptance/dashboards-test.js
+++ b/tests/acceptance/dashboards-test.js
@@ -43,6 +43,7 @@ module('Acceptance | dashboards', function(hooks) {
   test('visiting / when logged in and have collections among which the default collection is empty', async function(assert) {
     server.get('http://localhost:8080/v4/collections/1', hasEmptyDefaultCollection);
     await authenticateSession({ token: 'fakeToken' });
+    await visit('/dashboards/1');
     await visit('/');
 
     assert.equal(currentURL(), '/dashboards/1');
@@ -53,6 +54,7 @@ module('Acceptance | dashboards', function(hooks) {
 
   test('visiting / when logged in and have collections among which the default collection is not empty', async function(assert) {
     await authenticateSession({ token: 'fakeToken' });
+    await visit('/dashboards/1');
     await visit('/');
 
     assert.equal(currentURL(), '/dashboards/1');
@@ -120,6 +122,7 @@ module('Acceptance | dashboards', function(hooks) {
     server.get('http://localhost:8080/v4/pipelines', hasPipelines);
 
     await authenticateSession({ token: 'fakeToken' });
+    await visit('/dashboards/1');
     await visit('/');
     // Logged in but no collections, url should be `/`
     assert.equal(currentURL(), '/dashboards/1');

--- a/tests/acceptance/dashboards-test.js
+++ b/tests/acceptance/dashboards-test.js
@@ -43,7 +43,7 @@ module('Acceptance | dashboards', function(hooks) {
   test('visiting / when logged in and have collections among which the default collection is empty', async function(assert) {
     server.get('http://localhost:8080/v4/collections/1', hasEmptyDefaultCollection);
     await authenticateSession({ token: 'fakeToken' });
-    await visit('/dashboards/1');
+    localStorage.setItem('lastViewedCollectionId', 1);
     await visit('/');
 
     assert.equal(currentURL(), '/dashboards/1');
@@ -54,7 +54,7 @@ module('Acceptance | dashboards', function(hooks) {
 
   test('visiting / when logged in and have collections among which the default collection is not empty', async function(assert) {
     await authenticateSession({ token: 'fakeToken' });
-    await visit('/dashboards/1');
+    localStorage.setItem('lastViewedCollectionId', 1);
     await visit('/');
 
     assert.equal(currentURL(), '/dashboards/1');
@@ -122,7 +122,7 @@ module('Acceptance | dashboards', function(hooks) {
     server.get('http://localhost:8080/v4/pipelines', hasPipelines);
 
     await authenticateSession({ token: 'fakeToken' });
-    await visit('/dashboards/1');
+    localStorage.setItem('lastViewedCollectionId', 1);
     await visit('/');
     // Logged in but no collections, url should be `/`
     assert.equal(currentURL(), '/dashboards/1');


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
This PR enhances the PR https://github.com/screwdriver-cd/ui/pull/540

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
The PR https://github.com/screwdriver-cd/ui/pull/540 does not keep collection ID after going through Template/Command detail page. The lifetime is too short to be expected.

Using local storage is effective at these points.
- Keep collection ID when accessing collections page after go through Template/Command detail page
- Keep collection ID even if it was accessed from another tab of the browser

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/1383

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
