### PR TITLE
fix(2283): enable to download `sd-setup-init` log

### DIFF
--- a/app/components/build-log/component.js
+++ b/app/components/build-log/component.js
@@ -368,9 +368,26 @@ export default Component.extend({
     },
     download() {
       const { buildId, stepName } = this;
-      const downloadLink = `${ENV.APP.SDAPI_HOSTNAME}/${ENV.APP.SDAPI_NAMESPACE}/builds/${buildId}/steps/${stepName}/logs?type=download`;
 
-      window.open(downloadLink, '_blank');
+      if (stepName === 'sd-setup-init') {
+        const fileName = `${stepName}-log.text`;
+        const downloadLink = URL.createObjectURL(
+          new File([this.logs.map(({ m }) => m).join('\n')], fileName, {
+            type: 'text/plain'
+          })
+        );
+
+        const e = document.createElement('a');
+
+        e.setAttribute('href', downloadLink);
+        e.setAttribute('download', fileName);
+        e.setAttribute('target', '_blank');
+        e.click();
+      } else {
+        const downloadLink = `${ENV.APP.SDAPI_HOSTNAME}/${ENV.APP.SDAPI_NAMESPACE}/builds/${buildId}/steps/${stepName}/logs?type=download`;
+
+        window.open(downloadLink, '_blank');
+      }
     },
     logScroll() {
       const container = this.element.querySelectorAll('.wrap')[0];


### PR DESCRIPTION
## Context
API returns 500 when we try to download `sd-setup-init` log.
This PR makes it enable to download `sd-setup-init` log.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
- create log file for `sd-setup-init` by `URL.createObjectURL`
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
screwdriver-cd/screwdriver#2283
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
