### PR TITLE
fix: bump up memory/ram usage to HIGH

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -3,6 +3,8 @@ cache:
 
 shared:
   image: node:12
+  annotations:
+    screwdriver.cd/ram: HIGH
 
 jobs:
   main:


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
We are seeing pod crash at `publish` step, i.e. https://cd.screwdriver.cd/pipelines/7/builds/496545/steps/build

![image](https://user-images.githubusercontent.com/15989893/93633167-605e4e00-f9a3-11ea-9be8-d44e0d8731d4.png)

We thought it was because some step has been halted, however, when we look inside k8s, we saw the pod is crashed, and we didn't know pod has crashed until timed-out in the UI.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Increase the memory usage, from default 2G to use `High` which is `12G`


## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

```yaml
  annotations:
    screwdriver.cd/ram: HIGH
```

https://docs.screwdriver.cd/user-guide/configuration/annotations.html

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
