### PR TITLE
feat(2473): Add link to pipeline from template and command detail pages

### DIFF
--- a/app/components/collection-modal/component.js
+++ b/app/components/collection-modal/component.js
@@ -9,7 +9,7 @@ export default Component.extend({
   description: null,
   errorMessage: null,
   store: service(),
-  isSaveDisabled: computed('name', function() {
+  isSaveDisabled: computed('name', function isSaveDisabled() {
     return isEmpty(this.get('name'));
   }),
   actions: {

--- a/app/components/command-header/template.hbs
+++ b/app/components/command-header/template.hbs
@@ -1,8 +1,8 @@
 <h1>
   {{#if trusted}}<span title="Trusted">{{inline-svg "trusted" class="trusted"}}</span>{{/if}}
-  {{command.namespace}}/{{command.name}}
+  {{#link-to "pipeline" command.pipelineId title="Go to command pipeline"}}{{command.namespace}}/{{command.name}}{{/link-to}}
   {{#if scmUrl}}
-    <a href={{scmUrl}}>{{fa-icon "code-fork" title="Source code"}}</a>
+    <a href={{scmUrl}}> {{fa-icon "code-fork" title="Source code"}}</a>
   {{else}}
     {{fa-icon "code-fork" title="The pipeline for this command does not exist."}}
   {{/if}}

--- a/app/components/template-header/template.hbs
+++ b/app/components/template-header/template.hbs
@@ -1,8 +1,8 @@
 <h1>
   {{#if trusted}}<span title="Trusted">{{inline-svg "trusted" class="trusted"}}</span>{{/if}}
-  {{template.fullName}}
+  {{#link-to "pipeline" template.pipelineId title="Go to template pipeline"}}{{template.fullName}}{{/link-to}}
   {{#if scmUrl}}
-    <a href={{scmUrl}}>{{fa-icon "code-fork" title="Source code"}}</a>
+    <a href={{scmUrl}}> {{fa-icon "code-fork" title="Source code"}}</a>
   {{else}}
     {{fa-icon "code-fork" title="The pipeline for this template does not exist."}}
   {{/if}}

--- a/app/components/user-link/component.js
+++ b/app/components/user-link/component.js
@@ -5,7 +5,7 @@ import ENV from 'screwdriver-ui/config/environment';
 export default Component.extend({
   classNameBindings: ['large'],
 
-  showAvatar: computed(function() {
+  showAvatar: computed(function showAvatar() {
     return ENV.APP.SHOW_AVATAR === true;
   })
 });


### PR DESCRIPTION
## Context

Would be nice if users could go directly to the pipeline page that publishes a particular command or template.

## Objective

This PR adds a link to the pipeline page from the command/template detail page.

Before:
<img width="496" alt="Screen Shot 2021-06-10 at 4 47 46 PM" src="https://user-images.githubusercontent.com/3230529/121610776-9baa1c80-ca0b-11eb-807f-6a69b9e4449e.png">

After:
<img width="593" alt="Screen Shot 2021-06-10 at 4 36 43 PM" src="https://user-images.githubusercontent.com/3230529/121610675-656c9d00-ca0b-11eb-8562-35c1a45d1749.png">


## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2473

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
