### PR TITLE
fix: increase limit from 10 to 200 to load in job list view

### DIFF
--- a/app/pipeline/jobs/index/controller.js
+++ b/app/pipeline/jobs/index/controller.js
@@ -18,9 +18,13 @@ export default Controller.extend(ModelReloaderMixin, {
   lastRefreshed: moment(),
   shouldReload(model) {
     const job = model.jobs.find(j => {
-      return j.builds.find(b => {
-        return isActiveBuild(b.get('status'), b.get('endTime'));
-      });
+      if (j.hasMany('builds').value() !== null) {
+        return j.builds.find(b => {
+          return isActiveBuild(b.get('status'), b.get('endTime'));
+        });
+      }
+
+      return null;
     });
 
     let res;

--- a/app/pipeline/jobs/index/route.js
+++ b/app/pipeline/jobs/index/route.js
@@ -27,7 +27,10 @@ export default Route.extend(AuthenticatedRouteMixin, {
         count: ENV.APP.NUM_EVENTS_LISTED
       }),
       triggers: this.triggerService.getDownstreamTriggers(this.get('pipeline.id'))
-    }).catch(() => {
+    }).catch(err => {
+      // eslint-disable-next-line no-console
+      console.error('err', err);
+
       this.transitionTo('/404');
     });
   },

--- a/config/environment.js
+++ b/config/environment.js
@@ -55,7 +55,7 @@ module.exports = environment => {
       MINIMUM_JOBNAME_LENGTH: 20,
       NUM_EVENTS_LISTED: 5,
       NUM_PIPELINES_LISTED: 50,
-      LIST_VIEW_PAGE_SIZE: 20,
+      LIST_VIEW_PAGE_SIZE: 200,
       NUM_BUILDS_LISTED: 5,
       MAX_LOG_LINES: 1000,
       DEFAULT_LOG_PAGE_SIZE: 10,


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Since https://github.com/screwdriver-cd/ui/pull/651, we can increase the number of jobs displayed in the first load of the job-list-view, without triggering coverages that are not in the viewport.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
It's a trade off between loading/pre-loading a number of jobs in the job-list-view, or let users scroll multiple times to the desired number of jobs. So, this PR increases from 20 to 200.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
