### PR TITLE
fix(2459): Redirect if event pipelineId not match route pipelineId

### DIFF
--- a/app/pipeline/events/show/route.js
+++ b/app/pipeline/events/show/route.js
@@ -27,6 +27,16 @@ export default class PipelineEventsShowRoute extends Route {
     }
   }
 
+  async beforeModel() {
+    const { event_id: eventId } = this.paramsFor(this.routeName);
+    const event = await this.store.findRecord('event', eventId);
+    const { pipeline_id: pipelineId } = this.paramsFor('pipeline');
+
+    if (event.get('pipelineId') !== pipelineId) {
+      this.transitionTo('pipeline', pipelineId);
+    }
+  }
+
   async setupController(controller, model) {
     super.setupController(controller, model);
 

--- a/tests/mock/events.js
+++ b/tests/mock/events.js
@@ -23,7 +23,7 @@ const events = [
       url: 'http://example.com/u/batman'
     },
     startFrom: '~commit',
-    pipelineId: '12345',
+    pipelineId: '4',
     groupEventId: '23452',
     sha: 'abcdef1029384',
     type: 'pipeline',
@@ -56,7 +56,7 @@ const events = [
     pr: {
       url: 'http://example.com/batcave/batmobile/pulls/42'
     },
-    pipelineId: '12345',
+    pipelineId: '4',
     groupEventId: '23453',
     type: 'pr',
     prNum: 42,
@@ -90,7 +90,7 @@ const events = [
     pr: {
       url: 'http://example.com/batcave/batmobile/pulls/43'
     },
-    pipelineId: '12345',
+    pipelineId: '4',
     groupEventId: '23454',
     sha: '1030384bbb',
     type: 'pr',


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
When users access `/pipelines/PIPELINE_ID_A/events/EVENT_ID_B` and `EVENT_ID_B` is not `PIPELINE_ID_A`'s event, UI should redirect to a generic endpoint for `PIPELINE_ID_A`.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Verifies in beforeModel phase whether event's pipelineId matches param pipelineId or not.
When id does not match, UI redirect to a generic endpoint for param pipelineId.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
screwdriver-cd/screwdriver#2459

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
