### PR TITLE
fix: lazy load coverage when row/cell is in view-port

### DIFF
--- a/app/components/pipeline-list-coverage-cell/component.js
+++ b/app/components/pipeline-list-coverage-cell/component.js
@@ -1,24 +1,38 @@
 import Component from '@ember/component';
-import { computed } from '@ember/object';
 import { inject as service } from '@ember/service';
+import InViewportMixin from 'ember-in-viewport';
 
-export default Component.extend({
+export default Component.extend(InViewportMixin, {
   shuttle: service(),
 
-  result: computed('value', {
-    async get() {
-      if (this.value.buildId) {
-        if (this.value.coverage) {
-          return this.value.coverage;
-        }
+  init() {
+    this._super(...arguments);
+
+    this.setProperties({
+      coverage: undefined,
+      loaded: false,
+      loading: false
+    });
+  },
+
+  async didEnterViewport() {
+    if (this.loaded === false) {
+      try {
+        this.set('loading', true);
         const coverage = await this.shuttle.fetchCoverage(this.value);
 
-        this.set('value', { ...this.value, coverage });
-
-        return coverage;
+        this.setProperties({
+          coverage,
+          loaded: true
+        });
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error('err', err);
+      } finally {
+        if (!this.isDestroyed && !this.isDestroying) {
+          this.set('loading', false);
+        }
       }
-
-      return '';
     }
-  })
+  }
 });

--- a/app/components/pipeline-list-coverage-cell/template.hbs
+++ b/app/components/pipeline-list-coverage-cell/template.hbs
@@ -1,13 +1,13 @@
 <div class="coverage">
-  {{#if (is-pending result)}}
+  {{#if loading}}
     Loading
-  {{/if}}
-  {{#if (is-rejected result)}}
-    <span class="coverage-value">N/A</span>
-  {{/if}}
-  {{#if (is-fulfilled result)}}
-    <span class="coverage-value">
-      {{get (await result) "coverage"}}{{if (is-number (get (await result) "coverage")) "%"}}
-    </span>
+  {{else}}
+    {{#if loaded}}
+      <span class="coverage-value">
+        {{get coverage "coverage"}}{{if (is-number (get coverage "coverage")) "%"}}
+      </span>
+    {{else}}
+      N/A
+    {{/if}}
   {{/if}}
 </div>

--- a/app/pipeline/metrics/controller.js
+++ b/app/pipeline/metrics/controller.js
@@ -426,7 +426,7 @@ export default Controller.extend({
     // override default with configured functions
     return { y: { ...axis.y }, x: { ...axis.x, tick: { ...axis.x.tick, values, format } } };
   },
-  downtimeJobsAxis: computed('axis', 'downtimeJobsMetrics', 'isUTC', function() {
+  downtimeJobsAxis: computed('axis', 'downtimeJobsMetrics', 'isUTC', function downtimeJobsAxis() {
     const { axis, downtimeJobsChartData } = this;
     const times = downtimeJobsChartData.map(m => new Date(m.createTime));
 

--- a/tests/integration/components/pipeline-list-coverage-cell/component-test.js
+++ b/tests/integration/components/pipeline-list-coverage-cell/component-test.js
@@ -21,11 +21,10 @@ module('Integration | Component | pipeline-list-coverage-cell', function(hooks) 
   test('it renders with N/A', async function(assert) {
     assert.expect(2);
     await render(hbs`{{pipeline-list-coverage-cell}}`);
+    await settled();
 
-    return settled().then(() => {
-      assert.dom('.coverage-value').exists({ count: 0 });
-      assert.equal(find('.coverage').textContent.trim(), 'N/A');
-    });
+    assert.dom('.coverage-value').exists({ count: 0 });
+    assert.equal(find('.coverage').textContent.trim(), 'N/A');
   });
 
   test('it renders with actual coverage value', async function(assert) {
@@ -46,10 +45,9 @@ module('Integration | Component | pipeline-list-coverage-cell', function(hooks) 
     ]);
 
     await render(hbs`{{pipeline-list-coverage-cell}}`);
+    await settled();
 
-    return settled().then(() => {
-      assert.dom('.coverage-value').exists({ count: 1 });
-      assert.equal(find('.coverage-value').textContent.trim(), '71.4%');
-    });
+    assert.dom('.coverage-value').exists({ count: 1 });
+    assert.equal(find('.coverage-value').textContent.trim(), '71.4%');
   });
 });

--- a/tests/integration/components/pipeline-list-coverage-cell/component-test.js
+++ b/tests/integration/components/pipeline-list-coverage-cell/component-test.js
@@ -5,8 +5,18 @@ import Pretender from 'pretender';
 import ENV from 'screwdriver-ui/config/environment';
 import hbs from 'htmlbars-inline-precompile';
 
+let server;
+
 module('Integration | Component | pipeline-list-coverage-cell', function(hooks) {
   setupRenderingTest(hooks);
+
+  hooks.beforeEach(function() {
+    server = new Pretender();
+  });
+
+  hooks.afterEach(function() {
+    server.shutdown();
+  });
 
   test('it renders with N/A', async function(assert) {
     assert.expect(2);
@@ -20,8 +30,6 @@ module('Integration | Component | pipeline-list-coverage-cell', function(hooks) 
 
   test('it renders with actual coverage value', async function(assert) {
     assert.expect(2);
-
-    const server = new Pretender();
 
     server.get(`${ENV.APP.SDAPI_HOSTNAME}/v4/coverage/info`, () => [
       200,
@@ -42,7 +50,6 @@ module('Integration | Component | pipeline-list-coverage-cell', function(hooks) 
     return settled().then(() => {
       assert.dom('.coverage-value').exists({ count: 1 });
       assert.equal(find('.coverage-value').textContent.trim(), '71.4%');
-      server.shutdown();
     });
   });
 });

--- a/tests/integration/components/pipeline-list-coverage-cell/component-test.js
+++ b/tests/integration/components/pipeline-list-coverage-cell/component-test.js
@@ -8,15 +8,17 @@ import hbs from 'htmlbars-inline-precompile';
 module('Integration | Component | pipeline-list-coverage-cell', function(hooks) {
   setupRenderingTest(hooks);
 
-  test('it renders with loading', async function(assert) {
+  test('it renders with N/A', async function(assert) {
     assert.expect(2);
-    await render(hbs`{{pipeline-list-coverage-cell loading=true loaded=true}}`);
+    await render(hbs`{{pipeline-list-coverage-cell}}`);
 
-    assert.dom('.coverage-value').exists({ count: 0 });
-    assert.equal(find('.coverage').textContent.trim(), 'Loading');
+    return settled().then(() => {
+      assert.dom('.coverage-value').exists({ count: 0 });
+      assert.equal(find('.coverage').textContent.trim(), 'N/A');
+    });
   });
 
-  test('it renders', async function(assert) {
+  test('it renders with actual coverage value', async function(assert) {
     assert.expect(2);
 
     const server = new Pretender();
@@ -35,7 +37,7 @@ module('Integration | Component | pipeline-list-coverage-cell', function(hooks) 
       })
     ]);
 
-    await render(hbs`{{pipeline-list-coverage-cell coverage=coverage loading=false loaded=true}}`);
+    await render(hbs`{{pipeline-list-coverage-cell}}`);
 
     return settled().then(() => {
       assert.dom('.coverage-value').exists({ count: 1 });

--- a/tests/integration/components/pipeline-list-coverage-cell/component-test.js
+++ b/tests/integration/components/pipeline-list-coverage-cell/component-test.js
@@ -20,15 +20,14 @@ module('Integration | Component | pipeline-list-coverage-cell', function(hooks) 
   });
 
   test('it renders with N/A', async function(assert) {
-    assert.expect(3);
+    assert.expect(2);
 
     this.owner.unregister('component:pipeline-list-coverage-cell');
     this.owner.register(
       'component:pipeline-list-coverage-cell',
       PipelineCellComponent.extend({
-        didEnterViewport() {
-          assert.ok('didEnterViewport called');
-        }
+        // eslint-disable-next-line no-empty-function
+        async didEnterViewport() {}
       })
     );
 

--- a/tests/integration/components/pipeline-list-coverage-cell/component-test.js
+++ b/tests/integration/components/pipeline-list-coverage-cell/component-test.js
@@ -42,6 +42,7 @@ module('Integration | Component | pipeline-list-coverage-cell', function(hooks) 
     return settled().then(() => {
       assert.dom('.coverage-value').exists({ count: 1 });
       assert.equal(find('.coverage-value').textContent.trim(), '71.4%');
+      server.shutdown();
     });
   });
 });

--- a/tests/integration/components/pipeline-list-coverage-cell/component-test.js
+++ b/tests/integration/components/pipeline-list-coverage-cell/component-test.js
@@ -1,17 +1,30 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, find } from '@ember/test-helpers';
+import { render, find, settled } from '@ember/test-helpers';
+import Pretender from 'pretender';
+import ENV from 'screwdriver-ui/config/environment';
 import hbs from 'htmlbars-inline-precompile';
-import RSVP from 'rsvp';
 
 module('Integration | Component | pipeline-list-coverage-cell', function(hooks) {
   setupRenderingTest(hooks);
 
+  test('it renders with loading', async function(assert) {
+    assert.expect(2);
+    await render(hbs`{{pipeline-list-coverage-cell loading=true loaded=true}}`);
+
+    assert.dom('.coverage-value').exists({ count: 0 });
+    assert.equal(find('.coverage').textContent.trim(), 'Loading');
+  });
+
   test('it renders', async function(assert) {
     assert.expect(2);
-    this.set(
-      'result',
-      RSVP.resolve({
+
+    const server = new Pretender();
+
+    server.get(`${ENV.APP.SDAPI_HOSTNAME}/v4/coverage/info`, () => [
+      200,
+      { 'Content-Type': 'application/json' },
+      JSON.stringify({
         envVars: {
           SD_SONAR_AUTH_URL: 'https://api.screwdriver.cd/v4/coverage/token',
           SD_SONAR_HOST: 'https://sonar.screwdriver.cd'
@@ -20,11 +33,13 @@ module('Integration | Component | pipeline-list-coverage-cell', function(hooks) 
         tests: 'N/A',
         projectUrl: 'https://sonar.screwdriver.cd/dashboard?id=job%3A21'
       })
-    );
+    ]);
 
-    await render(hbs`{{pipeline-list-coverage-cell result=result}}`);
+    await render(hbs`{{pipeline-list-coverage-cell coverage=coverage loading=false loaded=true}}`);
 
-    assert.dom('.coverage-value').exists({ count: 1 });
-    assert.equal(find('.coverage-value').textContent.trim(), '71.4%');
+    return settled().then(() => {
+      assert.dom('.coverage-value').exists({ count: 1 });
+      assert.equal(find('.coverage-value').textContent.trim(), '71.4%');
+    });
   });
 });

--- a/tests/integration/components/pipeline-list-coverage-cell/component-test.js
+++ b/tests/integration/components/pipeline-list-coverage-cell/component-test.js
@@ -4,6 +4,7 @@ import { render, find, settled } from '@ember/test-helpers';
 import Pretender from 'pretender';
 import ENV from 'screwdriver-ui/config/environment';
 import hbs from 'htmlbars-inline-precompile';
+import PipelineCellComponent from 'screwdriver-ui/components/pipeline-list-coverage-cell/component';
 
 let server;
 
@@ -19,7 +20,18 @@ module('Integration | Component | pipeline-list-coverage-cell', function(hooks) 
   });
 
   test('it renders with N/A', async function(assert) {
-    assert.expect(2);
+    assert.expect(3);
+
+    this.owner.unregister('component:pipeline-list-coverage-cell');
+    this.owner.register(
+      'component:pipeline-list-coverage-cell',
+      PipelineCellComponent.extend({
+        didEnterViewport() {
+          assert.ok('didEnterViewport called');
+        }
+      })
+    );
+
     await render(hbs`{{pipeline-list-coverage-cell}}`);
     await settled();
 
@@ -29,6 +41,19 @@ module('Integration | Component | pipeline-list-coverage-cell', function(hooks) 
 
   test('it renders with actual coverage value', async function(assert) {
     assert.expect(2);
+
+    const jobData = {
+      jobId: 23,
+      buildId: 670131,
+      startTime: '2020-12-24T06:30:51.608Z',
+      endTime: '2020-12-24T06:33:44.157Z',
+      prNum: null,
+      jobName: 'beta',
+      pipelineName: 'screwdriver-cd/ui',
+      prParentJobId: null
+    };
+
+    this.set('value', jobData);
 
     server.get(`${ENV.APP.SDAPI_HOSTNAME}/v4/coverage/info`, () => [
       200,
@@ -44,7 +69,7 @@ module('Integration | Component | pipeline-list-coverage-cell', function(hooks) 
       })
     ]);
 
-    await render(hbs`{{pipeline-list-coverage-cell}}`);
+    await render(hbs`{{pipeline-list-coverage-cell value=value}}`);
     await settled();
 
     assert.dom('.coverage-value').exists({ count: 1 });

--- a/tests/integration/components/pipeline-list-coverage-cell/component-test.js
+++ b/tests/integration/components/pipeline-list-coverage-cell/component-test.js
@@ -13,6 +13,8 @@ module('Integration | Component | pipeline-list-coverage-cell', function(hooks) 
 
   hooks.beforeEach(function() {
     server = new Pretender();
+    // make sure component is in viewport to trigger didEnterView event
+    document.getElementById('ember-testing').scrollIntoView();
   });
 
   hooks.afterEach(function() {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Current implementation of getting coverages will trigger a second API call, with this PR, we will load on-demand and will only load coverages when in viewport.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Sample coverage pipeline: https://cd.screwdriver.cd/pipelines/67/jobs
## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
