### PR TITLE
feat(2267): refactor collection page and apply lazy loading

### DIFF
--- a/app/components/collection-table-row/component.js
+++ b/app/components/collection-table-row/component.js
@@ -27,11 +27,12 @@ export default Component.extend({
     return !this.isOrganizing && this.isAuthenticated;
   }),
 
-  didInsertElement() {
+  async didInsertElement() {
     if (!this.hasBothEventsAndLatestEventInfo) {
       this.updateEventMetrics();
     }
   },
+
   async updateEventMetrics() {
     const metrics = await this.store
       .query('metric', {

--- a/app/components/collection-table-row/template.hbs
+++ b/app/components/collection-table-row/template.hbs
@@ -8,15 +8,21 @@
 </td>
 <td class="branch">
   {{fa-icon "code-fork"}}
-  <span title={{pipeline.branch}}>{{pipeline.branch}}</span>
+  <span title={{branch}}>{{branch}}</span>
 </td>
 <td class="status">
   {{#link-to "pipeline" pipeline.id title=pipeline.scmRepo.name}}
     {{fa-icon lastEventInfo.icon class=lastEventInfo.statusColor}}
   {{/link-to}}
-  <a href={{lastEventInfo.commitUrl}}>
-    {{lastEventInfo.sha}}
-  </a>
+  {{#if storeQueryError}}
+    An error occur while loading events
+  {{else if hasBothEventsAndLatestEventInfo}}
+    <a href={{lastEventInfo.commitUrl}}>
+      {{lastEventInfo.sha}}
+    </a>
+  {{else}}
+    Loading events
+  {{/if}}
 </td>
 <td class="start">
   {{lastEventInfo.startTime}}
@@ -25,11 +31,13 @@
   {{lastEventInfo.durationText}}
 </td>
 <td class="history">
-  {{events-thumbnail
-      events=eventsInfo
-      pipelineId=pipeline.id
-      class="events-thumbnail"
-  }}
+  {{#if hasBothEventsAndLatestEventInfo}}
+    {{events-thumbnail
+        events=eventsInfo
+        pipelineId=pipeline.id
+        class="events-thumbnail"
+    }}
+  {{/if}}
 </td>
 <td class="collection-pipeline__remove">
   {{#if showRemoveButton}}

--- a/app/components/collection-view/component.js
+++ b/app/components/collection-view/component.js
@@ -18,10 +18,8 @@ const viewOptions = [
 export default Component.extend({
   store: service(),
   session: service(),
-  scmService: service('scm'),
   sortBy: ['scmRepo.name'],
   collection: null,
-  metricsMap: [],
   removePipelineError: null,
   activeViewOptionValue: localStorage.getItem('activeViewOptionValue') || viewOptions[0].value,
   viewOptions,
@@ -85,136 +83,12 @@ export default Component.extend({
   }),
   collectionPipelines: computed('collection.pipelines', {
     get() {
-      const { scmService } = this;
-      const getIcon = status => {
-        switch (status) {
-          case 'queued':
-          case 'running':
-            return 'refresh fa-spin';
-          case 'success':
-            return 'check-circle';
-          case 'failure':
-            return 'times-circle';
-          case 'aborted':
-            return 'stop-circle';
-          case 'blocked':
-            return 'ban';
-          case 'unstable':
-            return 'exclamation-circle';
-          case 'frozen':
-            return 'minus-circle';
-          default:
-            return 'question-circle';
-        }
-      };
-
-      const getColor = status => {
-        switch (status) {
-          case 'queued':
-          case 'running':
-            return 'build-running';
-          case 'success':
-            return 'build-success';
-          case 'failure':
-            return 'build-failure';
-          case 'aborted':
-            return 'build-failure';
-          case 'blocked':
-            return 'build-running';
-          case 'unstable':
-            return 'build-unstable';
-          case 'frozen':
-            return 'build-frozen';
-          default:
-            return 'build-unknown';
-        }
-      };
-
-      const formatTime = duration => {
-        const numOfTotalSeconds = duration;
-        const minute = 60;
-        const hour = 60 * minute;
-
-        if (numOfTotalSeconds === 0) {
-          return '0s';
-        }
-        if (numOfTotalSeconds < minute) {
-          return `${numOfTotalSeconds}s`;
-        }
-        if (numOfTotalSeconds < hour) {
-          const numOfMinutes = Math.floor(numOfTotalSeconds / minute);
-          const numOfSeconds = numOfTotalSeconds % minute;
-
-          return `${numOfMinutes}m ${numOfSeconds}s`;
-        }
-        const numOfHours = Math.floor(numOfTotalSeconds / hour);
-        const numOfMinutes = Math.floor((numOfTotalSeconds % hour) / minute);
-        const numOfSeconds = Math.floor(numOfTotalSeconds % minute);
-
-        return `${numOfHours}h ${numOfMinutes}m ${numOfSeconds}s`;
-      };
-
-      const getSha = sha => sha.substring(0, 7);
-
       let viewingId = this.get('collection.id');
 
       localStorage.setItem('lastViewedCollectionId', viewingId);
 
       if (this.get('collection.pipelines')) {
-        return this.get('collection.pipelines').map(pipeline => {
-          const scm = scmService.getScm(pipeline.scmContext);
-          const { id, scmRepo, prs } = pipeline;
-          const { branch, rootDir } = scmRepo;
-          const metrics = this.metricsMap[pipeline.id];
-          const ret = {
-            id,
-            scmRepo,
-            branch: rootDir ? `${branch}#${rootDir}` : branch,
-            scm: scm.displayName,
-            scmIcon: scm.iconType,
-            prs
-          };
-
-          if (metrics && metrics.length) {
-            const lastEvent = metrics.get('firstObject');
-            const lastEventStartTime = new Date(lastEvent.createTime);
-            const lastEventStartYear = lastEventStartTime.getFullYear();
-            const lastEventStartMonth = (lastEventStartTime.getMonth() + 1)
-              .toString()
-              .padStart(2, '0');
-            const lastEventStartDay = lastEventStartTime
-              .getDate()
-              .toString()
-              .padStart(2, '0');
-
-            ret.eventsInfo = metrics.map(event => ({
-              duration: event.duration || 0,
-              statusColor: getColor(event.status.toLowerCase())
-            }));
-            ret.lastEventInfo = {
-              startTime: `${lastEventStartMonth}/${lastEventStartDay}/${lastEventStartYear}`,
-              statusColor: getColor(lastEvent.status.toLowerCase()),
-              durationText: lastEvent.duration ? formatTime(lastEvent.duration) : '--',
-              sha: getSha(lastEvent.sha),
-              icon: getIcon(lastEvent.status.toLowerCase()),
-              commitMessage: lastEvent.commit.message,
-              commitUrl: lastEvent.commit.url
-            };
-          } else {
-            ret.eventsInfo = [];
-            ret.lastEventInfo = {
-              startTime: '--/--/----',
-              statusColor: 'build-empty',
-              durationText: '--',
-              sha: 'Not available',
-              icon: 'question-circle',
-              commitMessage: 'No events have been run for this pipeline',
-              commitUrl: '#'
-            };
-          }
-
-          return ret;
-        });
+        return this.get('collection.pipelines');
       }
 
       return [];

--- a/app/components/pipeline-card/component.js
+++ b/app/components/pipeline-card/component.js
@@ -1,8 +1,11 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
+import { inject as service } from '@ember/service';
 import { and } from '@ember/object/computed';
+import { formatMetrics } from 'screwdriver-ui/utils/metric';
 
 export default Component.extend({
+  store: service(),
   eventsInfo: null,
   lastEventInfo: null,
   isAuthenticated: undefined,
@@ -11,20 +14,46 @@ export default Component.extend({
   pipelineSelected: false,
   classNames: ['pipeline-card'],
   reset: false,
-
+  storeQueryError: false,
+  hasBothEventsAndLatestEventInfo: and('eventsInfo', 'lastEventInfo'),
   showCheckbox: and('isOrganizing', 'isAuthenticated'),
 
+  branch: computed('pipeline', function get() {
+    const { branch, rootDir } = this.pipeline.scmRepo;
+
+    return rootDir ? `${branch}#${rootDir}` : branch;
+  }),
   showRemoveButton: computed('isOrganizing', 'isAuthenticated', function showRemoveButton() {
     return !this.isOrganizing && this.isAuthenticated;
   }),
 
-  didReceiveAttrs() {
-    this.setProperties({
-      eventsInfo: this.pipeline.eventsInfo,
-      lastEventInfo: this.pipeline.lastEventInfo
-    });
+  async didInsertElement() {
+    if (!this.hasBothEventsAndLatestEventInfo) {
+      this.updateEventMetrics();
+    }
   },
 
+  async updateEventMetrics() {
+    const metrics = await this.store
+      .query('metric', {
+        pipelineId: this.pipeline.id,
+        page: 1,
+        count: 20
+      })
+      .catch(() => {
+        this.setProperties({
+          storeQueryError: true
+        });
+      });
+
+    const result = formatMetrics(metrics);
+    const { eventsInfo, lastEventInfo } = result;
+
+    this.setProperties({
+      eventsInfo,
+      lastEventInfo
+    });
+  },
   actions: {
     removePipeline() {
       this.removePipeline(this.pipeline.id);

--- a/app/components/pipeline-card/styles.scss
+++ b/app/components/pipeline-card/styles.scss
@@ -185,4 +185,8 @@
   .events-thumbnail {
     width: 100%;
   }
+
+  .placeholder {
+    height: 45px;
+  }
 }

--- a/app/components/pipeline-card/template.hbs
+++ b/app/components/pipeline-card/template.hbs
@@ -10,18 +10,14 @@
       &times;
     </span>
   {{/if}}
+
   <div class="branch-info">
     {{#link-to "pipeline" pipeline.id title=pipeline.scmRepo.name}}
-      {{!-- {{line-clamp
-        lines=1
-        interactive=false
-        text=pipeline.scmRepo.name
-      }} --}}
       {{pipeline.scmRepo.name}}
     {{/link-to}}
-    <div title={{pipeline.branch}}>
+    <div title={{branch}}>
       {{fa-icon "code-fork"}}
-      {{pipeline.branch}}
+      {{branch}}
     </div>
   </div>
   <div class="commit-info">
@@ -34,12 +30,13 @@
       </a>
     </div>
     <p class="commit-message" title={{lastEventInfo.commitMessage}}>
-      {{!-- {{line-clamp
-        lines=2
-        interactive=false
-        text=lastEventInfo.commitMessage
-      }} --}}
-      {{lastEventInfo.commitMessage}}
+      {{#if storeQueryError}}
+        An error occur while loading events
+      {{else if hasBothEventsAndLatestEventInfo}}
+        {{lastEventInfo.commitMessage}}
+      {{else}}
+        Loading events
+      {{/if}}
     </p>
   </div>
   <div class="time-metrics">
@@ -52,11 +49,16 @@
       <span class="badge-info">{{lastEventInfo.startTime}}</span>
     </div>
   </div>
+  
   <div class="events-thumbnail-wrapper">
-    {{events-thumbnail
-        class="events-thumbnail"
-        events=eventsInfo
-        pipelineId=pipeline.id
-    }}
+    {{#if hasBothEventsAndLatestEventInfo}}
+      {{events-thumbnail
+          class="events-thumbnail"
+          events=eventsInfo
+          pipelineId=pipeline.id
+      }}
+    {{else}}
+      <div class="placeholder"/>
+    {{/if}}
   </div>
 </div>

--- a/app/dashboard/show/controller.js
+++ b/app/dashboard/show/controller.js
@@ -4,7 +4,6 @@ import Controller from '@ember/controller';
 
 export default Controller.extend({
   collection: alias('model.collection'),
-  metricsMap: alias('model.metricsMap'),
   collections: alias('model.collections'),
   actions: {
     removePipeline(pipelineId) {

--- a/app/dashboard/show/route.js
+++ b/app/dashboard/show/route.js
@@ -1,7 +1,6 @@
 import RSVP from 'rsvp';
 import Route from '@ember/routing/route';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
-const MAX_NUM_EVENTS_SHOWN = 20;
 
 export default Route.extend(AuthenticatedRouteMixin, {
   model(params) {
@@ -11,17 +10,6 @@ export default Route.extend(AuthenticatedRouteMixin, {
       .findRecord('collection', params.collection_id, { reload: true })
       .then(collection => {
         return RSVP.hash({
-          metricsMap: RSVP.hash(
-            (collection.pipelineIds || []).reduce((oldMap, pipelineId) => {
-              oldMap[pipelineId] = this.store.query('metric', {
-                pipelineId,
-                page: 1,
-                count: MAX_NUM_EVENTS_SHOWN
-              });
-
-              return oldMap;
-            }, {})
-          ),
           collection,
           collections
         });

--- a/app/dashboard/show/template.hbs
+++ b/app/dashboard/show/template.hbs
@@ -11,7 +11,6 @@
       removeMultiplePipelines=(action "removeMultiplePipelines")
       collection=collection
       collections=collections
-      metricsMap=metricsMap
   }}
 </div>
 

--- a/app/utils/metric.js
+++ b/app/utils/metric.js
@@ -1,0 +1,113 @@
+const getIcon = status => {
+  switch (status) {
+    case 'queued':
+    case 'running':
+      return 'refresh fa-spin';
+    case 'success':
+      return 'check-circle';
+    case 'failure':
+      return 'times-circle';
+    case 'aborted':
+      return 'stop-circle';
+    case 'blocked':
+      return 'ban';
+    case 'unstable':
+      return 'exclamation-circle';
+    case 'frozen':
+      return 'minus-circle';
+    default:
+      return 'question-circle';
+  }
+};
+
+const getColor = status => {
+  switch (status) {
+    case 'queued':
+    case 'running':
+      return 'build-running';
+    case 'success':
+      return 'build-success';
+    case 'failure':
+      return 'build-failure';
+    case 'aborted':
+      return 'build-failure';
+    case 'blocked':
+      return 'build-running';
+    case 'unstable':
+      return 'build-unstable';
+    case 'frozen':
+      return 'build-frozen';
+    default:
+      return 'build-unknown';
+  }
+};
+
+const formatTime = duration => {
+  const numOfTotalSeconds = duration;
+  const minute = 60;
+  const hour = 60 * minute;
+
+  if (numOfTotalSeconds === 0) {
+    return '0s';
+  }
+  if (numOfTotalSeconds < minute) {
+    return `${numOfTotalSeconds}s`;
+  }
+  if (numOfTotalSeconds < hour) {
+    const numOfMinutes = Math.floor(numOfTotalSeconds / minute);
+    const numOfSeconds = numOfTotalSeconds % minute;
+
+    return `${numOfMinutes}m ${numOfSeconds}s`;
+  }
+  const numOfHours = Math.floor(numOfTotalSeconds / hour);
+  const numOfMinutes = Math.floor((numOfTotalSeconds % hour) / minute);
+  const numOfSeconds = Math.floor(numOfTotalSeconds % minute);
+
+  return `${numOfHours}h ${numOfMinutes}m ${numOfSeconds}s`;
+};
+
+const getSha = sha => sha.substring(0, 7);
+
+const formatMetrics = metrics => {
+  if (!metrics || !metrics.length) {
+    return {
+      eventsInfo: [],
+      lastEventInfo: {
+        startTime: '--/--/----',
+        statusColor: 'build-empty',
+        durationText: '--',
+        sha: 'Not available',
+        icon: 'question-circle',
+        commitMessage: 'No events have been run for this pipeline',
+        commitUrl: '#'
+      }
+    };
+  }
+
+  const lastEvent = metrics.get('firstObject');
+  const lastEventStartTime = new Date(lastEvent.createTime);
+  const lastEventStartYear = lastEventStartTime.getFullYear();
+  const lastEventStartMonth = (lastEventStartTime.getMonth() + 1).toString().padStart(2, '0');
+  const lastEventStartDay = lastEventStartTime
+    .getDate()
+    .toString()
+    .padStart(2, '0');
+
+  const eventsInfo = metrics.map(event => ({
+    duration: event.duration || 0,
+    statusColor: getColor(event.status.toLowerCase())
+  }));
+  const lastEventInfo = {
+    startTime: `${lastEventStartMonth}/${lastEventStartDay}/${lastEventStartYear}`,
+    statusColor: getColor(lastEvent.status.toLowerCase()),
+    durationText: lastEvent.duration ? formatTime(lastEvent.duration) : '--',
+    sha: getSha(lastEvent.sha),
+    icon: getIcon(lastEvent.status.toLowerCase()),
+    commitMessage: lastEvent.commit.message,
+    commitUrl: lastEvent.commit.url
+  };
+
+  return { eventsInfo, lastEventInfo };
+};
+
+export { getIcon, getColor, formatTime, getSha, formatMetrics };


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Collection page does not render until metrics for all pipeline are loaded.
## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Move metric query to each individual pipeline card/row component so collection page render without waiting for metrics 
## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/2267

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
