### PR TITLE
fix: Add Pointer icon while hovering on close button in quickStart guide modal

### DIFF
--- a/app/components/quickstart-guide/styles.scss
+++ b/app/components/quickstart-guide/styles.scss
@@ -139,6 +139,7 @@
       }
 
       .close-quickstart-guide {
+        cursor: pointer;
         display: flex;
         margin-left: auto;
         margin-right: 5%;


### PR DESCRIPTION
## Context

- Pointer for Cursor is not shown while hovering on close icon in QuickStart Guide wizard

## Objective

- Will show the pointer while hovering on close icon

**ScreenShots:**
Before:
 - 
<img width="1680" alt="actual" src="https://user-images.githubusercontent.com/10308692/111968472-3129c480-8b1f-11eb-9fc2-1aed8113d24d.png">

- After:
<img width="1680" alt="expected" src="https://user-images.githubusercontent.com/10308692/111969022-d04ebc00-8b1f-11eb-8999-856feff888e6.png">


## References

https://github.com/screwdriver-cd/screwdriver/issues/2389

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
