### PR TITLE
fix(2053): add display of warnAnnotations to validator

### DIFF
--- a/app/components/validator-results/component.js
+++ b/app/components/validator-results/component.js
@@ -23,6 +23,7 @@ export default Component.extend({
       return getWithDefault(this, 'results.parameters', {});
     }
   }),
+  warnAnnotations: map('results.warnAnnotations', w => (typeof w === 'string' ? w : w.message)),
   templateName: computed('results.template.{namespace,name,version}', {
     get() {
       // construct full template name

--- a/app/components/validator-results/styles.scss
+++ b/app/components/validator-results/styles.scss
@@ -5,4 +5,9 @@
     border: 1px solid $sd-failure;
     padding: 10px;
   }
+
+  .warning {
+    border: 1px solid $sd-warning;
+    padding: 10px;
+  }
 }

--- a/app/components/validator-results/template.hbs
+++ b/app/components/validator-results/template.hbs
@@ -1,6 +1,9 @@
 {{#each errors as |msg|}}
   <div class="error">{{msg}}</div>
 {{/each}}
+{{#each warnAnnotations as |msg|}}
+  <div class="warning">{{msg}}</div>
+{{/each}}
 {{#if isTemplate}}
   {{validator-job name=templateName job=results.template.config template=results.template isOpen=(unbound isOpen)}}
 {{else}}

--- a/tests/integration/components/validator-results/component-test.js
+++ b/tests/integration/components/validator-results/component-test.js
@@ -120,4 +120,23 @@ module('Integration | Component | validator results', function(hooks) {
     assert.dom('.error').hasText('there is an error');
     assert.dom('h4').hasText('batman/batmobile@1.0.0');
   });
+
+  test('it renders warnAnnotations results', async function(assert) {
+    this.set('validationMock', {
+      warnAnnotations: ['there is an warning'],
+      template: {
+        name: 'batman/batmobile',
+        version: '1.0.0',
+        config: {
+          image: 'int-test:1',
+          steps: [{ forgreatjustice: 'ba.sh' }]
+        }
+      }
+    });
+
+    await render(hbs`{{validator-results results=validationMock isTemplate=true}}`);
+
+    assert.dom('.warning').hasText('there is an warning');
+    assert.dom('h4').hasText('batman/batmobile@1.0.0');
+  });
 });


### PR DESCRIPTION
## Context
Add feature of https://github.com/screwdriver-cd/screwdriver/issues/2053
The API does not yet put any values into `warnAnnotations`. The screenshot below is a sample of how it will appear.
<img width="900" src="https://user-images.githubusercontent.com/24538326/95313077-ac2d5480-08ca-11eb-8d31-f36bf64ea743.png">

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
If the value of `warnAnnotations` is present, it is displayed as a warning in the validator.
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/screwdriver/issues/2053
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->


[1] https://github.com/screwdriver-cd/data-schema/pull/414
[2] https://github.com/screwdriver-cd/config-parser/pull/111
UI: https://github.com/screwdriver-cd/ui/pull/605 (this PR)

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
