### PR TITLE
fix: add default value

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -50,9 +50,9 @@ http {
         set_by_lua_block $csp_header {
           return "style-src 'self' 'unsafe-inline'; " ..
             "connect-src 'self' " .. os.getenv("ECOSYSTEM_API") .. " " .. os.getenv("ECOSYSTEM_STORE") .. "; " ..
-            "frame-src 'self' " .. os.getenv("ECOSYSTEM_API") .. " " .. os.getenv("ECOSYSTEM_STORE") .. " " .. os.getenv("FEEDBACK_HOSTNAME") .. "; " ..
+            "frame-src 'self' " .. os.getenv("ECOSYSTEM_API") .. " " .. os.getenv("ECOSYSTEM_STORE") .. " " .. os.getenv("FEEDBACK_HOSTNAME") or "".. "; " ..
             "default-src 'none'; " ..
-            "script-src 'self' " .. os.getenv("FEEDBACK_SCRIPT") .. "; " ..
+            "script-src 'self' " .. os.getenv("FEEDBACK_SCRIPT") or "" .. "; " ..
             "font-src 'self'; " ..
             "img-src 'self' https: data: " .. os.getenv("AVATAR_HOSTNAME") .. "; " ..
             "media-src 'self';" ..


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
When using `set_lua` to do string concatenation, it breaks on 'null' values.

## Objective
Add default values for nginx.conf
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
