### PR TITLE
fix(2437): Do not show read-only account for login dropdown

### DIFF
--- a/app/components/app-header/template.hbs
+++ b/app/components/app-header/template.hbs
@@ -110,15 +110,17 @@
             {{#dd.menu as |ddm|}}
               {{#ddm.item}}<span class="title">ACCOUNTS</span>{{/ddm.item}}
               {{#each scmContexts as |scmContext|}}
-                {{#ddm.item}}
-                  {{#if scmContext.isSignedIn}}
-                    <a class="active">{{fa-icon scmContext.iconType}} {{scmContext.displayName}} <span>active</span></a>
-                  {{else}}
-                    <a href="#authenticate"{{action "authenticate" scmContext.context}}>
-                      {{fa-icon scmContext.iconType}} {{scmContext.displayName}}
-                    </a>
-                  {{/if}}
-                {{/ddm.item}}
+                {{#unless scmContext.readOnly}}
+                  {{#ddm.item}}
+                    {{#if scmContext.isSignedIn}}
+                      <a class="active">{{fa-icon scmContext.iconType}} {{scmContext.displayName}} <span>active</span></a>
+                    {{else}}
+                      <a href="#authenticate"{{action "authenticate" scmContext.context}}>
+                        {{fa-icon scmContext.iconType}} {{scmContext.displayName}}
+                      </a>
+                    {{/if}}
+                  {{/ddm.item}}
+                {{/unless}}
               {{/each}}
               {{ddm.divider}}
               {{#if (not session.data.authenticated.isGuest)}}


### PR DESCRIPTION
## Context

We should not show option to login to read-only accounts from dropdown.

## Objective

This PR removes read-only SCM from accounts dropdown.

Before:
<img width="191" alt="Screen Shot 2021-06-22 at 12 04 49 AM" src="https://user-images.githubusercontent.com/3230529/122879775-1e758600-d2ee-11eb-8fb5-d6a7f1fb7236.png">

After:
<img width="192" alt="Screen Shot 2021-06-22 at 12 04 09 AM" src="https://user-images.githubusercontent.com/3230529/122879790-21707680-d2ee-11eb-9698-b079b85740be.png">

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2437

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
