### PR TITLE
fix(1967): aggregate view is broken when there are jobs with 0 builds

### DIFF
--- a/app/components/pipeline-list-view/component.js
+++ b/app/components/pipeline-list-view/component.js
@@ -96,9 +96,7 @@ export default Component.extend({
   getRows(jobsDetails = []) {
     let rows = jobsDetails.map(jobDetails => {
       const { jobId, jobName } = jobDetails;
-      const latestBuild = jobDetails.builds.length
-        ? get(jobDetails, 'builds.lastObject')
-        : null;
+      const latestBuild = jobDetails.builds.length ? get(jobDetails, 'builds.lastObject') : null
 
       const jobData = {
         jobName,

--- a/app/components/pipeline-list-view/component.js
+++ b/app/components/pipeline-list-view/component.js
@@ -96,7 +96,7 @@ export default Component.extend({
   getRows(jobsDetails = []) {
     let rows = jobsDetails.map(jobDetails => {
       const { jobId, jobName } = jobDetails;
-      const latestBuild = jobDetails.builds.length ? get(jobDetails, 'builds.lastObject') : null
+      const latestBuild = jobDetails.builds.length ? get(jobDetails, 'builds.lastObject') : null;
 
       const jobData = {
         jobName,

--- a/app/components/pipeline-list-view/component.js
+++ b/app/components/pipeline-list-view/component.js
@@ -96,7 +96,9 @@ export default Component.extend({
   getRows(jobsDetails = []) {
     let rows = jobsDetails.map(jobDetails => {
       const { jobId, jobName } = jobDetails;
-      const latestBuild = jobDetails.builds.length ? get(jobDetails, 'builds.lastObject') : null;
+      const latestBuild = jobDetails.builds.length
+        ? get(jobDetails, 'builds.lastObject')
+        : null;
 
       const jobData = {
         jobName,
@@ -115,20 +117,21 @@ export default Component.extend({
       let startTime;
       let status;
       let buildId;
+      let coverageData = {};
 
       if (latestBuild) {
         startTime = moment(latestBuild.startTime).format('lll');
         status = latestBuild.status;
         buildId = latestBuild.id;
         duration = this.getDuration(latestBuild.startTime, latestBuild.endTime, status);
-      }
 
-      const coverageData = {
-        jobId,
-        buildId,
-        startTime: latestBuild.startTime,
-        endTime: latestBuild.endTime
-      };
+        coverageData = {
+          jobId,
+          buildId,
+          startTime: latestBuild.startTime,
+          endTime: latestBuild.endTime
+        };
+      }
 
       return {
         job: jobData,


### PR DESCRIPTION
## Context

aggregate view is broken when there are jobs with 0 builds

## Objective

Add check when computing coverage.

## References

https://github.com/screwdriver-cd/screwdriver/issues/1967

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
