### PR TITLE
fix: fix secret tab regression

### DIFF
--- a/app/pipeline/secrets/route.js
+++ b/app/pipeline/secrets/route.js
@@ -24,8 +24,10 @@ export default Route.extend({
         secrets,
         pipeline
       }))
-      .catch(error =>
-        this.controllerFor('pipeline.secrets').set('errorMessage', error.errors[0].detail)
-      );
+      .catch(error => {
+        this.controllerFor('pipeline.secrets').set('errorMessage', error.errors[0].detail);
+
+        return { secrets, pipeline };
+      });
   }
 });


### PR DESCRIPTION
## Context

```
screwdriver-ui-ae9292dd71fc30bc654e2b8eedc538d4.js:528 Uncaught TypeError: Cannot read property 'annotations' of undefined
    at n.get (screwdriver-ui-ae9292dd71fc30bc654e2b8eedc538d4.js:528)
    at vendor-66ca79816001aded6a088aa0677266d2.js:1868
    at te (vendor-66ca79816001aded6a088aa0677266d2.js:1785)
    at i.o.get (vendor-66ca79816001aded6a088aa0677266d2.js:1868)
    at n.get [as pipelineDescription] (vendor-66ca79816001aded6a088aa0677266d2.js:1766)
    at Oe (vendor-66ca79816001aded6a088aa0677266d2.js:1843)
    at vendor-66ca79816001aded6a088aa0677266d2.js:1105
    at Z (vendor-66ca79816001aded6a088aa0677266d2.js:1783)
    at n.r.compute (vendor-66ca79816001aded6a088aa0677266d2.js:1105)
    at n.value (vendor-66ca79816001aded6a088aa0677266d2.js:1099)
```

## Objective

fix this regression

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
