### PR TITLE
fix: UI display for repo uses branch filters

### DIFF
--- a/app/pipeline/events/controller.js
+++ b/app/pipeline/events/controller.js
@@ -352,21 +352,27 @@ export default Controller.extend(ModelReloaderMixin, {
       if (!this.prChainEnabled) {
         return prEvents.map(prEvent => {
           const prWorkflowGraph = prEvent.workflowGraph;
-          const prNode = prWorkflowGraph.nodes.findBy('name', '~pr');
-          const edgesToRemove = [];
-          const nodesToAdd = [prNode];
 
+          const prNodes = prWorkflowGraph.nodes.filter(n =>
+            n.name.startsWith('~pr')
+          );
+          const edgesToAdd = [];
+          const nodesToAdd = [...prNodes];
+
+          // 1 level deep
           prWorkflowGraph.edges.forEach(e => {
-            if (prNode.name === e.src) {
-              const endNode = prWorkflowGraph.nodes.findBy('name', e.dest);
+            prNodes.forEach(prNode => {
+              if (prNode.name === e.src) {
+                const endNode = prWorkflowGraph.nodes.findBy('name', e.dest);
 
-              nodesToAdd.pushObject(endNode);
-            } else {
-              edgesToRemove.pushObject(e);
-            }
+                nodesToAdd.pushObject(endNode);
+                edgesToAdd.pushObject(e);
+              }
+            });
           });
 
-          prWorkflowGraph.edges.removeObjects(edgesToRemove);
+          prWorkflowGraph.edges.clear();
+          prWorkflowGraph.edges.pushObjects(edgesToAdd);
           prWorkflowGraph.nodes.clear();
           prWorkflowGraph.nodes.pushObjects(nodesToAdd);
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
For PR tabs, we only display jobs with exact name `~pr` as starting points, rather than `~pr:main`, `~pr:dev` that allowed to be used in screwdriver.yaml with [branch filtering](https://docs.screwdriver.cd/user-guide/configuration/workflow.html#branch-filtering)

## Objective
This PR enables job names starts with `~pr:` to be displayed
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
