### PR TITLE
fix(2038): show restart button in prchain job if it has build

### DIFF
--- a/app/components/pipeline-workflow/component.js
+++ b/app/components/pipeline-workflow/component.js
@@ -57,6 +57,27 @@ export default Component.extend({
     return prNum !== undefined && isPrChain;
   }),
 
+  prBuildExists: computed('tooltipData', function isStartablePrChainJob() {
+    const selectedEvent = get(this, 'selectedEventObj');
+
+    const tooltipData = get(this, 'tooltipData');
+
+    let selectedJobId;
+
+    if (tooltipData) {
+      selectedJobId = tooltipData.job.id ? tooltipData.job.id.toString() : null;
+    } else {
+      // job is not selected
+      return false;
+    }
+
+    const buildExists = selectedEvent.buildsSorted.filter(b => b.jobId === selectedJobId);
+
+    const { prNum } = selectedEvent;
+
+    return prNum && buildExists.length !== 0;
+  }),
+
   buildParameters: computed('tooltipData', function preselectBuildParameters() {
     const defaultParameters = this.getWithDefault('pipeline.parameters', {});
     const buildParameters = copy(defaultParameters, true);

--- a/app/components/pipeline-workflow/template.hbs
+++ b/app/components/pipeline-workflow/template.hbs
@@ -16,6 +16,7 @@
     {{workflow-tooltip
       tooltipData=tooltipData
       isPrChainJob=isPrChainJob
+      prBuildExists=prBuildExists
       displayRestartButton=displayRestartButton
       stopBuild=stopBuild
       showTooltip=showTooltip

--- a/app/components/workflow-tooltip/template.hbs
+++ b/app/components/workflow-tooltip/template.hbs
@@ -20,6 +20,10 @@
       {{else}}
         {{#if (eq isPrChainJob false)}}
           <a {{action confirmStartBuild}}>{{if tooltipData.job.status "Restart" "Start"}} pipeline from here</a>
+        {{else}}
+          {{#if (eq prBuildExists true)}}
+            <a {{action confirmStartBuild}}>{{if tooltipData.job.status "Restart" "Start"}} pipeline from here</a>
+          {{/if}}
         {{/if}}
       {{/if}}
     {{/if}}

--- a/tests/integration/components/workflow-tooltip/component-test.js
+++ b/tests/integration/components/workflow-tooltip/component-test.js
@@ -156,7 +156,7 @@ module('Integration | Component | workflow tooltip', function(hooks) {
     assert.dom('a:last-child').hasText('Restart pipeline from here');
   });
 
-  test('it hides restart link', async function(assert) {
+  test('it hides restart link if no build exists in PRChain', async function(assert) {
     const data = {
       job: {
         buildId: 1234,
@@ -167,7 +167,8 @@ module('Integration | Component | workflow tooltip', function(hooks) {
 
     this.set('data', data);
     this.set('confirmStartBuild', () => {});
-    this.set('isPrChain', true);
+    this.set('isPrChainJob', true);
+    this.set('prBuildExists', false);
 
     await render(hbs`{{
       workflow-tooltip
@@ -175,11 +176,40 @@ module('Integration | Component | workflow tooltip', function(hooks) {
       displayRestartButton=true
       confirmStartBuild="confirmStartBuild"
       isPrChain=isPrChain
+      prBuildExists=prBuildExists
     }}`);
 
     assert.dom('.content a').exists({ count: 2 });
     assert.dom('a:first-child').hasText('Go to build details');
     assert.dom('a:last-child').hasText('Go to build metrics');
+  });
+
+  test('it shows restart link if build exists in PRChain', async function(assert) {
+    const data = {
+      job: {
+        buildId: 1234,
+        name: 'batmobile',
+        status: 'SUCCESS'
+      }
+    };
+
+    this.set('data', data);
+    this.set('confirmStartBuild', () => {});
+    this.set('isPrChainJob', true);
+    this.set('prBuildExists', true);
+
+    await render(hbs`{{
+      workflow-tooltip
+      tooltipData=data
+      displayRestartButton=true
+      confirmStartBuild="confirmStartBuild"
+      isPrChain=isPrChain
+      prBuildExists=prBuildExists
+    }}`);
+
+    assert.dom('.content a').exists({ count: 3 });
+    assert.dom('a:first-child').hasText('Go to build details');
+    assert.dom('a:last-child').hasText('Restart pipeline from here');
   });
 
   test('it should update position and hidden status', async function(assert) {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Additional fix https://github.com/screwdriver-cd/screwdriver/issues/2038

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
In https://github.com/screwdriver-cd/ui/pull/701 we hides all restart link of prChain.
This PR is to show restart button it has build.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
If selected job has build in PRChain, it can be restarted.
<img width="338" alt="スクリーンショット 2021-04-26 12 45 46" src="https://user-images.githubusercontent.com/32473622/116026375-8eb8b000-a68d-11eb-8d1e-b6772f9da103.png">

Detached build never restarted because it has no build in PRChain
<img width="238" alt="スクリーンショット 2021-04-26 12 46 02" src="https://user-images.githubusercontent.com/32473622/116026393-9c6e3580-a68d-11eb-970d-58db53d904b0.png">


## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
