### PR TITLE
feat(#2451): Add latest-commit class on pipeline modal sha

### DIFF
--- a/app/components/pipeline-workflow/template.hbs
+++ b/app/components/pipeline-workflow/template.hbs
@@ -33,7 +33,10 @@
       <h3>Are you sure to start?</h3>
       <p>
         Job: <code>{{tooltipData.job.name}}</code><br>
-        Commit:<a href={{selectedEventObj.commit.url}}><code>{{selectedEventObj.truncatedMessage}}</code>({{selectedEventObj.truncatedSha}})</a>
+        Commit:<code>{{selectedEventObj.truncatedMessage}}</code>
+        <a class={{if (eq selectedEventObj.sha latestCommit.sha) "latest-commit"}} href={{selectedEventObj.commit.url}}>
+          #{{selectedEventObj.truncatedSha}}
+        </a>
       </p>
       {{#if (eq tooltipData.job.status "FROZEN")}}
         {{#if (get-length tooltipData.selectedEvent.meta.parameters)}}

--- a/app/pipeline/events/template.hbs
+++ b/app/pipeline/events/template.hbs
@@ -33,6 +33,7 @@
     {{pipeline-workflow
       jobId=jobId
       pipeline=pipeline
+      latestCommit=latestCommit
       showDownstreamTriggers=showDownstreamTriggers
       showPRJobs=showPRJobs
       completeWorkflowGraph=completeWorkflowGraph

--- a/tests/integration/components/pipeline-workflow/component-test.js
+++ b/tests/integration/components/pipeline-workflow/component-test.js
@@ -147,4 +147,54 @@ module('Integration | Component | pipeline workflow', function(hooks) {
     assert.dom('.graph-node.build-frozen').exists({ count: 1 });
     assert.dom('.workflow-tooltip').exists({ count: 1 });
   });
+
+  test('it renders with latest-commit', async function(assert) {
+    this.set(
+      'obj',
+      EmberObject.create({
+        builds: rsvp.resolve(BUILDS),
+        workflowGraph: GRAPH,
+        startFrom: '~commit',
+        causeMessage: 'test',
+        sha: 'abc123'
+      })
+    );
+    this.set(
+      'latestCommit',
+      EmberObject.create({
+        sha: 'abc123'
+      })
+    );
+
+    await render(
+      hbs`{{pipeline-workflow selectedEventObj=obj latestCommit=latestCommit graph=graph showPRJobs=true isShowingModal=true}}`
+    );
+
+    assert.dom('.latest-commit').exists({ count: 1 });
+  });
+
+  test('it renders without latest-commit', async function(assert) {
+    this.set(
+      'obj',
+      EmberObject.create({
+        builds: rsvp.resolve(BUILDS),
+        workflowGraph: GRAPH,
+        startFrom: '~commit',
+        causeMessage: 'test',
+        sha: 'abc123'
+      })
+    );
+    this.set(
+      'latestCommit',
+      EmberObject.create({
+        sha: 'efg456'
+      })
+    );
+
+    await render(
+      hbs`{{pipeline-workflow selectedEventObj=obj latestCommit=latestCommit graph=graph showPRJobs=true isShowingModal=true}}`
+    );
+
+    assert.dom('.latest-commit').doesNotExist();
+  });
 });


### PR DESCRIPTION
## Context

Solve the issue https://github.com/screwdriver-cd/screwdriver/issues/2451

## Objective

Fixed SHA displayed on restart to be highlighted in blue to make it easier to see that it is the latest commit

When latest commit:

![latest_commit_mod](https://user-images.githubusercontent.com/43719835/124235505-47004a00-db50-11eb-8f67-bb96d45b91c5.jpg)

When NOT latest commit:

![not_latest_commit_mod](https://user-images.githubusercontent.com/43719835/124235529-4c5d9480-db50-11eb-9331-f5ed13f2a320.jpg)

## References

https://github.com/screwdriver-cd/screwdriver/issues/2451

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
