### PR TITLE
feat(2210): Show parameter description

### DIFF
--- a/app/components/pipeline-parameterized-build/component.js
+++ b/app/components/pipeline-parameterized-build/component.js
@@ -124,11 +124,7 @@ export default Component.extend({
       }
     },
 
-    onUpdateDropdownValue(model, propertyName, value) {
-      this.updateValue({ model, propertyName, value });
-    },
-
-    onUpdateValue(value, model, propertyName) {
+    onUpdateValue(model, propertyName, value) {
       this.updateValue({ model, propertyName, value });
     },
 

--- a/app/components/pipeline-parameterized-build/template.hbs
+++ b/app/components/pipeline-parameterized-build/template.hbs
@@ -3,15 +3,22 @@
   onSubmit=(action "onSave" parameters) as |form|}}
 
   {{#each parameters as |parameter|}}
-    {{#if (is-array parameter.value)}}
-      {{#form.group}}
-        <label class="control-label col-md-4">{{parameter.name}}</label>
-        <div class="col-md-8">
+    {{#form.group}}
+      <label class="control-label col-md-4">
+        {{#if parameter.description}}
+          {{fa-icon "question-circle" title=parameter.description}}
+        {{else}}
+          {{fa-icon "question-circle" title="No description."}}
+        {{/if}}
+        {{parameter.name}}
+      </label>
+      <div class="col-md-8">
+        {{#if (is-array parameter.value)}}
           {{#power-select
             options=parameter.value
             renderInPlace=true
             selected=(get parameterizedModel parameter.name)
-            onchange=(action (action "onUpdateDropdownValue" parameterizedModel parameter.name))
+            onchange=(action (action "onUpdateValue" parameterizedModel parameter.name))
             onkeydown=(action (action "searchOrAddtoList" parameterizedModel parameter.name))
             searchPlaceholder="Type to filter"
             noMatchesMessage="Hit enter to override"
@@ -19,15 +26,18 @@
           }}
             {{selectedValue}}
           {{/power-select}}
-        </div>
-      {{/form.group}}
-    {{else}}
-      {{form.element
-        label=parameter.name
-        placeholder=parameter.value
-        property=parameter.name
-        onChange=(action "onUpdateValue")}}
-    {{/if}}
+        {{else}}
+          {{input
+            value=parameter.value
+            class="form-control"
+            label=parameter.value
+            placeholder=parameter.value
+            property=parameter.name
+            change=(action (action "onUpdateValue" parameterizedModel parameter.name parameter.value))
+          }}
+        {{/if}}
+      </div>
+    {{/form.group}}
   {{/each}}
 
   {{#if showSubmitButton}}

--- a/app/components/pipeline-parameterized-build/template.hbs
+++ b/app/components/pipeline-parameterized-build/template.hbs
@@ -7,8 +7,6 @@
       <label class="control-label col-md-4">
         {{#if parameter.description}}
           {{fa-icon "question-circle" title=parameter.description}}
-        {{else}}
-          {{fa-icon "question-circle" title="No description."}}
         {{/if}}
         {{parameter.name}}
       </label>

--- a/app/components/pipeline-workflow/component.js
+++ b/app/components/pipeline-workflow/component.js
@@ -57,12 +57,16 @@ export default Component.extend({
       const parameterNames = Object.keys(buildParameters);
 
       parameterNames.forEach(parameterName => {
-        const parameterValue = buildParameters[parameterName];
-        const currentEventParameterValue = currentEventParameters[parameterName].value;
+        const parameterValue =
+          buildParameters[parameterName].value || buildParameters[parameterName];
+        const currentEventParameterValue =
+          currentEventParameters[parameterName].value || currentEventParameters[parameterName];
 
         if (Array.isArray(parameterValue)) {
           parameterValue.removeObject(currentEventParameterValue);
           parameterValue.unshift(currentEventParameterValue);
+        } else if (buildParameters[parameterName].value) {
+          buildParameters[parameterName].value = currentEventParameterValue;
         } else {
           buildParameters[parameterName] = currentEventParameterValue;
         }

--- a/tests/integration/components/pipeline-parameterized-build/component-test.js
+++ b/tests/integration/components/pipeline-parameterized-build/component-test.js
@@ -62,6 +62,32 @@ module('Integration | Component | pipeline-parameterized-build', function(hooks)
       buildParameters=buildParameters
       showSubmitButton=showSubmitButton}}`);
     assert.dom('.form-group').exists({ count: 2 }, 'There are 2 parameters');
+    assert.dom('.fa-question-circle').exists({ count: 2 }, 'Theare are 2 description info');
+    assert.dom('.ember-basic-dropdown').exists({ count: 1 }, 'There is 1 dropdown list');
+    assert.dom('.form-control').exists({ count: 1 }, 'There is 1 input field');
+    assert.dom('button[type=submit]').exists({ count: 1 }, 'There is 1 submit button');
+  });
+
+  test('it renders description', async function(assert) {
+    this.setProperties({
+      buildParameters: {
+        from: {
+          value: 'latest',
+          description: 'promote from tag'
+        },
+        to: {
+          value: ['test', 'stable'],
+          description: 'promote to tag'
+        }
+      },
+      showSubmitButton: true
+    });
+
+    await render(hbs`{{pipeline-parameterized-build
+      buildParameters=buildParameters
+      showSubmitButton=showSubmitButton}}`);
+    assert.dom('.form-group').exists({ count: 2 }, 'There are 2 parameters');
+    assert.dom('.fa-question-circle').exists({ count: 2 }, 'Theare are 2 description info');
     assert.dom('.ember-basic-dropdown').exists({ count: 1 }, 'There is 1 dropdown list');
     assert.dom('.form-control').exists({ count: 1 }, 'There is 1 input field');
     assert.dom('button[type=submit]').exists({ count: 1 }, 'There is 1 submit button');

--- a/tests/integration/components/pipeline-parameterized-build/component-test.js
+++ b/tests/integration/components/pipeline-parameterized-build/component-test.js
@@ -62,7 +62,6 @@ module('Integration | Component | pipeline-parameterized-build', function(hooks)
       buildParameters=buildParameters
       showSubmitButton=showSubmitButton}}`);
     assert.dom('.form-group').exists({ count: 2 }, 'There are 2 parameters');
-    assert.dom('.fa-question-circle').exists({ count: 2 }, 'Theare are 2 description info');
     assert.dom('.ember-basic-dropdown').exists({ count: 1 }, 'There is 1 dropdown list');
     assert.dom('.form-control').exists({ count: 1 }, 'There is 1 input field');
     assert.dom('button[type=submit]').exists({ count: 1 }, 'There is 1 submit button');
@@ -78,7 +77,8 @@ module('Integration | Component | pipeline-parameterized-build', function(hooks)
         to: {
           value: ['test', 'stable'],
           description: 'promote to tag'
-        }
+        },
+        image: 'test-image'
       },
       showSubmitButton: true
     });
@@ -86,10 +86,10 @@ module('Integration | Component | pipeline-parameterized-build', function(hooks)
     await render(hbs`{{pipeline-parameterized-build
       buildParameters=buildParameters
       showSubmitButton=showSubmitButton}}`);
-    assert.dom('.form-group').exists({ count: 2 }, 'There are 2 parameters');
+    assert.dom('.form-group').exists({ count: 3 }, 'There are 2 parameters');
     assert.dom('.fa-question-circle').exists({ count: 2 }, 'Theare are 2 description info');
     assert.dom('.ember-basic-dropdown').exists({ count: 1 }, 'There is 1 dropdown list');
-    assert.dom('.form-control').exists({ count: 1 }, 'There is 1 input field');
+    assert.dom('.form-control').exists({ count: 2 }, 'There is 1 input field');
     assert.dom('button[type=submit]').exists({ count: 1 }, 'There is 1 submit button');
   });
 });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Show description of parameter on the UI.
Description is shown by moving cursor on icon.

<img width="200" alt="スクリーンショット 2020-10-09 18 40 43" src="https://user-images.githubusercontent.com/8113204/95568410-2858a100-0a5f-11eb-80bf-133ce2311fac.png">


<img width="200" alt="スクリーンショット 2020-10-09 18 40 04" src="https://user-images.githubusercontent.com/8113204/95568324-0b23d280-0a5f-11eb-837b-d983ceb96c2b.png">


## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Add an icon to head of the parameter name. If parameter description is defined, parameter description is shown on UI.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
screwdriver-cd/screwdriver#2210


## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
