### PR TITLE
fix: start detached job from workflowGraph

### DIFF
--- a/app/pipeline/events/controller.js
+++ b/app/pipeline/events/controller.js
@@ -56,13 +56,11 @@ export async function startDetachedBuild(job, options = {}) {
     const build = this.store.peekRecord('build', buildId);
 
     parentBuildId = get(build, 'parentBuildId');
-  } else {
+  } else if (event === undefined) {
     const builds = await get(job, 'builds');
     const latestBuild = get(builds, 'firstObject');
 
-    if (event === undefined) {
-      event = await this.store.findRecord('event', get(latestBuild, 'eventId'));
-    }
+    event = await this.store.findRecord('event', get(latestBuild, 'eventId'));
   }
 
   const parentEventId = get(event, 'id');


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
PR https://github.com/screwdriver-cd/ui/pull/716 fixed restart jobs from job list view, but introduced a new bug from starting detached jobs in workflow-graph view.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
This PR fix start detached jobs from workflow-graph view

Fixes https://github.com/screwdriver-cd/screwdriver/issues/2489

https://github.com/screwdriver-cd/ui/commit/186b2cf44ef22e68eef660d7985c47b2076b0680

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
