### PR TITLE
fix: handle remote case for undefined value for showPRJobs

### DIFF
--- a/app/components/pipeline-options/component.js
+++ b/app/components/pipeline-options/component.js
@@ -1,7 +1,7 @@
 import $ from 'jquery';
 import { inject as service } from '@ember/service';
 import { not, or, sort } from '@ember/object/computed';
-import { computed } from '@ember/object';
+import { computed, getWithDefault } from '@ember/object';
 import Component from '@ember/component';
 import ENV from 'screwdriver-ui/config/environment';
 import { parse, getCheckoutUrl } from 'screwdriver-ui/utils/git';
@@ -73,7 +73,7 @@ export default Component.extend({
 
     if (pipelinePreference) {
       desiredJobNameLength = pipelinePreference.jobNameLength;
-      showPRJobs = pipelinePreference.showPRJobs;
+      showPRJobs = getWithDefault(pipelinePreference, 'showPRJobs', true);
     }
 
     this.setProperties({ desiredJobNameLength, showPRJobs });

--- a/app/pipeline/events/controller.js
+++ b/app/pipeline/events/controller.js
@@ -280,7 +280,7 @@ export default Controller.extend(ModelReloaderMixin, {
     get() {
       if (this.activeTab === 'pulls') {
         this.cachedShowPRJobs = this.showPRJobs;
-        this.showPRJobs = false;
+        this.showPRJobs = true;
 
         return 'pr';
       }

--- a/app/pipeline/events/controller.js
+++ b/app/pipeline/events/controller.js
@@ -278,7 +278,16 @@ export default Controller.extend(ModelReloaderMixin, {
   }),
   currentEventType: computed('activeTab', {
     get() {
-      return this.activeTab === 'pulls' ? 'pr' : 'pipeline';
+      if (this.activeTab === 'pulls') {
+        this.cachedShowPRJobs = this.showPRJobs;
+        this.showPRJobs = false;
+
+        return 'pr';
+      }
+
+      this.showPRJobs = this.cachedShowPRJobs;
+
+      return 'pipeline';
     }
   }),
   // Aggregates first page events and events via ModelReloaderMixin

--- a/app/pipeline/events/controller.js
+++ b/app/pipeline/events/controller.js
@@ -278,16 +278,7 @@ export default Controller.extend(ModelReloaderMixin, {
   }),
   currentEventType: computed('activeTab', {
     get() {
-      if (this.activeTab === 'pulls') {
-        this.cachedShowPRJobs = this.showPRJobs;
-        this.showPRJobs = true;
-
-        return 'pr';
-      }
-
-      this.showPRJobs = this.cachedShowPRJobs;
-
-      return 'pipeline';
+      return this.activeTab === 'pulls' ? 'pr' : 'pipeline';
     }
   }),
   // Aggregates first page events and events via ModelReloaderMixin

--- a/app/pipeline/events/route.js
+++ b/app/pipeline/events/route.js
@@ -19,7 +19,7 @@ export default Route.extend({
 
     controller.setProperties({
       activeTab: 'events',
-      showPRJobs: pipelinePreference.showPRJobs
+      showPRJobs: getWithDefault(pipelinePreference, 'showPRJobs', true)
     });
 
     this.get('pipelineService').setBuildsLink('pipeline.events');

--- a/app/pipeline/pulls/route.js
+++ b/app/pipeline/pulls/route.js
@@ -13,7 +13,13 @@ export default EventsRoute.extend({
     this.render('pipeline.events');
   },
   model() {
-    this.controllerFor('pipeline.events').set('pipeline', this.pipeline);
+    const pipelineEventsController = this.controllerFor('pipeline.events');
+
+    pipelineEventsController.setProperties({
+      pipeline: this.pipeline,
+      showPRJobs: true
+    });
+
     const jobsPromise = this.get('pipeline.jobs');
 
     let events = [];


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
We treat undefined as false value for `showPRJobs`, thus the default of workflow graph now hide `~pr` jobs

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
This PR fixes just that
## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
