### PR TITLE
fix(2049): redirect to 404 page if pipeline id route does not exist

### DIFF
--- a/app/pipeline/events/route.js
+++ b/app/pipeline/events/route.js
@@ -24,6 +24,8 @@ export default Route.extend({
         count: ENV.APP.NUM_EVENTS_LISTED
       }),
       triggers: this.triggerService.getDownstreamTriggers(this.get('pipeline.id'))
+    }).catch(() => {
+      this.transitionTo('/404');
     });
   },
   actions: {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
PR: https://github.com/screwdriver-cd/screwdriver/issues/2049

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Now this PR will make the following links: 
1) https://cd.screwdriver.cd/pipelines/100000
2) https://cd.screwdriver.cd/pipelines/100000/builds/20000

to be redirected to 404 page

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/1400

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
