### PR TITLE
fix(2168): Highlight the latest commit in the events tab

### DIFF
--- a/app/components/pipeline-event-row/template.hbs
+++ b/app/components/pipeline-event-row/template.hbs
@@ -5,7 +5,10 @@
       {{#if (eq event.type "pr") }}
         <a href={{event.pr.url}}>PR-{{event.prNum}}</a>
       {{else}}
-        <a class={{if (eq event.id lastSuccessful) "last-successful"}} href={{event.commit.url}}>#{{event.truncatedSha}}</a>
+        <a class={{if (eq event.sha latestCommit.sha) "latest-commit"}} href={{event.commit.url}}>#{{event.truncatedSha}}</a>
+        {{#if (eq event.id lastSuccessful)}}
+          <div class="last-successful">Last successful</div>
+        {{/if}}
         {{#if event.label}}<div class="label">{{event.label}}</div>{{/if}}
       {{/if}}
     </div>

--- a/app/components/pipeline-events-list/component.js
+++ b/app/components/pipeline-events-list/component.js
@@ -4,10 +4,15 @@ import { scheduleOnce } from '@ember/runloop';
 import { inject as service } from '@ember/service';
 
 export default Component.extend({
+  shuttle: service(),
   router: service(),
   errorMessage: '',
   eventsList: computed('events.[]', {
     get() {
+      this.shuttle.getLatestCommitEvent(this.get('pipeline.id')).then(event => {
+        this.set('latestCommit', event);
+      });
+
       return get(this, 'events');
     }
   }),

--- a/app/components/pipeline-events-list/template.hbs
+++ b/app/components/pipeline-events-list/template.hbs
@@ -3,6 +3,7 @@
     {{pipeline-event-row
       event=event
       selectedEvent=selectedEvent
+      latestCommit=latestCommit
       lastSuccessful=lastSuccessful
       eventClick=(action "eventClick")
     }}

--- a/app/pipeline/events/template.hbs
+++ b/app/pipeline/events/template.hbs
@@ -58,6 +58,7 @@
       <div class="tab-content">
         {{#tab.pane activeId=activeTab elementId="events" title="Events"}}
           {{pipeline-events-list
+            pipeline=pipeline
             events=events
             selected=(mut selected)
             selectedEvent=selectedEvent
@@ -70,6 +71,7 @@
         {{#tab.pane activeId=activeTab elementId="pulls" title="Pull Requests"}}
           {{#if prChainEnabled}}
             {{pipeline-events-list
+            pipeline=pipeline
             events=events
             selected=(mut selected)
             selectedEvent=selectedEvent

--- a/app/shuttle/service.js
+++ b/app/shuttle/service.js
@@ -173,5 +173,17 @@ export default Service.extend({
     const url = `/pipelines/${pipelineId}/metrics?${query}`;
 
     return this.fetchFromApi(method, url);
+  },
+
+  /**
+   * getLatestCommitEvent
+   * @param  {Number} pipelineId  Pipeline Id
+   * @return {Promise}
+   */
+  async getLatestCommitEvent(pipelineId) {
+    const method = 'get';
+    const url = `/pipelines/${pipelineId}/latestCommitEvent`;
+
+    return this.fetchFromApi(method, url);
   }
 });

--- a/app/styles/column-view.scss
+++ b/app/styles/column-view.scss
@@ -12,7 +12,16 @@
 }
 
 .last-successful {
+  display: inline-block;
   background-color: $sd-success;
+  color: $sd-white;
+  border-radius: 3px;
+  padding: 3px 5px;
+}
+
+.latest-commit {
+  display: inline-block;
+  background-color: $sd-running;
   color: $sd-white;
   border-radius: 3px;
   padding: 3px 5px;

--- a/tests/acceptance/create-page-test.js
+++ b/tests/acceptance/create-page-test.js
@@ -16,6 +16,12 @@ module('Acceptance | create', function(hooks) {
       { 'Content-Type': 'application/json' },
       JSON.stringify([])
     ]);
+
+    server.get('http://localhost:8080/v4/pipelines/1/latestCommitEvent', () => [
+      200,
+      { 'Content-Type': 'application/json' },
+      JSON.stringify({})
+    ]);
   });
 
   hooks.afterEach(function() {

--- a/tests/acceptance/pipeline-builds-test.js
+++ b/tests/acceptance/pipeline-builds-test.js
@@ -81,6 +81,12 @@ module('Acceptance | pipeline build', function(hooks) {
       { 'Content-Type': 'application/json' },
       JSON.stringify([])
     ]);
+
+    server.get('http://localhost:8080/v4/pipelines/4/latestCommitEvent', () => [
+      200,
+      { 'Content-Type': 'application/json' },
+      JSON.stringify({})
+    ]);
   });
 
   hooks.afterEach(function() {

--- a/tests/acceptance/pipeline-childPipelines-test.js
+++ b/tests/acceptance/pipeline-childPipelines-test.js
@@ -56,6 +56,12 @@ module('Acceptance | child pipeline', function(hooks) {
       { 'Content-Type': 'application/json' },
       JSON.stringify([])
     ]);
+
+    server.get('http://localhost:8080/v4/pipelines/1/latestCommitEvent', () => [
+      200,
+      { 'Content-Type': 'application/json' },
+      JSON.stringify({ id: '2', sha: 'abcdef1029384' })
+    ]);
   });
 
   hooks.afterEach(function() {

--- a/tests/acceptance/pipeline-pr-chain-test.js
+++ b/tests/acceptance/pipeline-pr-chain-test.js
@@ -64,6 +64,12 @@ module('Acceptance | pipeline pr-chain', function(hooks) {
       { 'Content-Type': 'application/json' },
       JSON.stringify([])
     ]);
+
+    server.get('http://localhost:8080/v4/pipelines/4/latestCommitEvent', () => [
+      200,
+      { 'Content-Type': 'application/json' },
+      JSON.stringify({ id: '2', sha: 'abcdef1029384' })
+    ]);
   });
 
   hooks.afterEach(function() {
@@ -82,5 +88,7 @@ module('Acceptance | pipeline pr-chain', function(hooks) {
     assert.dom('.column-tabs-view .view .detail .commit').hasText('PR-42');
     assert.dom('.separator').exists({ count: 1 });
     assert.dom('.partial-view').exists({ count: 2 });
+    assert.dom('.last-successful').doesNotExist();
+    assert.dom('.latest-commit').doesNotExist();
   });
 });

--- a/tests/integration/components/pipeline-event-row/component-test.js
+++ b/tests/integration/components/pipeline-event-row/component-test.js
@@ -12,6 +12,7 @@ const event = {
   status: 'SUCCESS',
   type: 'pipeline',
   causeMessage: 'test',
+  sha: 'sha3',
   commit: {
     author: {
       url: '#',
@@ -68,8 +69,13 @@ module('Integration | Component | pipeline event row', function(hooks) {
     const eventMock = EmberObject.create(copy(event, true));
 
     this.set('event', eventMock);
+    this.set('latestCommit', {
+      sha: 'sha3'
+    });
 
-    await render(hbs`{{pipeline-event-row event=event selectedEvent=3 lastSuccessful=3}}`);
+    await render(
+      hbs`{{pipeline-event-row event=event selectedEvent=3 latestCommit=latestCommit lastSuccessful=3}}`
+    );
 
     assert.dom('.SUCCESS').exists({ count: 1 });
     assert.dom('.status .fa-check-circle-o').exists({ count: 1 });
@@ -80,6 +86,8 @@ module('Integration | Component | pipeline event row', function(hooks) {
     assert.dom('.graph-edge').exists({ count: 3 });
     assert.dom('.by').hasText('Started and committed by: batman');
     assert.dom('.date').hasText('Started now');
+    assert.dom('.last-successful').exists({ count: 1 });
+    assert.dom('.latest-commit').exists({ count: 1 });
   });
 
   test('it renders with pr event', async function(assert) {
@@ -100,8 +108,13 @@ module('Integration | Component | pipeline event row', function(hooks) {
     );
 
     this.set('event', eventMock);
+    this.set('latestCommit', {
+      sha: 'sha3'
+    });
 
-    await render(hbs`{{pipeline-event-row event=event selectedEvent=4 lastSuccessful=3}}`);
+    await render(
+      hbs`{{pipeline-event-row event=event selectedEvent=4 latestCommit=latestCommit lastSuccessful=3}}`
+    );
 
     assert.dom('.SUCCESS').exists({ count: 1 });
     assert.dom('.status .fa-check-circle-o').exists({ count: 1 });
@@ -112,6 +125,8 @@ module('Integration | Component | pipeline event row', function(hooks) {
     assert.dom('.graph-edge').exists({ count: 3 });
     assert.dom('.by').hasText('Started and committed by: batman');
     assert.dom('.date').hasText('Started now');
+    assert.dom('.last-successful').exists({ count: 1 });
+    assert.dom('.latest-commit').exists({ count: 1 });
   });
 
   test('it render when event creator and commit author is different', async function(assert) {
@@ -131,8 +146,13 @@ module('Integration | Component | pipeline event row', function(hooks) {
     );
 
     this.set('event', eventMock);
+    this.set('latestCommit', {
+      sha: 'sha3'
+    });
 
-    await render(hbs`{{pipeline-event-row event=event selectedEvent=3 lastSuccessful=3}}`);
+    await render(
+      hbs`{{pipeline-event-row event=event selectedEvent=3 latestCommit=latestCommit lastSuccessful=3}}`
+    );
 
     assert.dom('.SUCCESS').exists({ count: 1 });
     assert.dom('.status .fa-check-circle-o').exists({ count: 1 });
@@ -143,6 +163,8 @@ module('Integration | Component | pipeline event row', function(hooks) {
     assert.dom('.graph-edge').exists({ count: 3 });
     assert.dom('.by').hasText('Committed by: superman Started by: batman');
     assert.dom('.date').hasText('Started now');
+    assert.dom('.last-successful').exists({ count: 1 });
+    assert.dom('.latest-commit').exists({ count: 1 });
   });
 
   test('it render when event is trigger by external pipeline', async function(assert) {
@@ -158,8 +180,13 @@ module('Integration | Component | pipeline event row', function(hooks) {
     );
 
     this.set('event', eventMock);
+    this.set('latestCommit', {
+      sha: 'sha3'
+    });
 
-    await render(hbs`{{pipeline-event-row event=event selectedEvent=3 lastSuccessful=3}}`);
+    await render(
+      hbs`{{pipeline-event-row event=event selectedEvent=3 latestCommit=latestCommit lastSuccessful=3}}`
+    );
 
     assert.dom('.SUCCESS').exists({ count: 1 });
     assert.dom('.status .fa-check-circle-o').exists({ count: 1 });
@@ -170,6 +197,8 @@ module('Integration | Component | pipeline event row', function(hooks) {
     assert.dom('.graph-edge').exists({ count: 3 });
     assert.dom('.by').hasText('Committed by: batman Started by: External Trigger');
     assert.dom('.date').hasText('Started now');
+    assert.dom('.last-successful').exists({ count: 1 });
+    assert.dom('.latest-commit').exists({ count: 1 });
   });
 
   test('it render when event is trigger by same pipeline', async function(assert) {
@@ -187,8 +216,13 @@ module('Integration | Component | pipeline event row', function(hooks) {
     );
 
     this.set('event', eventMock);
+    this.set('latestCommit', {
+      sha: 'sha3'
+    });
 
-    await render(hbs`{{pipeline-event-row event=event selectedEvent=3 lastSuccessful=3}}`);
+    await render(
+      hbs`{{pipeline-event-row event=event selectedEvent=3 latestCommit=latestCommit lastSuccessful=3}}`
+    );
 
     assert.dom('.SUCCESS').exists({ count: 1 });
     assert.dom('.status .fa-check-circle-o').exists({ count: 1 });
@@ -199,6 +233,8 @@ module('Integration | Component | pipeline event row', function(hooks) {
     assert.dom('.graph-edge').exists({ count: 3 });
     assert.dom('.by').hasText('Started and committed by: batman');
     assert.dom('.date').hasText('Started now');
+    assert.dom('.last-successful').exists({ count: 1 });
+    assert.dom('.latest-commit').exists({ count: 1 });
   });
 
   test('it render when startFrom is missing', async function(assert) {
@@ -214,8 +250,13 @@ module('Integration | Component | pipeline event row', function(hooks) {
     );
 
     this.set('event', eventMock);
+    this.set('latestCommit', {
+      sha: 'sha3'
+    });
 
-    await render(hbs`{{pipeline-event-row event=event selectedEvent=3 lastSuccessful=3}}`);
+    await render(
+      hbs`{{pipeline-event-row event=event selectedEvent=3 latestCommit=latestCommit lastSuccessful=3}}`
+    );
 
     assert.dom('.SUCCESS').exists({ count: 1 });
     assert.dom('.status .fa-check-circle-o').exists({ count: 1 });
@@ -223,6 +264,8 @@ module('Integration | Component | pipeline event row', function(hooks) {
     assert.dom('.message').hasText('this was a test');
     assert.dom('.by').hasText('Started and committed by: batman');
     assert.dom('.date').hasText('Started now');
+    assert.dom('.last-successful').exists({ count: 1 });
+    assert.dom('.latest-commit').exists({ count: 1 });
   });
 
   test('it does not render graph when skipped event', async function(assert) {
@@ -246,8 +289,13 @@ module('Integration | Component | pipeline event row', function(hooks) {
     );
 
     this.set('event', eventMock);
+    this.set('latestCommit', {
+      sha: 'sha3'
+    });
 
-    await render(hbs`{{pipeline-event-row event=event selectedEvent=3 lastSuccessful=3}}`);
+    await render(
+      hbs`{{pipeline-event-row event=event selectedEvent=3 latestCommit=latestCommit lastSuccessful=3}}`
+    );
 
     assert.dom('.SKIPPED').exists({ count: 1 });
     assert.dom('.status .fa-exclamation-circle').exists({ count: 1 });
@@ -255,5 +303,7 @@ module('Integration | Component | pipeline event row', function(hooks) {
     assert.dom('.message').hasText('[skip ci] skip ci build.');
     assert.dom('.by').hasText('Started and committed by: batman');
     assert.dom('.date').hasText('Started now');
+    assert.dom('.last-successful').exists({ count: 1 });
+    assert.dom('.latest-commit').exists({ count: 1 });
   });
 });

--- a/tests/integration/components/pipeline-event-row/component-test.js
+++ b/tests/integration/components/pipeline-event-row/component-test.js
@@ -79,7 +79,7 @@ module('Integration | Component | pipeline event row', function(hooks) {
 
     assert.dom('.SUCCESS').exists({ count: 1 });
     assert.dom('.status .fa-check-circle-o').exists({ count: 1 });
-    assert.dom('.commit').hasText('#abc123');
+    assert.dom('.commit').hasText('#abc123 Last successful');
     assert.dom('.message').hasText('this was a test');
     assert.dom('svg').exists({ count: 1 });
     assert.dom('.graph-node').exists({ count: 4 });
@@ -125,8 +125,8 @@ module('Integration | Component | pipeline event row', function(hooks) {
     assert.dom('.graph-edge').exists({ count: 3 });
     assert.dom('.by').hasText('Started and committed by: batman');
     assert.dom('.date').hasText('Started now');
-    assert.dom('.last-successful').exists({ count: 1 });
-    assert.dom('.latest-commit').exists({ count: 1 });
+    assert.dom('.last-successful').doesNotExist();
+    assert.dom('.latest-commit').doesNotExist();
   });
 
   test('it render when event creator and commit author is different', async function(assert) {
@@ -156,7 +156,7 @@ module('Integration | Component | pipeline event row', function(hooks) {
 
     assert.dom('.SUCCESS').exists({ count: 1 });
     assert.dom('.status .fa-check-circle-o').exists({ count: 1 });
-    assert.dom('.commit').hasText('#abc123');
+    assert.dom('.commit').hasText('#abc123 Last successful');
     assert.dom('.message').hasText('this was a test');
     assert.dom('svg').exists({ count: 1 });
     assert.dom('.graph-node').exists({ count: 4 });
@@ -190,7 +190,7 @@ module('Integration | Component | pipeline event row', function(hooks) {
 
     assert.dom('.SUCCESS').exists({ count: 1 });
     assert.dom('.status .fa-check-circle-o').exists({ count: 1 });
-    assert.dom('.commit').hasText('#abc123');
+    assert.dom('.commit').hasText('#abc123 Last successful');
     assert.dom('.message').hasText('this was a test');
     assert.dom('svg').exists({ count: 1 });
     assert.dom('.graph-node').exists({ count: 4 });
@@ -202,7 +202,7 @@ module('Integration | Component | pipeline event row', function(hooks) {
   });
 
   test('it render when event is trigger by same pipeline', async function(assert) {
-    assert.expect(9);
+    assert.expect(11);
     this.actions.eventClick = () => {
       assert.ok(true);
     };
@@ -226,7 +226,7 @@ module('Integration | Component | pipeline event row', function(hooks) {
 
     assert.dom('.SUCCESS').exists({ count: 1 });
     assert.dom('.status .fa-check-circle-o').exists({ count: 1 });
-    assert.dom('.commit').hasText('#abc123');
+    assert.dom('.commit').hasText('#abc123 Last successful');
     assert.dom('.message').hasText('this was a test');
     assert.dom('svg').exists({ count: 1 });
     assert.dom('.graph-node').exists({ count: 4 });
@@ -238,7 +238,7 @@ module('Integration | Component | pipeline event row', function(hooks) {
   });
 
   test('it render when startFrom is missing', async function(assert) {
-    assert.expect(6);
+    assert.expect(8);
     this.actions.eventClick = () => {
       assert.ok(true);
     };
@@ -260,7 +260,7 @@ module('Integration | Component | pipeline event row', function(hooks) {
 
     assert.dom('.SUCCESS').exists({ count: 1 });
     assert.dom('.status .fa-check-circle-o').exists({ count: 1 });
-    assert.dom('.commit').hasText('#abc123');
+    assert.dom('.commit').hasText('#abc123 Last successful');
     assert.dom('.message').hasText('this was a test');
     assert.dom('.by').hasText('Started and committed by: batman');
     assert.dom('.date').hasText('Started now');
@@ -299,7 +299,7 @@ module('Integration | Component | pipeline event row', function(hooks) {
 
     assert.dom('.SKIPPED').exists({ count: 1 });
     assert.dom('.status .fa-exclamation-circle').exists({ count: 1 });
-    assert.dom('.commit').hasText('#abc123');
+    assert.dom('.commit').hasText('#abc123 Last successful');
     assert.dom('.message').hasText('[skip ci] skip ci build.');
     assert.dom('.by').hasText('Started and committed by: batman');
     assert.dom('.date').hasText('Started now');

--- a/tests/integration/components/pipeline-events-list/component-test.js
+++ b/tests/integration/components/pipeline-events-list/component-test.js
@@ -3,12 +3,27 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { click, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import Service from '@ember/service';
+import { Promise as EmberPromise } from 'rsvp';
 import sinon from 'sinon';
+
+const latestCommitEvent = {
+  id: 3,
+  sha: 'sha3'
+};
 
 module('Integration | Component | pipeline events list', function(hooks) {
   setupRenderingTest(hooks);
 
   test('it renders', async function(assert) {
+    const shuttleStub = Service.extend({
+      getLatestCommitEvent() {
+        return new EmberPromise(resolve => resolve(latestCommitEvent));
+      }
+    });
+    const pipeline = EmberObject.create({
+      id: 1
+    });
     const events = [
       EmberObject.create({
         id: 4,
@@ -85,11 +100,15 @@ module('Integration | Component | pipeline events list', function(hooks) {
       })
     ];
 
+    this.owner.register('service:shuttle', shuttleStub);
+
+    this.set('pipelineMock', pipeline);
     this.set('eventsMock', events);
     this.set('updateEventsMock', page => {
       assert.equal(page, 2);
     });
     await render(hbs`{{pipeline-events-list
+                      pipeline=pipelineMock
                       events=eventsMock
                       eventsPage=1
                       updateEvents=updateEventsMock}}`);
@@ -98,6 +117,11 @@ module('Integration | Component | pipeline events list', function(hooks) {
   });
 
   test('it will redirect to event page when click on pipeline event', async function(assert) {
+    const shuttleStub = Service.extend({
+      getLatestCommitEvent() {
+        return new EmberPromise(resolve => resolve(latestCommitEvent));
+      }
+    });
     const events = [
       EmberObject.create({
         pipelineId: 10000,
@@ -140,6 +164,8 @@ module('Integration | Component | pipeline events list', function(hooks) {
       })
     ];
 
+    this.owner.register('service:shuttle', shuttleStub);
+
     this.set('eventsMock', events);
     this.set('updateEventsMock', page => {
       assert.equal(page, 2);
@@ -158,6 +184,11 @@ module('Integration | Component | pipeline events list', function(hooks) {
   });
 
   test('it will not redirect to event page when click on PR event', async function(assert) {
+    const shuttleStub = Service.extend({
+      getLatestCommitEvent() {
+        return new EmberPromise(resolve => resolve(latestCommitEvent));
+      }
+    });
     const events = [
       EmberObject.create({
         pipelineId: 10000,
@@ -199,6 +230,8 @@ module('Integration | Component | pipeline events list', function(hooks) {
         ]
       })
     ];
+
+    this.owner.register('service:shuttle', shuttleStub);
 
     this.set('eventsMock', events);
     this.set('updateEventsMock', page => {

--- a/tests/unit/shuttle/service-test.js
+++ b/tests/unit/shuttle/service-test.js
@@ -92,4 +92,30 @@ module('Unit | Service | shuttle', function(hooks) {
       );
     });
   });
+
+  test('getLatestCommitEvent payload', function(assert) {
+    assert.expect(2);
+    let service = this.owner.lookup('service:shuttle');
+
+    server.get(`${ENV.APP.SDAPI_HOSTNAME}/v4/pipelines/123456/latestCommitEvent`, () => [
+      200,
+      {
+        'Content-Type': 'application/json',
+        'x-more-data': false
+      },
+      JSON.stringify({
+        id: 3,
+        sha: 'sha3'
+      })
+    ]);
+
+    const pipelineId = 123456;
+
+    service.getLatestCommitEvent(pipelineId).then(result => {
+      const { id, sha } = result;
+
+      assert.equal(id, '3', 'id is 3');
+      assert.equal(sha, 'sha3', 'sha is sha3');
+    });
+  });
 });


### PR DESCRIPTION
## Context
Highlight the latest commit in the events tab.

<img src="https://user-images.githubusercontent.com/24538326/103749751-40819180-5049-11eb-9daf-c01ff231c56e.png" width=300>

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
Changed the _sha_ of latest commit event to blue background color.
The last successful build will be tagged with a green background color.
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/screwdriver/issues/2168
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
