### PR TITLE
WIP: Cleanup warnings

### DIFF
--- a/app/commands/controller.js
+++ b/app/commands/controller.js
@@ -13,6 +13,9 @@ export default Controller.extend({
       );
 
       return params;
+    },
+    set(key, value) {
+      return value;
     }
   }),
   crumbs: computed('routeParams', {

--- a/app/pipeline/events/controller.js
+++ b/app/pipeline/events/controller.js
@@ -339,6 +339,9 @@ export default Controller.extend(ModelReloaderMixin, {
       }
 
       return [];
+    },
+    set(key, value) {
+      return value;
     }
   }),
   events: computed('pipelineEvents', 'prEvents', 'currentEventType', {
@@ -390,6 +393,11 @@ export default Controller.extend(ModelReloaderMixin, {
   selectedEvent: computed('selected', 'mostRecent', {
     get() {
       return this.selected || this.mostRecent;
+    },
+    set(key, value) {
+      this.set('selected', value.id);
+
+      return value;
     }
   }),
 
@@ -398,6 +406,12 @@ export default Controller.extend(ModelReloaderMixin, {
       const selected = this.selectedEvent;
 
       return this.events.find(e => get(e, 'id') === selected);
+    },
+    set(key, value) {
+      this.set('selected', value.id);
+      this.set('selectedEvent', value.id);
+
+      return value;
     }
   }),
 

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "ember-sinon": "^5.0.0",
     "ember-sinon-qunit": "^5.0.0",
     "ember-source": "~3.16.0",
-    "ember-toggle": "^5.3.3",
+    "ember-toggle": "^7.1.1",
     "ember-truth-helpers": "^2.1.0",
     "eslint": "^5.16.0",
     "eslint-config-prettier": "^5.1.0",

--- a/tests/integration/components/validator-pipeline/component-test.js
+++ b/tests/integration/components/validator-pipeline/component-test.js
@@ -15,7 +15,7 @@ module('Integration | Component | validator pipeline', function(hooks) {
     assert.dom('.annotations ul li').hasText('None defined');
 
     assert.dom('.workflow .label').hasText('Workflow:');
-    assert.ok(this.$('.workflow canvas'), 'workflow canvas');
+    assert.ok(this.element.querySelectorAll('.workflow canvas'), 'workflow canvas');
   });
 
   test('it renders pipeline annotations and workflow', async function(assert) {
@@ -34,6 +34,6 @@ module('Integration | Component | validator pipeline', function(hooks) {
     assert.dom('.annotations ul li').hasText('hello: hi');
 
     assert.dom('.workflow .label').hasText('Workflow:');
-    assert.ok(this.$('.workflow canvas'), 'workflow canvas');
+    assert.ok(this.element.querySelectorAll('.workflow canvas'), 'workflow canvas');
   });
 });

--- a/tests/unit/instance-initializers/supplementary-config-test.js
+++ b/tests/unit/instance-initializers/supplementary-config-test.js
@@ -3,6 +3,7 @@ import { run } from '@ember/runloop';
 import { initialize } from 'screwdriver-ui/instance-initializers/supplementary-config';
 import { module, test } from 'qunit';
 import ENV from 'screwdriver-ui/config/environment';
+import Resolver from 'ember-resolver';
 const NAMESPACE = ENV.APP.SDAPI_NAMESPACE;
 const HOSTNAME = ENV.APP.SDAPI_HOSTNAME;
 const { SDDOC_URL, SLACK_URL } = ENV.APP;
@@ -10,7 +11,7 @@ const { SDDOC_URL, SLACK_URL } = ENV.APP;
 module('Unit | Instance Initializer | supplementary config', function(hooks) {
   hooks.beforeEach(function() {
     run(() => {
-      this.TestApplication = Application.extend();
+      this.TestApplication = Application.extend({ Resolver });
       this.application = this.TestApplication.create({ autoboot: false });
       this.appInstance = this.application.buildInstance();
       delete window.SUPPLEMENTARY_CONFIG;


### PR DESCRIPTION
## Context

UI tests have lots of ember & sinon.js warnings on deprecated function usage

## Objective

Cleanup Deprecated warnings

## References

https://github.com/screwdriver-cd/screwdriver/issues/2493

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
