### PR TITLE
fix(2184): permalink for jobs is broken

### DIFF
--- a/app/pipeline/job-latest-build/route.js
+++ b/app/pipeline/job-latest-build/route.js
@@ -57,8 +57,8 @@ export default Route.extend({
   queryParams: {
     status: ''
   },
-  model(params, transition) {
-    const pipelineId = transition.params.pipeline.pipeline_id;
+  model(params /* , transition */) {
+    const pipelineId = this.paramsFor('pipeline').pipeline_id;
     const { job_name: jobName, status: buildStatus } = params;
 
     return getLatestBuild(this.get('session'), pipelineId, jobName, buildStatus);

--- a/app/pipeline/job-latest-build/route.js
+++ b/app/pipeline/job-latest-build/route.js
@@ -57,7 +57,7 @@ export default Route.extend({
   queryParams: {
     status: ''
   },
-  model(params /* , transition */) {
+  model(params) {
     const pipelineId = this.paramsFor('pipeline').pipeline_id;
     const { job_name: jobName, status: buildStatus } = params;
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Issue: https://github.com/screwdriver-cd/screwdriver/issues/2184

## Objective
Fix permalink issues

<!-- What does this PR fix? What intentional changes will this PR make? -->

Option 1)
```
const pipelineInfo = transition.to.parent.parent.params;
const pipelineId = pipelineInfo.pipeline_id;
```

Option 2)
```
const pipelineId = this.paramsFor('pipeline').pipeline_id;
```

2) looks more elegant 

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
1) https://github.com/emberjs/ember.js/issues/18004
2) https://deprecations.emberjs.com/v3.x/#toc_remove-handler-infos

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
