### PR TITLE
fix: Tooltip's message color of create page

### DIFF
--- a/app/components/pipeline-create-form/styles.scss
+++ b/app/components/pipeline-create-form/styles.scss
@@ -138,3 +138,9 @@
   left: 50%;
   width: 85%;
 }
+
+.tooltips {
+  a {
+    color: $sd-lighter-blue;
+  }
+}

--- a/app/components/pipeline-create-form/template.hbs
+++ b/app/components/pipeline-create-form/template.hbs
@@ -90,6 +90,6 @@
 <div class="tooltips">
   {{#bs-tooltip placement="right" triggerElement=".select-screwdriver-yaml" renderInPlace=true
   delayHide="1000"}}
-    What is a <a href="https://docs.screwdriver.cd/user-guide/configuration/" target="_blank" rel="noopener">screwdriver.yaml</a>
+    What is a <a href="https://docs.screwdriver.cd/user-guide/configuration/" target="_blank" rel="noopener">screwdriver.yaml</a>?
   {{/bs-tooltip}}
 </div>


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
The tooltip message on the pipeline creation screen may be partly too dark to be seen.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
This PR makes the text color of the tooltip link a little brighter.

before:
![スクリーンショット 2021-10-04 15 52 37](https://user-images.githubusercontent.com/32473622/135810044-9865f9a1-8699-4683-92c0-dd629dbed876.png)

after:
![スクリーンショット 2021-10-04 15 53 52](https://user-images.githubusercontent.com/32473622/135810084-3df082cf-c9ed-446d-90dc-045d7174de4b.png)

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
