### PR TITLE
 fix: Keep collection view type in localStorage

### DIFF
--- a/app/components/collection-view/component.js
+++ b/app/components/collection-view/component.js
@@ -24,7 +24,7 @@ export default Component.extend({
   collection: null,
   metricsMap: [],
   removePipelineError: null,
-  activeViewOptionValue: viewOptions[0].value,
+  activeViewOptionValue: localStorage.getItem('activeViewOptionValue') || viewOptions[0].value,
   viewOptions,
   isOrganizing: false,
   selectedPipelines: [],
@@ -51,6 +51,8 @@ export default Component.extend({
   ),
 
   isListView: computed('activeViewOptionValue', function isListView() {
+    localStorage.setItem('activeViewOptionValue', this.activeViewOptionValue);
+
     return this.activeViewOptionValue === viewOptions[1].value;
   }),
 


### PR DESCRIPTION
## Context
This PR is an additional feature of https://github.com/screwdriver-cd/ui/pull/543.

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective

This PR is to keep last viewed collection type.
Reload the screen to return to the default card type.
Therefore, I modify to Keep collection view type in localStorage.
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
Similar to https://github.com/screwdriver-cd/ui/pull/543
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
