### PR TITLE
fix: allow build logs to be viewed full screen

### DIFF
--- a/app/components/build-log/component.js
+++ b/app/components/build-log/component.js
@@ -10,7 +10,8 @@ const timeTypes = ['datetime', 'datetimeUTC', 'elapsedBuild', 'elapsedStep'];
 export default Component.extend({
   logService: service('build-logs'),
   store: service(),
-  classNames: ['build-log'],
+  classNames: ['build-log', 'fullscreen:fullscreen'],
+  fullScreen: false,
   autoscroll: true,
   isFetching: false,
   isDownloading: false,
@@ -406,6 +407,8 @@ export default Component.extend({
       index = index + 1 >= timeTypes.length ? 0 : index + 1;
       localStorage.setItem('screwdriver.logs.timeFormat', timeTypes[index]);
       set(this, 'timeFormat', timeTypes[index]);
-    }
+    },
+    toggleZoom() {
+      set(this, 'fullScreen', !!this.fullScreen);
   }
 });

--- a/app/components/build-log/component.js
+++ b/app/components/build-log/component.js
@@ -1,5 +1,5 @@
 import { Promise } from 'rsvp';
-import { set, getWithDefault, computed, observer } from '@ember/object';
+import { set, getWithDefault, computed, observer, togglerProperty } from '@ember/object';
 import { scheduleOnce, later } from '@ember/runloop';
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
@@ -409,7 +409,7 @@ export default Component.extend({
       set(this, 'timeFormat', timeTypes[index]);
     },
     toggleZoom() {
-      set(this, 'fullScreen', !!this.fullScreen);
+      togglerProperty(this, 'fullScreen')
     }
   }
 });

--- a/app/components/build-log/component.js
+++ b/app/components/build-log/component.js
@@ -10,7 +10,7 @@ const timeTypes = ['datetime', 'datetimeUTC', 'elapsedBuild', 'elapsedStep'];
 export default Component.extend({
   logService: service('build-logs'),
   store: service(),
-  classNames: ['build-log', 'fullscreen:fullscreen'],
+  classNames: ['build-log', 'fullScreen:fullScreen'],
   fullScreen: false,
   autoscroll: true,
   isFetching: false,

--- a/app/components/build-log/component.js
+++ b/app/components/build-log/component.js
@@ -410,5 +410,6 @@ export default Component.extend({
     },
     toggleZoom() {
       set(this, 'fullScreen', !!this.fullScreen);
+    }
   }
 });

--- a/app/components/build-log/styles.scss
+++ b/app/components/build-log/styles.scss
@@ -8,6 +8,13 @@
   grid-template-rows: auto 1fr;
 }
 
+&.fullScreen {
+	position: fixed;
+	left: 0;
+	top: 0;
+	z-index: 1; /* clear class="nav nav-tabs ember-view" being on top */
+}
+
 .row {
   display: grid;
   grid-template-columns: 1fr;
@@ -20,8 +27,13 @@
   color: $sd-text-med;
 }
 
-.row div:last-child {
+.row div:nth-child(2) {
   grid-column: 2;
+  text-align: center;
+}
+
+.row div:last-child {
+  grid-column: 3;
   cursor: pointer;
   text-align: right;
   padding: 5px 15px;

--- a/app/components/build-log/template.hbs
+++ b/app/components/build-log/template.hbs
@@ -16,6 +16,9 @@
         <span class="content"></span>
       </div>
       <div>
+        <a onClick={{action "toggleZoom"}} alt="Toggle full screen logs">{{fa-icon "compress"}}</a>
+      </div>
+      <div>
         <a onClick={{action "scrollToTop"}}>{{fa-icon "arrow-up"}}Go to Top</a>
         <a onClick={{action "scrollToBottom"}}>{{fa-icon "arrow-down"}}Go to Bottom</a>
         {{#unless inProgress}}


### PR DESCRIPTION
## Context
Logs from projects that use verbose stack traces (e.g. java) are very inconvenient to read in a tiny window.

When inspecting logs, nothing else in the UI matters for that time.

## Objective

Add a Toggle full screen button to the log component that allows it to take over the entire browser viewport. The toggle icon remains in the same position (log action header) to undo the action.

## References

n/a

## License


I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
