### PR TITLE
feat(2410): Add stop frozen build option

### DIFF
--- a/app/components/workflow-tooltip/template.hbs
+++ b/app/components/workflow-tooltip/template.hbs
@@ -22,6 +22,9 @@
     {{#if tooltipData.displayStop}}
       <a {{action stopBuild tooltipData.selectedEvent tooltipData.job}}>Stop build</a>
     {{/if}}
+    {{#if (eq tooltipData.job.status "FROZEN")}}
+      <a {{action stopBuild tooltipData.selectedEvent tooltipData.job}}>Stop frozen build</a>
+    {{/if}}
   {{/if}}
   {{yield}}
 </div>

--- a/tests/integration/components/workflow-tooltip/component-test.js
+++ b/tests/integration/components/workflow-tooltip/component-test.js
@@ -152,6 +152,30 @@ module('Integration | Component | workflow tooltip', function(hooks) {
     assert.dom('a:last-child').hasText('Restart pipeline from here');
   });
 
+  test('it renders stop frozen build link', async function(assert) {
+    const data = {
+      job: {
+        buildId: 1234,
+        name: 'batmobile',
+        status: 'FROZEN'
+      }
+    };
+
+    this.set('data', data);
+    this.set('confirmStartBuild', () => {});
+
+    await render(hbs`{{
+      workflow-tooltip
+      tooltipData=data
+      displayRestartButton=true
+      confirmStartBuild="confirmStartBuild"
+    }}`);
+
+    assert.dom('.content a').exists({ count: 3 });
+    assert.dom('a:first-child').hasText('Go to build details');
+    assert.dom('a:last-child').hasText('Stop frozen build');
+  });
+
   test('it should update position and hidden status', async function(assert) {
     this.set('show', true);
     this.set('pos', 'left');


### PR DESCRIPTION
## Context

Screwdriver needs a way to allow users to abort a build that has entered frozen state

## Objective

This PR adds an option to abort a build that is frozen

## References

https://github.com/screwdriver-cd/screwdriver/issues/2410

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
