### PR TITLE
fix(2448): git repo url validation

### DIFF
--- a/app/utils/git.js
+++ b/app/utils/git.js
@@ -7,7 +7,7 @@
 function parse(scmUrl) {
   // eslint-disable-next-line max-len
   const match = scmUrl.match(
-    /^(?:(?:https:\/\/(?:[^@/:\s]+@)?)|git@|org-\d+@)+([^/:\s]+)(?:\/|:)([^/:\s]+)\/([^\s]+?)(?:\.git)?(#[^\s]+)?$/
+    /^(?:(?:https:\/\/(?:[^@/:\s]+@)?)|git@|org-\d+@)+([^/:\s]+)(?:\/|:)([^/:\s]+)\/([^\s]+?)(?:\.git)(#[^:\s]+)?(:[^\s]+)?$/
   );
 
   if (!match) {
@@ -15,7 +15,6 @@ function parse(scmUrl) {
       valid: false
     };
   }
-
   const result = {
     server: match[1],
     owner: match[2],


### PR DESCRIPTION
## Context

Invalid git repo name marked as valid. "Create pipeline" page shows green check-mark for invalid git repo urls.

## Objective

Fix validation of git repo urls

## References

https://github.com/screwdriver-cd/screwdriver/issues/2448

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
