### PR TITLE
feat(2331): Support locked steps [4]

### DIFF
--- a/app/components/validator-job/component.js
+++ b/app/components/validator-job/component.js
@@ -42,9 +42,10 @@ export default Component.extend({
       if (c) {
         return c.map(s => {
           const name = Object.keys(s)[0];
-          const command = s[name];
+          const command = s[name].command || s[name];
+          const locked = s[name].locked || null;
 
-          return { name, command };
+          return { name, command, locked };
         });
       }
 

--- a/app/components/validator-job/template.hbs
+++ b/app/components/validator-job/template.hbs
@@ -55,7 +55,7 @@
   <span class="value">
     <ul>
       {{#each steps as |command|}}
-        <li><div class="name">{{command.name}}: </div><div class="value">{{command.command}}</div></li>
+        <li><div class="name">{{command.name}}: {{#if command.locked}}{{fa-icon "lock"}}{{/if}}</div><div class="value">{{command.command}}</div></li>
       {{/each}}
     </ul>
   </span>


### PR DESCRIPTION
## Context

Would be nice to see locked steps in UI.

## Objective

This PR adds locked symbol next to locked steps in the validator/template pages.
<img width="1644" alt="Screen Shot 2021-02-19 at 3 35 25 PM" src="https://user-images.githubusercontent.com/3230529/108879120-ca63ca80-75b5-11eb-8991-439379b3dbd2.png">


## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2331

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
