### PR TITLE
fix(2124): fix the scroll to take 80% and load 50 jobs if applicable

### DIFF
--- a/app/components/pipeline-list-view/component.js
+++ b/app/components/pipeline-list-view/component.js
@@ -5,6 +5,7 @@ import Table from 'ember-light-table';
 import isEqual from 'lodash.isequal';
 
 export default Component.extend({
+  isLoading: false,
   isShowingModal: false,
   sortingDirection: 'asc',
   sortingValuePath: 'job',
@@ -231,10 +232,12 @@ export default Component.extend({
 
   actions: {
     async onScrolledToBottom() {
+      this.set('isLoading', true);
       this.get('updateListViewJobs')().then(jobs => {
         const rows = this.getRows(jobs);
 
         this.table.addRows(rows);
+        this.set('isLoading', false);
       });
     },
 

--- a/app/components/pipeline-list-view/styles.scss
+++ b/app/components/pipeline-list-view/styles.scss
@@ -68,4 +68,8 @@
   .ember-light-table .tse-scrollbar {
     display: none;
   }
+
+  .ember-light-table div.lt-body-wrap {
+    overflow-y: auto;
+  }
 }

--- a/app/components/pipeline-list-view/template.hbs
+++ b/app/components/pipeline-list-view/template.hbs
@@ -12,7 +12,7 @@
   </div>
 </div>
 
-{{#light-table table height="80%" as |t|}}
+{{#light-table table height="60vh" as |t|}}
   {{t.head
     onColumnClick=(action "onColumnClick")
     iconSortable="fa fa-sort"
@@ -21,8 +21,15 @@
     fixed=true}}
   {{#t.body
     canSelect=false
-    onScrolledToBottom=(action "onScrolledToBottom")
-  }}{{/t.body}}
+    scrollBuffer=700
+    onScrolledToBottom=(action "onScrolledToBottom") as |body|
+  }}
+    {{#if isLoading}}
+      {{#body.loader}}
+        Loading...
+      {{/body.loader}}
+    {{/if}}
+  {{/t.body}}
 {{/light-table}}
 
 {{#if isShowingModal}}

--- a/app/components/pipeline-list-view/template.hbs
+++ b/app/components/pipeline-list-view/template.hbs
@@ -12,7 +12,7 @@
   </div>
 </div>
 
-{{#light-table table height="400px" as |t|}}
+{{#light-table table height="80%" as |t|}}
   {{t.head
     onColumnClick=(action "onColumnClick")
     iconSortable="fa fa-sort"

--- a/config/environment.js
+++ b/config/environment.js
@@ -55,7 +55,7 @@ module.exports = environment => {
       MINIMUM_JOBNAME_LENGTH: 20,
       NUM_EVENTS_LISTED: 5,
       NUM_PIPELINES_LISTED: 50,
-      LIST_VIEW_PAGE_SIZE: 50,
+      LIST_VIEW_PAGE_SIZE: 20,
       NUM_BUILDS_LISTED: 5,
       MAX_LOG_LINES: 1000,
       DEFAULT_LOG_PAGE_SIZE: 10,

--- a/config/environment.js
+++ b/config/environment.js
@@ -55,7 +55,7 @@ module.exports = environment => {
       MINIMUM_JOBNAME_LENGTH: 20,
       NUM_EVENTS_LISTED: 5,
       NUM_PIPELINES_LISTED: 50,
-      LIST_VIEW_PAGE_SIZE: 10,
+      LIST_VIEW_PAGE_SIZE: 50,
       NUM_BUILDS_LISTED: 5,
       MAX_LOG_LINES: 1000,
       DEFAULT_LOG_PAGE_SIZE: 10,


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Try to improve the loading experience on job lis view/`pipeline-list-view`
 
## Objective

- add loading indicator when fetching data for more rows
- adjust default loading size `LIST_VIEW_PAGE_SIZE ` from 10 to 20
- change `height="400px"`  to `height="60vh"` [css unit](https://www.w3schools.com/cssref/css_units.asp)

Add and pass [`scrollBuffer=700`](https://github.com/adopted-ember-addons/ember-light-table/blob/078a2617b8ba08c55d9320bdf01ea2b4447736e9/addon/templates/components/lt-body.hbs#L82) to ELT `t.body` to see if it can trigger early `scrollToBottom`

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
Ember Light Table `scrollBuffer`: [b93f0671 ](https://github.com/adopted-ember-addons/ember-light-table/commit/b93f0671ad635bf4024aaab1f7773db52df45cc7#diff-ab978ed79068759c70dd2fabbda2b02375a05478e690c38f03004d2d8bf7cb36)fix(occlusion): pass bufferSize based on scrollBuffer by Jan Buschtns 
FYI, [ETL](https://github.com/adopted-ember-addons/ember-light-table/) is based on [vertical-collection](https://github.com/html-next/vertical-collection)
## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
