### PR TITLE
fix(2319): Link to template with default namespace

### DIFF
--- a/app/components/validator-job/component.js
+++ b/app/components/validator-job/component.js
@@ -10,6 +10,15 @@ export default Component.extend({
       return this.get('job.environment.SD_TEMPLATE_FULLNAME');
     }
   }),
+  getTemplateLink: computed('job', {
+    get() {
+      const namespace = this.get('job.environment.SD_TEMPLATE_NAMESPACE');
+      const name = this.get('job.environment.SD_TEMPLATE_NAME');
+      const version = this.get('job.environment.SD_TEMPLATE_VERSION');
+
+      return `/templates/${namespace}/${name}/${version}`;
+    }
+  }),
   getTemplateVersion: computed('job', {
     get() {
       return this.get('job.environment.SD_TEMPLATE_VERSION');

--- a/app/components/validator-job/template.hbs
+++ b/app/components/validator-job/template.hbs
@@ -3,9 +3,9 @@
 {{/if}}
 {{#if getTemplateName}}
   {{#if template}}
-    <h4>This template extends <a href="/templates/{{getTemplateName}}/{{getTemplateVersion}}">{{getTemplateName}}</a> template.</h4>
+    <h4>This template extends <a href={{getTemplateLink}}>{{getTemplateName}}</a> template.</h4>
   {{else}}
-    <h4>This job uses <a href="/templates/{{getTemplateName}}/{{getTemplateVersion}}">{{getTemplateName}}</a> template.</h4>
+    <h4>This job uses <a href={{getTemplateLink}}>{{getTemplateName}}</a> template.</h4>
   {{/if}}
 {{/if}}
 {{#if template.description}}

--- a/tests/integration/components/validator-job/component-test.js
+++ b/tests/integration/components/validator-job/component-test.js
@@ -153,13 +153,13 @@ module('Integration | Component | validator job', function(hooks) {
     });
     this.set('jobMock', {
       image: 'int-test:1',
-      template: 'foo/bar',
+      template: 'baz',
       steps: [{ step1: 'echo hello' }, { step2: 'echo goodby' }],
       secrets: [],
       environment: {
-        SD_TEMPLATE_FULLNAME: 'foo/bar',
-        SD_TEMPLATE_NAMESPACE: 'foo',
-        SD_TEMPLATE_NAME: 'bar',
+        SD_TEMPLATE_FULLNAME: 'baz',
+        SD_TEMPLATE_NAMESPACE: 'default',
+        SD_TEMPLATE_NAME: 'baz',
         SD_TEMPLATE_VERSION: '2.0.0'
       },
       settings: {},
@@ -169,8 +169,8 @@ module('Integration | Component | validator job', function(hooks) {
     await render(hbs`{{validator-job name="int-test" index=0 job=jobMock template=templateMock}}`);
 
     assert.dom('h4:nth-of-type(1)').hasText('int-test');
-    assert.dom('h4:nth-of-type(2)').hasText('This template extends foo/bar template.');
-    assert.dom('h4:nth-of-type(2) a').hasAttribute('href', '/templates/foo/bar/2.0.0');
+    assert.dom('h4:nth-of-type(2)').hasText('This template extends baz template.');
+    assert.dom('h4:nth-of-type(2) a').hasAttribute('href', '/templates/default/baz/2.0.0');
   });
 
   test('it renders template name with version tag', async function(assert) {

--- a/tests/integration/components/validator-job/component-test.js
+++ b/tests/integration/components/validator-job/component-test.js
@@ -139,21 +139,38 @@ module('Integration | Component | validator job', function(hooks) {
     assert.dom('.sourcePaths ul li').hasText('None defined');
   });
 
-  test('it renders template name', async function(assert) {
+  test('it renders template name when template is used', async function(assert) {
+    this.set('templateMock', {
+      description: 'Test template',
+      maintainer: 'bruce@wayne.com',
+      images: {
+        stable: 'node:6',
+        development: 'node:7'
+      },
+      name: 'test',
+      namespace: 'batman',
+      version: '2.0.0'
+    });
     this.set('jobMock', {
       image: 'int-test:1',
+      template: 'foo/bar',
       steps: [{ step1: 'echo hello' }, { step2: 'echo goodby' }],
       secrets: [],
-      environment: { SD_TEMPLATE_FULLNAME: 'foo/bar' },
+      environment: {
+        SD_TEMPLATE_FULLNAME: 'foo/bar',
+        SD_TEMPLATE_NAMESPACE: 'foo',
+        SD_TEMPLATE_NAME: 'bar',
+        SD_TEMPLATE_VERSION: '2.0.0'
+      },
       settings: {},
       annotations: {}
     });
 
-    await render(hbs`{{validator-job name="int-test" index=0 job=jobMock}}`);
+    await render(hbs`{{validator-job name="int-test" index=0 job=jobMock template=templateMock}}`);
 
     assert.dom('h4:nth-of-type(1)').hasText('int-test');
-    assert.dom('h4:nth-of-type(2)').hasText('This job uses foo/bar template.');
-    assert.dom('h4:nth-of-type(2) a').hasAttribute('href', '/templates/foo/bar/');
+    assert.dom('h4:nth-of-type(2)').hasText('This template extends foo/bar template.');
+    assert.dom('h4:nth-of-type(2) a').hasAttribute('href', '/templates/foo/bar/2.0.0');
   });
 
   test('it renders template name with version tag', async function(assert) {
@@ -161,7 +178,12 @@ module('Integration | Component | validator job', function(hooks) {
       image: 'int-test:1',
       steps: [{ step1: 'echo hello' }, { step2: 'echo goodby' }],
       secrets: [],
-      environment: { SD_TEMPLATE_FULLNAME: 'foo/bar', SD_TEMPLATE_VERSION: 'latest' },
+      environment: {
+        SD_TEMPLATE_FULLNAME: 'foo/bar',
+        SD_TEMPLATE_NAMESPACE: 'foo',
+        SD_TEMPLATE_NAME: 'bar',
+        SD_TEMPLATE_VERSION: 'latest'
+      },
       settings: {},
       annotations: {}
     });
@@ -178,7 +200,12 @@ module('Integration | Component | validator job', function(hooks) {
       image: 'int-test:1',
       steps: [{ step1: 'echo hello' }, { step2: 'echo goodby' }],
       secrets: [],
-      environment: { SD_TEMPLATE_FULLNAME: 'foo/bar', SD_TEMPLATE_VERSION: '0.0.1' },
+      environment: {
+        SD_TEMPLATE_FULLNAME: 'foo/bar',
+        SD_TEMPLATE_NAMESPACE: 'foo',
+        SD_TEMPLATE_NAME: 'bar',
+        SD_TEMPLATE_VERSION: '0.0.1'
+      },
       settings: {},
       annotations: {}
     });


### PR DESCRIPTION
## Context

When the template has namespace "default", the link generated does not work.

## Objective

This PR gets the correct link for templates with default namespace.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2319

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
