### PR TITLE
fix(2302): Show warning when build parameters are different from default values

### DIFF
--- a/app/components/pipeline-event-row/template.hbs
+++ b/app/components/pipeline-event-row/template.hbs
@@ -63,6 +63,7 @@
         }}
           <h3>Parameters:</h3>
           {{pipeline-parameterized-build
+            pipeline=pipeline
             showSubmitButton=true
             buildParameters=event.meta.parameters
             submitButtonText="Close"

--- a/app/components/pipeline-events-list/template.hbs
+++ b/app/components/pipeline-events-list/template.hbs
@@ -1,6 +1,7 @@
 <div>
   {{#each groups as |group|}}
     {{pipeline-events-row-group
+      pipeline=pipeline
       expandedEventsGroup=expandedEventsGroup
       events=group
       selectedEvent=selectedEvent

--- a/app/components/pipeline-events-row-group/template.hbs
+++ b/app/components/pipeline-events-row-group/template.hbs
@@ -14,6 +14,7 @@
         <span class="clearfix" />
       {{/if}}
       {{pipeline-event-row
+              pipeline=pipeline
               event=event
               selectedEvent=selectedEvent
               lastSuccessful=lastSuccessful
@@ -22,6 +23,7 @@
       }}
     {{else if (eq isExpanded true)}}
       {{pipeline-event-row
+              pipeline=pipeline
               event=event
               selectedEvent=selectedEvent
               latestCommit=latestCommit

--- a/app/components/pipeline-list-view/template.hbs
+++ b/app/components/pipeline-list-view/template.hbs
@@ -42,6 +42,7 @@
   }}
     <h3>Are you sure to start?</h3>
     {{pipeline-parameterized-build
+      pipeline=pipeline
       showSubmitButton=true
       buildParameters=buildParameters
       onSave=(action "startBuild")

--- a/app/components/pipeline-parameterized-build/component.js
+++ b/app/components/pipeline-parameterized-build/component.js
@@ -50,10 +50,17 @@ export default Component.extend({
   /**
    * normalizeParameters transform given parameters from object into array of objects
    * this method also backfills with default properties
-   * For example: {
+   * For example:
+   * parameters = {
         "_started_at": "simple",
         "user": {
           "value": "adong",
+          "description": "User running build"
+        }
+     }
+     defaultParameters = {
+        "user": {
+          "value": "dummy",
           "description": "User running build"
         }
    * }
@@ -62,10 +69,12 @@ export default Component.extend({
    *  {
         name: "_started_at":
         value: "simple",
+        defaultValues: "simple"
         description: ""
       }, {
         name: "user"
         value: "adong",
+        defaultValues: "dummy"
         description: "User running build"
       }
    * ]

--- a/app/components/pipeline-parameterized-build/component.js
+++ b/app/components/pipeline-parameterized-build/component.js
@@ -32,12 +32,19 @@ export default Component.extend({
    */
   init() {
     this._super(...arguments);
-    const [parameters, parameterizedModel] = this.normalizeParameters(this.buildParameters);
+    const [parameters, parameterizedModel] = this.normalizeParameters(
+      this.buildParameters,
+      this.getDefaultBuildParameters()
+    );
 
     this.setProperties({
       parameters,
       parameterizedModel
     });
+  },
+
+  getDefaultBuildParameters() {
+    return this.getWithDefault('pipeline.parameters', {});
   },
 
   /**
@@ -62,20 +69,27 @@ export default Component.extend({
         description: "User running build"
       }
    * ]
-   * @param  {Object} parameters [description]
-   * @return {[type]}            [description]
+   * @param  {Object} parameters        [description]
+   * @param  {Object} defaultParameters [description]
+   * @return {[type]}                   [description]
    */
-  normalizeParameters(parameters = {}) {
+  normalizeParameters(parameters = {}, defaultParameters = {}) {
     const normalizedParameters = [];
     const normalizedParameterizedModel = {};
 
     Object.entries(parameters).forEach(([propertyName, propertyVal]) => {
       let value = propertyVal.value || propertyVal || '';
       const description = propertyVal.description || '';
+      // If no default value is found, fill with build parameter value
+      const defaultPropertyVal = defaultParameters[propertyName]
+        ? defaultParameters[propertyName]
+        : value;
+      const defaultValue = defaultPropertyVal.value || defaultPropertyVal || value;
 
       normalizedParameters.push({
         name: propertyName,
         value,
+        defaultValues: defaultValue,
         description
       });
 

--- a/app/components/pipeline-parameterized-build/styles.scss
+++ b/app/components/pipeline-parameterized-build/styles.scss
@@ -11,6 +11,27 @@ button.start-with-parameters-button {
     padding-left: 38%;
   }
 }
+
+.notice-default-values-icon {
+  position: absolute;
+  top: 50%;
+  bottom: 50%;
+  transform: translate(-50%, -50%);
+  left: 3%;
+  height: 1em;
+  color: $sd-warning;
+}
+
+// for single default value
+.notice-default-values-icon + input {
+  background: $sd-warning;
+}
+
+// for multi default values
+.notice-default-values-icon + .ember-basic-dropdown > div {
+  background: $sd-warning;
+}
+
 & {
   position: relative;
   padding-top: 20px;

--- a/app/components/pipeline-parameterized-build/template.hbs
+++ b/app/components/pipeline-parameterized-build/template.hbs
@@ -12,6 +12,11 @@
       </label>
       <div class="col-md-8">
         {{#if (is-array parameter.value)}}
+          {{#with (get parameterizedModel parameter.name) as |value|}}
+            {{#unless (array-includes value parameter.defaultValues)}}
+              {{fa-icon "exclamation-triangle" title=(concat "Default value: " parameter.defaultValues) class="notice-default-values-icon"}}
+            {{/unless}}
+          {{/with}}
           {{#power-select
             options=parameter.value
             renderInPlace=true
@@ -25,6 +30,9 @@
             {{selectedValue}}
           {{/power-select}}
         {{else}}
+          {{#unless (array-includes parameter.value parameter.defaultValues)}}
+            {{fa-icon "exclamation-triangle" title=(concat "Default value: " parameter.defaultValues) class="notice-default-values-icon"}}
+          {{/unless}}
           {{input
             value=parameter.value
             class="form-control"

--- a/app/components/pipeline-start/template.hbs
+++ b/app/components/pipeline-start/template.hbs
@@ -14,6 +14,7 @@
       }}
         <h3>Are you sure to start?</h3>
         {{pipeline-parameterized-build
+          pipeline=pipeline
           showSubmitButton=true
           buildParameters=buildParameters
           onSave=(action "startBuild")
@@ -33,6 +34,7 @@
       </div>
       {{#dd.menu class="start-with-parameters-menu"}}
         {{pipeline-parameterized-build
+          pipeline=pipeline
           showSubmitButton=true
           buildParameters=buildParameters
           onSave=(action "startBuild")

--- a/app/components/pipeline-workflow/template.hbs
+++ b/app/components/pipeline-workflow/template.hbs
@@ -35,6 +35,7 @@
       {{#if (eq tooltipData.job.status "FROZEN")}}
         {{#if (get-length tooltipData.selectedEvent.meta.parameters)}}
           {{#pipeline-parameterized-build
+            pipeline=pipeline
             buildParameters=tooltipData.selectedEvent.meta.parameters
             as |parameterizedBuild| }}
             <div class="form-group form-horizontal">
@@ -80,6 +81,7 @@
         {{/if}}
       {{else if (get-length tooltipData.selectedEvent.meta.parameters)}}
         {{#pipeline-parameterized-build
+          pipeline=pipeline
           buildParameters=buildParameters
           as |parameterizedBuild| }}
           <div class="row">

--- a/app/helpers/array-includes.js
+++ b/app/helpers/array-includes.js
@@ -1,0 +1,20 @@
+import { helper } from '@ember/component/helper';
+
+/**
+ * return whether toFind exists in array or not
+ * @method ansiColorize
+ * @param  {String}    toFind  Value Any string
+ * @param  {Array}     array   An array of string or a string
+ * @return {Boolean}
+ */
+export function arrayIncludes([toFind, array]) {
+  const list = Array.isArray(array) ? array : [array];
+
+  if (list.indexOf(toFind) > -1) {
+    return true;
+  }
+
+  return false;
+}
+
+export default helper(arrayIncludes);

--- a/app/helpers/array-includes.js
+++ b/app/helpers/array-includes.js
@@ -2,7 +2,7 @@ import { helper } from '@ember/component/helper';
 
 /**
  * return whether toFind exists in array or not
- * @method ansiColorize
+ * @method arrayIncludes
  * @param  {String}    toFind  Value Any string
  * @param  {Array}     array   An array of string or a string
  * @return {Boolean}

--- a/tests/integration/components/pipeline-parameterized-build/component-test.js
+++ b/tests/integration/components/pipeline-parameterized-build/component-test.js
@@ -86,10 +86,44 @@ module('Integration | Component | pipeline-parameterized-build', function(hooks)
     await render(hbs`{{pipeline-parameterized-build
       buildParameters=buildParameters
       showSubmitButton=showSubmitButton}}`);
-    assert.dom('.form-group').exists({ count: 3 }, 'There are 2 parameters');
+    assert.dom('.form-group').exists({ count: 3 }, 'There are 3 parameters');
     assert.dom('.fa-question-circle').exists({ count: 2 }, 'Theare are 2 description info');
     assert.dom('.ember-basic-dropdown').exists({ count: 1 }, 'There is 1 dropdown list');
-    assert.dom('.form-control').exists({ count: 2 }, 'There is 1 input field');
+    assert.dom('.form-control').exists({ count: 2 }, 'There are 2 input field');
+    assert.dom('button[type=submit]').exists({ count: 1 }, 'There is 1 submit button');
+  });
+
+  test('it renders default parameter', async function(assert) {
+    this.setProperties({
+      pipeline: {
+        parameters: {
+          from: 'latest',
+          to: {
+            value: ['test', 'stable']
+          },
+          image: 'test-image'
+        }
+      },
+      buildParameters: {
+        from: 'foo',
+        to: {
+          value: ['bar', 'test', 'stable']
+        },
+        image: 'test-image'
+      },
+      showSubmitButton: true
+    });
+
+    await render(hbs`{{pipeline-parameterized-build
+      pipeline=pipeline
+      buildParameters=buildParameters
+      showSubmitButton=showSubmitButton}}`);
+    assert.dom('.form-group').exists({ count: 3 }, 'There are 3 parameters');
+    assert
+      .dom('.fa-exclamation-triangle')
+      .exists({ count: 2 }, 'Theare are 2 default value warnings');
+    assert.dom('.ember-basic-dropdown').exists({ count: 1 }, 'There is 1 dropdown list');
+    assert.dom('.form-control').exists({ count: 2 }, 'There is 2 input field');
     assert.dom('button[type=submit]').exists({ count: 1 }, 'There is 1 submit button');
   });
 });

--- a/tests/integration/components/pipeline-parameterized-build/component-test.js
+++ b/tests/integration/components/pipeline-parameterized-build/component-test.js
@@ -121,7 +121,7 @@ module('Integration | Component | pipeline-parameterized-build', function(hooks)
     assert.dom('.form-group').exists({ count: 3 }, 'There are 3 parameters');
     assert
       .dom('.fa-exclamation-triangle')
-      .exists({ count: 2 }, 'Theare are 2 default value warnings');
+      .exists({ count: 2 }, 'There are are 2 default value warnings');
     assert.dom('.ember-basic-dropdown').exists({ count: 1 }, 'There is 1 dropdown list');
     assert.dom('.form-control').exists({ count: 2 }, 'There is 2 input field');
     assert.dom('button[type=submit]').exists({ count: 1 }, 'There is 1 submit button');

--- a/tests/unit/helpers/array-includes-test.js
+++ b/tests/unit/helpers/array-includes-test.js
@@ -1,0 +1,11 @@
+import { arrayIncludes } from 'screwdriver-ui/helpers/array-includes';
+import { module, test } from 'qunit';
+
+module('Unit | Helper | array includes', function() {
+  test('it works', function(assert) {
+    assert.ok(arrayIncludes(['val1', 'val1']));
+    assert.notOk(arrayIncludes(['foo', 'val1']));
+    assert.ok(arrayIncludes(['val1', ['val1', 'val2']]));
+    assert.notOk(arrayIncludes(['foo', ['val1', 'val2']]));
+  });
+});


### PR DESCRIPTION
## Context
Now we just need to test it.

When using parameter builds, it will show a warning if users fill values that differ from the default values defined in `screwdriver.yaml`.

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
When you change the value of the form from the default one defined in `screwdriver.yaml`, an icon will be displayed and the background color will change.
![image](https://user-images.githubusercontent.com/24538326/109245438-d1901000-7823-11eb-838a-adf73fc6fa03.gif)

The `screwdriver.yaml` used in the image above is the following.
```
parameters:
  nameA: "value1"
  nameB:
    value: "value2"
    description: "description of nameB"
  nameC: ["value3", "value4"]

jobs:
  main:
    image: node:12
    steps:
      - ls
```

The list view and parameter list display screens have been modified as well.
<img width="700" src="https://user-images.githubusercontent.com/24538326/109248644-8547ce80-7829-11eb-91f8-f3dcd6086b69.png">
<img width="500" src="https://user-images.githubusercontent.com/24538326/109248639-82e57480-7829-11eb-9e38-7814577da895.png">

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/screwdriver/issues/2302

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
