### PR TITLE
feat: Unify display for chainPR and non-chainPR Pull requests

### DIFF
--- a/app/components/pipeline-event-row/component.js
+++ b/app/components/pipeline-event-row/component.js
@@ -1,7 +1,7 @@
 import Component from '@ember/component';
 import { bool } from '@ember/object/computed';
 import { computed, get, getProperties } from '@ember/object';
-import { statusIcon } from 'screwdriver-ui/utils/build';
+import { statusIcon, isActiveBuild } from 'screwdriver-ui/utils/build';
 import MAX_NUM_OF_PARAMETERS_ALLOWED from 'screwdriver-ui/utils/constants';
 
 export default Component.extend({
@@ -95,7 +95,22 @@ export default Component.extend({
       return { build_id, pipeline_id };
     }
   }),
+  inited: true,
+  isJobsRunning: computed('jobs.@each.builds', 'inited', {
+    get() {
+      return this.jobs.some(j => {
+        const status = j.builds.get('firstObject.status');
+        const endTime = j.builds.get('firstObject.endTime');
 
+        return isActiveBuild(status, endTime);
+      });
+    }
+  }),
+  showJobs: computed('jobs.@each.builds', 'inited', {
+    get() {
+      return this.inited || this.jobs.some(j => !!j.get('builds.length'));
+    }
+  }),
   actions: {
     clickRow() {
       const fn = get(this, 'eventClick');

--- a/app/components/pipeline-event-row/template.hbs
+++ b/app/components/pipeline-event-row/template.hbs
@@ -1,51 +1,75 @@
 <div class="view">
   <div class="status">{{fa-icon icon fixedWidth=true}}</div>
   <div class="detail">
-    <div class="commit" title={{event.causeMessage}}>
-      {{#if (eq event.type "pr") }}
-        <a href={{event.pr.url}}>PR-{{event.prNum}}</a>
-      {{else}}
-        <a class={{if (eq event.sha latestCommit.sha) "latest-commit"}} href={{event.commit.url}}>#{{event.truncatedSha}}</a>
-        {{#if (eq event.id lastSuccessful)}}
-          <div class="last-successful">Last successful</div>
+    {{#if event}}
+      <div class="commit" title={{event.causeMessage}}>
+        {{#if (eq event.type "pr") }}
+          <a href={{event.pr.url}}>PR-{{event.prNum}}</a>
+        {{else}}
+          <a class={{if (eq event.sha latestCommit.sha) "latest-commit"}} href={{event.commit.url}}>#{{event.truncatedSha}}</a>
+          {{#if (eq event.id lastSuccessful)}}
+            <div class="last-successful">Last successful</div>
+          {{/if}}
+          {{#if event.label}}<div class="label">{{event.label}}</div>{{/if}}
         {{/if}}
-        {{#if event.label}}<div class="label">{{event.label}}</div>{{/if}}
-      {{/if}}
-      {{#if event.isRunning}}
-        {{#bs-button onClick=(action stopEvent) class="stopButton" title="Stop all builds for this event"}}Stop{{/bs-button}}
-      {{else}}
-        {{#if (eq event.type "pr")}}
-          {{#bs-button onClick=(action startPRBuild event.prNum events) class="startButton" title="Start all builds for this event"}}Start{{/bs-button}}
+        {{#if event.isRunning}}
+          {{#bs-button onClick=(action stopEvent) class="stopButton" title="Stop all builds for this event"}}Stop{{/bs-button}}
+        {{else}}
+          {{#if (eq event.type "pr")}}
+            {{#bs-button onClick=(action startPRBuild event.prNum events) class="startButton" title="Start all builds for this event"}}Start{{/bs-button}}
+          {{/if}}
         {{/if}}
-      {{/if}}
-    </div>
-    <div class="date greyOut">Started {{event.createTimeExact}}</div>
-    <span class="message" title={{event.commit.message}}>{{event.truncatedMessage}}</span>
-    <div class="by">
-      {{#if isCommiterDifferent}}
-        <span>Committed by: </span>
-        <a href={{event.commit.author.url}}>{{event.commit.author.name}}</a>
-        <br>
-        <span>Started by: </span>
-        {{#if isExternalTrigger}}
-          {{#if externalBuild.build_id}}
-            {{#link-to "pipeline.build" externalBuild.pipeline_id externalBuild.build_id}}External Trigger{{/link-to}}
+      </div>
+      <div class="date greyOut">Started {{event.createTimeExact}}</div>
+      <span class="message" title={{event.commit.message}}>{{event.truncatedMessage}}</span>
+      <div class="by">
+        {{#if isCommiterDifferent}}
+          <span>Committed by: </span>
+          <a href={{event.commit.author.url}}>{{event.commit.author.name}}</a>
+          <br>
+          <span>Started by: </span>
+          {{#if isExternalTrigger}}
+            {{#if externalBuild.build_id}}
+              {{#link-to "pipeline.build" externalBuild.pipeline_id externalBuild.build_id}}External Trigger{{/link-to}}
+            {{else}}
+              {{#link-to "pipeline" externalBuild.pipeline_id}}External Trigger{{/link-to}}
+            {{/if}}
           {{else}}
-            {{#link-to "pipeline" externalBuild.pipeline_id}}External Trigger{{/link-to}}
+            <a href={{event.creator.url}}>{{event.creator.name}}</a>
           {{/if}}
         {{else}}
-          <a href={{event.creator.url}}>{{event.creator.name}}</a>
+          {{#if isSubscribedEvent}}
+            <span>Started by subscribed event: </span>
+            <a href={{event.meta.subscribedSourceUrl}}>Subscribed Source</a>
+          {{else}}
+            <span>Started and committed by: </span>
+            <a href={{event.creator.url}}>{{event.creator.name}}</a>
+          {{/if}}
         {{/if}}
-      {{else}}
-        {{#if isSubscribedEvent}}
-          <span>Started by subscribed event: </span>
-          <a href={{event.meta.subscribedSourceUrl}}>Subscribed Source</a>
-        {{else}}
-          <span>Started and committed by: </span>
-          <a href={{event.creator.url}}>{{event.creator.name}}</a>
-        {{/if}}
+      </div>
+    {{else}}
+      {{#if jobs.length}}
+        <div class="commit" title={{jobs.0.title}}>
+          <a href={{jobs.0.url}}>PR-{{jobs.0.group}}</a>
+          {{isJobsRunning}}
+          {{#if isJobsRunning}}
+            {{#bs-button onClick=(action stopPRBuilds jobs) class="stopButton" title="Stop all builds for this event"}}Stop{{/bs-button}}
+          {{else}}
+            {{#bs-button onClick=(action startPRBuild jobs.0.group jobs) class="startButton" title="Start all builds for this event"}}Start{{/bs-button}}
+          {{/if}}
+        </div>
+        <span class="message" title={{jobs.0.title}}>{{jobs.0.title}}</span>
+        <div class="date greyOut">Started {{jobs.0.createTimeExact}}</div>
+        <div class="by">
+          <a href={{jobs.0.userProfile}}>{{jobs.0.username}}</a>
+        </div>
       {{/if}}
-    </div>
+    {{/if}}
+    {{#if showJobs}}
+      {{#each jobs as |job|}}
+       {{pipeline-pr-view job=job workflowGraph=pipelineWorkflowGraph}}
+      {{/each}}
+    {{/if}}
     {{#if (and (is-fulfilled event.builds) isShowGraph)}}
       <div class="workflow">
         {{workflow-graph-d3

--- a/app/components/pipeline-event-row/template.hbs
+++ b/app/components/pipeline-event-row/template.hbs
@@ -51,7 +51,6 @@
       {{#if jobs.length}}
         <div class="commit" title={{jobs.0.title}}>
           <a href={{jobs.0.url}}>PR-{{jobs.0.group}}</a>
-          {{isJobsRunning}}
           {{#if isJobsRunning}}
             {{#bs-button onClick=(action stopPRBuilds jobs) class="stopButton" title="Stop all builds for this event"}}Stop{{/bs-button}}
           {{else}}

--- a/app/components/pipeline-events-list/component.js
+++ b/app/components/pipeline-events-list/component.js
@@ -39,6 +39,9 @@ export default Component.extend({
     stopEvent() {
       this.stopEvent();
     },
+    stopPRBuilds() {
+      this.stopPRBuilds();
+    },
     eventClick(id, eventType) {
       set(this, 'selected', id);
 

--- a/app/components/pipeline-events-list/template.hbs
+++ b/app/components/pipeline-events-list/template.hbs
@@ -1,19 +1,41 @@
 <div>
-  {{#each groups as |group|}}
-    {{pipeline-events-row-group
-      pipeline=pipeline
-      expandedEventsGroup=expandedEventsGroup
-      events=group
-      selectedEvent=selectedEvent
-      latestCommit=latestCommit
-      lastSuccessful=lastSuccessful
-      startPRBuild=(action "startPRBuild")
-      stopEvent=(action "stopEvent")
-      eventClick=(action "eventClick")
-    }}
+  {{#if (or prChainEnabled groups)}}
+    {{#each groups as |group|}}
+      {{pipeline-events-row-group
+        prChainEnabled=prChainEnabled
+        pipeline=pipeline
+        expandedEventsGroup=expandedEventsGroup
+        events=group
+        selectedEvent=selectedEvent
+        latestCommit=latestCommit
+        lastSuccessful=lastSuccessful
+        startPRBuild=(action "startPRBuild")
+        stopEvent=(action "stopEvent")
+        eventClick=(action "eventClick")
+      }}
+    {{else}}
+      <div class="alert">No events have been run for this pipeline</div>
+    {{/each}}
   {{else}}
-    <div class="alert">No events have been run for this pipeline</div>
-  {{/each}}
+    {{#each pullRequestGroups as |prg|}}
+      {{pipeline-events-row-group
+          pipeline=pipeline
+          expandedEventsGroup=expandedEventsGroup
+          events=group
+          jobs=prg
+          pipelineWorkflowGraph=pipelineWorkflowGraph
+          selectedEvent=selectedEvent
+          latestCommit=latestCommit
+          lastSuccessful=lastSuccessful
+          startPRBuild=(action "startPRBuild")
+          stopPRBuilds=(action "stopPRBuilds")
+          stopEvent=(action "stopEvent")
+          eventClick=(action "eventClick")
+        }}
+    {{else}}
+      <div class="alert">No open pull requests</div>
+    {{/each}}
+  {{/if}}
 </div>
 
 {{yield}}

--- a/app/components/pipeline-events-row-group/template.hbs
+++ b/app/components/pipeline-events-row-group/template.hbs
@@ -36,7 +36,24 @@
       }}
     {{/if}}
   {{else}}
-    <div class="alert">No events have been run for this pipeline</div>
+    {{#if jobs.length}}
+      {{pipeline-event-row
+        prChainEnabled=prChainEnabled
+        pipeline=pipeline
+        event=event
+        jobs=jobs
+        pipelineWorkflowGraph=pipelineWorkflowGraph
+        selectedEvent=selectedEvent
+        latestCommit=latestCommit
+        lastSuccessful=lastSuccessful
+        startPRBuild=startPRBuild
+        stopPRBuilds=stopPRBuilds
+        stopEvent=stopEvent
+        eventClick=eventClick
+      }}
+    {{else}}
+      <div class="alert">No events have been run for this pipeline</div>
+    {{/if}}
   {{/each}}
 </div>
 

--- a/app/pipeline/events/controller.js
+++ b/app/pipeline/events/controller.js
@@ -142,10 +142,6 @@ export async function createEvent(eventPayload, toActiveTab) {
 
 // eslint-disable-next-line require-jsdoc
 export async function updateEvents(page) {
-  if (this.currentEventType === 'pr') {
-    return null;
-  }
-
   this.set('isFetching', true);
 
   const events = await this.store.query('event', {

--- a/app/pipeline/events/template.hbs
+++ b/app/pipeline/events/template.hbs
@@ -77,8 +77,7 @@
           <div style="padding: 20px;" onMouseEnter={{action "onEventListScroll"}}></div>
         {{/tab.pane}}
         {{#tab.pane activeId=activeTab elementId="pulls" title="Pull Requests"}}
-          {{#if prChainEnabled}}
-            {{pipeline-events-list
+          {{pipeline-events-list
             pipeline=pipeline
             expandedEventsGroup=expandedEventsGroup
             events=events
@@ -87,23 +86,15 @@
             latestCommit=latestCommit
             lastSuccessful=lastSuccessful
             eventsPage=eventsPage
+            prChainEnabled=prChainEnabled
+            pullRequestGroups=pullRequestGroups
+            isRestricted=isRestricted
+            pipelineWorkflowGraph=pipeline.workflowGraph
             startPRBuild=(action "startPRBuild")
             stopEvent=(action "stopEvent")
+            stopPRBuilds=(action "stopPRBuilds")
             updateEvents=(action "updateEvents")
-            }}
-          {{else}}
-            {{#each pullRequestGroups as |prg|}}
-              {{pipeline-pr-list
-                jobs=prg
-                isRestricted=isRestricted
-                startBuild=(action "startPRBuild")
-                stopPRBuilds=(action "stopPRBuilds")
-                workflowGraph=pipeline.workflowGraph
-              }}
-            {{else}}
-              <div class="alert">No open pull requests</div>
-            {{/each}}
-          {{/if}}
+          }}
         {{/tab.pane}}
       </div>
     {{/bs-tab}}


### PR DESCRIPTION
## Context

Events Graph not showing anything for non-chainPR Pull requests. 
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective

- Unify Pull Request views
- Even when chainPR is not used, workflow graph should be displayed.
- For Pipelines without chainPR we can display a simple workflow graph with all ~pr jobs at one level deep graph.

## References

Issue:
https://github.com/screwdriver-cd/screwdriver/issues/2546

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
