### PR TITLE
fix: sallow errors in catch when transitionTo is called

### DIFF
--- a/app/components/create-pipeline/component.js
+++ b/app/components/create-pipeline/component.js
@@ -34,7 +34,7 @@ export default Component.extend({
 
       try {
         pipeline = await this.store.createRecord('pipeline', payload).save();
-        await this.router.transitionTo('pipeline', pipeline.get('id'));
+        this.router.transitionTo('pipeline', pipeline.get('id'));
         if (!yaml) {
           this.set('showCreatePipeline', false);
         }


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Fix `await` is getting caught in catch errors

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
