### PR TITLE
fix: unreadable parameter names

### DIFF
--- a/app/styles/screwdriver-modal-styles.scss
+++ b/app/styles/screwdriver-modal-styles.scss
@@ -15,7 +15,7 @@
 }
 
 .detached-confirm-dialog {
-  max-width: 320px;
+  max-width: 80%;
 
   h3 {
     margin: 10px 0;


### PR DESCRIPTION
this changes make clear the original intent of the max-width property on modal dialogs: to not cover the screen from edge to edge, without being too small as it is today to the point of hiding important information.

With the current 320px it will not accommodate most of the content that is normally present on a dialog when there are parameters.

Before:

<img width="401" alt="Screen Shot 2020-05-06 at 12 27 09" src="https://user-images.githubusercontent.com/16908116/81222858-d84e4d80-8f99-11ea-94db-1e99ba4cc411.png">

One of the parameters is called `bucket1` and another `bucket2` i have a retina display with the browser maximized, and still there's no space to know which one is which :(

After this small change the dialog looks like (on the widest possible display, it won't pass this, not even close to the max-width because of other existing constraints):
<img width="710" alt="Screen Shot 2020-05-06 at 12 56 16" src="https://user-images.githubusercontent.com/16908116/81222975-10ee2700-8f9a-11ea-9fd2-69fc95a145a7.png">

and on very small screens (i.e the minimum that would be usable with the old size, 400ish px)
<img width="421" alt="Screen Shot 2020-05-06 at 12 57 54" src="https://user-images.githubusercontent.com/16908116/81223267-97a30400-8f9a-11ea-8095-c2eb4a8bb048.png">

PS: an even better approach would be to remove `float:left` from the input boxes on this modal and the `.start-with-parameters-menu` box, but i'm not too familiar with the ember templating choices used in this project.
This `float:left` removal from input boxes is what already happens on very small screens (as can be seen on last screenshot) and should be the default as it looks better, and more importantly do not hide information, on larger screens too.