### PR TITLE
fix(2342): Highlight the latest commit in group events

### DIFF
--- a/app/components/pipeline-events-row-group/template.hbs
+++ b/app/components/pipeline-events-row-group/template.hbs
@@ -17,12 +17,14 @@
               event=event
               selectedEvent=selectedEvent
               lastSuccessful=lastSuccessful
+              latestCommit=latestCommit
               eventClick=eventClick
       }}
     {{else if (eq isExpanded true)}}
       {{pipeline-event-row
               event=event
               selectedEvent=selectedEvent
+              latestCommit=latestCommit
               lastSuccessful=lastSuccessful
               eventClick=eventClick
       }}


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
In the [PR for showing group events together](https://github.com/screwdriver-cd/ui/pull/658), latestCommit was forgot to be passed to `pipeline-event-row`. Therefore, the latest commit is not highlighted in current UI.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Pass latestCommit to `pipeline-event-row`.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
issue: screwdriver-cd/screwdriver#2342
PR for implementing highlight latestCommit: https://github.com/screwdriver-cd/ui/pull/654
PR for implementing show group events together: https://github.com/screwdriver-cd/ui/pull/658

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
