### PR TITLE
fix(2315): Make collections delete and add operations more clear

### DIFF
--- a/app/components/collection-table-row/component.js
+++ b/app/components/collection-table-row/component.js
@@ -72,7 +72,7 @@ export default Component.extend({
   },
   actions: {
     removePipeline() {
-      this.removePipeline(this.pipeline.id);
+      this.removePipeline(this.pipeline.id, this.pipeline.name);
     },
     togglePipeline() {
       const pipelineId = this.pipeline.id;

--- a/app/components/collection-table-row/template.hbs
+++ b/app/components/collection-table-row/template.hbs
@@ -41,7 +41,7 @@
 </td>
 <td class="collection-pipeline__remove">
   {{#if showRemoveButton}}
-    <span onclick={{action "removePipeline"}}>
+    <span title="Remove {{pipeline.scmRepo.name}} pipeline from {{collectionName}} collection" onclick={{action "removePipeline"}}>
       &times;
     </span>
   {{/if}}

--- a/app/components/collection-view/component.js
+++ b/app/components/collection-view/component.js
@@ -33,7 +33,7 @@ export default Component.extend({
   searchedPipelines: [],
   selectedSearchedPipelines: [],
   linkCopied: '',
-  pipelineRemoved: '',
+  pipelineRemovedMessage: '',
   reset: false,
 
   showViewSwitch: computed('collection.pipelineIds', function showViewSwitch() {
@@ -116,7 +116,7 @@ export default Component.extend({
             this.setProperties({
               removePipelineError: null,
               collection,
-              pipelineRemoved: message
+              pipelineRemovedMessage: message
             });
           });
         })

--- a/app/components/collection-view/component.js
+++ b/app/components/collection-view/component.js
@@ -33,6 +33,7 @@ export default Component.extend({
   searchedPipelines: [],
   selectedSearchedPipelines: [],
   linkCopied: '',
+  pipelineRemoved: '',
   reset: false,
 
   showViewSwitch: computed('collection.pipelineIds', function showViewSwitch() {
@@ -99,19 +100,23 @@ export default Component.extend({
     /**
      * Action to remove a pipeline from a collection
      *
-     * @param {Number} pipelineId - id of pipeline to remove
-     * @param {Number} collectionId - id of collection to remove from
+     * @param {Number} pipelineId     ID of pipeline to remove
+     * @param {String} [pipelineName] Pipeline name
      * @returns {Promise}
      */
-    removePipeline(pipelineId) {
+    removePipeline(pipelineId, pipelineName) {
       const collectionId = this.get('collection.id');
+      const collectionName = this.get('collection.name');
+      const pipelineLabel = pipelineName ? ` ${pipelineName}` : '';
+      const message = `The pipeline${pipelineLabel} has been removed from the ${collectionName} collection.`;
 
       return this.onRemovePipeline(+pipelineId)
         .then(() => {
           this.store.findRecord('collection', collectionId).then(collection => {
             this.setProperties({
               removePipelineError: null,
-              collection
+              collection,
+              pipelineRemoved: message
             });
           });
         })

--- a/app/components/collection-view/template.hbs
+++ b/app/components/collection-view/template.hbs
@@ -12,16 +12,16 @@
     <div class="col-xs-12 col-sm-8">
       <h2 class="header__name">{{collection.name}}</h2>
 
-      {{#if (not-eq collection.type "default")}}
-        <span onclick={{action "toggleAddPipelineModal"}} class="collection-operation add-pipeline-operation">
+      {{#if (eq collection.type "normal")}}
+        <span onclick={{action "toggleAddPipelineModal"}} title="Add pipeline(s) to collection" class="collection-operation add-pipeline-operation">
           {{inline-svg "add" class="img"}}
         </span>
-        <span onclick={{action "toggleSettingModal"}} class="collection-operation settings-operation">
+        <span onclick={{action "toggleSettingModal"}} title="Collection settings" class="collection-operation settings-operation">
           {{inline-svg "setting" class="img"}}
         </span>
       {{/if}}
 
-      <span onclick={{action "copyLink"}} class="collection-operation copy-operation">
+      <span onclick={{action "copyLink"}} title="Copy collection link" class="collection-operation copy-operation">
         {{inline-svg "link" class="img"}}
       </span>
 
@@ -163,6 +163,7 @@
                   selectPipeline=(action "selectPipeline")
                   deselectPipeline=(action "deselectPipeline")
                   reset=reset
+                  collectionName=collection.name
               }}
             {{/each}}
           </tbody>
@@ -180,6 +181,7 @@
               selectPipeline=(action "selectPipeline")
               deselectPipeline=(action "deselectPipeline")
               reset=reset
+              collectionName=collection.name
           }}
         {{/each}}
       </div>

--- a/app/components/collection-view/template.hbs
+++ b/app/components/collection-view/template.hbs
@@ -8,6 +8,9 @@
   {{#if linkCopied}}
     {{info-message message=linkCopied type="success" icon="check"}}
   {{/if}}
+  {{#if pipelineRemoved}}
+    {{info-message message=pipelineRemoved type="success" icon="check"}}
+  {{/if}}
   <div class="header row">
     <div class="col-xs-12 col-sm-8">
       <h2 class="header__name">{{collection.name}}</h2>

--- a/app/components/collection-view/template.hbs
+++ b/app/components/collection-view/template.hbs
@@ -8,8 +8,8 @@
   {{#if linkCopied}}
     {{info-message message=linkCopied type="success" icon="check"}}
   {{/if}}
-  {{#if pipelineRemoved}}
-    {{info-message message=pipelineRemoved type="success" icon="check"}}
+  {{#if pipelineRemovedMessage}}
+    {{info-message message=pipelineRemovedMessage type="success" icon="check"}}
   {{/if}}
   <div class="header row">
     <div class="col-xs-12 col-sm-8">

--- a/app/components/collections-flyout/template.hbs
+++ b/app/components/collections-flyout/template.hbs
@@ -16,14 +16,14 @@
       {{#link-to "dashboard.show" collection.id title=collection.name}}
         {{collection.name}}
       {{/link-to}}
-      {{#unless (eq collection.type "default")}}
+      {{#if (eq collection.type "normal")}}
         <button
           class="collection-wrapper__delete"
           onclick={{action "setCollectionToDelete" collection}}
         >
           {{fa-icon "trash" title="Delete collection" size="md"}}
         </button>
-      {{/unless}}
+      {{/if}}
     </div>
   {{else}}
     <p class="no-collections-text">Please create a collection.</p>
@@ -31,7 +31,7 @@
   {{#if collectionToDelete}}
     {{!-- Confirmation modal for deleting a collection --}}
     {{#bs-modal-simple
-      title="Please confirm"
+      title="Please confirm deletion"
       closeTitle="Cancel"
       submitTitle="Confirm"
       size=null
@@ -39,7 +39,7 @@
       onSubmit=(action "deleteCollection" collectionToDelete)
       onHide=(action "cancelDeletingCollection")
     }}
-      You're about to delete {{collectionToDelete.name}}. Are you sure?
+      You're about to delete the collection {{collectionToDelete.name}}. This action cannot be undone. Are you sure?
     {{/bs-modal-simple}}
   {{/if}}
   {{collection-modal showModal=showModal}}

--- a/app/components/collections-flyout/template.hbs
+++ b/app/components/collections-flyout/template.hbs
@@ -31,7 +31,7 @@
   {{#if collectionToDelete}}
     {{!-- Confirmation modal for deleting a collection --}}
     {{#bs-modal-simple
-      title="Please confirm deletion"
+      title="Confirm deletion"
       closeTitle="Cancel"
       submitTitle="Confirm"
       size=null
@@ -39,7 +39,7 @@
       onSubmit=(action "deleteCollection" collectionToDelete)
       onHide=(action "cancelDeletingCollection")
     }}
-      You're about to delete the collection {{collectionToDelete.name}}. This action cannot be undone. Are you sure?
+      You're about to delete the collection "{{collectionToDelete.name}}". This action cannot be undone. Are you sure?
     {{/bs-modal-simple}}
   {{/if}}
   {{collection-modal showModal=showModal}}

--- a/app/components/pipeline-card/component.js
+++ b/app/components/pipeline-card/component.js
@@ -72,7 +72,7 @@ export default Component.extend({
   },
   actions: {
     removePipeline() {
-      this.removePipeline(this.pipeline.id);
+      this.removePipeline(this.pipeline.id, this.pipeline.name);
     },
     togglePipeline() {
       const pipelineId = this.pipeline.id;

--- a/app/components/pipeline-card/template.hbs
+++ b/app/components/pipeline-card/template.hbs
@@ -6,7 +6,7 @@
 {{/if}}
 <div class="pipeline-card-content {{if showCheckbox "show-checkbox" ""}}">
   {{#if showRemoveButton}}
-    <span class="remove-button" onclick={{action "removePipeline"}}>
+    <span class="remove-button" title="Remove {{pipeline.scmRepo.name}} pipeline from the collection" onclick={{action "removePipeline"}}>
       &times;
     </span>
   {{/if}}
@@ -25,7 +25,7 @@
       {{#link-to "pipeline" pipeline.id title=pipeline.scmRepo.name}}
         {{fa-icon lastEventInfo.icon class=lastEventInfo.statusColor}}
       {{/link-to}}
-      <a href={{lastEventInfo.commitUrl}}> 
+      <a href={{lastEventInfo.commitUrl}}>
         {{lastEventInfo.sha}}
       </a>
     </div>
@@ -49,7 +49,7 @@
       <span class="badge-info">{{lastEventInfo.startTime}}</span>
     </div>
   </div>
-  
+
   <div class="events-thumbnail-wrapper">
     {{#if hasBothEventsAndLatestEventInfo}}
       {{events-thumbnail

--- a/app/components/pipeline-card/template.hbs
+++ b/app/components/pipeline-card/template.hbs
@@ -6,7 +6,7 @@
 {{/if}}
 <div class="pipeline-card-content {{if showCheckbox "show-checkbox" ""}}">
   {{#if showRemoveButton}}
-    <span class="remove-button" title="Remove {{pipeline.scmRepo.name}} pipeline from the collection" onclick={{action "removePipeline"}}>
+    <span class="remove-button" title="Remove {{pipeline.scmRepo.name}} pipeline from {{collectionName}} collection" onclick={{action "removePipeline"}}>
       &times;
     </span>
   {{/if}}

--- a/app/components/pipeline-options/template.hbs
+++ b/app/components/pipeline-options/template.hbs
@@ -230,7 +230,7 @@
                   <p>Once you delete a pipeline, there is no going back.</p>
                 </div>
                 <div class="col-xs-1 col-md-4 right">
-                  <a href="#" {{action "showRemoveButtons"}} class="trash">{{fa-icon "trash"}} title="Delete pipeline"</a>
+                  <a href="#" {{action "showRemoveButtons"}} class="trash" title="Delete pipeline">{{fa-icon "trash"}} </a>
                 </div>
               </div>
             {{/if}}

--- a/app/components/pipeline-options/template.hbs
+++ b/app/components/pipeline-options/template.hbs
@@ -226,18 +226,18 @@
             {{#if showDangerButton}}
               <div class="row">
                 <div class="col-xs-1 col-md-8">
-                  <h4>Remove this pipeline</h4>
-                  <p>Once you remove a pipeline, there is no going back.</p>
+                  <h4>Delete this pipeline</h4>
+                  <p>Once you delete a pipeline, there is no going back.</p>
                 </div>
                 <div class="col-xs-1 col-md-4 right">
-                  <a href="#" {{action "showRemoveButtons"}} class="trash">{{fa-icon "trash"}}</a>
+                  <a href="#" {{action "showRemoveButtons"}} class="trash">{{fa-icon "trash"}} title="Delete pipeline"</a>
                 </div>
               </div>
             {{/if}}
             {{#if showRemoveButtons}}
               <h4>Are you absolutely sure?</h4>
               <a href="#" {{action "cancelRemove"}} class="cancel">{{fa-icon "ban"}} Cancel</a>
-              <a href="#" {{action "removePipeline"}} class="remove">{{fa-icon "trash"}} Remove</a>
+              <a href="#" {{action "removePipeline"}} class="remove">{{fa-icon "trash"}} Delete</a>
             {{/if}}
             {{#if isRemoving}}
               <p>Please wait...</p>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9850,9 +9850,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "5.7.3",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-          "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+          "version": "5.7.4",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+          "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
           "dev": true
         }
       }
@@ -28589,9 +28589,9 @@
       "dev": true
     },
     "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
     },
     "inline-source-map-comment": {

--- a/tests/integration/components/collections-flyout/component-test.js
+++ b/tests/integration/components/collections-flyout/component-test.js
@@ -240,7 +240,7 @@ module('Integration | Component | collections flyout', function(hooks) {
     await click('.collection-wrapper__delete');
 
     assert.dom('.modal').exists({ count: 1 });
-    assert.dom('.modal-title').hasText('Please confirm');
+    assert.dom('.modal-title').hasText('Please confirm deletion');
 
     await click('.modal-footer > .btn-primary');
 

--- a/tests/integration/components/collections-flyout/component-test.js
+++ b/tests/integration/components/collections-flyout/component-test.js
@@ -240,7 +240,7 @@ module('Integration | Component | collections flyout', function(hooks) {
     await click('.collection-wrapper__delete');
 
     assert.dom('.modal').exists({ count: 1 });
-    assert.dom('.modal-title').hasText('Please confirm deletion');
+    assert.dom('.modal-title').hasText('Confirm deletion');
 
     await click('.modal-footer > .btn-primary');
 

--- a/tests/integration/components/pipeline-options/component-test.js
+++ b/tests/integration/components/pipeline-options/component-test.js
@@ -85,8 +85,8 @@ module('Integration | Component | pipeline options', function(hooks) {
     // Danger Zone
     assert.dom('section.danger h3').hasText('Danger Zone');
     assert.dom('section.danger li').exists({ count: 1 });
-    assert.dom('section.danger h4').hasText('Remove this pipeline');
-    assert.dom('section.danger p').hasText('Once you remove a pipeline, there is no going back.');
+    assert.dom('section.danger h4').hasText('Delete this pipeline');
+    assert.dom('section.danger p').hasText('Once you delete a pipeline, there is no going back.');
     assert.dom('section.danger a i').hasClass('fa-trash');
   });
 
@@ -347,7 +347,7 @@ module('Integration | Component | pipeline options', function(hooks) {
       hbs`{{pipeline-options pipeline=mockPipeline onRemovePipeline=removePipelineMock}}`
     );
 
-    assert.dom('section.danger h4').hasText('Remove this pipeline');
+    assert.dom('section.danger h4').hasText('Delete this pipeline');
 
     await click('section.danger a');
 
@@ -356,7 +356,7 @@ module('Integration | Component | pipeline options', function(hooks) {
 
     await click('section.danger a');
 
-    assert.dom('section.danger h4').hasText('Remove this pipeline');
+    assert.dom('section.danger h4').hasText('Delete this pipeline');
 
     await click('section.danger a');
 


### PR DESCRIPTION
## Context

Would be nice to have clearer operations when interacting with Collections. It can be confusing when options to delete or remove appear and the user does not have permissions.

## Objective

This PR:
- adds titles to icons in collections pages such as trash icons, add pipeline, settings, copy link, etc
<img width="307" alt="Screen Shot 2021-01-20 at 3 15 25 PM" src="https://user-images.githubusercontent.com/3230529/105259223-4050be00-5b40-11eb-80e4-58b3339eacd2.png">
<img width="816" alt="Screen Shot 2021-01-20 at 2 57 37 PM" src="https://user-images.githubusercontent.com/3230529/105259244-4b0b5300-5b40-11eb-8021-6e90a400bcce.png">

- adds notification when pipeline is successfully removed
<img width="1192" alt="Screen Shot 2021-01-20 at 4 45 29 PM" src="https://user-images.githubusercontent.com/3230529/105259204-3464fc00-5b40-11eb-8762-b29c92c335c3.png">

- changes wording to "~Remove~Delete pipeline"
<img width="959" alt="Screen Shot 2021-01-20 at 4 56 20 PM" src="https://user-images.githubusercontent.com/3230529/105259379-8574f000-5b40-11eb-8c54-ed88534be93c.png">

- only shows options to delete or add when type is "normal"; type would be "shared" for viewing other people's collections and "default" when viewing default collection (https://github.com/screwdriver-cd/screwdriver/issues/2315)

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2315

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
