### PR TITLE
fix: restart latest build when pipeline has parameters dropdown

### DIFF
--- a/app/pipeline/events/controller.js
+++ b/app/pipeline/events/controller.js
@@ -45,18 +45,26 @@ export async function stopBuild(givenEvent, job) {
 export async function startDetachedBuild(job, options = {}) {
   this.set('isShowingModal', true);
 
-  const buildId = get(job, 'buildId');
+  let event = this.selectedEventObj;
 
   let parentBuildId = null;
+
+  const buildId = get(job, 'buildId');
   const { parameters, reason } = options;
 
   if (buildId) {
     const build = this.store.peekRecord('build', buildId);
 
     parentBuildId = get(build, 'parentBuildId');
+  } else {
+    const builds = await get(job, 'builds');
+    const latestBuild = get(builds, 'firstObject');
+
+    if (event === undefined) {
+      event = await this.store.findRecord('event', get(latestBuild, 'eventId'));
+    }
   }
 
-  const event = this.selectedEventObj;
   const parentEventId = get(event, 'id');
   const groupEventId = get(event, 'groupEventId');
   const pipelineId = get(this, 'pipeline.id');


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? --> 
If a pipeline has parameters, then when restart a build from job-list-view will fail.

i.e https://cd.screwdriver.cd/pipelines/3303/jobs

See screenshot:
![image](https://user-images.githubusercontent.com/15989893/119902519-30852400-befc-11eb-96cf-18177f3c5ac2.png)

![image](https://user-images.githubusercontent.com/15989893/119902294-e56b1100-befb-11eb-8811-d8b81992c42d.png)

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
This PR will correct the behavior: it fetches builds from a given jobId, and find the latest build's eventId, and get corresponding data from that event, such as parentEvent.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
