### PR TITLE
fix: workflow graphs "flicker" every few seconds.

### DIFF
--- a/app/event/serializer.js
+++ b/app/event/serializer.js
@@ -1,24 +1,30 @@
 import { assign } from '@ember/polyfills';
 import DS from 'ember-data';
+import _ from 'underscore';
+
+export const sortWorkflowGraph = workflowGraph => {
+  if (workflowGraph) {
+    if (workflowGraph.nodes) {
+      workflowGraph.nodes = _.sortBy(workflowGraph.nodes, node => {
+        return `${node.name}_____${node.id}`;
+      });
+    }
+    if (workflowGraph.edges) {
+      workflowGraph.edges = _.sortBy(workflowGraph.edges, edge => {
+        return `${edge.src}_____${edge.dest}`;
+      });
+    }
+  }
+};
 
 export default DS.RESTSerializer.extend({
   normalizeResponse(store, typeClass, payload, id, requestType) {
     if (payload.events) {
       payload.events.forEach(event => {
-        if (event.workflowGraph) {
-          // sorting on the dest should be enough
-          event.workflowGraph.edges = event.workflowGraph.edges.sort(({ dest: a }, { dest: b }) => {
-            if (a < b) {
-              return -1;
-            }
-            if (a > b) {
-              return 1;
-            }
-
-            return 0;
-          });
-        }
+        sortWorkflowGraph(event.workflowGraph);
       });
+    } else if (payload.event && payload.event.workflowGraph) {
+      sortWorkflowGraph(payload.event.workflowGraph);
     }
 
     return this._super(store, typeClass, payload, id, requestType);

--- a/app/event/serializer.js
+++ b/app/event/serializer.js
@@ -1,17 +1,20 @@
 import { assign } from '@ember/polyfills';
 import DS from 'ember-data';
-import _ from 'underscore';
+import _s from 'underscore.string';
 
 export const sortWorkflowGraph = workflowGraph => {
   if (workflowGraph) {
     if (workflowGraph.nodes) {
-      workflowGraph.nodes = _.sortBy(workflowGraph.nodes, node => {
-        return `${node.name}_____${node.id}`;
+      workflowGraph.nodes.sort((node1, node2) => {
+        return (
+          _s.naturalCmp(node1.name, node2.name) ||
+          _s.naturalCmp(node1.id ? node1.id.toString() : '', node2.id ? node2.id.toString() : '')
+        );
       });
     }
     if (workflowGraph.edges) {
-      workflowGraph.edges = _.sortBy(workflowGraph.edges, edge => {
-        return `${edge.src}_____${edge.dest}`;
+      workflowGraph.edges.sort((edge1, edge2) => {
+        return _s.naturalCmp(edge1.src, edge2.src) || _s.naturalCmp(edge1.dest, edge2.dest);
       });
     }
   }

--- a/app/pipeline/serializer.js
+++ b/app/pipeline/serializer.js
@@ -1,22 +1,13 @@
 import { assign } from '@ember/polyfills';
 import DS from 'ember-data';
+import { sortWorkflowGraph } from '../event/serializer';
 
 export default DS.RESTSerializer.extend({
   normalizeResponse(store, typeClass, payload, id, requestType) {
     const { pipeline } = payload;
 
     if (pipeline && pipeline.workflowGraph) {
-      // sorting on the dest should be enough
-      pipeline.workflowGraph.edges.sort(({ dest: a }, { dest: b }) => {
-        if (a < b) {
-          return -1;
-        }
-        if (a > b) {
-          return 1;
-        }
-
-        return 0;
-      });
+      sortWorkflowGraph(pipeline.workflowGraph);
     }
 
     return this._super(store, typeClass, payload, id, requestType);

--- a/package-lock.json
+++ b/package-lock.json
@@ -34948,9 +34948,9 @@
       }
     },
     "underscore": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.10.2.tgz",
-      "integrity": "sha512-N4P+Q/BuyuEKFJ43B9gYuOj4TQUHXX+j2FqguVOpjkssLUUrnJofCcBccJSCoeturDoZU6GorDTHSvUDlSQbTg==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.11.0.tgz",
+      "integrity": "sha512-xY96SsN3NA461qIRKZ/+qox37YXPtSBswMGfiNptr+wrt6ds4HaMw23TP612fEyGekRE6LNRiLYr/aqbHXNedw==",
       "dev": true
     },
     "underscore.string": {

--- a/package.json
+++ b/package.json
@@ -139,6 +139,6 @@
     "prettier": "^1.18.2",
     "qunit-dom": "^1.0.0",
     "sass": "^1.23.0",
-    "underscore": "^1.11.0"
+    "underscore.string": "^3.3.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
     "memoizerific": "^1.11.3",
     "prettier": "^1.18.2",
     "qunit-dom": "^1.0.0",
-    "sass": "^1.23.0"
+    "sass": "^1.23.0",
+    "underscore": "^1.11.0"
   }
 }

--- a/tests/unit/pipeline/serializer-test.js
+++ b/tests/unit/pipeline/serializer-test.js
@@ -147,18 +147,18 @@ module('Unit | Serializer | pipeline', function(hooks) {
       },
       {
         src: 'main',
-        dest: 'fan10'
-      },
-      {
-        src: 'main',
         dest: 'fan2'
       },
       {
-        src: '~pr',
-        dest: 'main'
+        src: 'main',
+        dest: 'fan10'
       },
       {
         src: '~commit',
+        dest: 'main'
+      },
+      {
+        src: '~pr',
         dest: 'main'
       }
     ];


### PR DESCRIPTION
## Context
The workflow graph flickers every few seconds.  This is due to different sorting of the nodes/edges every time we fetch it from the server.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
