### PR TITLE
fix: fix workflow nodes sorting

### DIFF
--- a/app/event/serializer.js
+++ b/app/event/serializer.js
@@ -5,17 +5,10 @@ const compare = (s1, s2) =>
   (s1 || '').localeCompare(s2 || '', undefined, { numeric: true, sensitivity: 'base' });
 
 export const sortWorkflowGraph = workflowGraph => {
-  if (workflowGraph) {
-    if (workflowGraph.nodes) {
-      workflowGraph.nodes.sort(
-        (node1, node2) => compare(node1.name, node2.name) || compare(node1.id, node2.id)
-      );
-    }
-    if (workflowGraph.edges) {
-      workflowGraph.edges.sort(
-        (edge1, edge2) => compare(edge1.src, edge2.src) || compare(edge1.dest, edge2.dest)
-      );
-    }
+  if (workflowGraph && workflowGraph.edges) {
+    workflowGraph.edges.sort(
+      (edge1, edge2) => compare(edge1.src, edge2.src) || compare(edge1.dest, edge2.dest)
+    );
   }
 };
 

--- a/app/event/serializer.js
+++ b/app/event/serializer.js
@@ -5,10 +5,28 @@ const compare = (s1, s2) =>
   (s1 || '').localeCompare(s2 || '', undefined, { numeric: true, sensitivity: 'base' });
 
 export const sortWorkflowGraph = workflowGraph => {
-  if (workflowGraph && workflowGraph.edges) {
-    workflowGraph.edges.sort(
-      (edge1, edge2) => compare(edge1.src, edge2.src) || compare(edge1.dest, edge2.dest)
-    );
+  if (workflowGraph) {
+    const notInFirstColumns = {};
+
+    if (workflowGraph.edges) {
+      workflowGraph.edges.forEach(({ dest }) => {
+        notInFirstColumns[dest] = true;
+      });
+      workflowGraph.edges.sort(
+        (edge1, edge2) => compare(edge1.src, edge2.src) || compare(edge1.dest, edge2.dest)
+      );
+    }
+
+    if (workflowGraph.nodes) {
+      const nodesNotInFirstColumn = workflowGraph.nodes.filter(n => !!notInFirstColumns[n.name]);
+      const nodesInFirstColumn = workflowGraph.nodes.filter(n => !notInFirstColumns[n.name]);
+
+      // we only sort the nodes that are not in the first column.
+      nodesNotInFirstColumn.sort(
+        (node1, node2) => compare(node1.name, node2.name) || compare(node1.id, node2.id)
+      );
+      workflowGraph.nodes = [...nodesInFirstColumn, ...nodesNotInFirstColumn];
+    }
   }
 };
 


### PR DESCRIPTION
## Context
Workflow nodes order on the first column should be the same order they appear in the `screwdriver.yaml` file.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
