### PR TITLE
fix(2117): Add dialog for checking to delete secret

### DIFF
--- a/app/components/secret-view/component.js
+++ b/app/components/secret-view/component.js
@@ -45,10 +45,9 @@ export default Component.extend({
       const { secret } = this;
 
       if (this.buttonAction === 'Delete' || this.buttonAction === 'Revert') {
-        return secret.destroyRecord().then(() => {
-          this.secrets.store.unloadRecord(secret);
-          this.secrets.reload();
-        });
+        this.set('secretToRemove', true);
+
+        return Promise.resolve(null);
       }
       if (this.buttonAction === 'Update') {
         if (this.newValue) {
@@ -85,6 +84,18 @@ export default Component.extend({
       } else {
         $(passwordInput).attr('type', 'password');
       }
+    },
+    removeSecret() {
+      const { secret } = this;
+
+      return secret.destroyRecord().then(() => {
+        this.secrets.store.unloadRecord(secret);
+        this.secrets.reload();
+      });
+    },
+    cancelRemovingSecret() {
+      this.set('secretToRemove', null);
+      this.set('isRemoving', false);
     }
   }
 });

--- a/app/components/secret-view/template.hbs
+++ b/app/components/secret-view/template.hbs
@@ -2,3 +2,27 @@
 <td class="pass">{{input type="password" placeholder=passwordPlaceholder size="40" value=newValue}}{{fa-icon "eye" class="toggle-icon" click=(action "togglePasswordInput")}}</td>
 <td class="allow">{{input type="checkbox" checked=secret.allowInPR}}</td>
 <td><button {{action "modifySecret"}} class={{buttonAction}}>{{buttonAction}}</button></td>
+{{#if secretToRemove}}
+  {{#if isRemoving}}
+    {{#modal-dialog clickOutsideToClose="false"
+      targetAttachment="center"
+      translucentOverlay=true
+    }}
+      {{loading-view}}
+    {{/modal-dialog}}
+  {{else}}
+    {{#bs-modal onSubmit=(action "removeSecret") onHide=(action "cancelRemovingSecret") as |modal|}}
+      {{#modal.header}}
+        <h4>Are you sure?</h4>
+      {{/modal.header}}
+      {{#modal.body}}
+        {{fa-icon "exclamation-triangle" pull="left" size=3}}
+        You're about to delete a secret <strong>{{secret.name}}</strong>. There might be existing jobs using this secret.
+      {{/modal.body}}
+      {{#modal.footer}}
+        {{#bs-button onClick=(action "cancelRemovingSecret")}}Cancel{{/bs-button}}
+        {{#bs-button onClick=(action "removeSecret") type="danger"}}{{fa-icon "trash"}} Confirm{{/bs-button}}
+      {{/modal.footer}}
+    {{/bs-modal}}
+  {{/if}}
+{{/if}}

--- a/tests/integration/components/secret-view/component-test.js
+++ b/tests/integration/components/secret-view/component-test.js
@@ -51,6 +51,66 @@ module('Integration | Component | secret view', function(hooks) {
     assert.dom('button').hasText('Delete');
   });
 
+  test('it trys to open dialog to delete a secret', async function(assert) {
+    assert.expect(5);
+
+    const testPipeline = EmberObject.create({
+      id: '123245'
+    });
+
+    this.set(
+      'mockSecret',
+      EmberObject.extend().create({
+        name: 'TEST_SECRET',
+        pipelineId: 123245,
+        value: null,
+        allowInPR: false
+      })
+    );
+    this.set('mockPipeline', testPipeline);
+
+    await render(hbs`{{secret-view secret=mockSecret pipeline=mockPipeline}}`);
+    // open dialog
+    await click('button');
+
+    assert.dom('div.modal-dialog').exists({ count: 1 });
+    assert.dom('h4').hasText('Are you sure?');
+    assert
+      .dom('div.modal-body')
+      .hasText(
+        "You're about to delete a secret TEST_SECRET. There might be existing jobs using this secret."
+      );
+    assert.dom('button.btn-default').hasText('Cancel');
+    assert.dom('button.btn-danger').hasText('Confirm');
+  });
+
+  test('it trys to cancel deleting a secret', async function(assert) {
+    assert.expect(1);
+
+    const testPipeline = EmberObject.create({
+      id: '123245'
+    });
+
+    this.set(
+      'mockSecret',
+      EmberObject.extend().create({
+        name: 'TEST_SECRET',
+        pipelineId: 123245,
+        value: null,
+        allowInPR: false
+      })
+    );
+    this.set('mockPipeline', testPipeline);
+
+    await render(hbs`{{secret-view secret=mockSecret pipeline=mockPipeline}}`);
+    // open dialog
+    await click('button');
+    // click cancel
+    await click('button.btn-default');
+
+    assert.dom('div.modal-dialog').doesNotExist();
+  });
+
   test('it trys to delete a secret', async function(assert) {
     assert.expect(3);
 
@@ -92,7 +152,10 @@ module('Integration | Component | secret view', function(hooks) {
     });
 
     await render(hbs`{{secret-view secret=mockSecret secrets=secrets pipeline=mockPipeline}}`);
+    // open dialog
     await click('button');
+    // click confirm
+    await click('button.btn-danger');
   });
 
   test('it saves changes to a secret', async function(assert) {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Fix https://github.com/screwdriver-cd/screwdriver/issues/2117

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Dialog appears when delete button is clicked.
![Screen Shot 2020-07-09 at 14 13 27](https://user-images.githubusercontent.com/32473622/86999919-c03fb800-c1ee-11ea-8dd2-8a050f4d90a5.jpg)

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/2117

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
