### PR TITLE
fix(2437): Show scm icon in child pipelines list

### DIFF
--- a/app/components/pipeline-list/template.hbs
+++ b/app/components/pipeline-list/template.hbs
@@ -11,6 +11,7 @@
         <tr>
           <th class="appId">Name</th>
           <th class="branch">Branch</th>
+          <th class="account">Account</th>
         </tr>
       </thead>
       <tbody>
@@ -18,6 +19,7 @@
           <tr>
             <td class="appId">{{#highlight-terms query}}{{#link-to "pipeline" pipeline.id}}{{pipeline.appId}}{{/link-to}}{{/highlight-terms}}</td>
             <td class="branch"><a href={{branch-url-encode pipeline.hubUrl}}>{{fa-icon "code-fork"}}{{pipeline.branch}}</a></td>
+            <td class="account">{{fa-icon pipeline.scmIcon}} {{pipeline.scm}}</td>
           </tr>
         {{/each}}
       </tbody>

--- a/app/pipeline/child-pipelines/controller.js
+++ b/app/pipeline/child-pipelines/controller.js
@@ -1,9 +1,25 @@
 import Controller from '@ember/controller';
+import { computed } from '@ember/object';
 import { reads } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 
 export default Controller.extend({
   session: service(),
-  pipelines: reads('model.pipelines'),
+  scmService: service('scm'),
+  pipelines: computed('model.pipelines', {
+    get() {
+      let pipelines = this.get('model.pipelines');
+
+      // add scm contexts into pipelines.
+      return pipelines.map(pipeline => {
+        const scm = this.scmService.getScm(pipeline.get('scmContext'));
+
+        pipeline.set('scm', scm.displayName);
+        pipeline.set('scmIcon', scm.iconType);
+
+        return pipeline;
+      });
+    }
+  }),
   pipeline: reads('model.pipeline')
 });

--- a/app/pipeline/child-pipelines/template.hbs
+++ b/app/pipeline/child-pipelines/template.hbs
@@ -2,6 +2,6 @@
   {{pipeline-nav pipeline=pipeline}}
 {{/if}}
 
-{{pipeline-list pipelines=pipelines pipeline=pipeline}}
+{{pipeline-list pipelines=pipelines}}
 
 {{outlet}}


### PR DESCRIPTION
## Context

It would be nice if we show the SCM icon in the child pipelines list page.

## Objective

This PR adds SCM icon to child pipelines list page.

Before:
<img width="1106" alt="Screen Shot 2021-06-16 at 7 16 53 PM" src="https://user-images.githubusercontent.com/3230529/122320814-b4b54080-ced7-11eb-942c-48eef1ef69e5.png">

After:
<img width="1123" alt="Screen Shot 2021-06-16 at 7 16 28 PM" src="https://user-images.githubusercontent.com/3230529/122320817-b7179a80-ced7-11eb-9aae-b201e2c792ff.png">

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2437

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
