### PR TITLE
fix(2396):Resets selectedPipelines array after completing pipeline actions

### DIFF
--- a/app/components/collection-view/component.js
+++ b/app/components/collection-view/component.js
@@ -146,6 +146,7 @@ export default Component.extend({
           this.store.findRecord('collection', this.get('collection.id')).then(collection => {
             this.setProperties({
               removePipelineError: null,
+              selectedPipelines: [],
               isOrganizing: false,
               collection
             });
@@ -190,6 +191,7 @@ export default Component.extend({
         .then(() => {
           this.setProperties({
             addCollectionError: null,
+            selectedPipelines: [],
             isOrganizing: false
           });
         })


### PR DESCRIPTION
## Context

- After completing remove/copy to action in collection view the selection pipeline is not being reset which is cause wrong selection count and displaying actions even though nothing is selected.

## Objective

This PR reset the selectionPipeline array once the copy/remove actions are completed successfully.

## References

https://github.com/screwdriver-cd/screwdriver/issues/2396

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
