### PR TITLE
fix(2175): fix parameters always use first input values

### DIFF
--- a/app/components/pipeline-start/component.js
+++ b/app/components/pipeline-start/component.js
@@ -47,14 +47,10 @@ export default Component.extend({
 
   actions: {
     startBuild(parameters) {
-      let args = this.startArgs;
-
-      if (parameters) {
-        args = parameters;
-      }
+      const args = this.startArgs;
       const startFunc = this.startBuild;
 
-      startFunc.apply(null, args);
+      startFunc.apply(null, [...args, parameters]);
     },
 
     toggleDropdown(toggleAction) {

--- a/app/components/pipeline-start/component.js
+++ b/app/components/pipeline-start/component.js
@@ -50,7 +50,7 @@ export default Component.extend({
       let args = this.startArgs;
 
       if (parameters) {
-        args.push(parameters);
+        args = parameters;
       }
       const startFunc = this.startBuild;
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Issue: https://github.com/screwdriver-cd/screwdriver/issues/2175

Current implementation keeps using the old data rather than the newer user input.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
This PR fixes the issue, and will use new user input instead.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
