### PR TITLE
fix(1892): Fix secrets delete and update button

### DIFF
--- a/app/components/secret-view/styles.scss
+++ b/app/components/secret-view/styles.scss
@@ -24,6 +24,26 @@ button {
   border-radius: 3px;
 }
 
+button.Update {
+  background-color: $sd-running;
+  color: $sd-white;
+}
+
+button.Override {
+  background-color: $sd-running;
+  color: $sd-white;
+}
+
+button.Delete {
+  background-color: $sd-failure;
+  color: $sd-white;
+}
+
+button.Revert {
+  background-color: $sd-failure;
+  color: $sd-white;
+}
+
 .toggle-icon {
   margin-left: -25px;
   position: relative;

--- a/app/components/secret-view/template.hbs
+++ b/app/components/secret-view/template.hbs
@@ -1,4 +1,4 @@
 <td class="name">{{secret.name}}</td>
 <td class="pass">{{input type="password" placeholder=passwordPlaceholder size="40" value=newValue}}{{fa-icon "eye" class="toggle-icon" click=(action "togglePasswordInput")}}</td>
 <td class="allow">{{input type="checkbox" checked=secret.allowInPR}}</td>
-<td><button {{action "modifySecret"}}>{{buttonAction}}</button></td>
+<td><button {{action "modifySecret"}} class={{buttonAction}}>{{buttonAction}}</button></td>


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
The button on Secrets UI is too simple that users do not notice that the button on right side of screen becomes `update`. 
Therefore, I modified `delete` and `update` button like below.
<img width="1636" alt="スクリーンショット 2020-07-02 16 55 44" src="https://user-images.githubusercontent.com/8113204/86332137-0e9c0680-bc85-11ea-8a19-98c4e1a61731.png">
<img width="1632" alt="スクリーンショット 2020-07-02 16 55 59" src="https://user-images.githubusercontent.com/8113204/86332145-13f95100-bc85-11ea-88db-98ade9524aa5.png">


## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
screwdriver-cd/screwdriver#1892

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
