### PR TITLE
fix: add event to paginateEvents in order to scrollToView

### DIFF
--- a/app/pipeline/events/show/route.js
+++ b/app/pipeline/events/show/route.js
@@ -35,7 +35,9 @@ export default class PipelineEventsShowRoute extends Route {
     const desiredEvent = pipelineEventsController.events.findBy('id', eventId);
 
     if (!desiredEvent) {
-      await this.store.findRecord('event', eventId);
+      const event = await this.store.findRecord('event', eventId);
+
+      pipelineEventsController.paginateEvents.pushObject(event);
     }
 
     pipelineEventsController.set('selected', eventId);


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
We need to add the load-on-demand event to paginateEvents to load in to the view.
## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
