### PR TITLE
fix: add loading message when loading template in create pipeline form

### DIFF
--- a/app/components/pipeline-create-form/component.js
+++ b/app/components/pipeline-create-form/component.js
@@ -25,6 +25,16 @@ export default Component.extend({
   isDisabled: or('isSaving', 'isInvalid'),
   autoKeysGeneration: false,
 
+  messageForSearching: computed('templates.[]', {
+    get() {
+      if (this.templates.length) {
+        return 'Not found.';
+      }
+
+      return 'Loading...';
+    }
+  }),
+
   isValid: computed('scmUrl', {
     get() {
       const val = this.scmUrl;

--- a/app/components/pipeline-create-form/template.hbs
+++ b/app/components/pipeline-create-form/template.hbs
@@ -51,6 +51,7 @@
             onchange=(action "selectTemplate")
             searchField="name"
             searchEnabled=true
+            noMatchesMessage="Loading..."
             as |template| }}
             {{template.name}}
           {{/power-select}}

--- a/app/components/pipeline-create-form/template.hbs
+++ b/app/components/pipeline-create-form/template.hbs
@@ -51,7 +51,7 @@
             onchange=(action "selectTemplate")
             searchField="name"
             searchEnabled=true
-            noMatchesMessage="Loading..."
+            noMatchesMessage=messageForSearching
             as |template| }}
             {{template.name}}
           {{/power-select}}


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Add message Loading... while loading templates during create pipeline page

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

I think there are 2 ways of doing it:

1) Using [`noMatchesMessage`](https://2-x.ember-power-select.com/docs/api-reference)

```javascript
          {{#power-select
            options=templates
            selected=selectedTemplate
            onchange=(action "selectTemplate")
            searchField="name"
            searchEnabled=true
            noMatchesMessage="Loading..."
            as |template| }}
            {{template.name}}
          {{/power-select}}
```

2) using `{{else}}` block 
```
{{#power-select
  options=templates
  selected=selectedTemplate
  onchange=(action "selectTemplate")
  searchField="name"
  searchEnabled=true
  as |template| }}
  {{template.name}}
{{else}}
  <span>Loading...</span>
{{/power-select}}
````

Unfortunately, 2nd way is being deprecated. Ref: https://github.com/cibernox/ember-power-select/issues/1370


Screenshot:
![2020-08-13_16-55-43 (1)](https://user-images.githubusercontent.com/15989893/90198293-25ef0900-dd86-11ea-807f-cebaea6b9e0f.gif)


## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
