### PR TITLE
fix(2398): Display branch for child pipelines

### DIFF
--- a/app/components/pipeline-list/styles.scss
+++ b/app/components/pipeline-list/styles.scss
@@ -16,6 +16,52 @@
     color: $sd-link;
   }
 
+  .appId {
+    text-align: left;
+    width: 45%;
+  }
+
+  .branch {
+    width: 25%;
+    text-align: right;
+  }
+
+  .account {
+    width: 20%;
+    text-align: left;
+    white-space: nowrap;
+  }
+
+  tbody tr:hover {
+    background-color: $sd-separator;
+    .appId {
+      text-decoration: underline;
+    }
+  }
+
+  .num-results {
+    padding: 10px;
+    font-size: 14px;
+    color: $sd-text-med;
+  }
+
+  table {
+    width: 100%;
+  }
+
+  th {
+    font-size: 14px;
+    text-transform: uppercase;
+    font-weight: 300;
+    color: $sd-text-med;
+  }
+
+  th,
+  td {
+    padding: 10px;
+    border-bottom: 1px solid $sd-text-light;
+  }
+
   li {
     list-style: none;
     padding: 10px;

--- a/app/components/pipeline-list/template.hbs
+++ b/app/components/pipeline-list/template.hbs
@@ -6,9 +6,22 @@
     <button {{action "startAll"}} class="start-button">Start All</button>
   </div>
   <ul class="col-xs-12 col-md-8">
-    {{#each pipelines as |pipeline|}}
-      <li class="appId">{{#link-to "pipeline" pipeline.id}}{{pipeline.appId}}{{/link-to}}</li>
-    {{/each}}
+    <table>
+      <thead>
+        <tr>
+          <th class="appId">Name</th>
+          <th class="branch">Branch</th>
+        </tr>
+      </thead>
+      <tbody>
+        {{#each pipelines as |pipeline|}}
+          <tr>
+            <td class="appId">{{#highlight-terms query}}{{#link-to "pipeline" pipeline.id}}{{pipeline.appId}}{{/link-to}}{{/highlight-terms}}</td>
+            <td class="branch"><a href={{branch-url-encode pipeline.hubUrl}}>{{fa-icon "code-fork"}}{{pipeline.branch}}</a></td>
+          </tr>
+        {{/each}}
+      </tbody>
+    </table>
   </ul>
 {{else}}
   <div class="num-results">

--- a/app/components/search-list/template.hbs
+++ b/app/components/search-list/template.hbs
@@ -22,7 +22,7 @@
     {{#each filteredPipelines as |pipeline|}}
       <tr>
         <td class="appId">{{#highlight-terms query}}{{#link-to "pipeline" pipeline.id}}{{pipeline.appId}}{{/link-to}}{{/highlight-terms}}</td>
-        <td class="branch">{{fa-icon "code-fork"}}{{pipeline.branch}}</td>
+        <td class="branch"><a href={{branch-url-encode pipeline.hubUrl}}>{{fa-icon "code-fork"}}{{pipeline.branch}}</a></td>
         <td class="account">{{fa-icon pipeline.scmIcon}} {{pipeline.scm}}</td>
         {{#if session.isAuthenticated}}
           <td class="add">

--- a/tests/acceptance/pipeline-childPipelines-test.js
+++ b/tests/acceptance/pipeline-childPipelines-test.js
@@ -73,7 +73,10 @@ module('Acceptance | child pipeline', function(hooks) {
     await visit('/pipelines/1/child-pipelines');
 
     assert.equal(currentURL(), '/pipelines/1/child-pipelines');
-    assert.dom('.appId:nth-child(1)').hasText('child/one');
-    assert.dom('.appId:nth-child(2)').hasText('child/two');
+    assert.dom('.appId:nth-child(1)').hasText('Name');
+    assert.dom('tbody tr:first-child td.appId').hasText('child/one');
+    assert.dom('tbody tr:first-child td.branch').hasText('master');
+    assert.dom('tbody tr:nth-child(2) td.appId').hasText('child/two');
+    assert.dom('tbody tr:nth-child(2) td.branch').hasText('master');
   });
 });

--- a/tests/integration/components/pipeline-list/component-test.js
+++ b/tests/integration/components/pipeline-list/component-test.js
@@ -35,8 +35,8 @@ module('Integration | Component | pipeline list', function(hooks) {
 
     await render(hbs`{{pipeline-list pipelines=pipelineList pipeline=pipeline}}`);
 
-    assert.dom(find('ul li:first-child')).hasText('foo/bar');
-    assert.dom('ul li:nth-child(2)').hasText('batman/tumbler');
+    assert.dom(find('tbody tr:first-child')).hasText('foo/bar master');
+    assert.dom('tbody tr:nth-child(2)').hasText('batman/tumbler waynecorp');
     assert.dom('button').hasText('Start All');
     assert.dom('.num-results span').hasText('Found 2 child pipeline(s)');
   });


### PR DESCRIPTION
## Context

Would be nice if branch/rootDir is shown in child pipelines drop down.

## Objective

This PR displays branch/rootDir for child pipelines. Also makes branch/rootDir clickable link in child pipelines and search list pages.

### Child pipelines:
<img width="1137" alt="Screen Shot 2021-04-09 at 11 29 05 AM" src="https://user-images.githubusercontent.com/3230529/114227147-70328500-9929-11eb-90e8-9406e78a0a5f.png">
<img width="1159" alt="Screen Shot 2021-04-09 at 11 28 53 AM" src="https://user-images.githubusercontent.com/3230529/114227136-6dd02b00-9929-11eb-95e5-3096d84e3231.png">

### Pipeline search:
<img width="1321" alt="Screen Shot 2021-04-09 at 11 28 13 AM" src="https://user-images.githubusercontent.com/3230529/114227072-57c26a80-9929-11eb-965a-e34c59fbde8c.png">
<img width="1323" alt="Screen Shot 2021-04-09 at 11 28 30 AM" src="https://user-images.githubusercontent.com/3230529/114227057-54c77a00-9929-11eb-9956-a4c021aee4a6.png">

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2398

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
