### PR TITLE
fix: bump up ram to turbo for publish job

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -21,6 +21,8 @@ jobs:
 
   # Publish the package to GitHub and build docker image
   publish:
+    annotations:
+        screwdriver.cd/ram: TURBO
     environment:
       RELEASE_FILE: sdui.tgz
       DOCKER_REPO: screwdrivercd/ui

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -22,7 +22,7 @@ jobs:
   # Publish the package to GitHub and build docker image
   publish:
     annotations:
-        screwdriver.cd/ram: TURBO
+      screwdriver.cd/ram: TURBO
     environment:
       RELEASE_FILE: sdui.tgz
       DOCKER_REPO: screwdrivercd/ui


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Often `publish` fails due to timeout, so bump up ram to turbo for `publish` job

## Objective
Bump up ram
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
