### PR TITLE
fix(2152): Support passing projectKey to getCoverageInfo

### DIFF
--- a/app/components/build-banner/component.js
+++ b/app/components/build-banner/component.js
@@ -109,7 +109,7 @@ export default Component.extend({
   coverageInfoCompute() {
     // Set coverage query startTime to build start time since user can do coverage during user step
     const buildStartTime = this.buildSteps[0].startTime;
-    const { coverageStepEndTime } = this;
+    const { coverageStepEndTime, buildMeta } = this;
 
     if (!coverageStepEndTime) {
       this.set('coverageInfo', {
@@ -130,7 +130,8 @@ export default Component.extend({
       pipelineId: this.pipelineId,
       prNum: this.prNumber,
       jobName: this.jobName,
-      pipelineName: this.pipelineName
+      pipelineName: this.pipelineName,
+      projectKey: buildMeta.build?.coverageKey || null
     };
 
     if (this.annotations && this.annotations['screwdriver.cd/coverageScope']) {

--- a/app/components/pipeline-list-coverage-cell/component.js
+++ b/app/components/pipeline-list-coverage-cell/component.js
@@ -6,30 +6,8 @@ export default Component.extend({
   shuttle: service(),
 
   result: computed('value', {
-    get: async () => {
-      const {
-        buildId,
-        jobId,
-        startTime,
-        endTime,
-        pipelineId,
-        prNum,
-        jobName,
-        pipelineName,
-        scope
-      } = this.value;
-
-      return this.shuttle.fetchCoverage(
-        buildId,
-        jobId,
-        startTime,
-        endTime,
-        pipelineId,
-        prNum,
-        jobName,
-        pipelineName,
-        scope
-      );
+    async get() {
+      return this.shuttle.fetchCoverage(this.value);
     }
   })
 });

--- a/app/components/pipeline-list-view/component.js
+++ b/app/components/pipeline-list-view/component.js
@@ -166,7 +166,7 @@ export default Component.extend({
           jobName,
           pipelineName: this.get('pipeline.name'),
           prParentJobId,
-          projectKey: latestBuild.meta?.build?.coverageKey || null
+          projectKey: latestBuild.meta?.build?.coverageKey
         };
 
         if (annotations && annotations['screwdriver.cd/coverageScope']) {

--- a/app/components/pipeline-list-view/component.js
+++ b/app/components/pipeline-list-view/component.js
@@ -124,7 +124,7 @@ export default Component.extend({
 
   getRows(jobsDetails = []) {
     let rows = jobsDetails.map(jobDetails => {
-      const { jobId, jobName, annotations } = jobDetails;
+      const { jobId, jobName, annotations, prParentJobId, prNum } = jobDetails;
       const latestBuild = jobDetails.builds.length ? get(jobDetails, 'builds.lastObject') : null;
 
       const jobData = {
@@ -142,9 +142,6 @@ export default Component.extend({
         hasParameters: Object.keys(this.get('buildParameters')).length > 0,
         openParametersModal: this.openParametersModal.bind(this)
       };
-
-      const prRegex = /^PR-(\d+)(?::([\w-]+))?$/;
-      const prNumMatch = jobName.match(prRegex);
 
       let duration;
 
@@ -165,9 +162,11 @@ export default Component.extend({
           startTime: latestBuild.startTime,
           endTime: latestBuild.endTime,
           pipelineId: latestBuild.pipelineId,
-          prNum: prNumMatch && prNumMatch.length > 1 ? prNumMatch[1] : null,
+          prNum,
           jobName,
-          pipelineName: this.get('pipeline.name')
+          pipelineName: this.get('pipeline.name'),
+          prParentJobId,
+          projectKey: latestBuild.meta?.build?.coverageKey || null
         };
 
         if (annotations && annotations['screwdriver.cd/coverageScope']) {

--- a/app/job/model.js
+++ b/app/job/model.js
@@ -1,5 +1,5 @@
 import { computed, get } from '@ember/object';
-import { equal, match } from '@ember/object/computed';
+import { alias, equal, match } from '@ember/object/computed';
 import DS from 'ember-data';
 import ENV from 'screwdriver-ui/config/environment';
 import { isActiveBuild } from 'screwdriver-ui/utils/build';
@@ -26,6 +26,7 @@ export default DS.Model.extend({
       return this.isPR ? parseInt(this.name.slice('PR-'.length), 10) : null;
     }
   }),
+  prNumber: alias('group'),
   username: DS.attr('string'),
   userProfile: DS.attr('string'),
   url: DS.attr('string'),

--- a/app/job/model.js
+++ b/app/job/model.js
@@ -37,6 +37,7 @@ export default DS.Model.extend({
       return `${humanizeDuration(duration, { round: true, largest: 1 })} ago`;
     }
   }),
+  prParentJobId: DS.attr('string'),
   // } for pr job only
   permutations: DS.attr(),
   annotations: computed('permutations.[]', {

--- a/app/pipeline/build/template.hbs
+++ b/app/pipeline/build/template.hbs
@@ -19,6 +19,7 @@
   isAuthenticated=session.isAuthenticated
   event=event
   prEvents=prEvents
+  prNumber=job.group
   onStart=(action "startBuild")
   onStop=(action "stopBuild")
   reloadBuild=(action "reload")

--- a/app/pipeline/build/template.hbs
+++ b/app/pipeline/build/template.hbs
@@ -19,7 +19,7 @@
   isAuthenticated=session.isAuthenticated
   event=event
   prEvents=prEvents
-  prNumber=job.group
+  prNumber=job.prNumber
   onStart=(action "startBuild")
   onStop=(action "stopBuild")
   reloadBuild=(action "reload")

--- a/app/pipeline/events/controller.js
+++ b/app/pipeline/events/controller.js
@@ -270,6 +270,9 @@ export default Controller.extend(ModelReloaderMixin, {
               nextJobDetail.jobName = job.name;
               nextJobDetail.jobPipelineId = job.pipelineId;
               nextJobDetail.annotations = job.annotations;
+              // PR-specific
+              nextJobDetail.prParentJobId = job.prParentJobId || null;
+              nextJobDetail.prNum = job.group || null;
             }
           });
 

--- a/app/shuttle/service.js
+++ b/app/shuttle/service.js
@@ -92,6 +92,20 @@ export default Service.extend({
     return this.fetchFromApi(method, url, data);
   },
 
+  /**
+   * Fetch coverage info from coverage plugin
+   * @param  {Object}  data
+   * @param  {String}  [data.jobId]        Job ID
+   * @param  {String}  [data.jobName]      Job name
+   * @param  {String}  [data.pipelineId]	 Pipeline ID
+   * @param  {String}  [data.pipelineName] Pipeline name
+   * @param  {String}  data.startTime      Build start time
+   * @param  {String}  data.endTime        Build end time
+   * @param  {String}  [data.prNum]        PR number
+   * @param  {String}  [data.scope]        Coverage scope (pipeline or job)
+   * @param  {String}  data.projectKey     Coverage key
+   * @return {Promise} Coverage object with coverage results and test data
+   */
   async fetchCoverage(data) {
     const method = 'get';
     const url = `/coverage/info`;

--- a/app/shuttle/service.js
+++ b/app/shuttle/service.js
@@ -92,24 +92,9 @@ export default Service.extend({
     return this.fetchFromApi(method, url, data);
   },
 
-  async fetchCoverage(
-    buildId,
-    jobId,
-    startTime,
-    endTime,
-    pipelineId,
-    prNum,
-    jobName,
-    pipelineName,
-    scope
-  ) {
+  async fetchCoverage(data) {
     const method = 'get';
     const url = `/coverage/info`;
-    const data = { buildId, jobId, startTime, endTime, pipelineId, prNum, jobName, pipelineName };
-
-    if (scope) {
-      data.scope = scope;
-    }
 
     return this.fetchFromApi(method, url, data);
   },

--- a/tests/integration/components/build-banner/component-test.js
+++ b/tests/integration/components/build-banner/component-test.js
@@ -59,6 +59,7 @@ const buildMock = EmberObject.create({
 });
 
 const buildMetaMock = {
+  build: {},
   tests: {
     coverage: '100',
     coverageUrl: '/coverage/666',
@@ -336,15 +337,19 @@ module('Integration | Component | build banner', function(hooks) {
       }
     ];
 
+    buildMetaMock.tests = {};
+
     assert.expect(4);
     this.set('eventMock', eventMock);
     this.set('buildStepsMock', coverageStepsMock);
+    this.set('buildMetaMock', buildMetaMock);
     this.set('prEvents', new EmberPromise(resolves => resolves([])));
 
     await render(hbs`{{build-banner
       buildContainer="node:6"
       duration="5 seconds"
       buildId=123
+      buildMeta=buildMetaMock
       buildStatus="SUCCESS"
       buildStart="2016-11-04T20:09:41.238Z"
       buildSteps=buildStepsMock
@@ -352,6 +357,9 @@ module('Integration | Component | build banner', function(hooks) {
       jobName="main"
       isAuthenticated=true
       event=eventMock
+      pipelineId=456
+      pipelineName="d2lam/mytest"
+      prNumber=null
       prEvents=prEvents
     }}`);
 
@@ -376,12 +384,14 @@ module('Integration | Component | build banner', function(hooks) {
     });
     this.set('eventMock', eventMock);
     this.set('buildStepsMock', coverageStepsMock);
+    this.set('buildMetaMock', buildMetaMock);
     this.set('prEvents', new EmberPromise(resolves => resolves([])));
 
     await render(hbs`{{build-banner
       buildContainer="node:6"
       duration="5 seconds"
       buildId=123
+      buildMeta=buildMetaMock
       buildStatus="RUNNING"
       buildStart="2016-11-04T20:09:41.238Z"
       buildSteps=buildStepsMock

--- a/tests/unit/pipeline/events/controller-test.js
+++ b/tests/unit/pipeline/events/controller-test.js
@@ -659,9 +659,30 @@ module('Unit | Controller | pipeline/events', function(hooks) {
     await settled();
 
     assert.deepEqual(controller.get('jobsDetails'), [
-      { jobId: 1, jobName: 'a', jobPipelineId: '1234', annotations: {} },
-      { jobId: 2, jobName: 'b', jobPipelineId: '1234', annotations: {} },
-      { jobId: 3, jobName: 'c', jobPipelineId: '1234', annotations: {} }
+      {
+        jobId: 1,
+        jobName: 'a',
+        jobPipelineId: '1234',
+        annotations: {},
+        prParentJobId: null,
+        prNum: null
+      },
+      {
+        jobId: 2,
+        jobName: 'b',
+        jobPipelineId: '1234',
+        annotations: {},
+        prParentJobId: null,
+        prNum: null
+      },
+      {
+        jobId: 3,
+        jobName: 'c',
+        jobPipelineId: '1234',
+        annotations: {},
+        prParentJobId: null,
+        prNum: null
+      }
     ]);
   });
 
@@ -715,10 +736,38 @@ module('Unit | Controller | pipeline/events', function(hooks) {
     await settled();
 
     assert.deepEqual(controller.get('jobsDetails'), [
-      { jobId: 1, jobName: 'a', jobPipelineId: '1234', annotations: {} },
-      { jobId: 2, jobName: 'b', jobPipelineId: '1234', annotations: {} },
-      { jobId: 3, jobName: 'c', jobPipelineId: '1234', annotations: {} },
-      { jobId: 4, jobName: 'd', jobPipelineId: '1234', annotations: {} }
+      {
+        jobId: 1,
+        jobName: 'a',
+        jobPipelineId: '1234',
+        annotations: {},
+        prParentJobId: null,
+        prNum: null
+      },
+      {
+        jobId: 2,
+        jobName: 'b',
+        jobPipelineId: '1234',
+        annotations: {},
+        prParentJobId: null,
+        prNum: null
+      },
+      {
+        jobId: 3,
+        jobName: 'c',
+        jobPipelineId: '1234',
+        annotations: {},
+        prParentJobId: null,
+        prNum: null
+      },
+      {
+        jobId: 4,
+        jobName: 'd',
+        jobPipelineId: '1234',
+        annotations: {},
+        prParentJobId: null,
+        prNum: null
+      }
     ]);
   });
 


### PR DESCRIPTION
## Context

Would be nice if we could use existing projectKey data to get coverage info.

## Objective

This PR passes projectKey to get coverage endpoint.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2152

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
