### PR TITLE
fix: only reload model if has internet access

### DIFF
--- a/app/mixins/model-reloader.js
+++ b/app/mixins/model-reloader.js
@@ -61,7 +61,12 @@ export default Mixin.create({
           .reload()
           .then(() => {
             if (model.model && model.model.reload) {
-              model.model.reload();
+              if (window.navigator.onLine) {
+                model.model.reload();
+              } else {
+                // eslint-disable-next-line no-console
+                console.error('offline');
+              }
             }
           })
           .finally(() => this.scheduleReload());

--- a/app/mixins/model-reloader.js
+++ b/app/mixins/model-reloader.js
@@ -57,16 +57,15 @@ export default Mixin.create({
 
     switch (shouldReload) {
       case SHOULD_RELOAD_YES:
+        if (!window.navigator.onLine) {
+          break;
+        }
+
         model
           .reload()
           .then(() => {
             if (model.model && model.model.reload) {
-              if (window.navigator.onLine) {
-                model.model.reload();
-              } else {
-                // eslint-disable-next-line no-console
-                console.error('offline');
-              }
+              model.model.reload();
             }
           })
           .finally(() => this.scheduleReload());

--- a/app/pipeline/events/route.js
+++ b/app/pipeline/events/route.js
@@ -3,6 +3,8 @@ import Route from '@ember/routing/route';
 import ENV from 'screwdriver-ui/config/environment';
 import RSVP from 'rsvp';
 
+const ERROR_MESSAGE = 'Session timed-out, please login back in to complete the action';
+
 export default Route.extend({
   triggerService: service('pipeline-triggers'),
   routeAfterAuthentication: 'pipeline.events',
@@ -16,7 +18,9 @@ export default Route.extend({
     this.get('pipelineService').setBuildsLink('pipeline.events');
   },
   model() {
-    this.controllerFor('pipeline.events').set('pipeline', this.pipeline);
+    const pipelineEventsController = this.controllerFor('pipeline.events');
+
+    pipelineEventsController.set('pipeline', this.pipeline);
 
     return RSVP.hash({
       jobs: this.get('pipeline.jobs'),
@@ -30,6 +34,8 @@ export default Route.extend({
       if (err === '0 Request Failed') {
         // eslint-disable-next-line no-console
         console.error('offline err', err);
+
+        pipelineEventsController.set('errorMessage', ERROR_MESSAGE);
       } else {
         this.transitionTo('/404');
       }

--- a/app/pipeline/events/route.js
+++ b/app/pipeline/events/route.js
@@ -1,9 +1,8 @@
 import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
 import ENV from 'screwdriver-ui/config/environment';
+import { getErrorMessage } from 'screwdriver-ui/utils/error-messages';
 import RSVP from 'rsvp';
-
-const ERROR_MESSAGE = 'Session timed-out, please login back in to complete the action';
 
 export default Route.extend({
   triggerService: service('pipeline-triggers'),
@@ -31,11 +30,10 @@ export default Route.extend({
       }),
       triggers: this.triggerService.getDownstreamTriggers(this.get('pipeline.id'))
     }).catch(err => {
-      if (err === '0 Request Failed') {
-        // eslint-disable-next-line no-console
-        console.error('offline err', err);
+      let errorMessage = getErrorMessage(err);
 
-        pipelineEventsController.set('errorMessage', ERROR_MESSAGE);
+      if (errorMessage !== '') {
+        pipelineEventsController.set('errorMessage', errorMessage);
       } else {
         this.transitionTo('/404');
       }

--- a/app/pipeline/events/route.js
+++ b/app/pipeline/events/route.js
@@ -26,8 +26,13 @@ export default Route.extend({
         count: ENV.APP.NUM_EVENTS_LISTED
       }),
       triggers: this.triggerService.getDownstreamTriggers(this.get('pipeline.id'))
-    }).catch(() => {
-      this.transitionTo('/404');
+    }).catch(err => {
+      if (err === '0 Request Failed') {
+        // eslint-disable-next-line no-console
+        console.error('offline err', err);
+      } else {
+        this.transitionTo('/404');
+      }
     });
   },
   actions: {

--- a/app/pipeline/jobs/index/route.js
+++ b/app/pipeline/jobs/index/route.js
@@ -31,7 +31,11 @@ export default Route.extend(AuthenticatedRouteMixin, {
       // eslint-disable-next-line no-console
       console.error('err', err);
 
-      this.transitionTo('/404');
+      if (window.navigator.onLine) {
+        this.transitionTo('/404');
+      } else {
+        console.log('offline');
+      }
     });
   },
   actions: {

--- a/app/pipeline/jobs/index/route.js
+++ b/app/pipeline/jobs/index/route.js
@@ -4,6 +4,8 @@ import ENV from 'screwdriver-ui/config/environment';
 import RSVP from 'rsvp';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
+const ERROR_MESSAGE = 'Session timed-out, please login back in to complete the action';
+
 export default Route.extend(AuthenticatedRouteMixin, {
   triggerService: service('pipeline-triggers'),
   routeAfterAuthentication: 'pipeline.jobs.index',
@@ -17,7 +19,9 @@ export default Route.extend(AuthenticatedRouteMixin, {
     this.get('pipelineService').setBuildsLink('pipeline.jobs.index');
   },
   model() {
-    this.controllerFor('pipeline.jobs.index').set('pipeline', this.pipeline);
+    const pipelineJobsIndexController = this.controllerFor('pipeline.jobs.index');
+
+    pipelineJobsIndexController.set('pipeline', this.pipeline);
 
     return RSVP.hash({
       jobs: this.get('pipeline.jobs'),
@@ -31,6 +35,8 @@ export default Route.extend(AuthenticatedRouteMixin, {
       if (err === '0 Request Failed') {
         // eslint-disable-next-line no-console
         console.error('offline err', err);
+
+        pipelineJobsIndexController.set('errorMessage', ERROR_MESSAGE);
       } else {
         this.transitionTo('/404');
       }

--- a/app/pipeline/jobs/index/route.js
+++ b/app/pipeline/jobs/index/route.js
@@ -28,13 +28,11 @@ export default Route.extend(AuthenticatedRouteMixin, {
       }),
       triggers: this.triggerService.getDownstreamTriggers(this.get('pipeline.id'))
     }).catch(err => {
-      // eslint-disable-next-line no-console
-      console.error('err', err);
-
-      if (window.navigator.onLine) {
-        this.transitionTo('/404');
+      if (err === '0 Request Failed') {
+        // eslint-disable-next-line no-console
+        console.error('offline err', err);
       } else {
-        console.log('offline');
+        this.transitionTo('/404');
       }
     });
   },

--- a/app/pipeline/jobs/index/route.js
+++ b/app/pipeline/jobs/index/route.js
@@ -3,8 +3,7 @@ import Route from '@ember/routing/route';
 import ENV from 'screwdriver-ui/config/environment';
 import RSVP from 'rsvp';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
-
-const ERROR_MESSAGE = 'Session timed-out, please login back in to complete the action';
+import { getErrorMessage } from 'screwdriver-ui/utils/error-messages';
 
 export default Route.extend(AuthenticatedRouteMixin, {
   triggerService: service('pipeline-triggers'),
@@ -32,11 +31,10 @@ export default Route.extend(AuthenticatedRouteMixin, {
       }),
       triggers: this.triggerService.getDownstreamTriggers(this.get('pipeline.id'))
     }).catch(err => {
-      if (err === '0 Request Failed') {
-        // eslint-disable-next-line no-console
-        console.error('offline err', err);
+      let errorMessage = getErrorMessage(err);
 
-        pipelineJobsIndexController.set('errorMessage', ERROR_MESSAGE);
+      if (errorMessage !== '') {
+        pipelineJobsIndexController.set('errorMessage', errorMessage);
       } else {
         this.transitionTo('/404');
       }

--- a/app/utils/error-messages.js
+++ b/app/utils/error-messages.js
@@ -1,0 +1,18 @@
+/**
+ * Format templates to add fullName and humanized date
+ * @param  {Array} Templates
+ * @return {Array} Formatted templates
+ */
+const getErrorMessage = err => {
+  let errorMessage = '';
+
+  if (err === '401 Invalid token') {
+    errorMessage = 'Session timed-out, please log back in to complete the action';
+  } else if (err === '0 Request Failed') {
+    errorMessage = 'Session timed-out, please log back in to complete the action';
+  }
+
+  return errorMessage;
+};
+
+export default { getErrorMessage };


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Every once in a while, users are offline from the internet or disconnected from VPN. Our users should be notified if they are offline, rather than being redirected to 404 page.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
This PR adds the warning only if it was an internet issue, and show screenshot like following:

![image](https://user-images.githubusercontent.com/15989893/106648110-aed04b80-6544-11eb-8f1b-b50069152630.png)

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/2325

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
