### PR TITLE
fix(2437): Pass pipeline info for startAll

### DIFF
--- a/app/pipeline/child-pipelines/template.hbs
+++ b/app/pipeline/child-pipelines/template.hbs
@@ -2,6 +2,6 @@
   {{pipeline-nav pipeline=pipeline}}
 {{/if}}
 
-{{pipeline-list pipelines=pipelines}}
+{{pipeline-list pipelines=pipelines pipeline=pipeline}}
 
 {{outlet}}


### PR DESCRIPTION
## Context

Start all for child pipelines is broken.

## Objective

This PR fixes start all issue.

## References

Revert bug introduced here: https://github.com/screwdriver-cd/ui/pull/726/files#diff-dbbb3f911563899c5256112ad1356a64e66126d69c689a04370bdb5252e26087L5
Related to https://github.com/screwdriver-cd/screwdriver/issues/2437

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
