### PR TITLE
fix(2124):  Pipeline list view issues

### DIFF
--- a/app/components/pipeline-list-actions-cell/component.js
+++ b/app/components/pipeline-list-actions-cell/component.js
@@ -18,7 +18,11 @@ export default Component.extend({
     startSingleBuild(status = undefined) {
       const value = this.get('value');
 
-      value.startSingleBuild(value.jobId, value.jobName, status);
+      if (value.hasParameters) {
+        value.openParametersModal(value.jobId);
+      } else {
+        value.startSingleBuild(value.jobId, value.jobName, status);
+      }
     },
     stopBuild() {
       const value = this.get('value');

--- a/app/components/pipeline-list-actions-cell/styles.scss
+++ b/app/components/pipeline-list-actions-cell/styles.scss
@@ -2,6 +2,7 @@
   .fa {
     width: 0.8em;
     font-size: 1.2em;
+    cursor: pointer;
   }
 
   .fa-play-circle-o,

--- a/app/components/pipeline-list-view/component.js
+++ b/app/components/pipeline-list-view/component.js
@@ -56,6 +56,10 @@ export default Component.extend({
     this.set('table', table);
   },
 
+  didDestroyElement() {
+    this.set('jobsDetails', []);
+  },
+
   getDuration(startTime, endTime, status) {
     const startDateTime = Date.parse(startTime);
     const endDateTime = Date.parse(endTime);

--- a/app/components/pipeline-list-view/component.js
+++ b/app/components/pipeline-list-view/component.js
@@ -61,6 +61,7 @@ export default Component.extend({
   },
 
   didDestroyElement() {
+    this._super(...arguments);
     this.set('jobsDetails', []);
   },
 

--- a/app/components/pipeline-list-view/template.hbs
+++ b/app/components/pipeline-list-view/template.hbs
@@ -11,3 +11,20 @@
     onScrolledToBottom=(action "onScrolledToBottom")
   }}{{/t.body}}
 {{/light-table}}
+
+{{#if isShowingModal}}
+  {{#modal-dialog
+    targetAttachment="center"
+    translucentOverlay=true
+    clickOutsideToClose=true
+    onClickOverlay=(action "resetForm")
+    containerClass="detached-confirm-dialog"
+  }}
+    <h3>Are you sure to start?</h3>
+    {{pipeline-parameterized-build
+      showSubmitButton=true
+      buildParameters=buildParameters
+      onSave=(action 'startBuild')
+      onClose=(action "closeModal")}}
+  {{/modal-dialog}}
+{{/if}}

--- a/app/components/pipeline-list-view/template.hbs
+++ b/app/components/pipeline-list-view/template.hbs
@@ -24,7 +24,7 @@
     {{pipeline-parameterized-build
       showSubmitButton=true
       buildParameters=buildParameters
-      onSave=(action 'startBuild')
+      onSave=(action "startBuild")
       onClose=(action "closeModal")}}
   {{/modal-dialog}}
 {{/if}}

--- a/app/pipeline/events/controller.js
+++ b/app/pipeline/events/controller.js
@@ -297,6 +297,9 @@ export default Controller.extend(ModelReloaderMixin, {
 
     if (jobsDetails.some(j => j.get('jobPipelineId') !== this.get('pipeline.id'))) {
       jobsDetails = [];
+    }
+
+    if (jobsDetails.length === 0) {
       this.set('listViewOffset', 0);
     }
 

--- a/app/pipeline/events/template.hbs
+++ b/app/pipeline/events/template.hbs
@@ -29,11 +29,14 @@
 
     {{#if showListView}}
       {{pipeline-list-view
+        pipeline=pipeline
+        jobs=jobs
         jobsDetails=jobsDetails
         updateListViewJobs=(action "updateListViewJobs")
         refreshListViewJobs=(action "refreshListViewJobs")
         startSingleBuild=(action "startSingleBuild")
         stopBuild=(action "stopBuild")
+        startDetachedBuild=(action "startDetachedBuild")
       }}
     {{else}}
       {{pipeline-workflow

--- a/tests/integration/components/pipeline-list-view/component-test.js
+++ b/tests/integration/components/pipeline-list-view/component-test.js
@@ -3,6 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { set } from '@ember/object';
+import wait from 'ember-test-helpers/wait';
 
 module('Integration | Component | pipeline list view', function(hooks) {
   setupRenderingTest(hooks);
@@ -87,6 +88,89 @@ module('Integration | Component | pipeline list view', function(hooks) {
     assert.dom('.lt-column').exists({ count: 6 });
     assert.dom('.lt-head').hasText('JOB HISTORY DURATION START TIME COVERAGE ACTIONS');
     assert.dom('.lt-row').exists({ count: 2 });
+  });
+
+  test('it renders then resets jobDetails', async function(assert) {
+    let ticker = 0;
+
+    set(this, 'jobsDetails', [
+      {
+        jobId: 1,
+        jobName: 'a',
+        builds: [
+          {
+            id: 1,
+            jobId: 1,
+            status: 'RUNNING',
+            startTime: '',
+            endTime: ''
+          },
+          {
+            id: 2,
+            jobId: 1,
+            status: 'RUNNING',
+            startTime: '',
+            endTime: ''
+          }
+        ]
+      },
+      {
+        jobId: 2,
+        jobName: 'a',
+        builds: [
+          {
+            id: 1,
+            jobId: 2,
+            status: 'ABORTED',
+            startTime: '',
+            endTime: ''
+          },
+          {
+            id: 2,
+            jobId: 2,
+            status: 'RUNNING',
+            startTime: '',
+            endTime: ''
+          }
+        ]
+      }
+    ]);
+    set(this, 'updateListViewJobs', () => {
+      if (ticker === 0) {
+        assert.ok(true);
+        ticker += 1;
+
+        return Promise.resolve(this.jobsDetails);
+      }
+
+      return Promise.resolve([]);
+    });
+    set(this, 'refreshListViewJobs', () => {
+      assert.ok(true);
+    });
+    set(this, 'startSingleBuild', () => {
+      assert.ok(true);
+    });
+    set(this, 'stopBuild', () => {
+      assert.ok(true);
+    });
+    set(this, 'buildParameters', [{ p1: 'p1' }]);
+    set(this, 'showPipelineListView', true);
+    await render(hbs`
+      {{#if showPipelineListView}}
+        {{pipeline-list-view
+        jobsDetails=jobsDetails
+        updateListViewJobs=updateListViewJobs
+        refreshListViewJobs=refreshListViewJobs
+        startSingleBuild=startSingleBuild
+        stopBuild=stopBuild
+        buildParameters=buildParameters}}
+      {{/if}}`);
+    set(this, 'showPipelineListView', false);
+
+    return wait().then(() => {
+      assert.equal(this.get('jobsDetails').length, 0);
+    });
   });
 
   test('it renders with duration', async function(assert) {

--- a/tests/integration/components/pipeline-list-view/component-test.js
+++ b/tests/integration/components/pipeline-list-view/component-test.js
@@ -71,6 +71,7 @@ module('Integration | Component | pipeline list view', function(hooks) {
     set(this, 'stopBuild', () => {
       assert.ok(true);
     });
+    set(this, 'buildParameters', []);
 
     await render(hbs`{{pipeline-list-view
       jobsDetails=jobsDetails
@@ -78,6 +79,7 @@ module('Integration | Component | pipeline list view', function(hooks) {
       refreshListViewJobs=refreshListViewJobs
       startSingleBuild=startSingleBuild
       stopBuild=stopBuild
+      buildParameters=buildParameters
     }}`);
 
     assert.dom('.lt-head-wrap').exists({ count: 1 });
@@ -127,6 +129,7 @@ module('Integration | Component | pipeline list view', function(hooks) {
     set(Date, 'prototype.getTimezoneOffset', () => {
       return 0;
     });
+    set(this, 'buildParameters', []);
 
     await render(hbs`{{pipeline-list-view
       jobsDetails=jobsDetails
@@ -134,6 +137,7 @@ module('Integration | Component | pipeline list view', function(hooks) {
       refreshListViewJobs=refreshListViewJobs
       startSingleBuild=startSingleBuild
       stopBuild=stopBuild
+      buildParameters=buildParameters
     }}`);
 
     assert.dom('.lt-head-wrap').exists({ count: 1 });
@@ -182,6 +186,7 @@ module('Integration | Component | pipeline list view', function(hooks) {
     set(this, 'stopBuild', () => {
       assert.ok(true);
     });
+    set(this, 'buildParameters', []);
 
     await render(hbs`{{pipeline-list-view
       jobsDetails=jobsDetails
@@ -189,6 +194,7 @@ module('Integration | Component | pipeline list view', function(hooks) {
       refreshListViewJobs=refreshListViewJobs
       startSingleBuild=startSingleBuild
       stopBuild=stopBuild
+      buildParameters=buildParameters
     }}`);
 
     assert.dom('.lt-head-wrap').exists({ count: 1 });
@@ -237,6 +243,7 @@ module('Integration | Component | pipeline list view', function(hooks) {
     set(this, 'stopBuild', () => {
       assert.ok(true);
     });
+    set(this, 'buildParameters', []);
 
     await render(hbs`{{pipeline-list-view
       jobsDetails=jobsDetails
@@ -244,6 +251,7 @@ module('Integration | Component | pipeline list view', function(hooks) {
       refreshListViewJobs=refreshListViewJobs
       startSingleBuild=startSingleBuild
       stopBuild=stopBuild
+      buildParameters=buildParameters
     }}`);
 
     assert.dom('.lt-head-wrap').exists({ count: 1 });
@@ -292,6 +300,7 @@ module('Integration | Component | pipeline list view', function(hooks) {
     set(this, 'stopBuild', () => {
       assert.ok(true);
     });
+    set(this, 'buildParameters', []);
 
     await render(hbs`{{pipeline-list-view
       jobsDetails=jobsDetails
@@ -299,6 +308,7 @@ module('Integration | Component | pipeline list view', function(hooks) {
       refreshListViewJobs=refreshListViewJobs
       startSingleBuild=startSingleBuild
       stopBuild=stopBuild
+      buildParameters=buildParameters
     }}`);
 
     assert.dom('.lt-head-wrap').exists({ count: 1 });
@@ -347,6 +357,7 @@ module('Integration | Component | pipeline list view', function(hooks) {
     set(this, 'stopBuild', () => {
       assert.ok(true);
     });
+    set(this, 'buildParameters', []);
 
     await render(hbs`{{pipeline-list-view
       jobsDetails=jobsDetails
@@ -354,6 +365,7 @@ module('Integration | Component | pipeline list view', function(hooks) {
       refreshListViewJobs=refreshListViewJobs
       startSingleBuild=startSingleBuild
       stopBuild=stopBuild
+      buildParameters=buildParameters
     }}`);
 
     assert.dom('.lt-head-wrap').exists({ count: 1 });
@@ -402,6 +414,7 @@ module('Integration | Component | pipeline list view', function(hooks) {
     set(this, 'stopBuild', () => {
       assert.ok(true);
     });
+    set(this, 'buildParameters', []);
 
     await render(hbs`{{pipeline-list-view
       jobsDetails=jobsDetails
@@ -409,6 +422,7 @@ module('Integration | Component | pipeline list view', function(hooks) {
       refreshListViewJobs=refreshListViewJobs
       startSingleBuild=startSingleBuild
       stopBuild=stopBuild
+      buildParameters=buildParameters
     }}`);
 
     assert.dom('.lt-head-wrap').exists({ count: 1 });
@@ -457,6 +471,7 @@ module('Integration | Component | pipeline list view', function(hooks) {
     set(this, 'stopBuild', () => {
       assert.ok(true);
     });
+    set(this, 'buildParameters', []);
 
     await render(hbs`{{pipeline-list-view
       jobsDetails=jobsDetails
@@ -464,6 +479,7 @@ module('Integration | Component | pipeline list view', function(hooks) {
       refreshListViewJobs=refreshListViewJobs
       startSingleBuild=startSingleBuild
       stopBuild=stopBuild
+      buildParameters=buildParameters
     }}`);
 
     assert.dom('.lt-head-wrap').exists({ count: 1 });
@@ -511,6 +527,7 @@ module('Integration | Component | pipeline list view', function(hooks) {
     set(this, 'stopBuild', () => {
       assert.ok(true);
     });
+    set(this, 'buildParameters', []);
 
     await render(hbs`{{pipeline-list-view
       jobsDetails=jobsDetails
@@ -518,6 +535,7 @@ module('Integration | Component | pipeline list view', function(hooks) {
       refreshListViewJobs=refreshListViewJobs
       startSingleBuild=startSingleBuild
       stopBuild=stopBuild
+      buildParameters=buildParameters
     }}`);
 
     assert.dom('.lt-head-wrap').exists({ count: 1 });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Issues from https://github.com/screwdriver-cd/screwdriver/issues/2124


## Objective

- [x] Clicking on the “play” button doesn’t bring up the build parameter modal if it’s enabled.

- [x] If you are on a list view, then click collection and click on another pipeline, it will land on the list view again but with jobs from the previously selected pipeline as well.

- [x] The clickable buttons should be using different cursor when hover.

- [ ] If you click any of the sortable column header, it seems it will query /v4/coverage/info for each job.


<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
- [Using the `wait` helper in Ember integration tests](https://til.hashrocket.com/posts/851fb1e6f7-using-the-wait-helper-in-ember-integration-tests)

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
