### PR TITLE
fix: add default value to 'event.pr.url' for prNumber

### DIFF
--- a/app/components/build-banner/component.js
+++ b/app/components/build-banner/component.js
@@ -23,7 +23,7 @@ export default Component.extend({
 
   prNumber: computed('event.pr.url', {
     get() {
-      let url = this.get('event.pr.url');
+      let url = this.getWithDefault('event.pr.url', '');
 
       return url.split('/').pop();
     }


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Currently, it blocks if `event.pr.url` is undefined, it will break the `prNumber`.

## Objective
This PR adds an empty string value to `prNumber`

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
![image](https://user-images.githubusercontent.com/15989893/88224394-c33e9d80-cc1d-11ea-8d98-008bb656a17a.png)
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
