### PR TITLE
fix: jobNameLength is not specific to each pipeline

### DIFF
--- a/app/components/pipeline-event-row/template.hbs
+++ b/app/components/pipeline-event-row/template.hbs
@@ -34,6 +34,7 @@
     {{#if (and (is-fulfilled event.builds) isShowGraph)}}
       <div class="workflow">
         {{workflow-graph-d3
+          pipeline=pipeline
           builds=event.builds
           workflowGraph=event.workflowGraph
           startFrom=event.startFrom

--- a/app/components/pipeline-options/component.js
+++ b/app/components/pipeline-options/component.js
@@ -63,7 +63,7 @@ export default Component.extend({
     let desiredJobNameLength = MINIMUM_JOBNAME_LENGTH;
 
     const pipelinePreference = await this.store.queryRecord('preference/pipeline', {
-      pipelineId: this.get('pipeline.id')
+      filter: { pipelineId: this.get('pipeline.id') }
     });
 
     if (pipelinePreference) {
@@ -162,7 +162,7 @@ export default Component.extend({
     async updateJobNameLength(jobNameLength) {
       const pipelineId = this.get('pipeline.id');
       const pipelinePreference = await this.store.queryRecord('preference/pipeline', {
-        pipelineId
+        filter: { pipelineId: this.get('pipeline.id') }
       });
 
       if (pipelinePreference) {

--- a/app/components/pipeline-options/styles.scss
+++ b/app/components/pipeline-options/styles.scss
@@ -127,8 +127,9 @@
     text-align: right;
   }
 
-  input.display-name {
+  input.display-job-name {
     margin-right: 25px;
+    width: 38px;
   }
 }
 

--- a/app/components/pipeline-options/template.hbs
+++ b/app/components/pipeline-options/template.hbs
@@ -172,7 +172,7 @@
             </div>
             <div class="col-xs-2 right">
               <input type="number"
-                class="display-name"
+                class="display-job-name"
                 min={{minDisplayLength}}
                 max="99"
                 placeholder={{minDisplayLength}}

--- a/app/components/pipeline-workflow/template.hbs
+++ b/app/components/pipeline-workflow/template.hbs
@@ -1,5 +1,6 @@
 {{#if (and (is-fulfilled selectedEventObj.builds) (is-fulfilled graph))}}
   {{#workflow-graph-d3
+    pipeline=pipeline
     completeWorkflowGraph=completeWorkflowGraph
     showDownstreamTriggers=showDownstreamTriggers
     builds=selectedEventObj.builds

--- a/app/components/workflow-graph-d3/component.js
+++ b/app/components/workflow-graph-d3/component.js
@@ -140,8 +140,11 @@ export default Component.extend({
   async draw(data) {
     let displayJobNameLength = ENV.APP.MINIMUM_JOBNAME_LENGTH;
 
-    const pipelineId = this.get('pipeline.id');
-    const pipelinePreference = await this.store.queryRecord('preference/pipeline', { pipelineId });
+    const pipelinePreference = await this.store.queryRecord('preference/pipeline', {
+      filter: {
+        pipelineId: this.get('pipeline.id')
+      }
+    });
 
     if (pipelinePreference) {
       const { jobNameLength } = pipelinePreference;

--- a/app/preference/pipeline/model.js
+++ b/app/preference/pipeline/model.js
@@ -1,7 +1,7 @@
 import Model, { attr } from '@ember-data/model';
 
 export default class PreferencePipelineModel extends Model {
-  @attr('number') pipelineId;
+  @attr('string') pipelineId;
 
   @attr('number') jobNameLength;
 }


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Currently, there's a bug when query local pipeline preferences, it will just fetch the first pipeline preference regardless of the query filter. Accidentally making pipeline specific settings across the app. (Will introduce a true global preference later 2020)

Also, the format issue is not consistent in Firefox, due to 
- Chrome will adjust input length when `<input>` type is number, and min & max is set, (in this case, min is `20` and max is `99`, making it 2 digits only), while firefox needs to set a width specifically. 


This PR fixes that.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
1) fix: fetch local pipeline preferences
  - change model `id` type from number to string, (ref: https://github.com/emberjs/data/issues/5279#issuecomment-358856561)
  - add `filter` when `queryRecord`for `ember-local-storage`

```javascript

    const records = this._getIndex(type)
      .filter(function(storageKey) {
        return storage[storageKey];
      })
      .map(function(storageKey) {
        return JSON.parse(storage[storageKey]);
      });

    if (query && query.filter) {
      const serializer = this.store.serializerFor(singularize(type));

      return records.filter((record) => {
        return this._queryFilter(record, serializer, query.filter);
      });
    }

    return records;
  },
```


https://github.com/funkensturm/ember-local-storage/blob/550954c022987214939ee17e3461affa5cff21a6/addon/adapters/base.js#L162-L179

2) fix: style issue in firefox

Before:
![image](https://user-images.githubusercontent.com/15989893/92279598-7e5c8680-eeac-11ea-88a6-170db637c15a.png)


After:
![image](https://user-images.githubusercontent.com/15989893/92279171-9a135d00-eeab-11ea-9aa3-224284430459.png)

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
