### PR TITLE
fix: Add exact start date in pr view

### DIFF
--- a/app/build/model.js
+++ b/app/build/model.js
@@ -1,5 +1,6 @@
 import { computed } from '@ember/object';
 import DS from 'ember-data';
+import { toCustomLocaleString } from 'screwdriver-ui/utils/time-range';
 
 /**
  * Calulate ms difference between two times
@@ -74,6 +75,17 @@ export default DS.Model.extend({
       return `${dt} ago`;
     }
   }),
+  createTimeExact: computed('createTime', {
+    get() {
+      if (this.createTime) {
+        let dateTime = this.createTime.getTime();
+
+        return `${toCustomLocaleString(new Date(dateTime))}`;
+      }
+
+      return '';
+    }
+  }),
   endTimeWords: computed('endTime', {
     get() {
       if (!this.endTime) {
@@ -81,6 +93,17 @@ export default DS.Model.extend({
       }
 
       return `${durationText.call(this, 'endTime', 'now')} ago`;
+    }
+  }),
+  endTimeExact: computed('endTime', {
+    get() {
+      if (this.endTime) {
+        let dateTime = this.endTime.getTime();
+
+        return `${toCustomLocaleString(new Date(dateTime))}`;
+      }
+
+      return null;
     }
   }),
   // Queue time and blocked time are merged into blockedDuration

--- a/app/components/pipeline-pr-list/template.hbs
+++ b/app/components/pipeline-pr-list/template.hbs
@@ -13,7 +13,7 @@
         <br>
         <span class="title">{{jobs.0.title}}</span>
       </div>
-      <div class="date greyOut">Opened {{jobs.0.createTimeWords}}</div>
+      <div class="date greyOut">Opened {{jobs.0.createTimeExact}}</div>
       <div class="by"><a href={{jobs.0.userProfile}} target="_blank" rel="noopener">{{jobs.0.username}}</a></div>
       {{#if showJobs }}
         {{#each jobs as |job|}}

--- a/app/components/pipeline-pr-view/template.hbs
+++ b/app/components/pipeline-pr-view/template.hbs
@@ -7,10 +7,10 @@
       {{else}}
         <span class="greyOut">{{displayName}}</span>
       {{/if}}
-      {{#if build.endTimeWords}}
-        <div class="date greyOut">Finished {{build.endTimeWords}}</div>
-      {{else if build.startTimeWords}}
-        <div class="date greyOut">Started {{build.startTimeWords}}</div>
+      {{#if build.endTimeExact}}
+        <div class="date greyOut">Finished {{build.endTimeExact}}</div>
+      {{else if build.startTimeExact}}
+        <div class="date greyOut">Started {{build.startTimeExact}}</div>
       {{/if}}
     </div>
   </div>

--- a/app/job/model.js
+++ b/app/job/model.js
@@ -2,6 +2,7 @@ import { computed, get } from '@ember/object';
 import { alias, equal, match } from '@ember/object/computed';
 import DS from 'ember-data';
 import ENV from 'screwdriver-ui/config/environment';
+import { toCustomLocaleString } from 'screwdriver-ui/utils/time-range';
 import { isActiveBuild } from 'screwdriver-ui/utils/build';
 import { SHOULD_RELOAD_NO, SHOULD_RELOAD_YES } from '../mixins/model-reloader';
 
@@ -37,6 +38,17 @@ export default DS.Model.extend({
       const duration = Date.now() - +this.createTime;
 
       return `${humanizeDuration(duration, { round: true, largest: 1 })} ago`;
+    }
+  }),
+  createTimeExact: computed('createTime', {
+    get() {
+      if (get(this, 'createTime')) {
+        let dateTime = get(this, 'createTime').getTime();
+
+        return `${toCustomLocaleString(new Date(dateTime))}`;
+      }
+
+      return '';
     }
   }),
   prParentJobId: DS.attr('string'),

--- a/tests/integration/components/pipeline-pr-view/component-test.js
+++ b/tests/integration/components/pipeline-pr-view/component-test.js
@@ -12,13 +12,15 @@ module('Integration | Component | pipeline pr view', function(hooks) {
       id: 'abcd',
       name: 'PR-1234:main',
       createTimeWords: 'now',
+      createTimeExact: '06/03/2021, 10:04 PM',
       title: 'update readme',
       username: 'anonymous',
       builds: [
         {
           id: '1234',
           status: 'SUCCESS',
-          startTimeWords: 'now'
+          startTimeWords: 'now',
+          startTimeExact: '06/03/2021, 10:04 PM'
         }
       ]
     });
@@ -47,9 +49,9 @@ module('Integration | Component | pipeline pr view', function(hooks) {
       find('.detail')
         .textContent.trim()
         .replace(/\s{2,}/g, ' '),
-      'myname Started now'
+      'myname Started 06/03/2021, 10:04 PM'
     );
-    assert.dom('.date').hasText('Started now');
+    assert.dom('.date').hasText('Started 06/03/2021, 10:04 PM');
     assert.dom('.status .fa-check-circle-o').exists({ count: 1 });
   });
 
@@ -59,13 +61,15 @@ module('Integration | Component | pipeline pr view', function(hooks) {
       id: 'abcd',
       name: 'PR-1234:main',
       createTimeWords: 'now',
+      createTimeExact: '06/03/2021, 10:04 PM',
       title: 'update readme',
       username: 'anonymous',
       builds: [
         {
           id: '1234',
           status: 'UNSTABLE',
-          startTimeWords: 'now'
+          startTimeWords: 'now',
+          startTimeExact: '06/03/2021, 10:04 PM'
         }
       ]
     });
@@ -98,13 +102,15 @@ module('Integration | Component | pipeline pr view', function(hooks) {
       id: 'abcd',
       name: 'PR-1234:main',
       createTimeWords: 'now',
+      createTimeExact: '06/03/2021, 10:04 PM',
       title: 'update readme',
       username: 'anonymous',
       builds: [
         {
           id: '1234',
           status: 'FAILURE',
-          startTimeWords: 'now'
+          startTimeWords: 'now',
+          startTimeExact: '06/03/2021, 10:04 PM'
         }
       ]
     });
@@ -137,13 +143,15 @@ module('Integration | Component | pipeline pr view', function(hooks) {
       id: 'abcd',
       name: 'PR-1234:main',
       createTimeWords: 'now',
+      createTimeExact: '06/03/2021, 10:04 PM',
       title: 'update readme',
       username: 'anonymous',
       builds: [
         {
           id: '1234',
           status: 'QUEUED',
-          startTimeWords: 'now'
+          startTimeWords: 'now',
+          startTimeExact: '06/03/2021, 10:04 PM'
         }
       ]
     });
@@ -176,13 +184,15 @@ module('Integration | Component | pipeline pr view', function(hooks) {
       id: 'abcd',
       name: 'PR-1234:main',
       createTimeWords: 'now',
+      createTimeExact: '06/03/2021, 10:04 PM',
       title: 'update readme',
       username: 'anonymous',
       builds: [
         {
           id: '1234',
           status: 'RUNNING',
-          startTimeWords: 'now'
+          startTimeWords: 'now',
+          startTimeExact: '06/03/2021, 10:04 PM'
         }
       ]
     });


### PR DESCRIPTION
## Context

Exact “Start Date” is not available on PR View page, only English approximation, so can’t easily compare against other events

## Objective

Show Exact Date Time in MM/DD/YYYY hh:mm AM/PM format for Start Date on Pr list View

## References

This PR is a part of following:
https://github.com/screwdriver-cd/ui/pull/731

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
