### PR TITLE
fix(2302): Tone down the warning

### DIFF
--- a/app/components/pipeline-parameterized-build/styles.scss
+++ b/app/components/pipeline-parameterized-build/styles.scss
@@ -22,16 +22,6 @@ button.start-with-parameters-button {
   color: $sd-warning;
 }
 
-// for single default value
-.notice-default-values-icon + input {
-  background: $sd-warning;
-}
-
-// for multi default values
-.notice-default-values-icon + .ember-basic-dropdown > div {
-  background: $sd-warning;
-}
-
 & {
   position: relative;
   padding-top: 20px;


### PR DESCRIPTION
## Context
Request for tone down.
https://github.com/screwdriver-cd/screwdriver/issues/2302#issuecomment-815325473
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

See https://github.com/screwdriver-cd/ui/pull/673 for the UI before the fix

## Objective
Toned down the warning display when the input parameters are different from the default values.
<!-- What does this PR fix? What intentional changes will this PR make? -->
<img src="https://user-images.githubusercontent.com/24538326/115514122-c2c35800-a2be-11eb-9a05-b088d83cb618.png" width="300" />

## References
https://github.com/screwdriver-cd/ui/pull/673
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
