### PR TITLE
[1]fix(1901): support screwdriver.cd/manualStartEnabled annotation

### DIFF
--- a/app/components/workflow-tooltip/styles.scss
+++ b/app/components/workflow-tooltip/styles.scss
@@ -19,13 +19,10 @@
     box-shadow: 0 4px 16px 0 $box-shadow;
     padding: 16px 18px;
 
-    a {
+    a,
+    p {
       display: block;
       margin-bottom: 10px;
-    }
-
-    a:last-of-type {
-      margin-bottom: 0;
     }
 
     &::before,
@@ -54,6 +51,9 @@
       border-width: 10px;
       margin-left: -10px;
     }
+  }
+  .content :last-child {
+    margin-bottom: 0;
   }
 
   &.left .content {

--- a/app/components/workflow-tooltip/template.hbs
+++ b/app/components/workflow-tooltip/template.hbs
@@ -13,6 +13,8 @@
     {{#if displayRestartButton}}
       {{#if (eq tooltipData.job.status "DISABLED")}}
         <p>{{tooltipData.job.stateChangeMessage}}</p>
+      {{else if tooltipData.job.manualStartDisabled}}
+        <p>Disabled manually starting</p>
       {{else}}
         <a {{action confirmStartBuild}}>{{if tooltipData.job.status "Restart" "Start"}} pipeline from here</a>
       {{/if}}

--- a/app/utils/graph-tools.js
+++ b/app/utils/graph-tools.js
@@ -232,6 +232,16 @@ const decorateGraph = ({ inputGraph, builds, jobs, start }) => {
           ? `${stateWithCapitalization} by ${stateChanger}`
           : stateWithCapitalization;
       }
+
+      // Set manualStartEnabled on the node
+      const annotations = j ? get(j, 'permutations.0.annotations') : null;
+
+      if (annotations) {
+        n.manualStartDisabled =
+          'screwdriver.cd/manualStartEnabled' in annotations
+            ? !annotations['screwdriver.cd/manualStartEnabled']
+            : false;
+      }
     }
 
     // Get build information

--- a/tests/integration/components/workflow-tooltip/component-test.js
+++ b/tests/integration/components/workflow-tooltip/component-test.js
@@ -81,6 +81,30 @@ module('Integration | Component | workflow tooltip', function(hooks) {
       .hasText('Go to downstream pipeline ~sd@1234:main Go to downstream pipeline ~sd@2:prod');
   });
 
+  test('it renders disabled manually starting', async function(assert) {
+    const data = {
+      job: {
+        buildId: 1234,
+        name: 'batmobile',
+        manualStartDisabled: true
+      }
+    };
+
+    this.set('data', data);
+    this.set('confirmStartBuild', () => {});
+
+    await render(hbs`{{
+      workflow-tooltip
+      tooltipData=data
+      displayRestartButton=true
+      confirmStartBuild="confirmStartBuild"
+    }}`);
+
+    assert.dom('.content a').exists({ count: 2 });
+    assert.dom('a:first-child').hasText('Go to build details');
+    assert.dom('p:last-child').hasText('Disabled manually starting');
+  });
+
   test('it renders start link', async function(assert) {
     const data = {
       job: {

--- a/tests/unit/utils/graph-tools-test.js
+++ b/tests/unit/utils/graph-tools-test.js
@@ -168,6 +168,62 @@ module('Unit | Utility | graph tools', function() {
     assert.deepEqual(result, expectedOutput);
   });
 
+  test('it processes a complex graph with jobs', function(assert) {
+    const jobs = [
+      { id: 1 },
+      {
+        id: 2,
+        permutations: [{ annotations: { 'screwdriver.cd/manualStartEnabled': true } }]
+      },
+      {
+        id: 3,
+        permutations: [{ annotations: { 'screwdriver.cd/manualStartEnabled': false } }]
+      },
+      {
+        id: 4,
+        state: ['message'],
+        permutations: [{ annotations: {} }]
+      }
+    ];
+    const expectedOutput = {
+      nodes: [
+        { name: '~pr', pos: { x: 0, y: 0 } },
+        { name: '~commit', pos: { x: 0, y: 1 } },
+        { name: 'main', id: 1, pos: { x: 1, y: 0 } },
+        {
+          name: 'A',
+          id: 2,
+          pos: { x: 2, y: 0 },
+          manualStartDisabled: false
+        },
+        { name: 'B', id: 3, pos: { x: 2, y: 1 }, manualStartDisabled: true },
+        {
+          name: 'C',
+          id: 4,
+          pos: { x: 3, y: 0 },
+          manualStartDisabled: false
+        },
+        { name: 'D', id: 5, pos: { x: 4, y: 0 } }
+      ],
+      edges: [
+        { src: '~pr', dest: 'main', from: { x: 0, y: 0 }, to: { x: 1, y: 0 } },
+        { src: '~commit', dest: 'main', from: { x: 0, y: 1 }, to: { x: 1, y: 0 } },
+        { src: 'main', dest: 'A', from: { x: 1, y: 0 }, to: { x: 2, y: 0 } },
+        { src: 'main', dest: 'B', from: { x: 1, y: 0 }, to: { x: 2, y: 1 } },
+        { src: 'A', dest: 'C', from: { x: 2, y: 0 }, to: { x: 3, y: 0 } },
+        { src: 'B', dest: 'D', from: { x: 2, y: 1 }, to: { x: 4, y: 0 } },
+        { src: 'C', dest: 'D', from: { x: 3, y: 0 }, to: { x: 4, y: 0 } }
+      ],
+      meta: {
+        height: 2,
+        width: 5
+      }
+    };
+    const result = decorateGraph({ inputGraph: COMPLEX_GRAPH, jobs });
+
+    assert.deepEqual(result, expectedOutput);
+  });
+
   test('it handles detached jobs', function(assert) {
     const inputGraph = {
       nodes: [


### PR DESCRIPTION
## Context
Some users want to disable "Start pipeline from here button" for safety.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
Hides the START link on the pipeline by setting the annotation. For the annotation name, I chose what I thought was the best idea. https://github.com/screwdriver-cd/screwdriver/issues/1901#issuecomment-736059949
```
jobs:
  main:
    requires: []
    annotations:
        screwdriver.cd/manualStartEnabled: false
```

<img width="240" src="https://user-images.githubusercontent.com/24538326/108309873-c02c7f80-71f5-11eb-8cb9-4682b41ff172.png">

Note: The display of the text was slightly broken, so it has been fixed.  
Before:
<img width="140" src="https://user-images.githubusercontent.com/24538326/108310049-01bd2a80-71f6-11eb-9300-547e4e89750a.png">

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/screwdriver/issues/1901
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
