### PR TITLE
fix: loads events list on initial loads

### DIFF
--- a/app/components/pipeline-list-view/component.js
+++ b/app/components/pipeline-list-view/component.js
@@ -44,7 +44,8 @@ export default Component.extend({
 
   init() {
     this._super(...arguments);
-    let table = new Table(this.get('columns'), this.get('sortedRows'));
+    const sortedRows = this.getRows(this.jobsDetails);
+    const table = new Table(this.get('columns'), sortedRows);
     let sortColumn = table.get('allColumns').findBy('valuePath', this.get('sortingValuePath'));
 
     // Setup initial sort column


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Initially, we only load data if `list-view` option is selected. 

![image](https://user-images.githubusercontent.com/15989893/84871415-5a1fa500-b035-11ea-9c57-6e467866f3e6.png)

![image](https://user-images.githubusercontent.com/15989893/84871361-496f2f00-b035-11ea-80e1-54eacb297ee9.png)

We run into issues within event route, if other sub-pages are selected, then use back button to go to list view. i.e. Go to `Events` & select `list-view`, click on `Opitons`, and then go back to `Events`.

![image](https://user-images.githubusercontent.com/15989893/84871477-715e9280-b035-11ea-9372-f85f1b0ba9da.png)

This causes errors, since `list-view` is selected already.
![image](https://user-images.githubusercontent.com/15989893/84871872-ed58da80-b035-11ea-948a-4b273a922711.png)

Instead of asking users to toggle click list view again, or manually click `refresh` button to load data, we will load data on `init()` hook of the component to load data.

## Objective
This PR will fix that to load event list on `init`, rather than upon clicking `list-view`
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
