### PR TITLE
fix: hide options to disable PR jobs

### DIFF
--- a/app/components/pipeline-options/template.hbs
+++ b/app/components/pipeline-options/template.hbs
@@ -84,25 +84,27 @@
             </div>
           </div>
           {{#each sortedJobs as |job|}}
-            <li>
-              <div class="row">
-                <div class="col-xs-10">
-                  <h4>{{job.name}}</h4>
-                  {{#if job.stateChanger}}
-                    <i class="float-right"><small>{{job.stateChangeTimeWords}}</small></i>
-                    <p>{{if job.isDisabled "Disabled" "Enabled"}} by {{job.stateChanger}}{{#if job.stateChangeMessage}}: {{job.stateChangeMessage}}{{/if}}</p>
-                  {{/if}}
+            {{#unless (starts-with job.name "PR-")}}
+              <li>
+                <div class="row">
+                  <div class="col-xs-10">
+                    <h4>{{job.name}}</h4>
+                    {{#if job.stateChanger}}
+                      <i class="float-right"><small>{{job.stateChangeTimeWords}}</small></i>
+                      <p>{{if job.isDisabled "Disabled" "Enabled"}} by {{job.stateChanger}}{{#if job.stateChangeMessage}}: {{job.stateChangeMessage}}{{/if}}</p>
+                    {{/if}}
+                  </div>
+                  <div class="col-xs-2 right" title="Toggle to {{if job.isDisabled "enable" "disable"}} the {{job.name}} job.">
+                    {{x-toggle
+                      size="small"
+                      value=(not job.isDisabled)
+                      onLabel="Enabled::false"
+                      offLabel="Disabled::true"
+                      onToggle=(action "toggleJob" job.id username job.name)}}
+                  </div>
                 </div>
-                <div class="col-xs-2 right" title="Toggle to {{if job.isDisabled "enable" "disable"}} the {{job.name}} job.">
-                  {{x-toggle
-                    size="small"
-                    value=(not job.isDisabled)
-                    onLabel="Enabled::false"
-                    offLabel="Disabled::true"
-                    onToggle=(action "toggleJob" job.id username job.name)}}
-                </div>
-              </div>
-            </li>
+              </li>
+            {{/unless}}
           {{/each}}
         </li>
       </ul>

--- a/app/helpers/starts-with.js
+++ b/app/helpers/starts-with.js
@@ -1,0 +1,13 @@
+import { helper } from '@ember/component/helper';
+
+/**
+ * return whether string starts with given string
+ * @param  {[String]}  str        Any string
+ * @param  {[String]}  searchString  Any string
+ * @return {Boolean}
+ */
+export function startsWith([str = '', searchString] /* , hash */) {
+  return str.startsWith(searchString);
+}
+
+export default helper(startsWith);

--- a/app/helpers/starts-with.js
+++ b/app/helpers/starts-with.js
@@ -2,7 +2,7 @@ import { helper } from '@ember/component/helper';
 
 /**
  * return whether string starts with given string
- * @param  {[String]}  str        Any string
+ * @param  {[String]}  str           Any string
  * @param  {[String]}  searchString  Any string
  * @return {Boolean}
  */

--- a/tests/integration/components/pipeline-options/component-test.js
+++ b/tests/integration/components/pipeline-options/component-test.js
@@ -533,7 +533,7 @@ module('Integration | Component | pipeline options', function(hooks) {
     assert.dom('section.cache li:first-child h4').hasText('Pipeline');
     assert.dom('section.cache li:nth-child(2) h4').hasText('Job A');
     assert.dom('section.cache li:nth-child(3) h4').hasText('Job B');
-    assert.dom('section.cache li:last-child h4').hasText('Job main');
+    assert.dom('section.cache li:nth-child(4) h4').hasText('Job main');
 
     // Danger Zone should not render
     assert.dom('section.danger h3').doesNotExist();

--- a/tests/integration/components/pipeline-options/component-test.js
+++ b/tests/integration/components/pipeline-options/component-test.js
@@ -496,6 +496,11 @@ module('Integration | Component | pipeline options', function(hooks) {
           id: '2345',
           name: 'A',
           isDisabled: false
+        }),
+        EmberObject.create({
+          id: '1',
+          name: 'PR-123:component',
+          isDisabled: false
         })
       ])
     );
@@ -511,6 +516,10 @@ module('Integration | Component | pipeline options', function(hooks) {
     assert.dom('section.jobs li:nth-child(2) h4').hasText('A');
     assert.dom('section.jobs li:nth-child(3) h4').hasText('B');
     assert.dom('section.jobs li:nth-child(4) h4').hasText('main');
+
+    // PR Job should not render
+    assert.dom('section.jobs li:nth-child(5) h4').doesNotExist();
+
     // eslint-disable-next-line max-len
     assert.dom('section.jobs p').hasText('Toggle to disable or enable the job.');
     assert.dom('.x-toggle-container').hasClass('x-toggle-container-checked');

--- a/tests/integration/helpers/starts-with-test.js
+++ b/tests/integration/helpers/starts-with-test.js
@@ -8,10 +8,18 @@ module('Integration | Helper | startsWith', function(hooks) {
 
   // Replace this with your real tests.
   test('it renders', async function(assert) {
-    this.set('inputValue', '1234');
+    this.set('str', 'PR-123');
 
-    await render(hbs`{{starts-with inputValue}}`);
+    await render(hbs`{{starts-with str 'PR-'}}`);
 
-    assert.equal(this.element.textContent.trim(), '1234');
+    assert.equal(this.element.textContent.trim(), 'true');
+  });
+
+  test('it does not render', async function(assert) {
+    this.set('str', '1234');
+
+    await render(hbs`{{starts-with str 'PR-'}}`);
+
+    assert.equal(this.element.textContent.trim(), 'false');
   });
 });

--- a/tests/integration/helpers/starts-with-test.js
+++ b/tests/integration/helpers/starts-with-test.js
@@ -1,0 +1,17 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Helper | startsWith', function(hooks) {
+  setupRenderingTest(hooks);
+
+  // Replace this with your real tests.
+  test('it renders', async function(assert) {
+    this.set('inputValue', '1234');
+
+    await render(hbs`{{starts-with inputValue}}`);
+
+    assert.equal(this.element.textContent.trim(), '1234');
+  });
+});


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
It seems we overlooked the use case of disabling PR jobs, which does not make much sense.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Before
![image](https://user-images.githubusercontent.com/15989893/107466285-86ce8280-6b18-11eb-9b2d-53be5be86bb2.png)

After:
![image](https://user-images.githubusercontent.com/15989893/107466281-8209ce80-6b18-11eb-9531-844e721c4ada.png)

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
