### PR TITLE
fix: fix license badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Code licensed under the BSD 3-Clause license. See LICENSE file for terms.
 [version-image]: https://img.shields.io/github/tag/screwdriver-cd/ui.svg
 [version-url]: https://github.com/screwdriver-cd/ui/releases/
 [downloads-image]: https://img.shields.io/docker/pulls/screwdrivercd/ui.svg
-[license-image]: https://img.shields.io/github/license/screwdriver-cd/ui.svg
+[license-image]: https://img.shields.io/badge/license-BSD--3--Clause-green
 [issues-image]: https://img.shields.io/github/issues/screwdriver-cd/screwdriver.svg
 [issues-url]: https://github.com/screwdriver-cd/screwdriver/issues
 [build-image]: https://cd.screwdriver.cd/pipelines/7/badge


### PR DESCRIPTION


## Context

currently license badge is broken
<img width="208" alt="Screen Shot 2020-11-24 at 10 55 51 AM" src="https://user-images.githubusercontent.com/55161078/100138989-aae8c480-2e43-11eb-825f-ffd9ff312804.png">


<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective

fix it
<img width="152" alt="Screen Shot 2020-11-24 at 10 55 40 AM" src="https://user-images.githubusercontent.com/55161078/100139010-b2a86900-2e43-11eb-9a37-ac080622dd18.png">
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
