### PR TITLE
fix: ui onboarding more improvements

### DIFF
--- a/app/components/create-pipeline/component.js
+++ b/app/components/create-pipeline/component.js
@@ -34,7 +34,7 @@ export default Component.extend({
 
       try {
         pipeline = await this.store.createRecord('pipeline', payload).save();
-        await this.router.transitionTo('pipeline', pipeline.get('id'));
+        this.router.transitionTo('pipeline', pipeline.get('id'));
       } catch (err) {
         let error = err.errors[0] || {};
 

--- a/app/components/create-pipeline/component.js
+++ b/app/components/create-pipeline/component.js
@@ -34,7 +34,7 @@ export default Component.extend({
 
       try {
         pipeline = await this.store.createRecord('pipeline', payload).save();
-        this.router.transitionTo('pipeline', pipeline.get('id'));
+        await this.router.transitionTo('pipeline', pipeline.get('id'));
       } catch (err) {
         let error = err.errors[0] || {};
 
@@ -49,18 +49,22 @@ export default Component.extend({
         }
       } finally {
         this.set('isSaving', false);
+        if (!yaml) {
+          this.set('showCreatePipeline', false);
+        }
       }
 
       if (pipeline) {
         try {
           if (yaml && yaml.length) {
-            const pr = await this.shuttle.openPr(scmUrl, yaml);
+            const pipelineId = pipeline.get('id');
+            const pr = await this.shuttle.openPr(scmUrl, yaml, pipelineId);
             const { prUrl } = pr.payload;
 
             this.set('prUrl', prUrl);
 
             try {
-              await this.router.transitionTo('pipeline.events', pipeline.get('id'));
+              await this.router.transitionTo('pipeline.events', pipelineId);
               const ctrl = getOwner(this).lookup('controller:pipeline.events');
               const prLink = `<a href="${prUrl}" rel="noopener">${prUrl}</a>`;
 

--- a/app/components/create-pipeline/component.js
+++ b/app/components/create-pipeline/component.js
@@ -34,7 +34,10 @@ export default Component.extend({
 
       try {
         pipeline = await this.store.createRecord('pipeline', payload).save();
-        this.router.transitionTo('pipeline', pipeline.get('id'));
+        await this.router.transitionTo('pipeline', pipeline.get('id'));
+        if (!yaml) {
+          this.set('showCreatePipeline', false);
+        }
       } catch (err) {
         let error = err.errors[0] || {};
 
@@ -49,9 +52,6 @@ export default Component.extend({
         }
       } finally {
         this.set('isSaving', false);
-        if (!yaml) {
-          this.set('showCreatePipeline', false);
-        }
       }
 
       if (pipeline) {

--- a/app/components/create-pipeline/component.js
+++ b/app/components/create-pipeline/component.js
@@ -56,17 +56,16 @@ export default Component.extend({
           if (yaml && yaml.length) {
             const pr = await this.shuttle.openPr(scmUrl, yaml);
             const { prUrl } = pr.payload;
-            const that = this;
 
             this.set('prUrl', prUrl);
 
             try {
               await this.router.transitionTo('pipeline.events', pipeline.get('id'));
-              const ctrl = getOwner(that).lookup('controller:pipeline.events');
+              const ctrl = getOwner(this).lookup('controller:pipeline.events');
               const prLink = `<a href="${prUrl}" rel="noopener">${prUrl}</a>`;
 
               ctrl.set('errorMessage', `PR: ${prLink}`);
-              that.set('showCreatePipeline', false);
+              this.set('showCreatePipeline', false);
             } catch (e) {
               console.error('error', e);
             }

--- a/app/templates/detail/template.hbs
+++ b/app/templates/detail/template.hbs
@@ -9,7 +9,7 @@
 }}
 
 <h4>Contents:</h4>
-{{validator-job name=versionTemplate.fullName job=versionTemplate.config template=versionTemplate collapsible=false}}
+{{validator-job name=versionTemplate.fullName job=versionTemplate.config template=versionTemplate collapsible=false isOpen=true}}
 
 {{template-versions templates=templates}}
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Keep the old behavior that if users only want to create a pipeline without  `screwdriver.yaml`. We will create a pipeline and close modal
## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Improvements:

- close create pipeline modal if users only create pipeline w/o yaml (keep pipeline creation of old behavior)

- open validator-job under `template`'s content for template details view

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
