### PR TITLE
fix(2038): hide restart button of PrChain

### DIFF
--- a/app/components/pipeline-workflow/component.js
+++ b/app/components/pipeline-workflow/component.js
@@ -49,6 +49,14 @@ export default Component.extend({
     });
   },
 
+  isPrChainJob: computed('tooltipData', function isPrChainJob() {
+    const selectedEvent = get(this, 'selectedEventObj');
+    const { prNum } = selectedEvent;
+    const isPrChain = get(this, 'pipeline.prChain');
+
+    return prNum !== undefined && isPrChain;
+  }),
+
   buildParameters: computed('tooltipData', function preselectBuildParameters() {
     const defaultParameters = this.getWithDefault('pipeline.parameters', {});
     const buildParameters = copy(defaultParameters, true);

--- a/app/components/pipeline-workflow/template.hbs
+++ b/app/components/pipeline-workflow/template.hbs
@@ -15,6 +15,7 @@
   }}
     {{workflow-tooltip
       tooltipData=tooltipData
+      isPrChainJob=isPrChainJob
       displayRestartButton=displayRestartButton
       stopBuild=stopBuild
       showTooltip=showTooltip

--- a/app/components/workflow-tooltip/template.hbs
+++ b/app/components/workflow-tooltip/template.hbs
@@ -18,7 +18,9 @@
       {{else if tooltipData.job.manualStartDisabled}}
         <p>Disabled manually starting</p>
       {{else}}
-        <a {{action confirmStartBuild}}>{{if tooltipData.job.status "Restart" "Start"}} pipeline from here</a>
+        {{#if (eq isPrChainJob false)}}
+          <a {{action confirmStartBuild}}>{{if tooltipData.job.status "Restart" "Start"}} pipeline from here</a>
+        {{/if}}
       {{/if}}
     {{/if}}
     {{#if tooltipData.displayStop}}

--- a/tests/integration/components/workflow-tooltip/component-test.js
+++ b/tests/integration/components/workflow-tooltip/component-test.js
@@ -115,12 +115,14 @@ module('Integration | Component | workflow tooltip', function(hooks) {
 
     this.set('data', data);
     this.set('confirmStartBuild', () => {});
+    this.set('isPrChainJob', false);
 
     await render(hbs`{{
       workflow-tooltip
       tooltipData=data
       displayRestartButton=true
       confirmStartBuild="confirmStartBuild"
+      isPrChainJob=isPrChainJob
     }}`);
 
     assert.dom('.content a').exists({ count: 3 });
@@ -139,17 +141,45 @@ module('Integration | Component | workflow tooltip', function(hooks) {
 
     this.set('data', data);
     this.set('confirmStartBuild', () => {});
+    this.set('isPrChainJob', false);
 
     await render(hbs`{{
       workflow-tooltip
       tooltipData=data
       displayRestartButton=true
       confirmStartBuild="confirmStartBuild"
+      isPrChainJob=isPrChainJob
     }}`);
 
     assert.dom('.content a').exists({ count: 3 });
     assert.dom('a:first-child').hasText('Go to build details');
     assert.dom('a:last-child').hasText('Restart pipeline from here');
+  });
+
+  test('it hides restart link', async function(assert) {
+    const data = {
+      job: {
+        buildId: 1234,
+        name: 'batmobile',
+        status: 'SUCCESS'
+      }
+    };
+
+    this.set('data', data);
+    this.set('confirmStartBuild', () => {});
+    this.set('isPrChain', true);
+
+    await render(hbs`{{
+      workflow-tooltip
+      tooltipData=data
+      displayRestartButton=true
+      confirmStartBuild="confirmStartBuild"
+      isPrChain=isPrChain
+    }}`);
+
+    assert.dom('.content a').exists({ count: 2 });
+    assert.dom('a:first-child').hasText('Go to build details');
+    assert.dom('a:last-child').hasText('Go to build metrics');
   });
 
   test('it should update position and hidden status', async function(assert) {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
fix https://github.com/screwdriver-cd/screwdriver/issues/2038

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

This PR fixes tooltips not to show `start pipeline from here` for prChain jobs that cannot started from tooltip.

PRChain Job:
<img width="272" alt="スクリーンショット 2021-04-22 18 07 00" src="https://user-images.githubusercontent.com/32473622/115688116-ce358280-a395-11eb-9f91-9d1e47d1a122.png">

commit Job:
<img width="318" alt="スクリーンショット 2021-04-22 18 07 14" src="https://user-images.githubusercontent.com/32473622/115688040-bcec7600-a395-11eb-9bfc-d7bcb1b71727.png">

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
