### PR TITLE
feat: add a badge to display canary release

### DIFF
--- a/app/components/app-header/component.js
+++ b/app/components/app-header/component.js
@@ -6,6 +6,7 @@ export default Component.extend({
   showSearch: false,
   docUrl: ENV.APP.SDDOC_URL,
   slackUrl: ENV.APP.SLACK_URL,
+  showReleaseBadge: ENV.APP.CANARY_RELEASE,
   searchTerm: '',
   actions: {
     invalidateSession() {

--- a/app/components/app-header/styles.scss
+++ b/app/components/app-header/styles.scss
@@ -154,6 +154,23 @@
     }
   }
 
+  .canary-feature {
+    position: relative;
+  
+    &:after {
+      content: 'Canary';
+      color: #fff;
+      background: #4a3bd0;
+      font-size: 0.75em;
+      position: absolute;
+      line-height: 1;
+      top: 1.5em;
+      right: 1em;
+      padding: 4px 6px;
+      border-radius: 7px;
+    }
+  }
+
   .dropdown-menu > li > a {
     span {
       padding-left: 0.5em;

--- a/app/components/app-header/template.hbs
+++ b/app/components/app-header/template.hbs
@@ -46,6 +46,11 @@
     {{/navbar.nav}}
 
     {{#navbar.nav classNames="navbar-nav navbar-right" as |nav|}}
+      {{#if showReleaseBadge}}
+        {{#nav.item}}
+          <span class="canary-feature"></span>
+        {{/nav.item}}
+      {{/if}}
       {{#if showSearch}}
         {{#nav.item}}
           <form class="navbar-form navbar-right" role="search">

--- a/config/environment.js
+++ b/config/environment.js
@@ -61,7 +61,8 @@ module.exports = environment => {
       DEFAULT_LOG_PAGE_SIZE: 10,
       FORCE_RELOAD_WAIT: 100, // Wait 100ms before force reload
       WAITING_TO_SCROLL_TIME: 1000,
-      DEBOUNCED_SCROLL_TIME: 3000
+      DEBOUNCED_SCROLL_TIME: 3000,
+      CANARY_RELEASE: false
     },
     moment: {
       allowEmpty: true // allow empty dates


### PR DESCRIPTION
## Context

Add canary badge in header to identify release

## Objective

This PR adds a badge in the header controlled via env vars to view the release

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
