### PR TITLE
fix: allow org-xxx to be valid scmUrl

### DIFF
--- a/app/utils/git.js
+++ b/app/utils/git.js
@@ -7,7 +7,7 @@
 function parse(scmUrl) {
   // eslint-disable-next-line max-len
   const match = scmUrl.match(
-    /^(?:(?:https:\/\/(?:[^@/:\s]+@)?)|git@)+([^/:\s]+)(?:\/|:)([^/:\s]+)\/([^\s]+?)(?:\.git)?(#[^\s]+)?$/
+    /^(?:(?:https:\/\/(?:[^@/:\s]+@)?)|git@|org-\d+@)+([^/:\s]+)(?:\/|:)([^/:\s]+)\/([^\s]+?)(?:\.git)?(#[^\s]+)?$/
   );
 
   if (!match) {

--- a/tests/unit/utils/git-test.js
+++ b/tests/unit/utils/git-test.js
@@ -38,9 +38,9 @@ module('Unit | Utility | git', function() {
   });
 
   test('it parses the org checkout URL correctly', assert => {
-    const orgGitUrl = 'org-xxx@github.com:bananas/peel.git#tree';
+    const orgGitUrl = 'org-1000@github.com:bananas/peel.git#tree';
     let result = git.parse(orgGitUrl);
 
-    assert.ok(result.valid, 'org-xxx is valid');
+    assert.ok(result.valid, `${orgGitUrl} is valid`);
   });
 });

--- a/tests/unit/utils/git-test.js
+++ b/tests/unit/utils/git-test.js
@@ -36,4 +36,11 @@ module('Unit | Utility | git', function() {
 
     assert.strictEqual(result, 'git@github.com:bananas/peel.git#master');
   });
+
+  test('it parses the org checkout URL correctly', assert => {
+    const orgGitUrl = 'org-xxx@github.com:bananas/peel.git#tree';
+    let result = git.parse(orgGitUrl);
+
+    assert.ok(result.valid, 'org-xxx is valid');
+  });
 });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Making changes according to
https://github.com/screwdriver-cd/data-schema/pull/400/files#diff-77dea1a61b658aff6ad9cd0d2528d2daR83

Which allow `org-xxx@github.com:org/repo.git` to be valid, whereas `xxx` are digits. i.e. `org-111@github.com:org/repo.git`

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
Reference PR: https://github.com/screwdriver-cd/data-schema/pull/400

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
