### PR TITLE
fix: catch edge case of undefined for pipeline.settings.metricsDowntimeJobs

### DIFF
--- a/app/pipeline/metrics/controller.js
+++ b/app/pipeline/metrics/controller.js
@@ -149,7 +149,7 @@ export default Controller.extend({
 
     let downtimeJobs = [];
 
-    if (pipeline.settings) {
+    if (pipeline.settings && pipeline.settings.metricsDowntimeJobs) {
       downtimeJobs = pipeline.settings.metricsDowntimeJobs;
     }
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
This catches one edges that case prevents metricsDowntimeJobs to be undefined.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
