### PR TITLE
fix: exclude CREATED build from event status

### DIFF
--- a/app/event/model.js
+++ b/app/event/model.js
@@ -108,17 +108,14 @@ export default DS.Model.extend(ModelReloaderMixin, {
 
     builds.then(list => {
       if (!this.isDestroying && !this.isDestroyed) {
-        const validList = list.filter(b => get(b, 'status') !== 'SUCCESS');
+        const validList = list.filter(
+          b => get(b, 'status') !== 'SUCCESS' && get(b, 'status') !== 'CREATED'
+        );
 
         if (validList.length) {
           status = get(validList[0], 'status');
         } else {
           status = get(this, 'isComplete') ? 'SUCCESS' : 'RUNNING';
-        }
-
-        // override CREATED status to RUNNING for event status
-        if (status === 'CREATED') {
-          status = 'RUNNING';
         }
 
         set(this, 'status', status);


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
event with `CREATED` build shouldn't be marked as in `running` state

before:
<img width="577" alt="Screen Shot 2021-05-11 at 4 53 01 PM" src="https://user-images.githubusercontent.com/55161078/117899394-e7866c00-b27b-11eb-95d8-dd801db78fb5.png">
<img width="572" alt="Screen Shot 2021-05-11 at 4 39 14 PM" src="https://user-images.githubusercontent.com/55161078/117899397-e8b79900-b27b-11eb-9dd5-56a141361ac8.png">
<img width="569" alt="Screen Shot 2021-05-11 at 4 38 39 PM" src="https://user-images.githubusercontent.com/55161078/117899399-e8b79900-b27b-11eb-9170-6de16150d7cc.png">

after:
<img width="575" alt="Screen Shot 2021-05-11 at 4 56 07 PM" src="https://user-images.githubusercontent.com/55161078/117899424-f1a86a80-b27b-11eb-9cb3-c4f6267150a6.png">
<img width="569" alt="Screen Shot 2021-05-11 at 4 56 23 PM" src="https://user-images.githubusercontent.com/55161078/117899426-f2410100-b27b-11eb-809a-c7eefd9d8eec.png">
<img width="564" alt="Screen Shot 2021-05-11 at 4 56 14 PM" src="https://user-images.githubusercontent.com/55161078/117899427-f2410100-b27b-11eb-8b42-d39fffca34d2.png">

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
exclude `CREATED` build from event status calculation
## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
