### PR TITLE
fix: add startBuild to allow users to start build without viewing parameters

### DIFF
--- a/app/components/pipeline-start/template.hbs
+++ b/app/components/pipeline-start/template.hbs
@@ -1,7 +1,7 @@
 {{#if hasParameters}}
   {{#if hasLargeNumberOfParameters}}
     <div class="btn-group">
-      <button class="btn start-button" title="Start a new event from latest commit">Start{{#if prNum}} PR-{{prNum}}{{/if}}</button>
+      <button {{action "startBuild"}} class="btn start-button" title="Start a new event from latest commit">Start{{#if prNum}} PR-{{prNum}}{{/if}}</button>
       <button class="btn start-with-parameters-button" onClick={{action "toggleModal"}}>{{fa-icon (concat "caret-" direction)}}</button>
     </div>
     {{#if isShowingModal}}


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Currently, for a large number of parameters, users have to view parameters dropdown and click `submit` to trigger the pipeline. 
## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
This PR will relax and allow users to click on start button to kick-off build directly
## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
