### PR TITLE
fix: remove redundant build coverage requests when changing jobs table sorting

### DIFF
--- a/app/components/pipeline-list-coverage-cell/component.js
+++ b/app/components/pipeline-list-coverage-cell/component.js
@@ -7,7 +7,18 @@ export default Component.extend({
 
   result: computed('value', {
     async get() {
-      return this.shuttle.fetchCoverage(this.value);
+      if (this.value.buildId) {
+        if (this.value.coverage) {
+          return this.value.coverage;
+        }
+        const coverage = await this.shuttle.fetchCoverage(this.value);
+
+        this.set('value', { ...this.value, coverage });
+
+        return coverage;
+      }
+
+      return '';
     }
   })
 });


### PR DESCRIPTION
## Context
Each time when we change the jobs table sorting, the latest build coverage is fetched from the back-end.
The solution is to simply cache the coverage response for each build on the first time we fetch it.  Then, if the table sorting changes, we can use the cached data.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
