### PR TITLE
fix(2152): Pass in pipelineId and prNum to Sonar coverage [2]

### DIFF
--- a/app/components/build-banner/component.js
+++ b/app/components/build-banner/component.js
@@ -126,7 +126,9 @@ export default Component.extend({
       buildId: this.buildId,
       jobId: this.jobId,
       startTime: buildStartTime,
-      endTime: coverageStepEndTime
+      endTime: coverageStepEndTime,
+      pipelineId: this.pipelineId,
+      prNum: this.prNumber
     };
 
     this.coverage.getCoverageInfo(config).then(data => {

--- a/app/components/pipeline-list-coverage-cell/component.js
+++ b/app/components/pipeline-list-coverage-cell/component.js
@@ -7,9 +7,9 @@ export default Component.extend({
 
   result: computed('value', {
     async get() {
-      const { buildId, jobId, startTime, endTime } = this.value;
+      const { buildId, jobId, startTime, endTime, pipelineId, prNum } = this.value;
 
-      return this.shuttle.fetchCoverage(buildId, jobId, startTime, endTime);
+      return this.shuttle.fetchCoverage(buildId, jobId, startTime, endTime, pipelineId, prNum);
     }
   })
 });

--- a/app/components/pipeline-list-view/component.js
+++ b/app/components/pipeline-list-view/component.js
@@ -112,6 +112,9 @@ export default Component.extend({
         stopBuild: this.get('stopBuild')
       };
 
+      const prRegex = /^PR-(\d+)(?::([\w-]+))?$/;
+      const prNumMatch = jobName.match(prRegex);
+
       let duration;
       let startTime;
       let status;
@@ -128,7 +131,9 @@ export default Component.extend({
           jobId,
           buildId,
           startTime: latestBuild.startTime,
-          endTime: latestBuild.endTime
+          endTime: latestBuild.endTime,
+          pipelineId: latestBuild.pipelineId,
+          prNum: prNumMatch ? prNumMatch[1] : null
         };
       }
 

--- a/app/components/pipeline-list-view/component.js
+++ b/app/components/pipeline-list-view/component.js
@@ -133,7 +133,7 @@ export default Component.extend({
           startTime: latestBuild.startTime,
           endTime: latestBuild.endTime,
           pipelineId: latestBuild.pipelineId,
-          prNum: prNumMatch ? prNumMatch[1] : null
+          prNum: prNumMatch && prNumMatch.length > 1 ? prNumMatch[1] : null
         };
       }
 

--- a/app/pipeline/build/template.hbs
+++ b/app/pipeline/build/template.hbs
@@ -13,6 +13,7 @@
   buildMeta=build.meta
   jobName=job.name
   jobId=job.id
+  pipelineId=pipeline.id
   isAuthenticated=session.isAuthenticated
   event=event
   prEvents=prEvents

--- a/app/shuttle/service.js
+++ b/app/shuttle/service.js
@@ -91,10 +91,10 @@ export default Service.extend({
     return this.fetchFromApi(method, url, data);
   },
 
-  async fetchCoverage(buildId, jobId, startTime, endTime) {
+  async fetchCoverage(buildId, jobId, startTime, endTime, pipelineId, prNum) {
     const method = 'get';
     const url = `/coverage/info`;
-    const data = { buildId, jobId, startTime, endTime };
+    const data = { buildId, jobId, startTime, endTime, pipelineId, prNum };
 
     return this.fetchFromApi(method, url, data);
   },

--- a/tests/unit/coverage/service-test.js
+++ b/tests/unit/coverage/service-test.js
@@ -47,7 +47,9 @@ module('Unit | Service | coverage ', function(hooks) {
       buildId: 123,
       jobId: 1,
       startTime: '2018-05-10T19:05:53.123Z',
-      endTime: '2018-05-10T19:06:53.123Z'
+      endTime: '2018-05-10T19:06:53.123Z',
+      pipelineId: 456,
+      prNum: 5
     };
 
     const p = service.getCoverageInfo(config);
@@ -64,7 +66,7 @@ module('Unit | Service | coverage ', function(hooks) {
       assert.deepEqual(
         request.url,
         // eslint-disable-next-line max-len
-        'http://localhost:8080/v4/coverage/info?buildId=123&jobId=1&startTime=2018-05-10T19%3A05%3A53.123Z&endTime=2018-05-10T19%3A06%3A53.123Z'
+        'http://localhost:8080/v4/coverage/info?buildId=123&jobId=1&startTime=2018-05-10T19%3A05%3A53.123Z&endTime=2018-05-10T19%3A06%3A53.123Z&pipelineId=456&prNum=5'
       );
     });
   });

--- a/tests/unit/shuttle/service-test.js
+++ b/tests/unit/shuttle/service-test.js
@@ -78,8 +78,10 @@ module('Unit | Service | shuttle', function(hooks) {
     const jobId = 21;
     const startTime = '2020-05-06T23:36:46.779Z';
     const endTime = '2020-05-06T23:50:18.590Z';
+    const pipelineId = 123456;
+    const prNum = null;
 
-    service.fetchCoverage(buildId, jobId, startTime, endTime).then(result => {
+    service.fetchCoverage(buildId, jobId, startTime, endTime, pipelineId, prNum).then(result => {
       const { coverage, projectUrl } = result;
 
       assert.equal(coverage, '71.4', 'coverage is 71.4');


### PR DESCRIPTION
## Context

Need to pass in pipelineId and prNum for new Sonar coverage calls.

## Objective

This PR passes in pipelineId and prNum to get Sonar coverage info.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2152

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
