### PR TITLE
fix(2458): Do not show option to remove pipelines from Default Collection

### DIFF
--- a/app/components/collection-table-row/component.js
+++ b/app/components/collection-table-row/component.js
@@ -12,6 +12,7 @@ export default Component.extend({
   lastEventInfo: null,
   isAuthenticated: false,
   isOrganizing: false,
+  isDefaultCollection: false,
   pipeline: null,
   pipelineSelected: false,
   reset: false,
@@ -24,9 +25,14 @@ export default Component.extend({
 
     return rootDir ? `${branch}#${rootDir}` : branch;
   }),
-  showRemoveButton: computed('isOrganizing', 'isAuthenticated', function showRemoveButton() {
-    return !this.isOrganizing && this.isAuthenticated;
-  }),
+  showRemoveButton: computed(
+    'isOrganizing',
+    'isAuthenticated',
+    'isDefaultCollection',
+    function showRemoveButton() {
+      return !this.isDefaultCollection && !this.isOrganizing && this.isAuthenticated;
+    }
+  ),
 
   didInsertElement() {
     if (!this.hasBothEventsAndLatestEventInfo) {

--- a/app/components/collection-view/component.js
+++ b/app/components/collection-view/component.js
@@ -76,6 +76,10 @@ export default Component.extend({
     return this.selectedPipelines.length > 0;
   }),
 
+  isDefaultCollection: computed('collection.type', function isDefaultCollection() {
+    return this.collection.type === 'default';
+  }),
+
   description: computed('collection', {
     get() {
       let description = this.get('collection.description');

--- a/app/components/collection-view/template.hbs
+++ b/app/components/collection-view/template.hbs
@@ -97,7 +97,9 @@
         {{#if isOrganizing}}
           {{#if showOperations}}
             <span>{{selectedPipelines.length}}&nbsp;&nbsp;Selected</span>
-            <BsButton class="operation-button" onclick={{action "removeSelectedPipelines"}}>Remove</BsButton>
+            {{#unless isDefaultCollection}}
+              <BsButton class="operation-button" onclick={{action "removeSelectedPipelines"}}>Remove</BsButton>
+            {{/unless}}
             {{collection-dropdown
                 class="copy-pipeline"
                 collections=collections
@@ -164,6 +166,7 @@
                   pipeline=pipeline
                   isAuthenticated=session.isAuthenticated
                   isOrganizing=isOrganizing
+                  isDefaultCollection=isDefaultCollection
                   selectPipeline=(action "selectPipeline")
                   deselectPipeline=(action "deselectPipeline")
                   reset=reset
@@ -182,6 +185,7 @@
               pipeline=pipeline
               isAuthenticated=session.isAuthenticated
               isOrganizing=isOrganizing
+              isDefaultCollection=isDefaultCollection
               selectPipeline=(action "selectPipeline")
               deselectPipeline=(action "deselectPipeline")
               reset=reset

--- a/app/components/pipeline-card/component.js
+++ b/app/components/pipeline-card/component.js
@@ -11,6 +11,7 @@ export default Component.extend({
   lastEventInfo: null,
   isAuthenticated: undefined,
   isOrganizing: false,
+  isDefaultCollection: false,
   pipeline: null,
   pipelineSelected: false,
   classNames: ['pipeline-card'],
@@ -24,9 +25,14 @@ export default Component.extend({
 
     return rootDir ? `${branch}#${rootDir}` : branch;
   }),
-  showRemoveButton: computed('isOrganizing', 'isAuthenticated', function showRemoveButton() {
-    return !this.isOrganizing && this.isAuthenticated;
-  }),
+  showRemoveButton: computed(
+    'isOrganizing',
+    'isAuthenticated',
+    'isDefaultCollection',
+    function showRemoveButton() {
+      return !this.isDefaultCollection && !this.isOrganizing && this.isAuthenticated;
+    }
+  ),
 
   didInsertElement() {
     if (!this.hasBothEventsAndLatestEventInfo) {

--- a/tests/integration/components/collection-view/component-test.js
+++ b/tests/integration/components/collection-view/component-test.js
@@ -116,6 +116,111 @@ const mockDefaultCollection = EmberObject.create({
   pipelineIds: [1, 2, 3, 4]
 });
 
+const mockNormalCollection = EmberObject.create({
+  id: 1,
+  name: 'My Pipelines',
+  description: 'Normal Collection',
+  type: 'normal',
+  pipelines: [
+    {
+      id: 1,
+      scmUri: 'github.com:12345678:master',
+      createTime: '2017-01-05T00:55:46.775Z',
+      admins: {
+        username: true
+      },
+      workflow: ['main'],
+      scmRepo: {
+        name: 'screwdriver-cd/screwdriver',
+        branch: 'master',
+        url: 'https://github.com/screwdriver-cd/screwdriver/tree/master'
+      },
+      scmContext: 'github:github.com',
+      annotations: {},
+      lastEventId: 12,
+      lastBuilds: [
+        {
+          id: 123,
+          status: 'SUCCESS',
+          // Most recent build
+          createTime: '2017-09-05T04:02:20.890Z'
+        }
+      ]
+    },
+    {
+      id: 2,
+      scmUri: 'github.com:87654321:master',
+      createTime: '2017-01-05T00:55:46.775Z',
+      admins: {
+        username: true
+      },
+      workflow: ['main', 'publish'],
+      scmRepo: {
+        name: 'screwdriver-cd/ui',
+        branch: 'master',
+        url: 'https://github.com/screwdriver-cd/ui/tree/master'
+      },
+      scmContext: 'github:github.com',
+      annotations: {},
+      prs: {
+        open: 2,
+        failing: 1
+      }
+    },
+    {
+      id: 3,
+      scmUri: 'github.com:54321876:master',
+      createTime: '2017-01-05T00:55:46.775Z',
+      admins: {
+        username: true
+      },
+      workflow: ['main'],
+      scmRepo: {
+        name: 'screwdriver-cd/models',
+        branch: 'master',
+        url: 'https://github.com/screwdriver-cd/models/tree/master'
+      },
+      scmContext: 'bitbucket:bitbucket.org',
+      annotations: {},
+      lastEventId: 23,
+      lastBuilds: [
+        {
+          id: 125,
+          status: 'FAILURE',
+          // 2nd most recent build
+          createTime: '2017-09-05T04:01:41.789Z'
+        }
+      ]
+    },
+    {
+      id: 4,
+      scmUri: 'github.com:54321879:master:lib',
+      createTime: '2017-01-05T00:55:46.775Z',
+      admins: {
+        username: true
+      },
+      workflow: ['main'],
+      scmRepo: {
+        name: 'screwdriver-cd/zzz',
+        branch: 'master',
+        url: 'https://github.com/screwdriver-cd/zzz/tree/master',
+        rootDir: 'lib'
+      },
+      scmContext: 'bitbucket:bitbucket.org',
+      annotations: {},
+      lastEventId: 23,
+      lastBuilds: [
+        {
+          id: 125,
+          status: 'UNSTABLE',
+          createTime: '2017-09-05T04:01:41.789Z'
+        }
+      ]
+    }
+  ],
+  pipelineIds: [1, 2, 3, 4]
+});
+
 const mockPipelines = [
   {
     id: 1,
@@ -220,6 +325,7 @@ module('Integration | Component | collection view', function(hooks) {
     this.owner.register('service:store', storeStub);
     this.setProperties({
       collection: mockDefaultCollection,
+      normalCollection: mockNormalCollection,
       collections: mockCollections,
       onRemovePipeline: onRemovePipelineSpy,
       addMultipleToCollection: addMultipleToCollectionSpy,
@@ -413,7 +519,7 @@ module('Integration | Component | collection view', function(hooks) {
         assert.strictEqual(model, 'collection');
         assert.strictEqual(id, 1);
 
-        return resolve(mockDefaultCollection);
+        return resolve(mockNormalCollection);
       }
     });
 
@@ -431,7 +537,7 @@ module('Integration | Component | collection view', function(hooks) {
 
     await render(hbs`
       {{collection-view
-        collection=collection
+        collection=normalCollection
         collections=collections
         metricsMap=metricsMap
         onRemovePipeline=onRemovePipeline
@@ -456,7 +562,7 @@ module('Integration | Component | collection view', function(hooks) {
         assert.strictEqual(model, 'collection');
         assert.strictEqual(id, 1);
 
-        return resolve(mockDefaultCollection);
+        return resolve(mockNormalCollection);
       }
     });
 
@@ -474,7 +580,7 @@ module('Integration | Component | collection view', function(hooks) {
 
     await render(hbs`
       {{collection-view
-        collection=collection
+        collection=normalCollection
         collections=collections
         metricsMap=metricsMap
         onRemovePipeline=onRemovePipeline
@@ -509,7 +615,7 @@ module('Integration | Component | collection view', function(hooks) {
 
     await render(hbs`
       {{collection-view
-        collection=collection
+        collection=normalCollection
         collections=collections
         metricsMap=metricsMap
         onRemovePipeline=onRemovePipeline
@@ -542,7 +648,7 @@ module('Integration | Component | collection view', function(hooks) {
 
     await render(hbs`
       {{collection-view
-        collection=collection
+        collection=normalCollection
         collections=collections
         metricsMap=metricsMap
         onRemovePipeline=onRemovePipeline
@@ -563,7 +669,7 @@ module('Integration | Component | collection view', function(hooks) {
 
     await render(hbs`
       {{collection-view
-        collection=collection
+        collection=normalCollection
         collections=collections
         metricsMap=metricsMap
         onRemovePipeline=onRemovePipeline
@@ -578,7 +684,7 @@ module('Integration | Component | collection view', function(hooks) {
 
     await render(hbs`
       {{collection-view
-        collection=collection
+        collection=normalCollection
         collections=collections
         metricsMap=metricsMap
         onRemovePipeline=onRemovePipeline
@@ -726,7 +832,7 @@ module('Integration | Component | collection view', function(hooks) {
         assert.strictEqual(model, 'collection');
         assert.strictEqual(id, 1);
 
-        return resolve(mockDefaultCollection);
+        return resolve(mockNormalCollection);
       }
     });
 
@@ -744,7 +850,7 @@ module('Integration | Component | collection view', function(hooks) {
 
     await render(hbs`
       {{collection-view
-        collection=collection
+        collection=normalCollection
         collections=collections
         metricsMap=metricsMap
         removeMultiplePipelines=removeMultiplePipelines
@@ -779,7 +885,7 @@ module('Integration | Component | collection view', function(hooks) {
         assert.strictEqual(model, 'collection');
         assert.strictEqual(id, 1);
 
-        return resolve(mockDefaultCollection);
+        return resolve(mockNormalCollection);
       }
     });
 
@@ -797,7 +903,7 @@ module('Integration | Component | collection view', function(hooks) {
 
     await render(hbs`
       {{collection-view
-        collection=collection
+        collection=normalCollection
         collections=collections
         metricsMap=metricsMap
         removeMultiplePipelines=removeMultiplePipelines
@@ -835,7 +941,7 @@ module('Integration | Component | collection view', function(hooks) {
         assert.strictEqual(model, 'collection');
         assert.strictEqual(id, 1);
 
-        return resolve(mockDefaultCollection);
+        return resolve(mockNormalCollection);
       }
     });
 
@@ -859,7 +965,7 @@ module('Integration | Component | collection view', function(hooks) {
 
     await render(hbs`
       {{collection-view
-        collection=collection
+        collection=normalCollection
         collections=collections
         metricsMap=metricsMap
         removeMultiplePipelines=removeMultiplePipelines
@@ -897,7 +1003,7 @@ module('Integration | Component | collection view', function(hooks) {
         assert.strictEqual(model, 'collection');
         assert.strictEqual(id, 1);
 
-        return resolve(mockDefaultCollection);
+        return resolve(mockNormalCollection);
       }
     });
 
@@ -921,7 +1027,7 @@ module('Integration | Component | collection view', function(hooks) {
 
     await render(hbs`
       {{collection-view
-        collection=collection
+        collection=normalCollection
         collections=collections
         metricsMap=metricsMap
         removeMultiplePipelines=removeMultiplePipelines


### PR DESCRIPTION
## Context

Should not show option to remove pipelines from Default collection.

## Objective

This PR adds logic to check if collection type is default or not and determine if it should show option to remove pipelines.

Now:
<img width="766" alt="Screen Shot 2021-06-10 at 2 19 49 PM" src="https://user-images.githubusercontent.com/3230529/121601092-503b4280-c9fa-11eb-92bc-ed927c27e79d.png">
<img width="1302" alt="Screen Shot 2021-06-10 at 2 20 01 PM" src="https://user-images.githubusercontent.com/3230529/121601103-55988d00-c9fa-11eb-85b5-00a2b7f8c27c.png">
<img width="1295" alt="Screen Shot 2021-06-10 at 2 20 14 PM" src="https://user-images.githubusercontent.com/3230529/121601113-59c4aa80-c9fa-11eb-9a41-f29cc22a2e28.png">


## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2458

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
