### PR TITLE
fix: not triggering scrolling event when events are collapsed

### DIFF
--- a/app/components/pipeline-events-row-group/component.js
+++ b/app/components/pipeline-events-row-group/component.js
@@ -11,9 +11,7 @@ export default Component.extend({
       return !!expandedGroups[groupEventId];
     }
   }),
-  init() {
-    this._super(...arguments);
-  },
+
   actions: {
     toggleExpanded() {
       this.expandedEventsGroup[this.events[0].groupEventId] = !this.isExpanded;

--- a/app/pipeline/events/template.hbs
+++ b/app/pipeline/events/template.hbs
@@ -68,6 +68,7 @@
             eventsPage=eventsPage
             updateEvents=(action "updateEvents")
           }}
+          <div style="padding: 20px;" onMouseEnter={{action "onEventListScroll"}}></div>
         {{/tab.pane}}
         {{#tab.pane activeId=activeTab elementId="pulls" title="Pull Requests"}}
           {{#if prChainEnabled}}


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
[Scroll event](https://developer.mozilla.org/en-US/docs/Web/API/Document/scroll_event) is not triggered when events are grouped together and collapsed


https://github.com/screwdriver-cd/ui/blob/388d37e33dcbaa28da8dcc9e755c92a9cc9f253a/app/pipeline/events/template.hbs#L47

https://github.com/screwdriver-cd/ui/blob/388d37e33dcbaa28da8dcc9e755c92a9cc9f253a/app/pipeline/events/controller.js#L434-L437

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Example:  https://www.w3schools.com/jsref/tryit.asp?filename=tryjsref_onscroll 
If you change the height to 300px, you will see no scroll events will be triggered

To accommodate this, I'm adding a bottom element to trigger when the mouse is entered, see screenshot
![image](https://user-images.githubusercontent.com/15989893/105409062-b9095600-5be4-11eb-8759-f13520c7d1b0.png)

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
More Handling Events - Components - Ember Guides https://guides.emberjs.com/v2.0.0/components/handling-events/
## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
