### PR TITLE
fix: implement dropdown to 'pipeline start from here' on workflow graph

### DIFF
--- a/app/components/pipeline-workflow/component.js
+++ b/app/components/pipeline-workflow/component.js
@@ -43,8 +43,13 @@ export default Component.extend({
     setProperties(this, {
       builds: [],
       showDownstreamTriggers: false,
-      reason: ''
+      reason: '',
+      buildParameters: this.getDefaultBuildParameters()
     });
+  },
+
+  getDefaultBuildParameters() {
+    return this.getWithDefault('pipeline.parameters', {});
   },
 
   didUpdateAttrs() {

--- a/app/components/pipeline-workflow/template.hbs
+++ b/app/components/pipeline-workflow/template.hbs
@@ -78,7 +78,7 @@
         {{/if}}
       {{else if (get-length tooltipData.selectedEvent.meta.parameters)}}
         {{#pipeline-parameterized-build
-          buildParameters=tooltipData.selectedEvent.meta.parameters
+          buildParameters=buildParameters
           as |parameterizedBuild| }}
           <div class="row">
             <div class="col-xs-6">


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Currently, the dropdown selection is only shown at the start of the pipeline, this PR will implement and add dropdown selection to `Start pipeline from here`

## Objective

After
![image](https://user-images.githubusercontent.com/15989893/91810559-f3953680-ebe2-11ea-9a61-e12df267f11e.png)

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
