### PR TITLE
fix(2065): fix workflow tooltip to make it easier to remove

### DIFF
--- a/app/components/pipeline-viz-chart/style.scss
+++ b/app/components/pipeline-viz-chart/style.scss
@@ -13,3 +13,7 @@
     fill: green;
   }
 }
+
+.workflow {
+  height: 100vh;
+}

--- a/app/components/workflow-graph-d3/styles.scss
+++ b/app/components/workflow-graph-d3/styles.scss
@@ -19,6 +19,12 @@
 
 & {
   position: relative;
+  height: 100%;
+}
+
+svg {
+  min-width: 100%;
+  min-height: 100%;
 }
 
 g {


### PR DESCRIPTION
## Context
Modify SCSS so that workflow tooltips can be easily removed.

## Objective
Previously it could be deleted by clicking on the yellow area.
<img width="819" alt="スクリーンショット 2021-11-25 15 51 38" src="https://user-images.githubusercontent.com/23443081/143394270-8e789b5b-2352-4053-926c-4ec305cb5162.png">

This fix expands the area where tooltips can be removed.
<img width="815" alt="スクリーンショット 2021-11-25 15 51 59" src="https://user-images.githubusercontent.com/23443081/143394279-6eace0f8-eb8b-4f81-abc7-016fb70cac03.png">

## References
https://github.com/screwdriver-cd/screwdriver/issues/2065

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
