### PR TITLE
feat(1785): Pass in groupEventId when restarting build [5]

### DIFF
--- a/app/event/model.js
+++ b/app/event/model.js
@@ -17,6 +17,7 @@ export default DS.Model.extend(ModelReloaderMixin, {
   reloadWithoutNewBuilds: DS.attr('number', { defaultValue: 0 }),
   parentBuildId: DS.attr('number'),
   parentEventId: DS.attr('number'),
+  groupEventId: DS.attr('number'),
   pipelineId: DS.attr('string'),
   pr: DS.attr(),
   prNum: DS.attr('number'),

--- a/app/event/serializer.js
+++ b/app/event/serializer.js
@@ -47,6 +47,10 @@ export default DS.RESTSerializer.extend({
       data.parentEventId = parseInt(snapshot.attr('parentEventId'), 10);
     }
 
+    if (snapshot.attr('groupEventId')) {
+      data.groupEventId = parseInt(snapshot.attr('groupEventId'), 10);
+    }
+
     if (snapshot.attr('buildId')) {
       data.buildId = parseInt(snapshot.attr('buildId'), 10);
     }

--- a/app/pipeline/events/controller.js
+++ b/app/pipeline/events/controller.js
@@ -288,6 +288,7 @@ export default Controller.extend(ModelReloaderMixin, {
 
       const event = this.selectedEventObj;
       const parentEventId = get(event, 'id');
+      const groupEventId = get(event, 'groupEventId');
       const pipelineId = get(this, 'pipeline.id');
       const token = get(this, 'session.data.authenticated.token');
       const user = get(decoder(token), 'username');
@@ -310,6 +311,7 @@ export default Controller.extend(ModelReloaderMixin, {
         startFrom,
         parentBuildId,
         parentEventId,
+        groupEventId,
         causeMessage
       };
 


### PR DESCRIPTION
## Context

Need to pass in `groupEventId` when restarting builds and events.

## Objective

This PR adds new field `groupEventId` to event model and passes it in during event create.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/1785

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
