### PR TITLE
fix: set max length for display name length

### DIFF
--- a/app/components/pipeline-options/component.js
+++ b/app/components/pipeline-options/component.js
@@ -7,7 +7,7 @@ import Component from '@ember/component';
 import ENV from 'screwdriver-ui/config/environment';
 import { parse, getCheckoutUrl } from 'screwdriver-ui/utils/git';
 
-const { MINIMUM_JOBNAME_LENGTH, DOWNTIME_JOBS } = ENV.APP;
+const { MINIMUM_JOBNAME_LENGTH, MAXIMUM_JOBNAME_LENGTH, DOWNTIME_JOBS } = ENV.APP;
 
 export default Component.extend({
   store: service(),
@@ -36,7 +36,9 @@ export default Component.extend({
   isUpdatingMetricsDowntimeJobs: false,
   metricsDowntimeJobs: [],
   displayDowntimeJobs: DOWNTIME_JOBS,
+  displayJobNameLength: 20,
   minDisplayLength: MINIMUM_JOBNAME_LENGTH,
+  maxDisplayLength: MAXIMUM_JOBNAME_LENGTH,
   sortedJobs: computed('jobs', function filterThenSortJobs() {
     const prRegex = /PR-\d+:.*/;
 
@@ -206,7 +208,19 @@ export default Component.extend({
         .finally(() => this.set('isShowingModal', false));
     },
 
-    async updateJobNameLength(displayJobNameLength) {
+    async updateJobNameLength(inputJobNameLength) {
+      let displayJobNameLength = inputJobNameLength;
+
+      if (parseInt(displayJobNameLength, 10) > MAXIMUM_JOBNAME_LENGTH) {
+        displayJobNameLength = MAXIMUM_JOBNAME_LENGTH;
+      }
+
+      if (parseInt(displayJobNameLength, 10) < MINIMUM_JOBNAME_LENGTH) {
+        displayJobNameLength = MINIMUM_JOBNAME_LENGTH;
+      }
+
+      this.$('input.display-job-name').val(displayJobNameLength);
+
       debounce(this, this.updateJobNameLength, displayJobNameLength, 1000);
     },
     async updatePipelineSettings(metricsDowntimeJobs) {

--- a/app/components/pipeline-options/template.hbs
+++ b/app/components/pipeline-options/template.hbs
@@ -207,7 +207,7 @@
               <input type="number"
                 class="display-job-name"
                 min={{minDisplayLength}}
-                max="99"
+                max={{maxDisplayLength}}
                 placeholder={{minDisplayLength}}
                 value={{desiredJobNameLength}}
                 onchange={{action "updateJobNameLength" value="target.value"}}>

--- a/app/shuttle/service.js
+++ b/app/shuttle/service.js
@@ -196,7 +196,13 @@ export default Service.extend({
     const method = 'get';
     const url = `/users/settings`;
 
-    return this.fetchFromApi(method, url);
+    try {
+      const userSettings = await this.fetchFromApi(method, url);
+
+      return userSettings;
+    } catch (e) {
+      return {};
+    }
   },
 
   /**

--- a/config/environment.js
+++ b/config/environment.js
@@ -54,6 +54,7 @@ module.exports = environment => {
       EVENT_RELOAD_TIMER: 60000, // 1 minute
       LOG_RELOAD_TIMER: 3000,
       MINIMUM_JOBNAME_LENGTH: 20,
+      MAXIMUM_JOBNAME_LENGTH: 99,
       NUM_EVENTS_LISTED: 5,
       NUM_PIPELINES_LISTED: 50,
       LIST_VIEW_PAGE_SIZE: 200,


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Add guard to make sure input value are in range (20 - 99)

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Now, the UI will not block users from the normal workflow, even if the data was legacy (out of range previously).
![image](https://user-images.githubusercontent.com/15989893/119186213-a08f3800-ba2c-11eb-8514-23d78867a388.png)

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
