### PR TITLE
fix(2360): fix template/command breadcrumbs

### DIFF
--- a/app/commands/route.js
+++ b/app/commands/route.js
@@ -8,7 +8,7 @@ export default Route.extend(AuthenticatedRouteMixin, {
   },
   actions: {
     willTransition(transition) {
-      let newParams = transition.params[transition.targetName];
+      let newParams = transition.to.params;
 
       this.controller.set('routeParams', newParams);
     }

--- a/app/templates/route.js
+++ b/app/templates/route.js
@@ -8,7 +8,7 @@ export default Route.extend(AuthenticatedRouteMixin, {
   },
   actions: {
     willTransition(transition) {
-      let newParams = transition.params[transition.targetName];
+      let newParams = transition.to.params;
 
       this.controller.set('routeParams', newParams);
     }


### PR DESCRIPTION
## Context
[willTransition](https://github.com/sonic-screwdriver-cd/ui/blob/723a7e8e89e40e8f36d69e24a1babf49a0fa3944/app/templates/route.js#L10) always throws an error because the value of `transition.params` is undefined. So template/command breadcrumbs do not work as expected.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
This PR fixes `willTransition`. We set `transition.to.params` as `newParams` which has the information of the destination url. As a result, The breadcrumbs work correctly when we click the button pointed to in the image below. 

<img width="814" alt="Template" src="https://user-images.githubusercontent.com/22903716/127425023-333a72f2-0d7f-41de-87b2-764505372452.png">

However, if we specify the namespace from the following button, the breadcrumb will not appear.

<img width="843" alt="Template-2" src="https://user-images.githubusercontent.com/22903716/127426503-71e76217-cb0a-4efe-8c3e-1e862f9dea73.png">

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/screwdriver/issues/2360
https://api.emberjs.com/ember/3.27/classes/Transition/properties/to?anchor=to
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
