### PR TITLE
fix: UI improvements - remove graph navigation toggle for chainPR

### DIFF
--- a/app/components/pipeline-graph-nav/template.hbs
+++ b/app/components/pipeline-graph-nav/template.hbs
@@ -46,9 +46,7 @@
     <div class="col-xs-3">
       {{#if session.isAuthenticated}}
         {{#if (not-eq selectedEventObj.type "pr")}}
-          {{#if (not selectedEventObj.isRunning)}}
-            {{pipeline-start startBuild=(action startMainBuild) pipeline=pipeline}}
-          {{/if}}
+          {{pipeline-start startBuild=(action startMainBuild) pipeline=pipeline}}
         {{/if}}
       {{/if}}
     </div>

--- a/app/components/pipeline-graph-nav/template.hbs
+++ b/app/components/pipeline-graph-nav/template.hbs
@@ -1,17 +1,19 @@
 {{#if showGraphNavRow}}
   <div class="row">
 
-    <div class="col-xs-2">
-      {{#bs-button-group
-              class="view-toggle"
-              value=showListView
-              type="radio"
-              onChange=(action setShowListView) as |bg|
-      }}
-        {{#bg.button value=false}}{{fa-icon "th"}}{{/bg.button}}
-        {{#bg.button value=true}}{{fa-icon "th-list"}}{{/bg.button}}
-      {{/bs-button-group}}
-    </div>
+    {{#if (not isPR)}}
+      <div class="col-xs-2">
+        {{#bs-button-group
+                class="view-toggle"
+                value=showListView
+                type="radio"
+                onChange=(action setShowListView) as |bg|
+        }}
+          {{#bg.button value=false}}{{fa-icon "th"}}{{/bg.button}}
+          {{#bg.button value=true}}{{fa-icon "th-list"}}{{/bg.button}}
+        {{/bs-button-group}}
+      </div>
+    {{/if}}
 
     <div class="col-xs-4">
       {{#if isPR}}
@@ -28,17 +30,19 @@
         {{/each}}
       {{/bs-button-group}}
     </div>
-    <div class="col-xs-3" title="Toggle to {{if showDownstreamTriggers "hide" "show"}} the downstream trigger nodes.">
-      {{x-toggle
-        size="medium"
-        theme="material"
-        showLabels=true
-        value=showDownstreamTriggers
-        offLabel="Hide triggers"
-        onLabel="Show triggers"
-        onToggle=(action setDownstreamTrigger)
-      }}
-    </div>
+    {{#if (not isPR)}}
+      <div class="col-xs-3" title="Toggle to {{if showDownstreamTriggers "hide" "show"}} the downstream trigger nodes.">
+        {{x-toggle
+          size="medium"
+          theme="material"
+          showLabels=true
+          value=showDownstreamTriggers
+          offLabel="Hide triggers"
+          onLabel="Show triggers"
+          onToggle=(action setDownstreamTrigger)
+        }}
+      </div>
+    {{/if}}
     <div class="col-xs-3">
       {{#if session.isAuthenticated}}
         {{#if (not-eq selectedEventObj.type "pr")}}

--- a/tests/integration/components/pipeline-graph-nav/component-test.js
+++ b/tests/integration/components/pipeline-graph-nav/component-test.js
@@ -167,7 +167,7 @@ module('Integration | Component | pipeline graph nav', function (hooks) {
     }}`);
 
     assert.dom('.row strong').hasText('Pull Requests');
-    assert.dom('.row button').exists({ count: 4 });
+    assert.dom('.row button').exists({ count: 2 });
   });
 
   test('it renders when selectedEvent is a skipped event', async function (assert) {


### PR DESCRIPTION
## Context

When a chainPR event is selected, the graph navigation area shows 

1. A toggle button for Show/Hide Trigger 
2. A toggle button to see events in grid/list view when 

Which are not useful for chainPR events. 

Also, Start Button in top left of graph navigation is hidden when a selected event is running. Start button should always be shown to create new events irrespective of the current running event.

## Objective

1. Hide Toggle buttons on Graph nav header when chainPR event is selected.
2. Always show Start button for new events 

## References

A part of this PR:
https://github.com/screwdriver-cd/ui/pull/742

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.