### PR TITLE
fix: prevent clicking on pr event will trigger redirect to event pages

### DIFF
--- a/app/components/pipeline-event-row/component.js
+++ b/app/components/pipeline-event-row/component.js
@@ -89,7 +89,9 @@ export default Component.extend({
       const fn = get(this, 'eventClick');
 
       if (typeof fn === 'function') {
-        fn(get(this, 'event.id'));
+        const { id, type } = this.event;
+
+        fn(id, type);
       }
     },
     toggleParametersPreview() {

--- a/app/components/pipeline-events-list/component.js
+++ b/app/components/pipeline-events-list/component.js
@@ -16,13 +16,15 @@ export default Component.extend({
     scheduleOnce('afterRender', this, 'updateEvents', this.eventsPage + 1);
   },
   actions: {
-    eventClick(id) {
+    eventClick(id, eventType) {
       set(this, 'selected', id);
 
-      const currentEvent = this.eventsList.findBy('id', id);
-      const { pipelineId } = currentEvent;
+      if (eventType !== 'pr') {
+        const currentEvent = this.eventsList.findBy('id', id);
+        const { pipelineId } = currentEvent;
 
-      this.router.transitionTo('pipeline.events.show', pipelineId, id);
+        this.router.transitionTo('pipeline.events.show', pipelineId, id);
+      }
     }
   }
 });

--- a/tests/integration/components/pipeline-events-list/component-test.js
+++ b/tests/integration/components/pipeline-events-list/component-test.js
@@ -150,8 +150,8 @@ module('Integration | Component | pipeline events list', function(hooks) {
                       eventsPage=1
                       updateEvents=updateEventsMock}}`);
 
-    const route = this.owner.lookup('route:application');
-    const transitionToStub = sinon.stub(route, 'transitionTo');
+    const routerService = this.owner.lookup('service:router');
+    const transitionToStub = sinon.stub(routerService, 'transitionTo');
 
     await click('div.view');
     assert.ok(transitionToStub.calledOnce, 'transitionTo was called once');
@@ -210,8 +210,8 @@ module('Integration | Component | pipeline events list', function(hooks) {
                       eventsPage=1
                       updateEvents=updateEventsMock}}`);
 
-    const route = this.owner.lookup('route:application');
-    const transitionToStub = sinon.stub(route, 'transitionTo');
+    const routerService = this.owner.lookup('service:router');
+    const transitionToStub = sinon.stub(routerService, 'transitionTo');
 
     await click('div.view');
     assert.ok(transitionToStub.notCalled, 'transitionTo was not called');

--- a/tests/integration/components/pipeline-events-list/component-test.js
+++ b/tests/integration/components/pipeline-events-list/component-test.js
@@ -1,8 +1,9 @@
 import EmberObject from '@ember/object';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { click, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import sinon from 'sinon';
 
 module('Integration | Component | pipeline events list', function(hooks) {
   setupRenderingTest(hooks);
@@ -94,5 +95,125 @@ module('Integration | Component | pipeline events list', function(hooks) {
                       updateEvents=updateEventsMock}}`);
 
     assert.dom('.view').exists({ count: 2 });
+  });
+
+  test('it will redirect to event page when click on pipeline event', async function(assert) {
+    const events = [
+      EmberObject.create({
+        pipelineId: 10000,
+        id: 4,
+        startFrom: '~commit',
+        type: 'pipeline',
+        causeMessage: 'test',
+        commit: {
+          url: '#',
+          message: 'this was a test'
+        },
+        creator: {
+          url: '#',
+          name: 'batman'
+        },
+        createTimeWords: 'now',
+        durationText: '1 sec',
+        truncatedMessage: 'this was a test',
+        truncatedSha: 'abc124',
+        workflowGraph: {
+          nodes: [
+            { name: '~pr' },
+            { name: '~commit' },
+            { id: 1, name: 'main' },
+            { id: 2, name: 'A' },
+            { id: 3, name: 'B' }
+          ],
+          edges: [
+            { src: '~pr', dest: 'main' },
+            { src: '~commit', dest: 'main' },
+            { src: 'main', dest: 'A' },
+            { src: 'A', dest: 'B' }
+          ]
+        },
+        builds: [
+          { jobId: 1, id: 4, status: 'SUCCESS' },
+          { jobId: 2, id: 5, status: 'SUCCESS' },
+          { jobId: 3, id: 6, status: 'FAILURE' }
+        ]
+      })
+    ];
+
+    this.set('eventsMock', events);
+    this.set('updateEventsMock', page => {
+      assert.equal(page, 2);
+    });
+
+    await render(hbs`{{pipeline-events-list
+                      events=eventsMock
+                      eventsPage=1
+                      updateEvents=updateEventsMock}}`);
+
+    const route = this.owner.lookup('route:application');
+    const transitionToStub = sinon.stub(route, 'transitionTo');
+
+    await click('div.view');
+    assert.ok(transitionToStub.calledOnce, 'transitionTo was called once');
+  });
+
+  test('it will not redirect to event page when click on PR event', async function(assert) {
+    const events = [
+      EmberObject.create({
+        pipelineId: 10000,
+        id: 4,
+        startFrom: '~pr',
+        type: 'pr',
+        causeMessage: 'test',
+        commit: {
+          url: '#',
+          message: 'this was a test'
+        },
+        creator: {
+          url: '#',
+          name: 'batman'
+        },
+        createTimeWords: 'now',
+        durationText: '1 sec',
+        truncatedMessage: 'this was a test',
+        truncatedSha: 'abc124',
+        workflowGraph: {
+          nodes: [
+            { name: '~pr' },
+            { name: '~commit' },
+            { id: 1, name: 'main' },
+            { id: 2, name: 'A' },
+            { id: 3, name: 'B' }
+          ],
+          edges: [
+            { src: '~pr', dest: 'main' },
+            { src: '~commit', dest: 'main' },
+            { src: 'main', dest: 'A' },
+            { src: 'A', dest: 'B' }
+          ]
+        },
+        builds: [
+          { jobId: 1, id: 4, status: 'SUCCESS' },
+          { jobId: 2, id: 5, status: 'SUCCESS' },
+          { jobId: 3, id: 6, status: 'FAILURE' }
+        ]
+      })
+    ];
+
+    this.set('eventsMock', events);
+    this.set('updateEventsMock', page => {
+      assert.equal(page, 2);
+    });
+
+    await render(hbs`{{pipeline-events-list
+                      events=eventsMock
+                      eventsPage=1
+                      updateEvents=updateEventsMock}}`);
+
+    const route = this.owner.lookup('route:application');
+    const transitionToStub = sinon.stub(route, 'transitionTo');
+
+    await click('div.view');
+    assert.ok(transitionToStub.notCalled, 'transitionTo was not called');
   });
 });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Some user reports that click on PR-build, will trigger redirect to event page.
![image](https://user-images.githubusercontent.com/15989893/93527211-609c1200-f8ed-11ea-9bb1-99ee9874fef3.png)

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
This is a regression issue, and this PR will fix that.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
