### PR TITLE
fix: remove duplicate events by eventId

### DIFF
--- a/app/pipeline/events/controller.js
+++ b/app/pipeline/events/controller.js
@@ -151,7 +151,7 @@ export async function updateEvents(page) {
     this.set('eventsPage', page);
     this.set('isFetching', false);
 
-    // Skip duplicate ones if new events got added added to the head
+    // Skip duplicate ones if new events got added to the head of the events list
     const noDuplicateEvents = nextEvents.filter(
       nextEvent => !this.paginateEvents.findBy('id', nextEvent.id)
     );

--- a/app/pipeline/events/controller.js
+++ b/app/pipeline/events/controller.js
@@ -166,21 +166,23 @@ export default Controller.extend(ModelReloaderMixin, {
   lastRefreshed: moment(),
   expandedEventsGroup: {},
   shouldReload(model) {
-    const event = model.events.find(m => m.isRunning);
+    let res = SHOULD_RELOAD_SKIP;
 
-    let res;
+    if (this.isDestroyed || this.isDestroying) {
+      const event = model.events.find(m => m.isRunning);
 
-    let diff;
-    const lastRefreshed = this.get('lastRefreshed');
+      let diff;
+      const lastRefreshed = this.get('lastRefreshed');
 
-    if (event) {
-      res = SHOULD_RELOAD_YES;
-    } else {
-      diff = moment().diff(lastRefreshed, 'milliseconds');
-      if (diff > this.reloadTimeout * 2) {
+      if (event) {
         res = SHOULD_RELOAD_YES;
       } else {
-        res = SHOULD_RELOAD_SKIP;
+        diff = moment().diff(lastRefreshed, 'milliseconds');
+        if (diff > this.reloadTimeout * 2) {
+          res = SHOULD_RELOAD_YES;
+        } else {
+          res = SHOULD_RELOAD_SKIP;
+        }
       }
     }
 

--- a/app/pipeline/events/controller.js
+++ b/app/pipeline/events/controller.js
@@ -151,9 +151,12 @@ export async function updateEvents(page) {
     this.set('eventsPage', page);
     this.set('isFetching', false);
 
-    // FIXME: Skip duplicate ones if new events got added added to the head
-    // of events list
-    this.set('paginateEvents', this.paginateEvents.concat(nextEvents));
+    // Skip duplicate ones if new events got added added to the head
+    const noDuplicateEvents = nextEvents.filter(
+      nextEvent => !this.paginateEvents.findBy('id', nextEvent.id)
+    );
+
+    this.paginateEvents.pushObjects(noDuplicateEvents);
   }
 
   return null;


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
To fix duplicate issues when the URL is anchored to a specific event and the user scrolls down to fetch more events.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
`https://cd.screwdriver.cd/pipelines/6862/events/618770`

Before:
![2021-03-15_10-07-24 (1)](https://user-images.githubusercontent.com/15989893/111192531-6611a680-8576-11eb-86e2-c1c2aa0f814c.gif)

After:
![image](https://user-images.githubusercontent.com/15989893/111191770-a290d280-8575-11eb-802e-e2ad8b562077.png)

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
