### PR TITLE
fix(466): add error catch to log fetch

### DIFF
--- a/app/build-logs/service.js
+++ b/app/build-logs/service.js
@@ -55,7 +55,11 @@ export default Service.extend({
             }
             done = started && jqXHR.getResponseHeader('x-more-data') === 'false';
           })
-          .catch(() => [])
+          .catch(error => {
+            if (error.jqXHR && (error.jqXHR.status === 403 || error.jqXHR.status === 404)) {
+              done = true;
+            }
+          })
           // always resolve something
           .finally(() => {
             this.setCache(buildId, stepName, { done });

--- a/app/build-logs/service.js
+++ b/app/build-logs/service.js
@@ -56,7 +56,7 @@ export default Service.extend({
             done = started && jqXHR.getResponseHeader('x-more-data') === 'false';
           })
           .catch(error => {
-            if (error.jqXHR && (error.jqXHR.status === 403 || error.jqXHR.status === 404)) {
+            if (error.jqXHR && [403, 404].includes(error.jqXHR.status)) {
               done = true;
             }
           })

--- a/tests/unit/build-logs/service-test.js
+++ b/tests/unit/build-logs/service-test.js
@@ -54,7 +54,7 @@ const noNewLogs = () => {
 
 const badLogs = () => {
   server.get('http://localhost:8080/v4/builds/1/steps/banana/logs/', () => [
-    404,
+    500,
     {
       'Content-Type': 'application/json'
     },


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
should catch 403/404 error in log fetch logic to prevent endless api calls
## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
add appropriate error catch
## References
https://github.com/screwdriver-cd/screwdriver/issues/466
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
