### PR TITLE
fix(2350): template/command trusted logic fix

### DIFF
--- a/app/commands/detail/controller.js
+++ b/app/commands/detail/controller.js
@@ -19,7 +19,7 @@ export default Controller.extend({
     }
   }),
   trusted: computed('commands.commandData.[]', function computeTrusted() {
-    return this.commands.commandData.some(c => c.trusted);
+    return this.commands.commandData.some(c => c.trusted && c.latest);
   }),
   isAdmin: computed(function isAdmin() {
     const token = this.get('session.data.authenticated.token');

--- a/app/templates/detail/controller.js
+++ b/app/templates/detail/controller.js
@@ -14,7 +14,7 @@ export default Controller.extend({
     this.set('errorMessage', '');
   },
   trusted: computed('templates.templateData.[]', function computeTrusted() {
-    return this.templates.templateData.some(t => t.trusted);
+    return this.templates.templateData.some(t => t.trusted && t.latest);
   }),
   isAdmin: computed(function isAdmin() {
     const token = this.get('session.data.authenticated.token');

--- a/tests/unit/commands/detail/controller-test.js
+++ b/tests/unit/commands/detail/controller-test.js
@@ -41,7 +41,7 @@ module('Unit | Controller | commands/detail', function(hooks) {
 
     controller.set('model', {
       commandData: [
-        { id: 3, version: '3.0.0', trusted: true },
+        { id: 3, version: '3.0.0', trusted: true, latest: true },
         { id: 2, version: '2.0.0' },
         { id: 1, version: '1.0.0' }
       ],

--- a/tests/unit/templates/detail/controller-test.js
+++ b/tests/unit/templates/detail/controller-test.js
@@ -41,7 +41,7 @@ module('Unit | Controller | templates/detail', function(hooks) {
 
     controller.set('model', {
       templateData: [
-        { id: 3, version: '3.0.0', trusted: true },
+        { id: 3, version: '3.0.0', trusted: true, latest: true },
         { id: 2, version: '2.0.0' },
         { id: 1, version: '1.0.0' }
       ],


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
ui should only render template/command as trusted only if latest template/command was trusted
## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
ui should only render template/command as trusted only if latest template/command was trusted
## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/2350
## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
