### PR TITLE
feat: Add show Triggers in user pref settings

### DIFF
--- a/app/components/pipeline-workflow/component.js
+++ b/app/components/pipeline-workflow/component.js
@@ -1,5 +1,6 @@
 import { alias } from '@ember/object/computed';
 import Component from '@ember/component';
+import { inject as service } from '@ember/service';
 import {
   get,
   getWithDefault,
@@ -15,6 +16,7 @@ import { copy } from 'ember-copy';
 export default Component.extend({
   // get all downstream triggers for a pipeline
   classNames: ['pipelineWorkflow'],
+  shuttle: service(),
   showTooltip: false,
   graph: computed(
     'workflowGraph',
@@ -52,12 +54,26 @@ export default Component.extend({
 
   displayRestartButton: alias('authenticated'),
 
-  init() {
+  async init() {
     this._super(...arguments);
+
+    let showDownstreamTriggers = false;
+
+    const pipelinePreference = await this.shuttle.getUserPipelinePreference(
+      this.get('pipeline.id')
+    );
+
+    if (pipelinePreference) {
+      showDownstreamTriggers = getWithDefault(
+        pipelinePreference,
+        'showDownstreamTriggers',
+        false
+      ); //
+    }
 
     setProperties(this, {
       builds: [],
-      showDownstreamTriggers: false,
+      showDownstreamTriggers,
       reason: ''
     });
   },

--- a/app/pipeline/events/controller.js
+++ b/app/pipeline/events/controller.js
@@ -450,8 +450,33 @@ export default Controller.extend(ModelReloaderMixin, {
   createEvent,
 
   actions: {
-    setDownstreamTrigger() {
-      this.set('showDownstreamTriggers', !this.get('showDownstreamTriggers'));
+    async setDownstreamTrigger() {
+      let showDownstreamTriggers = !this.get('showDownstreamTriggers');
+
+      // this.set('showDownstreamTriggers', !this.get('showDownstreamTriggers'));
+
+      const pipelineId = this.get('pipeline.id');
+
+      let pipelinePreference = await this.store
+        .peekAll('preference/pipeline')
+        .findBy('id', pipelineId);
+
+      if (pipelinePreference) {
+        pipelinePreference.showDownstreamTriggers = showDownstreamTriggers;
+      } else {
+        pipelinePreference = this.store.createRecord('preference/pipeline', {
+          pipelineId,
+          showDownstreamTriggers
+        });
+      }
+
+      pipelinePreference
+        .save()
+        .then(() =>
+          this.shuttle.updateUserPreference(pipelineId, pipelinePreference)
+        );
+
+      this.set('showDownstreamTriggers', showDownstreamTriggers);
     },
     setShowListView(showListView) {
       if (showListView) {

--- a/app/pipeline/events/route.js
+++ b/app/pipeline/events/route.js
@@ -19,7 +19,12 @@ export default Route.extend({
 
     controller.setProperties({
       activeTab: 'events',
-      showPRJobs: getWithDefault(pipelinePreference, 'showPRJobs', true)
+      showPRJobs: getWithDefault(pipelinePreference, 'showPRJobs', true),
+      showDownstreamTriggers: getWithDefault(
+        pipelinePreference,
+        'showDownstreamTriggers',
+        false
+      )
     });
 
     this.get('pipelineService').setBuildsLink('pipeline.events');

--- a/app/shuttle/service.js
+++ b/app/shuttle/service.js
@@ -265,6 +265,7 @@ export default Service.extend({
    * @param  {Number}  [pipelineId]
    * @param  {Object}  pipelineSettings
    * @param  {Boolean} [pipelineSettings.showPRJobs]
+   * @param  {Boolean} [pipelineSettings.showDownstreamTriggers]
    * @return {Promise}
    */
   async updateUserPreference(pipelineId, pipelineSettings) {


### PR DESCRIPTION
## Context

When clicking "Show Triggers" for a pipeline, it doesn't persist when the page is reloaded.

## Objective

The UI should remember the last-chosen settings for each pipeline. So add showTrigger in user preferences settings.

## References

https://github.com/screwdriver-cd/screwdriver/issues/1721

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
