### PR TITLE
feat(2152): Support job annotation for coverage scope [5]

### DIFF
--- a/app/components/build-banner/component.js
+++ b/app/components/build-banner/component.js
@@ -128,8 +128,14 @@ export default Component.extend({
       startTime: buildStartTime,
       endTime: coverageStepEndTime,
       pipelineId: this.pipelineId,
-      prNum: this.prNumber
+      prNum: this.prNumber,
+      jobName: this.jobName,
+      pipelineName: this.pipelineName
     };
+
+    if (this.annotations && this.annotations['screwdriver.cd/coverageScope']) {
+      config.scope = this.annotations['screwdriver.cd/coverageScope'];
+    }
 
     this.coverage.getCoverageInfo(config).then(data => {
       this.set('coverageInfo', data);

--- a/app/components/pipeline-list-coverage-cell/component.js
+++ b/app/components/pipeline-list-coverage-cell/component.js
@@ -7,9 +7,29 @@ export default Component.extend({
 
   result: computed('value', {
     async get() {
-      const { buildId, jobId, startTime, endTime, pipelineId, prNum } = this.value;
+      const {
+        buildId,
+        jobId,
+        startTime,
+        endTime,
+        pipelineId,
+        prNum,
+        jobName,
+        pipelineName,
+        scope
+      } = this.value;
 
-      return this.shuttle.fetchCoverage(buildId, jobId, startTime, endTime, pipelineId, prNum);
+      return this.shuttle.fetchCoverage(
+        buildId,
+        jobId,
+        startTime,
+        endTime,
+        pipelineId,
+        prNum,
+        jobName,
+        pipelineName,
+        scope
+      );
     }
   })
 });

--- a/app/components/pipeline-list-view/component.js
+++ b/app/components/pipeline-list-view/component.js
@@ -123,7 +123,7 @@ export default Component.extend({
 
   getRows(jobsDetails = []) {
     let rows = jobsDetails.map(jobDetails => {
-      const { jobId, jobName } = jobDetails;
+      const { jobId, jobName, annotations } = jobDetails;
       const latestBuild = jobDetails.builds.length ? get(jobDetails, 'builds.lastObject') : null;
 
       const jobData = {
@@ -163,8 +163,14 @@ export default Component.extend({
           startTime: latestBuild.startTime,
           endTime: latestBuild.endTime,
           pipelineId: latestBuild.pipelineId,
-          prNum: prNumMatch && prNumMatch.length > 1 ? prNumMatch[1] : null
+          prNum: prNumMatch && prNumMatch.length > 1 ? prNumMatch[1] : null,
+          jobName,
+          pipelineName: this.get('pipeline.name')
         };
+
+        if (annotations && annotations['screwdriver.cd/coverageScope']) {
+          coverageData.scope = annotations['screwdriver.cd/coverageScope'];
+        }
       }
 
       return {

--- a/app/job/model.js
+++ b/app/job/model.js
@@ -1,4 +1,4 @@
-import { computed } from '@ember/object';
+import { computed, get } from '@ember/object';
 import { equal, match } from '@ember/object/computed';
 import DS from 'ember-data';
 import ENV from 'screwdriver-ui/config/environment';
@@ -39,6 +39,11 @@ export default DS.Model.extend({
   }),
   // } for pr job only
   permutations: DS.attr(),
+  annotations: computed('permutations.[]', {
+    get() {
+      return get(this, 'permutations[0].annotations') || {};
+    }
+  }),
   builds: DS.hasMany('build', { async: true }),
   isDisabled: equal('state', 'DISABLED'),
   modelToReload: 'builds',

--- a/app/pipeline/build/template.hbs
+++ b/app/pipeline/build/template.hbs
@@ -13,7 +13,9 @@
   buildMeta=build.meta
   jobName=job.name
   jobId=job.id
+  annotations=job.annotations
   pipelineId=pipeline.id
+  pipelineName=pipeline.name
   isAuthenticated=session.isAuthenticated
   event=event
   prEvents=prEvents

--- a/app/pipeline/events/controller.js
+++ b/app/pipeline/events/controller.js
@@ -266,6 +266,7 @@ export default Controller.extend(ModelReloaderMixin, {
             if (job) {
               nextJobDetail.jobName = job.name;
               nextJobDetail.jobPipelineId = job.pipelineId;
+              nextJobDetail.annotations = job.annotations;
             }
           });
 

--- a/app/shuttle/service.js
+++ b/app/shuttle/service.js
@@ -91,10 +91,24 @@ export default Service.extend({
     return this.fetchFromApi(method, url, data);
   },
 
-  async fetchCoverage(buildId, jobId, startTime, endTime, pipelineId, prNum) {
+  async fetchCoverage(
+    buildId,
+    jobId,
+    startTime,
+    endTime,
+    pipelineId,
+    prNum,
+    jobName,
+    pipelineName,
+    scope
+  ) {
     const method = 'get';
     const url = `/coverage/info`;
-    const data = { buildId, jobId, startTime, endTime, pipelineId, prNum };
+    const data = { buildId, jobId, startTime, endTime, pipelineId, prNum, jobName, pipelineName };
+
+    if (scope) {
+      data.scope = scope;
+    }
 
     return this.fetchFromApi(method, url, data);
   },

--- a/tests/unit/coverage/service-test.js
+++ b/tests/unit/coverage/service-test.js
@@ -49,7 +49,9 @@ module('Unit | Service | coverage ', function(hooks) {
       startTime: '2018-05-10T19:05:53.123Z',
       endTime: '2018-05-10T19:06:53.123Z',
       pipelineId: 456,
-      prNum: 5
+      prNum: 5,
+      jobName: 'main',
+      pipelineName: 'd2lam/mytest'
     };
 
     const p = service.getCoverageInfo(config);
@@ -66,7 +68,56 @@ module('Unit | Service | coverage ', function(hooks) {
       assert.deepEqual(
         request.url,
         // eslint-disable-next-line max-len
-        'http://localhost:8080/v4/coverage/info?buildId=123&jobId=1&startTime=2018-05-10T19%3A05%3A53.123Z&endTime=2018-05-10T19%3A06%3A53.123Z&pipelineId=456&prNum=5'
+        'http://localhost:8080/v4/coverage/info?buildId=123&jobId=1&startTime=2018-05-10T19%3A05%3A53.123Z&endTime=2018-05-10T19%3A06%3A53.123Z&pipelineId=456&prNum=5&jobName=main&pipelineName=d2lam%2Fmytest'
+      );
+    });
+  });
+
+  test('it fetches coverage info with scope', function(assert) {
+    assert.expect(3);
+    server.get('http://localhost:8080/v4/coverage/info', () => [
+      200,
+      {
+        'Content-Type': 'application/json'
+      },
+      JSON.stringify({
+        coverage: 98,
+        projectUrl: 'https://sonar.foo.bar',
+        tests: '7/10'
+      })
+    ]);
+
+    let service = this.owner.lookup('service:coverage');
+
+    assert.ok(service);
+
+    const config = {
+      buildId: 123,
+      jobId: 1,
+      startTime: '2018-05-10T19:05:53.123Z',
+      endTime: '2018-05-10T19:06:53.123Z',
+      pipelineId: 456,
+      prNum: 5,
+      jobName: 'main',
+      pipelineName: 'd2lam/mytest',
+      scope: 'job'
+    };
+
+    const p = service.getCoverageInfo(config);
+
+    p.then(data => {
+      const [request] = server.handledRequests;
+
+      assert.deepEqual(data, {
+        coverage: '98%',
+        coverageUrl: 'https://sonar.foo.bar',
+        tests: '7/10',
+        testsUrl: 'https://sonar.foo.bar'
+      });
+      assert.deepEqual(
+        request.url,
+        // eslint-disable-next-line max-len
+        'http://localhost:8080/v4/coverage/info?buildId=123&jobId=1&startTime=2018-05-10T19%3A05%3A53.123Z&endTime=2018-05-10T19%3A06%3A53.123Z&pipelineId=456&prNum=5&jobName=main&pipelineName=d2lam%2Fmytest&scope=job'
       );
     });
   });

--- a/tests/unit/job/model-test.js
+++ b/tests/unit/job/model-test.js
@@ -9,7 +9,6 @@ module('Unit | Model | job', function(hooks) {
   test('it exists', function(assert) {
     let model = run(() => this.owner.lookup('service:store').createRecord('job'));
 
-    // let store = this.store();
     assert.ok(!!model);
   });
 });

--- a/tests/unit/pipeline/events/controller-test.js
+++ b/tests/unit/pipeline/events/controller-test.js
@@ -606,10 +606,15 @@ module('Unit | Controller | pipeline/events', function(hooks) {
         EmberObject.create({
           id: '1234',
           jobs: [
-            EmberObject.create({ id: '1', name: 'a', pipelineId: '1234' }),
-            EmberObject.create({ id: '2', name: 'b', pipelineId: '1234' }),
-            EmberObject.create({ id: '3', name: 'c', pipelineId: '1234' }),
-            EmberObject.create({ id: '4', name: 'd', pipelineId: '1234' })
+            EmberObject.create({
+              id: '1',
+              name: 'a',
+              pipelineId: '1234',
+              annotations: {}
+            }),
+            EmberObject.create({ id: '2', name: 'b', pipelineId: '1234', annotations: {} }),
+            EmberObject.create({ id: '3', name: 'c', pipelineId: '1234', annotations: {} }),
+            EmberObject.create({ id: '4', name: 'd', pipelineId: '1234', annotations: {} })
           ]
         })
       );
@@ -633,9 +638,9 @@ module('Unit | Controller | pipeline/events', function(hooks) {
     await settled();
 
     assert.deepEqual(controller.get('jobsDetails'), [
-      { jobId: 1, jobName: 'a', jobPipelineId: '1234' },
-      { jobId: 2, jobName: 'b', jobPipelineId: '1234' },
-      { jobId: 3, jobName: 'c', jobPipelineId: '1234' }
+      { jobId: 1, jobName: 'a', jobPipelineId: '1234', annotations: {} },
+      { jobId: 2, jobName: 'b', jobPipelineId: '1234', annotations: {} },
+      { jobId: 3, jobName: 'c', jobPipelineId: '1234', annotations: {} }
     ]);
   });
 
@@ -658,10 +663,10 @@ module('Unit | Controller | pipeline/events', function(hooks) {
         EmberObject.create({
           id: '1234',
           jobs: [
-            EmberObject.create({ id: '1', name: 'a', pipelineId: '1234' }),
-            EmberObject.create({ id: '2', name: 'b', pipelineId: '1234' }),
-            EmberObject.create({ id: '3', name: 'c', pipelineId: '1234' }),
-            EmberObject.create({ id: '4', name: 'd', pipelineId: '1234' })
+            EmberObject.create({ id: '1', name: 'a', pipelineId: '1234', annotations: {} }),
+            EmberObject.create({ id: '2', name: 'b', pipelineId: '1234', annotations: {} }),
+            EmberObject.create({ id: '3', name: 'c', pipelineId: '1234', annotations: {} }),
+            EmberObject.create({ id: '4', name: 'd', pipelineId: '1234', annotations: {} })
           ]
         })
       );
@@ -689,10 +694,10 @@ module('Unit | Controller | pipeline/events', function(hooks) {
     await settled();
 
     assert.deepEqual(controller.get('jobsDetails'), [
-      { jobId: 1, jobName: 'a', jobPipelineId: '1234' },
-      { jobId: 2, jobName: 'b', jobPipelineId: '1234' },
-      { jobId: 3, jobName: 'c', jobPipelineId: '1234' },
-      { jobId: 4, jobName: 'd', jobPipelineId: '1234' }
+      { jobId: 1, jobName: 'a', jobPipelineId: '1234', annotations: {} },
+      { jobId: 2, jobName: 'b', jobPipelineId: '1234', annotations: {} },
+      { jobId: 3, jobName: 'c', jobPipelineId: '1234', annotations: {} },
+      { jobId: 4, jobName: 'd', jobPipelineId: '1234', annotations: {} }
     ]);
   });
 


### PR DESCRIPTION
## Context

Users might want to configure job scope for Sonar projects even if they're using enterprise edition.

## Objective

This PR passes in extra params such as jobName, pipelineName, and job annotation for coverage scope.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2152

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
