### PR TITLE
fix(1584): pipeline title on a pr build page should link pr tab

### DIFF
--- a/app/components/build-banner/template.hbs
+++ b/app/components/build-banner/template.hbs
@@ -1,6 +1,10 @@
 <ul>
   <li class="job-name build-{{buildStatus}}">
-    {{#link-to "pipeline.events.show" pipelineId event.id (query-params jobId=jobId) classNames="banner-value"}}{{jobName}}{{/link-to}}
+    {{#if event.pr.url}}
+      {{#link-to "pipeline.pulls" pipelineId classNames="banner-value"}}{{jobName}}{{/link-to}}
+    {{else}}
+      {{#link-to "pipeline.events.show" pipelineId event.id (query-params jobId=jobId) classNames="banner-value"}}{{jobName}}{{/link-to}}
+    {{/if}}
     <span class="banner-label">Job</span>
   </li>
   <li class="commit">
@@ -41,7 +45,7 @@
       <li class="subsection"><span class="banner-value">{{imagePullDuration}} pulling image</span></li>
       <li class="subsection"><span class="banner-value">{{buildDuration}} in build</span></li>
     </details>
-    {{#link-to "pipeline.metrics" (query-params jobId=jobId)}}See build metrics{{/link-to}}
+    {{#link-to "pipeline.metrics" pipelineId (query-params jobId=jobId)}}See build metrics{{/link-to}}
     <span class="banner-label">Duration</span>
   </li>
   <li class="created">


### PR DESCRIPTION
## Context
If users click on the pipeline title link in the pr build details page, users will be get the events tab page, which should be the pr tab page.

https://cd.screwdriver.cd/pipelines/2539/builds/107009
<img width="500" src="https://user-images.githubusercontent.com/24538326/121456279-c7fc7380-c9e0-11eb-845d-13085bf61645.png">

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
For pr builds, fix the link destination of the pipeline title to `/pipelines/${pipelineId}/pulls`.
<!-- What does this PR fix? What intentional changes will this PR make? -->

I'd like to make it a permalink for a specific pr event, but since there is currently no permalink that selects a specific PR event, I've implemented just link to the pr tab page for now.

## References
https://github.com/screwdriver-cd/screwdriver/issues/1584
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
