### PR TITLE
fix(2273): matchNode could be null

### DIFF
--- a/app/components/pipeline-pr-view/component.js
+++ b/app/components/pipeline-pr-view/component.js
@@ -17,9 +17,12 @@ export default Component.extend({
         .split(':')
         .pop();
       const matchedNode = nodes.find(node => node.name === jobName);
-      const displayName = matchedNode.displayName !== undefined ? matchedNode.displayName : jobName;
 
-      return displayName;
+      if (matchedNode && matchedNode.displayName) {
+        return matchedNode.displayName;
+      }
+
+      return jobName;
     }
   }),
   icon: computed('build.status', {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
matchNode could be null and would break ui upon refresh or clicking back button
## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Add null check on matchNode
## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/2273
## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
