### PR TITLE
fix(2181): fix not loading more items when scrolling

### DIFF
--- a/app/components/pipeline-list-view/template.hbs
+++ b/app/components/pipeline-list-view/template.hbs
@@ -1,5 +1,5 @@
 <button {{action "refreshListViewJobs"}} class="refresh-btn">Refresh</button>
-{{#light-table table height="inherit" as |t|}}
+{{#light-table table height="400px" as |t|}}
   {{t.head
     onColumnClick=(action "onColumnClick")
     iconSortable="fa fa-sort"


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Issue: https://github.com/screwdriver-cd/screwdriver/issues/2181
## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
This will fix the issue raised: https://github.com/screwdriver-cd/screwdriver/issues/2181

Please see my analysis in the comment section. 

Why `400px`? It's not a magic number. 

It's the `(row height) * (number of rows)` we are loading

`row height` is defined in https://github.com/screwdriver-cd/ui/blob/073db603beb4065123ea1fa6d1d8a32c60765ca1/app/components/pipeline-list-view/styles.scss#L49

`number of rows` is defined in https://github.com/screwdriver-cd/ui/blob/073db603beb4065123ea1fa6d1d8a32c60765ca1/app/pipeline/events/controller.js#L227

which is 
https://github.com/screwdriver-cd/ui/blob/073db603beb4065123ea1fa6d1d8a32c60765ca1/config/environment.js#L57

Thus, `40px` * `100` = `400px`.

This is not the best solution I'm looking for, but it will unblock users for now.



## References
In case there is some update on https://github.com/offirgolan/ember-light-table/pull/693#issuecomment-673753184, we can re-work this. 
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
