### PR TITLE
feat(1820): Group events together

### DIFF
--- a/app/components/pipeline-events-list/component.js
+++ b/app/components/pipeline-events-list/component.js
@@ -40,7 +40,7 @@ export default Component.extend({
       if (eventType !== 'pr') {
         const currentEvent = this.groups.find(g => g.find(e => e.id === id))[0];
         const { pipelineId } = currentEvent;
-        const expandedEventsGroup = get(this, 'expandedEventsGroup');
+        const expandedEventsGroup = get(this, 'expandedEventsGroup') || {};
 
         expandedEventsGroup[currentEvent.groupEventId] = true;
         set(this, 'expandedEventsGroup', expandedEventsGroup);

--- a/app/components/pipeline-events-list/component.js
+++ b/app/components/pipeline-events-list/component.js
@@ -39,8 +39,10 @@ export default Component.extend({
 
       if (eventType !== 'pr') {
         const currentEvent = this.groups.find(g => g.find(e => e.id === id))[0];
-
         const { pipelineId } = currentEvent;
+
+        this.expandedEventsGroup[currentEvent.groupEventId] = true;
+        set(this, 'expandedEventsGroup', this.expandedEventsGroup);
 
         this.router.transitionTo('pipeline.events.show', pipelineId, id);
       }

--- a/app/components/pipeline-events-list/component.js
+++ b/app/components/pipeline-events-list/component.js
@@ -2,18 +2,31 @@ import { computed, get, set } from '@ember/object';
 import Component from '@ember/component';
 import { scheduleOnce } from '@ember/runloop';
 import { inject as service } from '@ember/service';
+import groupBy from 'lodash.groupby';
+import moment from 'moment';
 
 export default Component.extend({
   shuttle: service(),
   router: service(),
   errorMessage: '',
-  eventsList: computed('events.[]', {
+  groups: computed('events.[]', {
     get() {
       this.shuttle.getLatestCommitEvent(this.get('pipeline.id')).then(event => {
         this.set('latestCommit', event);
       });
 
-      return get(this, 'events');
+      const events = get(this, 'events');
+      const groups = groupBy(events, 'groupEventId');
+      const groupsArray = Object.keys(groups).map(key => groups[key]);
+
+      groupsArray.forEach(arr =>
+        arr.sort((a, b) => moment(b.createTime).valueOf() - moment(a.createTime).valueOf())
+      );
+      groupsArray.sort(
+        (a, b) => moment(b[0].createTime).valueOf() - moment(a[0].createTime).valueOf()
+      );
+
+      return groupsArray;
     }
   }),
   init() {
@@ -25,7 +38,8 @@ export default Component.extend({
       set(this, 'selected', id);
 
       if (eventType !== 'pr') {
-        const currentEvent = this.eventsList.findBy('id', id);
+        const currentEvent = this.groups.find(g => g.find(e => e.id === id))[0];
+
         const { pipelineId } = currentEvent;
 
         this.router.transitionTo('pipeline.events.show', pipelineId, id);

--- a/app/components/pipeline-events-list/component.js
+++ b/app/components/pipeline-events-list/component.js
@@ -40,9 +40,10 @@ export default Component.extend({
       if (eventType !== 'pr') {
         const currentEvent = this.groups.find(g => g.find(e => e.id === id))[0];
         const { pipelineId } = currentEvent;
+        const expandedEventsGroup = get(this, 'expandedEventsGroup');
 
-        this.expandedEventsGroup[currentEvent.groupEventId] = true;
-        set(this, 'expandedEventsGroup', this.expandedEventsGroup);
+        expandedEventsGroup[currentEvent.groupEventId] = true;
+        set(this, 'expandedEventsGroup', expandedEventsGroup);
 
         this.router.transitionTo('pipeline.events.show', pipelineId, id);
       }

--- a/app/components/pipeline-events-list/template.hbs
+++ b/app/components/pipeline-events-list/template.hbs
@@ -1,7 +1,8 @@
 <div>
-  {{#each eventsList as |event|}}
-    {{pipeline-event-row
-      event=event
+  {{#each groups as |group|}}
+    {{pipeline-events-row-group
+      expandedEventsGroup=expandedEventsGroup
+      events=group
       selectedEvent=selectedEvent
       latestCommit=latestCommit
       lastSuccessful=lastSuccessful

--- a/app/components/pipeline-events-row-group/component.js
+++ b/app/components/pipeline-events-row-group/component.js
@@ -9,7 +9,10 @@ export default Component.extend({
   }),
   isExpanded: computed('expandedEventsGroup', 'events.[]', {
     get() {
-      return !!get(this, 'expandedEventsGroup')[this.events[0].groupEventId];
+      const expandedGroups = get(this, 'expandedEventsGroup');
+      const { groupEventId } = this.events[0];
+
+      return !!expandedGroups[groupEventId];
     }
   }),
   init() {

--- a/app/components/pipeline-events-row-group/component.js
+++ b/app/components/pipeline-events-row-group/component.js
@@ -1,0 +1,24 @@
+import { computed, get, set } from '@ember/object';
+import Component from '@ember/component';
+
+export default Component.extend({
+  events: computed('events.[]', {
+    get() {
+      return get(this, 'events');
+    }
+  }),
+  isExpanded: computed('expandedEventsGroup', 'events.[]', {
+    get() {
+      return !!get(this, 'expandedEventsGroup')[this.events[0].groupEventId];
+    }
+  }),
+  init() {
+    this._super(...arguments);
+  },
+  actions: {
+    toggleExpanded() {
+      this.expandedEventsGroup[this.events[0].groupEventId] = !this.isExpanded;
+      set(this, 'expandedEventsGroup', { ...this.expandedEventsGroup });
+    }
+  }
+});

--- a/app/components/pipeline-events-row-group/component.js
+++ b/app/components/pipeline-events-row-group/component.js
@@ -2,11 +2,7 @@ import { computed, get, set } from '@ember/object';
 import Component from '@ember/component';
 
 export default Component.extend({
-  events: computed('events.[]', {
-    get() {
-      return get(this, 'events');
-    }
-  }),
+  events: [],
   isExpanded: computed('expandedEventsGroup', 'events.[]', {
     get() {
       const expandedGroups = get(this, 'expandedEventsGroup');

--- a/app/components/pipeline-events-row-group/styles.scss
+++ b/app/components/pipeline-events-row-group/styles.scss
@@ -1,0 +1,10 @@
+.pipeline-events-group {
+  .expand-collapse {
+    text-decoration: none;
+    padding: 0.25rem;
+  }
+
+  margin: 1rem;
+  border: 1px solid $grey-400;
+  border-radius: 0.25rem;
+}

--- a/app/components/pipeline-events-row-group/template.hbs
+++ b/app/components/pipeline-events-row-group/template.hbs
@@ -1,16 +1,18 @@
 <div class="pipeline-events-group">
   {{#each events as |event index|}}
     {{#if (eq index 0)}}
-      <a onclick={{action "toggleExpanded"}} class="pull-right expand-collapse">
-        {{#if (eq isExpanded true)}}
-          Collapse
-          {{fa-icon "chevron-circle-up"}}
-        {{else}}
-          Expend
-          {{fa-icon "chevron-circle-down"}}
-        {{/if}}
-      </a>
-      <span class="clearfix" />
+      {{#if (not-eq events.length 1)}}
+        <a onclick={{action "toggleExpanded"}} class="pull-right expand-collapse">
+          {{#if (eq isExpanded true)}}
+            Collapse
+            {{fa-icon "chevron-circle-up"}}
+          {{else}}
+            Expand
+            {{fa-icon "chevron-circle-down"}}
+          {{/if}}
+        </a>
+        <span class="clearfix" />
+      {{/if}}
       {{pipeline-event-row
               event=event
               selectedEvent=selectedEvent

--- a/app/components/pipeline-events-row-group/template.hbs
+++ b/app/components/pipeline-events-row-group/template.hbs
@@ -1,0 +1,33 @@
+<div class="pipeline-events-group">
+  {{#each events as |event index|}}
+    {{#if (eq index 0)}}
+      <a onclick={{action "toggleExpanded"}} class="pull-right expand-collapse">
+        {{#if (eq isExpanded true)}}
+          Collapse
+          {{fa-icon "chevron-circle-up"}}
+        {{else}}
+          Expend
+          {{fa-icon "chevron-circle-down"}}
+        {{/if}}
+      </a>
+      <span class="clearfix" />
+      {{pipeline-event-row
+              event=event
+              selectedEvent=selectedEvent
+              lastSuccessful=lastSuccessful
+              eventClick=eventClick
+      }}
+    {{else if (eq isExpanded true)}}
+      {{pipeline-event-row
+              event=event
+              selectedEvent=selectedEvent
+              lastSuccessful=lastSuccessful
+              eventClick=eventClick
+      }}
+    {{/if}}
+  {{else}}
+    <div class="alert">No events have been run for this pipeline</div>
+  {{/each}}
+</div>
+
+{{yield}}

--- a/app/pipeline/events/controller.js
+++ b/app/pipeline/events/controller.js
@@ -161,6 +161,7 @@ export async function updateEvents(page) {
 
 export default Controller.extend(ModelReloaderMixin, {
   lastRefreshed: moment(),
+  expandedEventsGroup: {},
   shouldReload(model) {
     const event = model.events.find(m => m.isRunning);
 

--- a/app/pipeline/events/show/route.js
+++ b/app/pipeline/events/show/route.js
@@ -38,6 +38,13 @@ export default class PipelineEventsShowRoute extends Route {
       const event = await this.store.findRecord('event', eventId);
 
       pipelineEventsController.paginateEvents.pushObject(event);
+    } else {
+      const { groupEventId } = desiredEvent;
+
+      const expandedEventsGroup = pipelineEventsController.get('pipelineEventsController') || {};
+
+      expandedEventsGroup[groupEventId] = true;
+      pipelineEventsController.set('expandedEventsGroup', expandedEventsGroup);
     }
 
     pipelineEventsController.set('selected', eventId);

--- a/app/pipeline/events/show/route.js
+++ b/app/pipeline/events/show/route.js
@@ -41,9 +41,11 @@ export default class PipelineEventsShowRoute extends Route {
     } else {
       const { groupEventId } = desiredEvent;
 
-      const expandedEventsGroup = pipelineEventsController.get('pipelineEventsController') || {};
+      const expandedEventsGroup = pipelineEventsController.expandedEventsGroup || {};
 
-      expandedEventsGroup[groupEventId] = true;
+      if (expandedEventsGroup[groupEventId] === undefined) {
+        expandedEventsGroup[groupEventId] = true;
+      }
       pipelineEventsController.set('expandedEventsGroup', expandedEventsGroup);
     }
 

--- a/app/pipeline/events/template.hbs
+++ b/app/pipeline/events/template.hbs
@@ -73,6 +73,7 @@
           {{#if prChainEnabled}}
             {{pipeline-events-list
             pipeline=pipeline
+            expandedEventsGroup=expandedEventsGroup
             events=events
             selected=(mut selected)
             selectedEvent=selectedEvent

--- a/app/pipeline/events/template.hbs
+++ b/app/pipeline/events/template.hbs
@@ -59,6 +59,7 @@
         {{#tab.pane activeId=activeTab elementId="events" title="Events"}}
           {{pipeline-events-list
             pipeline=pipeline
+            expandedEventsGroup=expandedEventsGroup
             events=events
             selected=(mut selected)
             selectedEvent=selectedEvent

--- a/package-lock.json
+++ b/package-lock.json
@@ -30253,6 +30253,12 @@
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
+    "lodash.groupby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
+      "integrity": "sha1-Cwih3PaDl8OXhVwyOXg4Mt90A9E=",
+      "dev": true
+    },
     "lodash.identity": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash.identity/-/lodash.identity-2.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
     "jstree": "^3.3.7",
     "lint-staged": "^8.1.7",
     "loader.js": "^4.7.0",
+    "lodash.groupby": "^4.6.0",
     "lodash.isequal": "^4.5.0",
     "lodash.uniqby": "^4.7.0",
     "memoizerific": "^1.11.3",

--- a/tests/integration/components/build-banner/component-test.js
+++ b/tests/integration/components/build-banner/component-test.js
@@ -46,6 +46,7 @@ const eventMock = EmberObject.create({
     url: 'https://github.com/screwdriver-cd/ui/pull/292'
   },
   pipelineId: '12345',
+  groupEventId: '23450',
   sha: 'abcdef1029384',
   truncatedSha: 'abcdef1',
   type: 'pipelineId',

--- a/tests/integration/components/pipeline-events-list/component-test.js
+++ b/tests/integration/components/pipeline-events-list/component-test.js
@@ -27,6 +27,7 @@ module('Integration | Component | pipeline events list', function(hooks) {
     const events = [
       EmberObject.create({
         id: 4,
+        groupEventId: '2341234',
         startFrom: '~commit',
         causeMessage: 'test',
         commit: {

--- a/tests/mock/events.js
+++ b/tests/mock/events.js
@@ -24,6 +24,7 @@ const events = [
     },
     startFrom: '~commit',
     pipelineId: '12345',
+    groupEventId: '23452',
     sha: 'abcdef1029384',
     type: 'pipeline',
     workflowGraph: {
@@ -56,6 +57,7 @@ const events = [
       url: 'http://example.com/batcave/batmobile/pulls/42'
     },
     pipelineId: '12345',
+    groupEventId: '23453',
     type: 'pr',
     prNum: 42,
     sha: '1029384bbb',
@@ -89,6 +91,7 @@ const events = [
       url: 'http://example.com/batcave/batmobile/pulls/43'
     },
     pipelineId: '12345',
+    groupEventId: '23454',
     sha: '1030384bbb',
     type: 'pr',
     prNum: 43,

--- a/tests/mock/jobs.js
+++ b/tests/mock/jobs.js
@@ -5,6 +5,7 @@ export default () =>
     [
       {
         id: '12345',
+        groupEventId: '23456',
         name: 'main',
         pipelineId: '4',
         state: 'ENABLED',
@@ -12,6 +13,7 @@ export default () =>
       },
       {
         id: '12346',
+        groupEventId: '23456',
         name: 'publish',
         pipelineId: '4',
         state: 'ENABLED',
@@ -19,6 +21,7 @@ export default () =>
       },
       {
         id: '12347',
+        groupEventId: '23457',
         name: 'PR-42:main',
         pipelineId: '4',
         state: 'ENABLED',
@@ -26,6 +29,7 @@ export default () =>
       },
       {
         id: '12348',
+        groupEventId: '23457',
         name: 'PR-42:publish',
         pipelineId: '4',
         state: 'ENABLED',
@@ -33,6 +37,7 @@ export default () =>
       },
       {
         id: '12349',
+        groupEventId: '23458',
         name: 'PR-43:main',
         pipelineId: '4',
         state: 'ENABLED',

--- a/tests/unit/pr-events/service-test.js
+++ b/tests/unit/pr-events/service-test.js
@@ -37,6 +37,7 @@ const initServer = () => {
           url: 'https://github.com/screwdriver-cd/ui/pull/292'
         },
         pipelineId: '12345',
+        groupEventId: '23455',
         sha: 'abcdef1029384',
         truncatedSha: 'abcdef',
         type: 'pr',


### PR DESCRIPTION
## Context

We want to be able to group jobs with the same commit id in order to reduce the clutter.

## Objective

Group all jobs with the same commit id.  Allow this group to expand and collapse.

![image](https://user-images.githubusercontent.com/552784/104496889-6d283280-558e-11eb-8e6d-1367b3190b1d.png)

## References

https://github.com/screwdriver-cd/screwdriver/issues/1820

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
