### PR TITLE
fix: refactor user/settings

### DIFF
--- a/app/components/pipeline-options/styles.scss
+++ b/app/components/pipeline-options/styles.scss
@@ -128,8 +128,7 @@
   }
 
   input.display-job-name {
-    margin-right: 25px;
-    width: 38px;
+    width: 45px;
   }
 
   .pipeline {

--- a/app/components/pipeline-workflow/component.js
+++ b/app/components/pipeline-workflow/component.js
@@ -1,6 +1,6 @@
 import { alias } from '@ember/object/computed';
 import Component from '@ember/component';
-import { get, computed, set, setProperties } from '@ember/object';
+import { get, getWithDefault, computed, set, setProperties } from '@ember/object';
 import { reject } from 'rsvp';
 import { isRoot } from 'screwdriver-ui/utils/graph-tools';
 import { isActiveBuild } from 'screwdriver-ui/utils/build';
@@ -50,7 +50,7 @@ export default Component.extend({
   },
 
   isPrChainJob: computed('tooltipData', function isPrChainJob() {
-    const selectedEvent = get(this, 'selectedEventObj');
+    const selectedEvent = getWithDefault(this, 'selectedEventObj', {});
     const { prNum } = selectedEvent;
     const isPrChain = get(this, 'pipeline.prChain');
 

--- a/app/components/workflow-graph-d3/component.js
+++ b/app/components/workflow-graph-d3/component.js
@@ -180,25 +180,24 @@ export default Component.extend({
   async draw(data) {
     const self = this;
 
-    let displayJobNameLength = ENV.APP.MINIMUM_JOBNAME_LENGTH;
+    let desiredJobNameLength = ENV.APP.MINIMUM_JOBNAME_LENGTH;
 
-    const pipelinePreference = await this.store.queryRecord('preference/pipeline', {
-      filter: {
-        pipelineId: this.get('pipeline.id')
-      }
-    });
+    const pipelineId = this.get('pipeline.id');
+    const pipelinePreference = await this.store
+      .peekAll('preference/pipeline')
+      .findBy('id', pipelineId);
 
     if (pipelinePreference) {
-      const { jobNameLength } = pipelinePreference;
+      const { displayJobNameLength } = pipelinePreference;
 
-      if (jobNameLength > displayJobNameLength) {
-        displayJobNameLength = jobNameLength;
+      if (displayJobNameLength > desiredJobNameLength) {
+        desiredJobNameLength = displayJobNameLength;
       }
     }
 
     const MAX_LENGTH = Math.min(
       data.nodes.reduce((max, cur) => Math.max(cur.name.length, max), 0),
-      displayJobNameLength
+      desiredJobNameLength
     );
     const { ICON_SIZE, TITLE_SIZE, ARROWHEAD } = this.elementSizes;
 
@@ -319,7 +318,7 @@ export default Component.extend({
         .text(d => {
           const displayName = d.displayName !== undefined ? d.displayName : d.name;
 
-          return displayName.length >= displayJobNameLength
+          return displayName.length >= desiredJobNameLength
             ? `${displayName.substr(0, 8)}...${displayName.substr(-8)}`
             : displayName;
         })

--- a/app/pipeline/events/route.js
+++ b/app/pipeline/events/route.js
@@ -38,7 +38,7 @@ export default Route.extend({
         count: ENV.APP.NUM_EVENTS_LISTED
       }),
       triggers: this.triggerService.getDownstreamTriggers(pipelineId),
-      pipelinePreference: this.shuttle.getUserPreference(pipelineId)
+      pipelinePreference: this.shuttle.getUserPipelinePreference(pipelineId)
     }).catch(err => {
       let errorMessage = getErrorMessage(err);
 

--- a/app/preference/pipeline/model.js
+++ b/app/preference/pipeline/model.js
@@ -1,9 +1,7 @@
 import Model, { attr } from '@ember-data/model';
 
 export default class PreferencePipelineModel extends Model {
-  @attr('string') pipelineId;
-
-  @attr('number', { defaultValue: 20 }) jobNameLength;
+  @attr('number', { defaultValue: 20 }) displayJobNameLength;
 
   @attr('boolean', { defaultValue: true }) showPRJobs;
 }

--- a/app/utils/error-messages.js
+++ b/app/utils/error-messages.js
@@ -15,7 +15,7 @@ const getErrorMessage = err => {
       errorMessage = 'Action cannot be completed, please make sure you are online';
     } else if (message.startsWith('The ajax operation was aborted')) {
       errorMessage = 'Action cannot be completed, please make sure you are online';
-    } else if (message.startsWith('Request was rejected due to server error')) {
+    } else if (message.startsWith('Request was rejected')) {
       errorMessage = message;
     }
   } else if (err === '401 Invalid token') {

--- a/tests/integration/components/pipeline-options/component-test.js
+++ b/tests/integration/components/pipeline-options/component-test.js
@@ -211,6 +211,25 @@ module('Integration | Component | pipeline options', function(hooks) {
             showJobPRs: false
           }
         });
+      },
+      peekAll() {
+        assert.ok(true, 'peekAll called');
+
+        return A([
+          EmberObject.create({
+            id: '1',
+            showPRJobs: true
+          }),
+          EmberObject.create({
+            id: '7',
+            showPRJobs: true
+          }),
+          EmberObject.create({
+            id: '7290',
+            displayJobNameLength: 20,
+            showPRJobs: false
+          })
+        ]);
       }
     });
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Refactor user/settings to support storing job name length to the API (which already supported)

https://github.com/screwdriver-cd/data-schema/blob/83024712039a2243e88a58f2e6caa5c0aaa6c0de/config/settings.js#L32-L35

## Objective
This PR enables users to store job name length to the backend
<!-- What does this PR fix? What intentional changes will this PR make? -->


Update label width: 
![image](https://user-images.githubusercontent.com/15989893/117348997-bbc04c00-ae5f-11eb-95d2-7f367641bc00.png)

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
[peekAll returns DS.RecordArray](https://api.emberjs.com/ember-data/3.3/classes/DS.Store/methods/peekAll?anchor=peekAll)

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
