### PR TITLE
fix: displaying duplicate jobs when toggle list view and workflow view buttons

### DIFF
--- a/app/pipeline/events/controller.js
+++ b/app/pipeline/events/controller.js
@@ -346,7 +346,10 @@ export default Controller.extend(ModelReloaderMixin, {
     },
     setShowListView(showListView) {
       if (!showListView) {
-        this.set('listViewOffset', 0);
+        this.setProperties({
+          listViewOffset: 0,
+          jobsDetails: []
+        });
       }
 
       this.set('showListView', showListView);

--- a/tests/unit/pipeline/events/controller-test.js
+++ b/tests/unit/pipeline/events/controller-test.js
@@ -696,4 +696,31 @@ module('Unit | Controller | pipeline/events', function(hooks) {
       { jobId: 4, jobName: 'd', jobPipelineId: '1234' }
     ]);
   });
+
+  test('it setShowListView reset listViewOffset and jobsDetails', async function(assert) {
+    assert.expect(4);
+
+    const controller = this.owner.lookup('controller:pipeline/events');
+    const listViewOffset = 10;
+    const dummyJob = {};
+    const jobsDetails = [dummyJob, dummyJob, dummyJob];
+
+    run(() => {
+      controller.setProperties({
+        listViewOffset,
+        jobsDetails
+      });
+
+      assert.equal(
+        controller.get('listViewOffset'),
+        listViewOffset,
+        `has listViewOffset of ${listViewOffset}`
+      );
+      assert.equal(controller.get('jobsDetails').length, 3, 'has 3 jobs');
+
+      controller.send('setShowListView', false);
+      assert.equal(controller.get('listViewOffset'), 0, `has listViewOffset of 0`);
+      assert.equal(controller.get('jobsDetails').length, 0, 'has 0 jobs');
+    });
+  });
 });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
- Reset jobs when toggle view button clicked

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
- Add test to cover when button clicked

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
