### PR TITLE
fix(2273): Job name on PR is updated with screwdriver.cd/displayName

### DIFF
--- a/app/components/pipeline-pr-list/template.hbs
+++ b/app/components/pipeline-pr-list/template.hbs
@@ -17,7 +17,7 @@
       <div class="by"><a href={{jobs.0.userProfile}} target="_blank" rel="noopener">{{jobs.0.username}}</a></div>
       {{#if showJobs }}
         {{#each jobs as |job|}}
-          {{pipeline-pr-view job=job}}
+          {{pipeline-pr-view job=job workflowGraph=workflowGraph}}
         {{/each}}
       {{else}}
         {{#if isRestricted}}

--- a/app/components/pipeline-pr-view/component.js
+++ b/app/components/pipeline-pr-view/component.js
@@ -11,10 +11,15 @@ export default Component.extend({
   }),
   displayName: computed('job.name', {
     get() {
-      return this.get('job.name')
+      const nodes = this.get('workflowGraph.nodes');
+      const jobName = this.get('job.name')
         .replace('PR-', '')
         .split(':')
         .pop();
+      const matchedNode = nodes.find(node => node.name === jobName);
+      const displayName = matchedNode.displayName !== undefined ? matchedNode.displayName : jobName;
+
+      return displayName;
     }
   }),
   icon: computed('build.status', {

--- a/app/pipeline/events/template.hbs
+++ b/app/pipeline/events/template.hbs
@@ -84,6 +84,7 @@
                 isRestricted=isRestricted
                 startBuild=(action "startPRBuild")
                 stopPRBuilds=(action "stopPRBuilds")
+                workflowGraph=pipeline.workflowGraph
               }}
             {{else}}
               <div class="alert">No open pull requests</div>

--- a/tests/integration/components/pipeline-pr-list/component-test.js
+++ b/tests/integration/components/pipeline-pr-list/component-test.js
@@ -24,7 +24,7 @@ module('Integration | Component | pipeline pr list', function(hooks) {
       }),
       EmberObject.create({
         id: 'efgh',
-        name: 'revert',
+        name: 'A',
         createTimeWords: 'now',
         title: 'revert PR-1234',
         username: 'suomynona',
@@ -37,9 +37,24 @@ module('Integration | Component | pipeline pr list', function(hooks) {
       })
     ];
 
-    this.set('jobsMock', jobs);
+    const workflowgraph = {
+      nodes: [
+        { name: '~pr' },
+        { name: '~commit' },
+        { id: 1, name: 'main', displayName: 'myname' },
+        { id: 2, name: 'A' }
+      ],
+      edges: [
+        { src: '~pr', dest: 'main' },
+        { src: '~commit', dest: 'main' },
+        { src: 'main', dest: 'A' }
+      ]
+    };
 
-    await render(hbs`{{pipeline-pr-list jobs=jobsMock}}`);
+    this.set('jobsMock', jobs);
+    this.set('workflowGraphMock', workflowgraph);
+
+    await render(hbs`{{pipeline-pr-list jobs=jobsMock workflowGraph=workflowGraphMock}}`);
 
     assert.dom('.view .view .detail').exists({ count: 2 });
     assert.dom('.title').hasText('update readme');
@@ -94,15 +109,31 @@ module('Integration | Component | pipeline pr list', function(hooks) {
       })
     ];
 
+    const workflowgraph = {
+      nodes: [
+        { name: '~pr' },
+        { name: '~commit' },
+        { id: 1, name: 'main', displayName: 'myname' },
+        { id: 2, name: 'A' }
+      ],
+      edges: [
+        { src: '~pr', dest: 'main' },
+        { src: '~commit', dest: 'main' },
+        { src: 'main', dest: 'A' }
+      ]
+    };
+
     this.set('jobsMock', jobs);
     this.set('isRestricted', true);
     this.set('startBuild', Function.prototype);
     this.set('stopPRBuilds', Function.prototype);
+    this.set('workflowGraphMock', workflowgraph);
 
     await render(hbs`{{pipeline-pr-list
       jobs=jobsMock
       isRestricted=isRestricted
       startBuild=startBuild
+      workflowGraph=workflowGraphMock
       stopPRBuilds=stopPRBuilds}}`);
 
     assert.dom('.prsStop').exists({ count: 1 });

--- a/tests/integration/components/pipeline-pr-view/component-test.js
+++ b/tests/integration/components/pipeline-pr-view/component-test.js
@@ -23,16 +23,31 @@ module('Integration | Component | pipeline pr view', function(hooks) {
       ]
     });
 
-    this.set('jobMock', job);
+    const workflowgraph = {
+      nodes: [
+        { name: '~pr' },
+        { name: '~commit' },
+        { id: 1, name: 'main', displayName: 'myname' },
+        { id: 2, name: 'A' }
+      ],
+      edges: [
+        { src: '~pr', dest: 'main' },
+        { src: '~commit', dest: 'main' },
+        { src: 'main', dest: 'A' }
+      ]
+    };
 
-    await render(hbs`{{pipeline-pr-view job=jobMock}}`);
+    this.set('jobMock', job);
+    this.set('workflowGraphMock', workflowgraph);
+
+    await render(hbs`{{pipeline-pr-view job=jobMock workflowGraph=workflowGraphMock}}`);
 
     assert.dom('.SUCCESS').exists({ count: 1 });
     assert.equal(
       find('.detail')
         .textContent.trim()
         .replace(/\s{2,}/g, ' '),
-      'main Started now'
+      'myname Started now'
     );
     assert.dom('.date').hasText('Started now');
     assert.dom('.status .fa-check-circle-o').exists({ count: 1 });
@@ -55,9 +70,24 @@ module('Integration | Component | pipeline pr view', function(hooks) {
       ]
     });
 
-    this.set('jobMock', job);
+    const workflowgraph = {
+      nodes: [
+        { name: '~pr' },
+        { name: '~commit' },
+        { id: 1, name: 'main', displayName: 'myname' },
+        { id: 2, name: 'A' }
+      ],
+      edges: [
+        { src: '~pr', dest: 'main' },
+        { src: '~commit', dest: 'main' },
+        { src: 'main', dest: 'A' }
+      ]
+    };
 
-    await render(hbs`{{pipeline-pr-view job=jobMock}}`);
+    this.set('jobMock', job);
+    this.set('workflowGraphMock', workflowgraph);
+
+    await render(hbs`{{pipeline-pr-view job=jobMock workflowGraph=workflowGraphMock}}`);
 
     assert.dom('.UNSTABLE').exists({ count: 1 });
     assert.dom('.fa-exclamation-circle').exists({ count: 1 });
@@ -79,9 +109,24 @@ module('Integration | Component | pipeline pr view', function(hooks) {
       ]
     });
 
-    this.set('jobMock', job);
+    const workflowgraph = {
+      nodes: [
+        { name: '~pr' },
+        { name: '~commit' },
+        { id: 1, name: 'main', displayName: 'myname' },
+        { id: 2, name: 'A' }
+      ],
+      edges: [
+        { src: '~pr', dest: 'main' },
+        { src: '~commit', dest: 'main' },
+        { src: 'main', dest: 'A' }
+      ]
+    };
 
-    await render(hbs`{{pipeline-pr-view job=jobMock}}`);
+    this.set('jobMock', job);
+    this.set('workflowGraphMock', workflowgraph);
+
+    await render(hbs`{{pipeline-pr-view job=jobMock workflowGraph=workflowGraphMock}}`);
 
     assert.dom('.FAILURE').exists({ count: 1 });
     assert.dom('.fa-times-circle-o').exists({ count: 1 });
@@ -103,9 +148,24 @@ module('Integration | Component | pipeline pr view', function(hooks) {
       ]
     });
 
-    this.set('jobMock', job);
+    const workflowgraph = {
+      nodes: [
+        { name: '~pr' },
+        { name: '~commit' },
+        { id: 1, name: 'main', displayName: 'myname' },
+        { id: 2, name: 'A' }
+      ],
+      edges: [
+        { src: '~pr', dest: 'main' },
+        { src: '~commit', dest: 'main' },
+        { src: 'main', dest: 'A' }
+      ]
+    };
 
-    await render(hbs`{{pipeline-pr-view job=jobMock}}`);
+    this.set('jobMock', job);
+    this.set('workflowGraphMock', workflowgraph);
+
+    await render(hbs`{{pipeline-pr-view job=jobMock workflowGraph=workflowGraphMock}}`);
 
     assert.dom('.QUEUED').exists({ count: 1 });
     assert.dom('.fa-spinner').exists({ count: 1 });
@@ -127,9 +187,24 @@ module('Integration | Component | pipeline pr view', function(hooks) {
       ]
     });
 
-    this.set('jobMock', job);
+    const workflowgraph = {
+      nodes: [
+        { name: '~pr' },
+        { name: '~commit' },
+        { id: 1, name: 'main', displayName: 'myname' },
+        { id: 2, name: 'A' }
+      ],
+      edges: [
+        { src: '~pr', dest: 'main' },
+        { src: '~commit', dest: 'main' },
+        { src: 'main', dest: 'A' }
+      ]
+    };
 
-    await render(hbs`{{pipeline-pr-view job=jobMock}}`);
+    this.set('jobMock', job);
+    this.set('workflowGraphMock', workflowgraph);
+
+    await render(hbs`{{pipeline-pr-view job=jobMock workflowGraph=workflowGraphMock}}`);
 
     assert.dom('.RUNNING').exists({ count: 1 });
     assert.dom('.fa-spinner').exists({ count: 1 });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
https://github.com/screwdriver-cd/screwdriver/issues/2273
This PR fixes about comment below.

> PR job names are not updated

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Job name of PR build is overwritten by screwdriver.cd/displayName annotation.

<img src="https://user-images.githubusercontent.com/32473622/100981105-a762e500-3589-11eb-84ff-114677372bdb.jpg" width=300 />

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/2273

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
