### PR TITLE
fix: set forbidEval to true for autoImport

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -4,6 +4,9 @@ const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
 module.exports = function(defaults) {
   let app = new EmberApp(defaults, {
+    autoImport: {
+      forbidEval: true
+    },
     // Add options here
     'ember-font-awesome': {
       useScss: true // for ember-cli-sass


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

We are now seeing errors like
![image](https://user-images.githubusercontent.com/15989893/90053601-95ce9800-dc8f-11ea-981a-f80e68f68204.png)

when click on **Aggregate view** and set **enable/disable jobs**

This happens only during local `development` mode, and it does not happen in `production` environment.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
This happened because we have introduced `ember-auto-import` from PR: https://github.com/screwdriver-cd/ui/pull/576

_I think `ember-cli-update --to 3.16.0` will auto add these newer dependencies to `package.json`_ 


Because we are running [ember-cli-content-security-policy](https://github.com/rwjblue/ember-cli-content-security-policy#ember-auto-import) and [ember-auto-import](https://github.com/ef4/ember-auto-import#i-use-content-security-policy-csp-and-it-breaks-ember-auto-import) at the same time during development mode.

`eval` mode set to be used for faster sourcemap generation.


> forbidEval: boolean, defaults to false. We use eval in development by default (because that is the fastest way to provide sourcemaps). If you need to comply with a strict Content Security Policy (CSP), you can set forbidEval: true. You will still get sourcemaps, they will just use a slower implementation.


In `production`:

1) Our environment variable is set to `production` and  `ember-auto-import` disables `forbidEval`.

2) We dont use `ember-cli-content-security-policy` after `ember build --environment=production`, and  [CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) is configured using [nginx.conf](https://github.com/screwdriver-cd/ui/blob/master/nginx.conf)


To fix such issue, either we remove `ember-auto-import` or add the following lines to `ember-cli-build.js` like this PR

```
    autoImport: {
      forbidEval: true
    },
```


## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
