### PR TITLE
fix: Reset collectionId cache

### DIFF
--- a/app/components/collections-flyout/component.js
+++ b/app/components/collections-flyout/component.js
@@ -57,6 +57,10 @@ export default Component.extend({
     deleteCollection(collection) {
       const c = this.store.peekRecord('collection', collection.id);
 
+      if (collection.id === localStorage.getItem('lastViewedCollectionId')) {
+        localStorage.removeItem('lastViewedCollectionId');
+      }
+
       return c.destroyRecord().then(() => {
         this.set('collectionToDelete', null);
         c.unloadRecord();

--- a/app/dashboard/show/route.js
+++ b/app/dashboard/show/route.js
@@ -30,6 +30,8 @@ export default Route.extend(AuthenticatedRouteMixin, {
 
   actions: {
     error() {
+      localStorage.removeItem('lastViewedCollectionId');
+
       return this.transitionTo('/404');
     }
   }


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
If user accesses deleted collection URL, deleted collection ID is stored in localstorage.
Then, user accesses home (e.g. `https://mysdhost/`), user redirected to the collection which is stored in localstorage. However, collection collection which is stored in localstorage is already deleted, user redirected to `404` page.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
- Reset localstorage when redirect to `404` page.
- Reset localstorage when deleting collection which is displayed.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
