### PR TITLE
feat(2185): Handle default branch in scm plugin [3]

### DIFF
--- a/app/components/create-pipeline/component.js
+++ b/app/components/create-pipeline/component.js
@@ -86,7 +86,14 @@ export default Component.extend({
         try {
           if (yaml && yaml.length) {
             const pipelineId = pipeline.get('id');
-            const pr = await this.shuttle.openPr(scmUrl, yaml, pipelineId);
+
+            let checkoutUrl = scmUrl;
+
+            // Set branch if missing
+            if (scmUrl.split('#').length === 1) {
+              checkoutUrl = checkoutUrl.concat(`#${pipeline.get('branch')}`);
+            }
+            const pr = await this.shuttle.openPr(checkoutUrl, yaml, pipelineId);
             const { prUrl } = pr.payload;
 
             this.set('prUrl', prUrl);

--- a/app/components/pipeline-create-form/template.hbs
+++ b/app/components/pipeline-create-form/template.hbs
@@ -12,7 +12,7 @@
     {{input
       class="text-input scm-url"
       key-up=(action "scmChange")
-      placeholder="Enter your repository url (eg: git@github.com:screwdriver-cd/ui.git#master)"
+      placeholder="Enter your repository url (eg: git@github.com:screwdriver-cd/ui.git#branchName)"
       value=scmUrl
       enter=(action "saveData")
     }}

--- a/app/components/quickstart-guide/template.hbs
+++ b/app/components/quickstart-guide/template.hbs
@@ -67,7 +67,7 @@
     <div class="item">
       <div class="icon"></div>
       <div class="section">
-        <span>If no BRANCH_NAME is provided, it will default to the master branch. Click Use this repository to confirm and then click Create Pipeline.</span>
+        <span>If no BRANCH_NAME is provided, it will set to the default branch. Click Use this repository to confirm and then click Create Pipeline.</span>
       </div>
     </div>
 

--- a/app/utils/git.js
+++ b/app/utils/git.js
@@ -20,7 +20,7 @@ function parse(scmUrl) {
     server: match[1],
     owner: match[2],
     repo: match[3],
-    branch: match[4] ? match[4].slice(1) : 'master',
+    branch: match[4] ? match[4].slice(1) : null,
     valid: true
   };
 

--- a/tests/unit/utils/git-test.js
+++ b/tests/unit/utils/git-test.js
@@ -13,7 +13,7 @@ module('Unit | Utility | git', function() {
       server: 'github.com',
       owner: 'bananas',
       repo: 'peel',
-      branch: 'master',
+      branch: null,
       valid: true
     });
 


### PR DESCRIPTION
## Context

Currently, default branch for Screwdriver pipeline is hardcoded to `master`. It would be nice if the default branch actually took in the Github `default_branch`.

## Objective

This PR moves handling of default branch to the scm plugin.

## References

Related to #2185 

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
