### PR TITLE
fix: add hide PR button under pipeline options

### DIFF
--- a/app/components/pipeline-options/component.js
+++ b/app/components/pipeline-options/component.js
@@ -25,6 +25,7 @@ export default Component.extend({
   showDangerButton: true,
   showRemoveButtons: false,
   showToggleModal: false,
+  showPRJobs: true,
   // Job disable/enable
   name: null,
   state: null,
@@ -66,15 +67,18 @@ export default Component.extend({
 
     let desiredJobNameLength = MINIMUM_JOBNAME_LENGTH;
 
+    let showPRJobs = true;
+
     const pipelinePreference = await this.store.queryRecord('preference/pipeline', {
       filter: { pipelineId: this.get('pipeline.id') }
     });
 
     if (pipelinePreference) {
       desiredJobNameLength = pipelinePreference.jobNameLength;
+      showPRJobs = pipelinePreference.showPRJobs;
     }
 
-    this.set('desiredJobNameLength', desiredJobNameLength);
+    this.setProperties({ desiredJobNameLength, showPRJobs });
 
     if (this.displayDowntimeJobs) {
       const metricsDowntimeJobs = this.getWithDefault(
@@ -216,6 +220,27 @@ export default Component.extend({
       } finally {
         this.set('isUpdatingMetricsDowntimeJobs', false);
       }
+    },
+
+    async updateShowPRJobs(showPRJobs) {
+      const pipelineId = this.get('pipeline.id');
+      const pipelinePreference = await this.store.queryRecord('preference/pipeline', {
+        filter: { pipelineId }
+      });
+
+      if (pipelinePreference) {
+        pipelinePreference.set('showPRJobs', showPRJobs);
+        pipelinePreference.save();
+      } else {
+        this.store
+          .createRecord('preference/pipeline', {
+            pipelineId,
+            showPRJobs
+          })
+          .save();
+      }
+
+      this.set('showPRJobs', showPRJobs);
     }
   }
 });

--- a/app/components/pipeline-options/template.hbs
+++ b/app/components/pipeline-options/template.hbs
@@ -212,7 +212,23 @@
             </div>
           </div>
         </li>
-
+        <li>
+          <div class="row">
+            <div class="col-xs-10">
+              <h4>Show PR Jobs</h4>
+              <p>Show or Hide jobs that are triggered from Pull Request</p>
+            </div>
+            <div class="col-xs-2 right" title="Toggle to {{if showPRJobs "show" "hide"}} the jobs that are triggered from PRs">
+              {{x-toggle
+                size="small"
+                value=showPRJobs
+                onLabel="showPRJobs:true"
+                offLabel="showPRJobs::false"
+                onToggle=(action "updateShowPRJobs")
+              }}
+            </div>
+          </div>
+        </li>
       </ul>
     </section>
   </div>

--- a/app/components/pipeline-workflow/component.js
+++ b/app/components/pipeline-workflow/component.js
@@ -41,6 +41,7 @@ export default Component.extend({
 
   init() {
     this._super(...arguments);
+
     setProperties(this, {
       builds: [],
       showDownstreamTriggers: false,

--- a/app/components/pipeline-workflow/template.hbs
+++ b/app/components/pipeline-workflow/template.hbs
@@ -4,6 +4,7 @@
     pipeline=pipeline
     completeWorkflowGraph=completeWorkflowGraph
     showDownstreamTriggers=showDownstreamTriggers
+    showPRJobs=showPRJobs
     builds=selectedEventObj.builds
     jobs=jobs
     workflowGraph=selectedEventObj.workflowGraph

--- a/app/components/workflow-graph-d3/component.js
+++ b/app/components/workflow-graph-d3/component.js
@@ -10,8 +10,10 @@ export default Component.extend({
   router: service(),
   classNameBindings: ['minified'],
   displayJobNames: true,
+  showPRJobs: true,
   graph: { nodes: [], edges: [] },
   decoratedGraph: computed(
+    'showPRJobs',
     'showDownstreamTriggers',
     'workflowGraph',
     'startFrom',
@@ -53,6 +55,15 @@ export default Component.extend({
 
             graph.edges.removeObjects(endEdges);
           });
+        }
+
+        // remove jobs that starts from ~pr
+        if (!this.showPRJobs) {
+          const prNodes = graph.nodes.filter(node => node.name === '~pr');
+          const prEdges = graph.edges.filter(edge => edge.src === '~pr');
+
+          graph.nodes.removeObjects(prNodes);
+          graph.edges.removeObjects(prEdges);
         }
 
         set(this, 'graph', graph);

--- a/app/pipeline/events/controller.js
+++ b/app/pipeline/events/controller.js
@@ -200,6 +200,7 @@ export default Controller.extend(ModelReloaderMixin, {
     });
   },
   showListView: false,
+  showPRJobs: true,
 
   reload() {
     try {

--- a/app/pipeline/events/route.js
+++ b/app/pipeline/events/route.js
@@ -13,10 +13,17 @@ export default Route.extend({
   },
   setupController(controller, model) {
     this._super(controller, model);
-    controller.set('activeTab', 'events');
+    const { pipelinePreference } = model;
+
+    controller.setProperties({
+      activeTab: 'events',
+      showPRJobs: pipelinePreference.showPRJobs
+    });
+
     this.get('pipelineService').setBuildsLink('pipeline.events');
   },
   model() {
+    const pipelineId = this.get('pipeline.id');
     const pipelineEventsController = this.controllerFor('pipeline.events');
 
     pipelineEventsController.set('pipeline', this.pipeline);
@@ -24,11 +31,14 @@ export default Route.extend({
     return RSVP.hash({
       jobs: this.get('pipeline.jobs'),
       events: this.store.query('event', {
-        pipelineId: this.get('pipeline.id'),
+        pipelineId,
         page: 1,
         count: ENV.APP.NUM_EVENTS_LISTED
       }),
-      triggers: this.triggerService.getDownstreamTriggers(this.get('pipeline.id'))
+      triggers: this.triggerService.getDownstreamTriggers(this.get('pipeline.id')),
+      pipelinePreference: this.store.queryRecord('preference/pipeline', {
+        filter: { pipelineId }
+      })
     }).catch(err => {
       let errorMessage = getErrorMessage(err);
 

--- a/app/pipeline/events/template.hbs
+++ b/app/pipeline/events/template.hbs
@@ -33,6 +33,7 @@
       jobId=jobId
       pipeline=pipeline
       showDownstreamTriggers=showDownstreamTriggers
+      showPRJobs=showPRJobs
       completeWorkflowGraph=completeWorkflowGraph
       workflowGraph=pipeline.workflowGraph
       jobs=jobs

--- a/app/preference/pipeline/model.js
+++ b/app/preference/pipeline/model.js
@@ -4,4 +4,6 @@ export default class PreferencePipelineModel extends Model {
   @attr('string') pipelineId;
 
   @attr('number') jobNameLength;
+
+  @attr('boolean') showPRJobs;
 }


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Some users prefer only to see jobs that are triggered by `~commit`, and not from `~pr`

So, we are implementing a preference and leave the choices to users.
## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
See screenshot:
![2021-02-05_16-30-05 (1)](https://user-images.githubusercontent.com/15989893/107102511-8740e380-67cf-11eb-9d6d-2b5db036eb54.gif)


TEST PENDING, DO NOT MERGE
## References

<!-- Links or resources that

 help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
