### PR TITLE
fix: Add the latestCommit marker to pipeline-graph-nav

### DIFF
--- a/app/components/pipeline-events-list/component.js
+++ b/app/components/pipeline-events-list/component.js
@@ -11,10 +11,6 @@ export default Component.extend({
   errorMessage: '',
   groups: computed('events.[]', {
     get() {
-      this.shuttle.getLatestCommitEvent(this.get('pipeline.id')).then(event => {
-        this.set('latestCommit', event);
-      });
-
       const events = get(this, 'events');
       const groups = groupBy(events, 'groupEventId');
       const groupsArray = Object.keys(groups).map(key => groups[key]);

--- a/app/components/pipeline-events-list/component.js
+++ b/app/components/pipeline-events-list/component.js
@@ -6,7 +6,6 @@ import groupBy from 'lodash.groupby';
 import moment from 'moment';
 
 export default Component.extend({
-  shuttle: service(),
   router: service(),
   errorMessage: '',
   groups: computed('events.[]', {

--- a/app/components/pipeline-graph-nav/styles.scss
+++ b/app/components/pipeline-graph-nav/styles.scss
@@ -1,4 +1,6 @@
 & {
+  @import 'app/styles/column-view';
+
   padding: 15px 0 15px 10px;
 
   strong {
@@ -9,6 +11,12 @@
   a {
     vertical-align: middle;
     line-height: 33px;
+  }
+
+  .status {
+    font-size: unset;
+    padding: unset;
+    color: unset;
   }
 
   .btn.event__stop {

--- a/app/components/pipeline-graph-nav/template.hbs
+++ b/app/components/pipeline-graph-nav/template.hbs
@@ -64,7 +64,7 @@
       <div class="event-info">
         <div class="col">
           <span class="title">Commit</span><br>
-          <a href={{selectedEventObj.commit.url}}>#{{selectedEventObj.truncatedSha}}</a>
+          <a class={{if (eq selectedEventObj.sha latestCommit.sha) "latest-commit"}} href={{selectedEventObj.commit.url}}>#{{selectedEventObj.truncatedSha}}</a>
         </div>
         <div class="col">
           <span class="title">Message</span><br>

--- a/app/pipeline/events/controller.js
+++ b/app/pipeline/events/controller.js
@@ -171,6 +171,7 @@ export async function updateEvents(page) {
 }
 
 export default Controller.extend(ModelReloaderMixin, {
+  shuttle: service(),
   lastRefreshed: moment(),
   expandedEventsGroup: {},
   shouldReload(model) {
@@ -323,6 +324,10 @@ export default Controller.extend(ModelReloaderMixin, {
   }),
   pipelineEvents: computed('modelEvents', 'paginateEvents.[]', {
     get() {
+      this.shuttle.getLatestCommitEvent(this.get('pipeline.id')).then(event => {
+        this.set('latestCommit', event);
+      });
+
       return [].concat(this.modelEvents, this.paginateEvents);
     }
   }),

--- a/app/pipeline/events/template.hbs
+++ b/app/pipeline/events/template.hbs
@@ -14,6 +14,7 @@
     {{pipeline-graph-nav
       pipeline=pipeline
       mostRecent=mostRecent
+      latestCommit=latestCommit
       lastSuccessful=lastSuccessful
       graphType=currentEventType
       selectedEvent=selectedEvent
@@ -64,6 +65,7 @@
             events=events
             selected=(mut selected)
             selectedEvent=selectedEvent
+            latestCommit=latestCommit
             lastSuccessful=lastSuccessful
             mostRecent=mostRecent
             eventsPage=eventsPage
@@ -79,6 +81,7 @@
             events=events
             selected=(mut selected)
             selectedEvent=selectedEvent
+            latestCommit=latestCommit
             lastSuccessful=lastSuccessful
             eventsPage=eventsPage
             updateEvents=(action "updateEvents")

--- a/tests/integration/components/pipeline-graph-nav/component-test.js
+++ b/tests/integration/components/pipeline-graph-nav/component-test.js
@@ -9,6 +9,7 @@ module('Integration | Component | pipeline graph nav', function(hooks) {
 
   test('it renders', async function(assert) {
     set(this, 'obj', {
+      sha: 'abc123',
       truncatedSha: 'abc123',
       status: 'SUCCESS',
       commit: {
@@ -16,6 +17,9 @@ module('Integration | Component | pipeline graph nav', function(hooks) {
       }
     });
     set(this, 'selected', 2);
+    set(this, 'latestCommit', {
+      sha: 'latestSha'
+    });
     set(this, 'startBuild', () => {
       assert.ok(true);
     });
@@ -30,6 +34,7 @@ module('Integration | Component | pipeline graph nav', function(hooks) {
 
     await render(hbs`{{pipeline-graph-nav
       mostRecent=3
+      latestCommit=latestCommit
       lastSuccessful=2
       selectedEvent=2
       selectedEventObj=obj
@@ -66,6 +71,8 @@ module('Integration | Component | pipeline graph nav', function(hooks) {
 
     assert.dom('.SUCCESS').exists({ count: 1 });
 
+    assert.dom('.latest-commit').doesNotExist();
+
     assert.dom('.event-options-toggle').hasText('Most Recent Last Successful');
 
     assert.dom('.x-toggle-component').includesText('Show triggers');
@@ -75,6 +82,9 @@ module('Integration | Component | pipeline graph nav', function(hooks) {
     assert.expect(1);
     set(this, 'obj', { truncatedSha: 'abc123' });
     set(this, 'selected', 2);
+    set(this, 'latestCommit', {
+      sha: 'latestSha'
+    });
     set(this, 'startBuild', () => {
       assert.ok(true);
     });
@@ -89,6 +99,7 @@ module('Integration | Component | pipeline graph nav', function(hooks) {
 
     await render(hbs`{{pipeline-graph-nav
       mostRecent=3
+      latestCommit=latestCommit
       lastSuccessful=2
       selectedEvent=2
       selectedEventObj=obj
@@ -115,6 +126,9 @@ module('Integration | Component | pipeline graph nav', function(hooks) {
       type: 'pr'
     });
     set(this, 'selected', 2);
+    set(this, 'latestCommit', {
+      sha: 'latestSha'
+    });
     set(this, 'startBuild', (prNum, jobs) => {
       assert.equal(prNum, 1);
       assert.equal(jobs[0].group, 1);
@@ -133,6 +147,7 @@ module('Integration | Component | pipeline graph nav', function(hooks) {
     });
     await render(hbs`{{pipeline-graph-nav
       mostRecent=3
+      latestCommit=latestCommit
       lastSuccessful=2
       selectedEvent=2
       selectedEventObj=obj
@@ -159,6 +174,9 @@ module('Integration | Component | pipeline graph nav', function(hooks) {
       type: 'pipeline'
     });
     set(this, 'selected', 2);
+    set(this, 'latestCommit', {
+      sha: 'latestSha'
+    });
     set(this, 'startBuild', () => {
       assert.ok(true);
     });
@@ -172,6 +190,7 @@ module('Integration | Component | pipeline graph nav', function(hooks) {
     });
     await render(hbs`{{pipeline-graph-nav
       mostRecent=3
+      latestCommit=latestCommit
       lastSuccessful=2
       selectedEvent=2
       selectedEventObj=obj
@@ -194,6 +213,9 @@ module('Integration | Component | pipeline graph nav', function(hooks) {
     assert.expect(2);
     set(this, 'obj', { truncatedSha: 'abc123' });
     set(this, 'selected', 2);
+    set(this, 'latestCommit', {
+      sha: 'latestSha'
+    });
     set(this, 'startBuild', () => {
       assert.ok(true);
     });
@@ -207,6 +229,7 @@ module('Integration | Component | pipeline graph nav', function(hooks) {
     });
     await render(hbs`{{pipeline-graph-nav
       mostRecent=3
+      latestCommit=latestCommit
       lastSuccessful=2
       graphType=currentEventType
       selectedEvent=2
@@ -232,6 +255,9 @@ module('Integration | Component | pipeline graph nav', function(hooks) {
       type: 'pipeline'
     });
     set(this, 'selected', 2);
+    set(this, 'latestCommit', {
+      sha: 'latestSha'
+    });
     set(this, 'startBuild', () => {
       assert.ok(true);
     });
@@ -245,6 +271,7 @@ module('Integration | Component | pipeline graph nav', function(hooks) {
     });
     await render(hbs`{{pipeline-graph-nav
       mostRecent=3
+      latestCommit=latestCommit
       lastSuccessful=2
       selectedEvent=2
       selectedEventObj=obj
@@ -270,6 +297,9 @@ module('Integration | Component | pipeline graph nav', function(hooks) {
       type: 'pipeline'
     });
     set(this, 'selected', 2);
+    set(this, 'latestCommit', {
+      sha: 'latestSha'
+    });
     set(this, 'startBuild', () => {
       assert.ok(true);
     });
@@ -284,6 +314,7 @@ module('Integration | Component | pipeline graph nav', function(hooks) {
 
     await render(hbs`{{pipeline-graph-nav
       mostRecent=3
+      latestCommit=latestCommit
       lastSuccessful=2
       selectedEvent=2
       selectedEventObj=obj
@@ -298,5 +329,48 @@ module('Integration | Component | pipeline graph nav', function(hooks) {
 
     assert.dom('.ABORTED').exists({ count: 1 });
     assert.dom('.status .fa-stop-circle').exists({ count: 1 });
+  });
+
+  test('it renders when selectedEvent is latestCommit event', async function(assert) {
+    set(this, 'obj', {
+      sha: 'latestSha',
+      truncatedSha: 'latestSha',
+      status: 'SUCCESS',
+      commit: { message: 'this is success event.' },
+      creator: { name: 'anonymous' },
+      type: 'pipeline'
+    });
+    set(this, 'selected', 2);
+    set(this, 'latestCommit', {
+      sha: 'latestSha'
+    });
+    set(this, 'startBuild', () => {
+      assert.ok(true);
+    });
+    set(this, 'currentEventType', 'pipeline');
+    set(this, 'showDownstreamTriggers', false);
+    set(this, 'setDownstreamTrigger', () => {
+      assert.ok(true);
+    });
+    set(this, 'setShowListView', () => {
+      assert.ok(true);
+    });
+
+    await render(hbs`{{pipeline-graph-nav
+      mostRecent=3
+      latestCommit=latestCommit
+      lastSuccessful=2
+      selectedEvent=2
+      selectedEventObj=obj
+      selected=selected
+      startMainBuild=startBuild
+      startPRBuild=startBuild
+      graphType=currentEventType
+      showDownstreamTriggers=showDownstreamTriggers
+      setDownstreamTrigger=setDownstreamTrigger
+      setShowListView=setShowListView
+    }}`);
+
+    assert.dom('.latest-commit').exists({ count: 1 });
   });
 });


### PR DESCRIPTION
## Context
If user select the latestCommit event, mark the SHA of `pipeline-graph-nav` to indicate that it is the latestCommit event.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
In the event list, the latestCommit is shown with a blue background, and the pipeline-graph-nav will show the same mark.
<img width="600" src="https://user-images.githubusercontent.com/24538326/120611059-be2dba00-c48e-11eb-83c9-8c265937ec67.png">

## References
The `.status` class in CSS resets each parameter because we don't want [them](https://github.com/screwdriver-cd/ui/blob/457f2c1cf18b8a870cf7f380d6366eaaadb2bbbd/app/styles/column-view.scss#L44-L48) to be used.
https://github.com/screwdriver-cd/ui/pull/717/files#diff-c77f1fdf1df50bb4b96a45c80dcd5838d188057a59650a0a25dd187762215425R16-R21

https://github.com/screwdriver-cd/screwdriver/issues/2168
https://github.com/screwdriver-cd/ui/pull/654

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
