### PR TITLE
feat(2319): [4] Show inherited template on template page

### DIFF
--- a/app/components/validator-job/template.hbs
+++ b/app/components/validator-job/template.hbs
@@ -1,7 +1,13 @@
 {{#if collapsible}}
   <h4 class="job" {{action "nameClick"}}>{{fa-icon (if isOpen "minus-square" "plus-square")}} {{name}}{{#if index }}.{{index}}{{/if}}</h4>
 {{/if}}
-{{#if getTemplateName}}<h4>This job uses <a href="/templates/{{getTemplateName}}/{{getTemplateVersion}}">{{getTemplateName}}</a> template.</h4>{{/if}}
+{{#if getTemplateName}}
+  {{#if template}}
+    <h4>This template extends <a href="/templates/{{getTemplateName}}/{{getTemplateVersion}}">{{getTemplateName}}</a> template.</h4>
+  {{else}}
+    <h4>This job uses <a href="/templates/{{getTemplateName}}/{{getTemplateVersion}}">{{getTemplateName}}</a> template.</h4>
+  {{/if}}
+{{/if}}
 {{#if template.description}}
   <div class="template-description" title="This is the description of the template">
     <span class="label">Template Description:</span>

--- a/app/components/validator-job/template.hbs
+++ b/app/components/validator-job/template.hbs
@@ -1,6 +1,7 @@
 {{#if collapsible}}
-  <h4 class="job" {{action "nameClick"}}>{{fa-icon (if isOpen "minus-square" "plus-square")}} {{name}}{{#if index }}.{{index}}{{/if}}</h4>{{#if getTemplateName}}<h4>This job uses <a href="/templates/{{getTemplateName}}/{{getTemplateVersion}}">{{getTemplateName}}</a> template.</h4>{{/if}}
+  <h4 class="job" {{action "nameClick"}}>{{fa-icon (if isOpen "minus-square" "plus-square")}} {{name}}{{#if index }}.{{index}}{{/if}}</h4>
 {{/if}}
+{{#if getTemplateName}}<h4>This job uses <a href="/templates/{{getTemplateName}}/{{getTemplateVersion}}">{{getTemplateName}}</a> template.</h4>{{/if}}
 {{#if template.description}}
   <div class="template-description" title="This is the description of the template">
     <span class="label">Template Description:</span>


### PR DESCRIPTION
## Context

Would be nice if users could see inherited template name on template details page.

## Objective

This PR shows inherited template on template page.
<img width="650" alt="Screen Shot 2021-01-27 at 4 28 38 PM" src="https://user-images.githubusercontent.com/3230529/106072284-c038d400-60bc-11eb-9c57-836e311623fb.png">


## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2319

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
