### PR TITLE
feat(2437): Support read-only SCM [7]

### DIFF
--- a/app/components/login-button/template.hbs
+++ b/app/components/login-button/template.hbs
@@ -9,9 +9,11 @@
 </p>
 
 {{#each scmContexts as |scmContext|}}
-  <p>
-    <a href="#authenticate"{{action "authenticate" scmContext.context}}>{{fa-icon "sign-in"}} Sign in with {{scmContext.displayName}}</a>
-  </p>
+  {{#unless scmContext.readOnly}}
+    <p>
+      <a href="#authenticate"{{action "authenticate" scmContext.context}}>{{fa-icon "sign-in"}} Sign in with {{scmContext.displayName}}</a>
+    </p>
+  {{/unless}}
 {{else}}
   <a href="#authenticate"{{action "authenticate"}}>{{fa-icon "sign-in"}} Sign in with SCM Provider</a>
 {{/each}}

--- a/app/scm/model.js
+++ b/app/scm/model.js
@@ -5,5 +5,6 @@ export default DS.Model.extend({
   displayName: DS.attr('string'),
   iconType: DS.attr('string'),
   isSignedIn: DS.attr('boolean', { defaultValue: false }),
-  autoDeployKeyGeneration: DS.attr('boolean', { defaultValue: false })
+  autoDeployKeyGeneration: DS.attr('boolean', { defaultValue: false }),
+  readOnly: DS.attr('boolean', { defaultValue: false })
 });

--- a/app/scm/service.js
+++ b/app/scm/service.js
@@ -59,7 +59,8 @@ export default Service.extend({
             displayName: scmContext.displayName,
             iconType: getIconType(scmContext.context),
             isSignedIn,
-            autoDeployKeyGeneration: scmContext.autoDeployKeyGeneration
+            autoDeployKeyGeneration: scmContext.autoDeployKeyGeneration,
+            readOnly: scmContext.readOnly || false
           });
         });
 
@@ -92,7 +93,8 @@ export default Service.extend({
           context: scm.get('context'),
           displayName: scm.get('displayName'),
           iconType: getIconType(scmContext),
-          autoDeployKeyGeneration: scm.get('autoDeployKeyGeneration')
+          autoDeployKeyGeneration: scm.get('autoDeployKeyGeneration'),
+          readOnly: scm.get('readOnly')
         };
       }
     });

--- a/tests/helpers/inject-scm.js
+++ b/tests/helpers/inject-scm.js
@@ -7,13 +7,22 @@ const scms = [
     displayName: 'github.com',
     iconType: 'github',
     autoDeployKeyGeneration: true,
-    isSignedIn: true
+    isSignedIn: true,
+    readOnly: false
   },
   {
     context: 'bitbucket:bitbucket.org',
     displayName: 'bitbucket.org',
     iconType: 'bitbucket',
-    isSignedIn: false
+    isSignedIn: false,
+    readOnly: false
+  },
+  {
+    context: 'gitlab:gitlab.com',
+    displayName: 'gitlab.com',
+    iconType: 'gitlab',
+    isSignedIn: false,
+    readOnly: true
   }
 ];
 

--- a/tests/integration/components/login-button/component-test.js
+++ b/tests/integration/components/login-button/component-test.js
@@ -36,9 +36,12 @@ module('Integration | Component | login button', function(hooks) {
     const a = findAll('a');
 
     contexts.forEach(async (context, i) => {
-      assert.dom(a[i]).hasText(`Sign in with ${context.displayName}`);
+      // Should skip showing read-only SCM logins
+      if (!context.readOnly) {
+        assert.dom(a[i]).hasText(`Sign in with ${context.displayName}`);
 
-      await click(a[i]);
+        await click(a[i]);
+      }
     });
   });
 });


### PR DESCRIPTION
## Context

Should not give option to login to read-only SCM.

## Objective

This PR:
- takes in readOnly flag and skips showing login option to read-only SCM

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2437

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
