### PR TITLE
fix: build parameters dropdown w/ override

### DIFF
--- a/app/components/pipeline-parameterized-build/component.js
+++ b/app/components/pipeline-parameterized-build/component.js
@@ -1,5 +1,5 @@
 import Component from '@ember/component';
-import { set } from '@ember/object';
+import { getWithDefault, set } from '@ember/object';
 
 /**
  @class PipelineParameterizedBuild
@@ -70,7 +70,7 @@ export default Component.extend({
     const normalizedParameterizedModel = {};
 
     Object.entries(parameters).forEach(([propertyName, propertyVal]) => {
-      const value = propertyVal.value || propertyVal || '';
+      let value = propertyVal.value || propertyVal || '';
       const description = propertyVal.description || '';
 
       normalizedParameters.push({
@@ -78,6 +78,10 @@ export default Component.extend({
         value,
         description
       });
+
+      if (Array.isArray(value)) {
+        value = getWithDefault(value, '0', '');
+      }
 
       normalizedParameterizedModel[propertyName] = value;
     });
@@ -109,9 +113,17 @@ export default Component.extend({
     throw new Error('Not implemented');
   },
 
+  updateValue({ model, propertyName, value }) {
+    set(model, propertyName, value);
+  },
+
   actions: {
+    onUpdateDropdownValue(model, propertyName, value) {
+      this.updateValue({ model, propertyName, value });
+    },
+
     onUpdateValue(value, model, propertyName) {
-      set(model, propertyName, value);
+      this.updateValue({ model, propertyName, value });
     },
 
     /**

--- a/app/components/pipeline-parameterized-build/component.js
+++ b/app/components/pipeline-parameterized-build/component.js
@@ -118,6 +118,12 @@ export default Component.extend({
   },
 
   actions: {
+    searchOrAddtoList(model, propertyName, value, e) {
+      if (e.keyCode === 13) {
+        this.updateValue({ model, propertyName, value: value.searchText });
+      }
+    },
+
     onUpdateDropdownValue(model, propertyName, value) {
       this.updateValue({ model, propertyName, value });
     },

--- a/app/components/pipeline-parameterized-build/template.hbs
+++ b/app/components/pipeline-parameterized-build/template.hbs
@@ -3,11 +3,28 @@
   onSubmit=(action "onSave" parameters) as |form|}}
 
   {{#each parameters as |parameter|}}
-    {{form.element
-      label=parameter.name
-      placeholder=parameter.value
-      property=parameter.name
-      onChange=(action "onUpdateValue")}}
+    {{#if (is-array parameter.value)}}
+      {{#form.group}}
+        <label class="control-label col-md-4">{{parameter.name}}</label>
+        <div class="col-md-8">
+          {{#power-select
+            options=parameter.value
+            renderInPlace=true
+            selected=(get parameterizedModel parameter.name)
+            onchange=(action (action "onUpdateDropdownValue" parameterizedModel parameter.name))
+            as |selectedValue|
+          }}
+            {{selectedValue}}
+          {{/power-select}}
+        </div>
+      {{/form.group}}
+    {{else}}
+      {{form.element
+        label=parameter.name
+        placeholder=parameter.value
+        property=parameter.name
+        onChange=(action "onUpdateValue")}}
+    {{/if}}
   {{/each}}
 
   {{#if showSubmitButton}}

--- a/app/components/pipeline-parameterized-build/template.hbs
+++ b/app/components/pipeline-parameterized-build/template.hbs
@@ -12,6 +12,9 @@
             renderInPlace=true
             selected=(get parameterizedModel parameter.name)
             onchange=(action (action "onUpdateDropdownValue" parameterizedModel parameter.name))
+            onkeydown=(action (action "searchOrAddtoList" parameterizedModel parameter.name))
+            searchPlaceholder="Type to filter"
+            noMatchesMessage="Hit enter to override"
             as |selectedValue|
           }}
             {{selectedValue}}

--- a/tests/integration/components/pipeline-parameterized-build/component-test.js
+++ b/tests/integration/components/pipeline-parameterized-build/component-test.js
@@ -48,4 +48,22 @@ module('Integration | Component | pipeline-parameterized-build', function(hooks)
     `);
     await click('button.test-button');
   });
+
+  test('it renders as dropdown list', async function(assert) {
+    this.setProperties({
+      buildParameters: {
+        from: 'latest',
+        to: ['test', 'stable']
+      },
+      showSubmitButton: true
+    });
+
+    await render(hbs`{{pipeline-parameterized-build
+      buildParameters=buildParameters
+      showSubmitButton=showSubmitButton}}`);
+    assert.dom('.form-group').exists({ count: 2 }, 'There are 2 parameters');
+    assert.dom('.ember-basic-dropdown').exists({ count: 1 }, 'There is 1 dropdown list');
+    assert.dom('.form-control').exists({ count: 1 }, 'There is 1 input field');
+    assert.dom('button[type=submit]').exists({ count: 1 }, 'There is 1 submit button');
+  });
 });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

An alternative solution to https://github.com/screwdriver-cd/ui/pull/573

`Screwdriver.yaml` file: https://github.com/adong/sd-paramters-dropdown/blob/master/screwdriver.yaml

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Try to squeeze much code in the handlebars using `power-select`, it is cool that `power-select` is able to handle it :) 


## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

ember-power-select 2.x:

- [onkeydown](https://2-x.ember-power-select.com/docs/api-reference/)

ember-bootstrap:

- [Form Group](https://www.ember-bootstrap.com/api/classes/Components.FormGroup.html)


I also applied function currying to `Ember Action`, i.e.

```handlebars
            onchange=(action (action "onUpdateDropdownValue" parameterizedModel parameter.name))
            onkeydown=(action (action "searchOrAddtoList" parameterizedModel parameter.name))
```



and I learned from [A note on actions | EmberMap](https://embermap.com/notes/26-a-note-on-actions) (highly recommended to read)

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
