### PR TITLE
Fixed Slack and GitHub typos

### DIFF
--- a/app/components/app-header/template.hbs
+++ b/app/components/app-header/template.hbs
@@ -88,12 +88,12 @@
             {{/ddm.item}}
             {{#ddm.item}}
               <a href={{slackUrl}} class="icon community">
-                {{inline-svg "slack" class="img"}}<span>Slack Channel</span>
+                {{inline-svg "slack" class="img"}}<span>Slack Workspace</span>
               </a>
             {{/ddm.item}}
             {{#ddm.item}}
               <a href="https://github.com/screwdriver-cd" class="icon github">
-                {{inline-svg "github" class="img"}}<span>Github</span>
+                {{inline-svg "github" class="img"}}<span>GitHub</span>
               </a>
             {{/ddm.item}}
           {{/dd.menu}}


### PR DESCRIPTION
- The slack link goes to not a channel but a workspace.
- GitHub is officially "GitHub", not Github.

Signed-off-by: JJ Asghar <jjasghar@gmail.com>
Co-authored-by: Adam Roberts <aroberts@uk.ibm.com>

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
