### PR TITLE
fix(2327): Restart dialog in workflow graph is confusing

### DIFF
--- a/app/components/workflow-tooltip/template.hbs
+++ b/app/components/workflow-tooltip/template.hbs
@@ -14,7 +14,7 @@
       {{#if (eq tooltipData.job.status "DISABLED")}}
         <p>{{tooltipData.job.stateChangeMessage}}</p>
       {{else}}
-        <a {{action confirmStartBuild}}>Start pipeline from here</a>
+        <a {{action confirmStartBuild}}>{{if tooltipData.job.status "Restart" "Start"}} pipeline from here</a>
       {{/if}}
     {{/if}}
     {{#if tooltipData.displayStop}}

--- a/tests/integration/components/workflow-tooltip/component-test.js
+++ b/tests/integration/components/workflow-tooltip/component-test.js
@@ -81,7 +81,7 @@ module('Integration | Component | workflow tooltip', function(hooks) {
       .hasText('Go to downstream pipeline ~sd@1234:main Go to downstream pipeline ~sd@2:prod');
   });
 
-  test('it renders restart link', async function(assert) {
+  test('it renders start link', async function(assert) {
     const data = {
       job: {
         buildId: 1234,
@@ -102,6 +102,30 @@ module('Integration | Component | workflow tooltip', function(hooks) {
     assert.dom('.content a').exists({ count: 3 });
     assert.dom('a:first-child').hasText('Go to build details');
     assert.dom('a:last-child').hasText('Start pipeline from here');
+  });
+
+  test('it renders restart link', async function(assert) {
+    const data = {
+      job: {
+        buildId: 1234,
+        name: 'batmobile',
+        status: 'SUCCESS'
+      }
+    };
+
+    this.set('data', data);
+    this.set('confirmStartBuild', () => {});
+
+    await render(hbs`{{
+      workflow-tooltip
+      tooltipData=data
+      displayRestartButton=true
+      confirmStartBuild="confirmStartBuild"
+    }}`);
+
+    assert.dom('.content a').exists({ count: 3 });
+    assert.dom('a:first-child').hasText('Go to build details');
+    assert.dom('a:last-child').hasText('Restart pipeline from here');
   });
 
   test('it should update position and hidden status', async function(assert) {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Sometimes words can be confusing to our users, we are adding `Restart` if the build had run before, `Start` otherwise, see issue https://github.com/screwdriver-cd/screwdriver/issues/2327 for more context.


## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Before:
![image](https://user-images.githubusercontent.com/15989893/106861041-1340f700-667a-11eb-8259-712bf59c043c.png)

After:
![image](https://user-images.githubusercontent.com/15989893/106861115-2eac0200-667a-11eb-86cc-6b9abef8beee.png)

![image](https://user-images.githubusercontent.com/15989893/106859491-fa374680-6677-11eb-8fde-dcc1f3d8123f.png)

If a job's status is undefined, then we will show it as `Start`, otherwise, will show it as `Restart`.

![image](https://user-images.githubusercontent.com/15989893/106859646-3074c600-6678-11eb-90c5-f0feeded8ba5.png)


## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

Issue: https://github.com/screwdriver-cd/screwdriver/issues/2327
## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
