### PR TITLE
Revert "feat(2346): Support for job level parameters (#754)"

### DIFF
--- a/app/components/pipeline-event-row/component.js
+++ b/app/components/pipeline-event-row/component.js
@@ -31,47 +31,13 @@ export default Component.extend({
     }
   }),
 
-  init() {
-    this._super(...arguments);
+  numberOfParameters: computed('event.meta.parameters', {
+    get() {
+      const parameters = this.getWithDefault('event.meta.parameters', {});
 
-    const pipelineParameters = {};
-    const jobParameters = {};
-
-    // Segregate pipeline level and job level parameters
-    Object.entries(this.getWithDefault('event.meta.parameters', {})).forEach(
-      ([propertyName, propertyVal]) => {
-        const keys = Object.keys(propertyVal);
-
-        if (keys.length === 1 && keys[0] === 'value') {
-          pipelineParameters[propertyName] = propertyVal;
-        } else {
-          jobParameters[propertyName] = propertyVal;
-        }
-      }
-    );
-
-    this.setProperties({
-      pipelineParameters,
-      jobParameters
-    });
-  },
-
-  numberOfParameters: computed(
-    'pipelineParameters',
-    'jobParameters',
-    function numberOfParameters() {
-      return (
-        Object.keys(this.pipelineParameters).length +
-        Object.values(this.jobParameters).reduce((count, parameters) => {
-          if (count) {
-            return count + Object.keys(parameters).length;
-          }
-
-          return Object.keys(parameters).length;
-        }, 0)
-      );
+      return Object.keys(parameters).length;
     }
-  ),
+  }),
 
   isInlineParameters: computed('numberOfParameters', {
     get() {
@@ -95,7 +61,7 @@ export default Component.extend({
     }
   }),
 
-  isCommitterDifferent: computed(
+  isCommiterDifferent: computed(
     'isExternalTrigger',
     'event.{creator.name,commit.author.name}',
     {

--- a/app/components/pipeline-event-row/template.hbs
+++ b/app/components/pipeline-event-row/template.hbs
@@ -22,7 +22,7 @@
     <div class="date greyOut">Started {{event.createTimeExact}}</div>
     <span class="message" title={{event.commit.message}}>{{event.truncatedMessage}}</span>
     <div class="by">
-      {{#if isCommitterDifferent}}
+      {{#if isCommiterDifferent}}
         <span>Committed by: </span>
         <a href={{event.commit.author.url}}>{{event.commit.author.name}}</a>
         <br>
@@ -72,8 +72,7 @@
           {{pipeline-parameterized-build
             pipeline=pipeline
             showSubmitButton=true
-            buildPipelineParameters=pipelineParameters
-            buildJobParameters=jobParameters
+            buildParameters=event.meta.parameters
             submitButtonText="Close"
             onSave=(action "toggleParametersPreview")}}
         {{/modal-dialog}}
@@ -83,34 +82,12 @@
         {{#if isInlineParameters}}
           <span>Parameters:</span>
           <ul>
-            {{#if (get-length pipelineParameters)}}
+            {{#each-in event.meta.parameters as |pName pVal|}}
               <li>
-                <span class="parameter-group badge">Shared</span>
-                <ul>
-                  {{#each-in pipelineParameters as |pName pVal|}}
-                    <li>
-                      <span class="parameter-name badge">{{pName}}</span>
-                      <span class="parameter-value">:{{pVal.value}}</span>
-                    </li>
-                  {{/each-in}}
-                </ul>
+                <span class="parameter-name badge">{{pName}}</span>
+                <span class="parameter-value">:{{pVal.value}}</span>
               </li>
-            {{/if}}
-            {{#if (get-length jobParameters)}}
-              {{#each-in jobParameters as |jobName parameters|}}
-                <li>
-                  <span class="parameter-group badge">Job: {{jobName}}</span>
-                  <ul>
-                    {{#each-in parameters as |pName pVal|}}
-                      <li>
-                        <span class="parameter-name badge">{{pName}}</span>
-                        <span class="parameter-value">:{{pVal.value}}</span>
-                      </li>
-                    {{/each-in}}
-                  </ul>
-                </li>
-              {{/each-in}}
-            {{/if}}
+            {{/each-in}}
           </ul>
         {{else}}
           <span>

--- a/app/components/pipeline-list-view/component.js
+++ b/app/components/pipeline-list-view/component.js
@@ -71,8 +71,7 @@ export default Component.extend({
 
     this.setProperties({
       table,
-      pipelineParameters: this.getDefaultPipelineParameters(),
-      jobParameters: this.getDefaultJobParameters()
+      buildParameters: this.getDefaultBuildParameters()
     });
   },
 
@@ -81,23 +80,8 @@ export default Component.extend({
     this.set('jobsDetails', []);
   },
 
-  getDefaultPipelineParameters() {
+  getDefaultBuildParameters() {
     return this.getWithDefault('pipeline.parameters', {});
-  },
-
-  getDefaultJobParameters() {
-    const jobs = this.getWithDefault('pipeline.jobs', []);
-    const parameters = {};
-
-    jobs.forEach(job => {
-      const jobParameters = job.permutations[0].parameters; // TODO: Revisit while supporting matrix job
-
-      if (jobParameters) {
-        parameters[job.name] = jobParameters;
-      }
-    });
-
-    return parameters;
   },
 
   /**
@@ -167,10 +151,6 @@ export default Component.extend({
         build: latestBuild
       };
 
-      const hasParameters =
-        Object.keys(this.getWithDefault('pipelineParameters', {})).length > 0 ||
-        Object.keys(this.getWithDefault('jobParameters', {})).length > 0;
-
       const actionsData = {
         jobId,
         jobName,
@@ -178,7 +158,8 @@ export default Component.extend({
         startSingleBuild: this.get('startSingleBuild'),
         stopBuild: this.get('stopBuild'),
         isShowingModal: this.isShowingModal,
-        hasParameters,
+        hasParameters:
+          Object.keys(this.getWithDefault('buildParameters', {})).length > 0,
         openParametersModal: this.openParametersModal.bind(this)
       };
 
@@ -308,8 +289,7 @@ export default Component.extend({
     resetForm() {
       this.setProperties({
         isShowingModal: false,
-        pipelineParameters: this.getDefaultPipelineParameters(),
-        jobParameters: this.getDefaultJobParameters()
+        buildParameters: this.getDefaultBuildParameters()
       });
     },
 

--- a/app/components/pipeline-list-view/template.hbs
+++ b/app/components/pipeline-list-view/template.hbs
@@ -44,8 +44,7 @@
     {{pipeline-parameterized-build
       pipeline=pipeline
       showSubmitButton=true
-      buildPipelineParameters=pipelineParameters
-      buildJobParameters=jobParameters
+      buildParameters=buildParameters
       onSave=(action "startBuild")
       onClose=(action "closeModal")}}
   {{/modal-dialog}}

--- a/app/components/pipeline-parameterized-build/styles.scss
+++ b/app/components/pipeline-parameterized-build/styles.scss
@@ -9,27 +9,6 @@ button.start-with-parameters-button {
 
   .btn-group {
     padding-left: 38%;
-    margin-top: 10px;
-  }
-}
-
-.parameter-group-list {
-  max-height: 70vh;
-  overflow-y: scroll;
-
-  .parameter-group {
-    margin: 10px 10px 0 0;
-    border-radius: 3px;
-    border: 1px solid $sd-separator;
-    padding: 10px;
-    font-weight: 300;
-    color: $sd-text;
-  }
-
-  .parameter-list {
-    &.collapsed {
-      display: none;
-    }
   }
 }
 
@@ -49,7 +28,7 @@ button.start-with-parameters-button {
 
   &:after {
     position: absolute;
-    top: 0;
+    top: 0px;
     left: 8px;
     font-size: 12px;
     font-weight: 700;

--- a/app/components/pipeline-parameterized-build/template.hbs
+++ b/app/components/pipeline-parameterized-build/template.hbs
@@ -2,113 +2,49 @@
   class="start-with-parameters-form"
   onSubmit=(action "onSave" parameters) as |form|}}
 
-  <div class="parameter-group-list">
-    {{#if (get-length pipelineParameters.parameters)}}
-      <div class="parameter-group">
-        <h4 {{action "onExpandCollapseParamGroup" null}}>{{fa-icon (if pipelineParameters.isOpen "minus-square" "plus-square")}} Shared</h4>
-        <div class="parameter-list {{if pipelineParameters.isOpen "expanded" "collapsed"}}">
-          {{#each pipelineParameters.parameters as |parameter|}}
-            {{#form.group}}
-              <label class="control-label col-md-4">
-                {{#if parameter.description}}
-                  {{fa-icon "question-circle" title=parameter.description}}
-                {{/if}}
-                {{parameter.name}}
-              </label>
-              <div class="col-md-8">
-                {{#if (is-array parameter.value)}}
-                  {{#with (get parameterizedModel parameter.name) as |value|}}
-                    {{#unless (array-includes value parameter.defaultValues)}}
-                      {{fa-icon "exclamation-triangle" title=(concat "Default value: " parameter.defaultValues) class="notice-default-values-icon"}}
-                    {{/unless}}
-                  {{/with}}
-                  {{#power-select
-                    options=parameter.value
-                    renderInPlace=true
-                    selected=(get parameterizedModel parameter.name)
-                    onchange=(action (action "onUpdateValue" parameterizedModel null parameter.name))
-                    onkeydown=(action (action "searchOrAddtoList" parameterizedModel null parameter.name))
-                    searchPlaceholder="Type to filter"
-                    noMatchesMessage="Hit enter to override"
-                    as |selectedValue|
-                  }}
-                    {{selectedValue}}
-                  {{/power-select}}
-                {{else}}
-                  {{#unless (array-includes parameter.value parameter.defaultValues)}}
-                    {{fa-icon "exclamation-triangle" title=(concat "Default value: " parameter.defaultValues) class="notice-default-values-icon"}}
-                  {{/unless}}
-                  {{input
-                    value=parameter.value
-                    class="form-control"
-                    label=parameter.value
-                    placeholder=parameter.value
-                    property=parameter.name
-                    change=(action (action "onUpdateValue" parameterizedModel null parameter.name parameter.value))
-                  }}
-                {{/if}}
-              </div>
-            {{/form.group}}
-          {{/each}}
-        </div>
+  {{#each parameters as |parameter|}}
+    {{#form.group}}
+      <label class="control-label col-md-4">
+        {{#if parameter.description}}
+          {{fa-icon "question-circle" title=parameter.description}}
+        {{/if}}
+        {{parameter.name}}
+      </label>
+      <div class="col-md-8">
+        {{#if (is-array parameter.value)}}
+          {{#with (get parameterizedModel parameter.name) as |value|}}
+            {{#unless (array-includes value parameter.defaultValues)}}
+              {{fa-icon "exclamation-triangle" title=(concat "Default value: " parameter.defaultValues) class="notice-default-values-icon"}}
+            {{/unless}}
+          {{/with}}
+          {{#power-select
+            options=parameter.value
+            renderInPlace=true
+            selected=(get parameterizedModel parameter.name)
+            onchange=(action (action "onUpdateValue" parameterizedModel parameter.name))
+            onkeydown=(action (action "searchOrAddtoList" parameterizedModel parameter.name))
+            searchPlaceholder="Type to filter"
+            noMatchesMessage="Hit enter to override"
+            as |selectedValue|
+          }}
+            {{selectedValue}}
+          {{/power-select}}
+        {{else}}
+          {{#unless (array-includes parameter.value parameter.defaultValues)}}
+            {{fa-icon "exclamation-triangle" title=(concat "Default value: " parameter.defaultValues) class="notice-default-values-icon"}}
+          {{/unless}}
+          {{input
+            value=parameter.value
+            class="form-control"
+            label=parameter.value
+            placeholder=parameter.value
+            property=parameter.name
+            change=(action (action "onUpdateValue" parameterizedModel parameter.name parameter.value))
+          }}
+        {{/if}}
       </div>
-    {{/if}}
-
-    {{#each jobParameters as |jobParameterGroup|}}
-      <div class="parameter-group">
-        <h4 onClick={{action "onExpandCollapseParamGroup" jobParameterGroup.jobName}}>
-          {{fa-icon (if jobParameterGroup.isOpen "minus-square" "plus-square")}} Job: {{jobParameterGroup.jobName}}
-        </h4>
-        <div class="parameter-list {{if jobParameterGroup.isOpen "expanded" "collapsed"}}">
-          {{#each jobParameterGroup.parameters as |parameter|}}
-            {{#form.group}}
-              <label class="control-label col-md-4">
-                {{#if parameter.description}}
-                  {{fa-icon "question-circle" title=parameter.description}}
-                {{/if}}
-                {{parameter.name}}
-              </label>
-              <div class="col-md-8">
-                {{#if (is-array parameter.value)}}
-                  {{#with (get parameterizedModel parameter.name) as |value|}}
-                    {{#unless (array-includes value parameter.defaultValues)}}
-                      {{fa-icon "exclamation-triangle" title=(concat "Default value: " parameter.defaultValues) class="notice-default-values-icon"}}
-                    {{/unless}}
-                  {{/with}}
-                  {{#with (get parameterizedModel jobParameterGroup.jobName) as |jobParameterizedModel|}}
-                    {{#power-select
-                      options=parameter.value
-                      renderInPlace=true
-                      selected=(get jobParameterizedModel parameter.name)
-                      onchange=(action (action "onUpdateValue" parameterizedModel jobParameterGroup.jobName parameter.name))
-                      onkeydown=(action (action "searchOrAddtoList" parameterizedModel jobParameterGroup.jobName parameter.name))
-                      searchPlaceholder="Type to filter"
-                      noMatchesMessage="Hit enter to override"
-                    as |selectedValue|
-                    }}
-                      {{selectedValue}}
-                    {{/power-select}}
-                  {{/with}}
-                {{else}}
-                  {{#unless (array-includes parameter.value parameter.defaultValues)}}
-                    {{fa-icon "exclamation-triangle" title=(concat "Default value: " parameter.defaultValues) class="notice-default-values-icon"}}
-                  {{/unless}}
-                  {{input
-                    value=parameter.value
-                    class="form-control"
-                    label=parameter.value
-                    placeholder=parameter.value
-                    property=parameter.name
-                    change=(action (action "onUpdateValue" parameterizedModel jobParameterGroup.jobName parameter.name parameter.value))
-                  }}
-                {{/if}}
-              </div>
-            {{/form.group}}
-          {{/each}}
-        </div>
-      </div>
-    {{/each}}
-  </div>
+    {{/form.group}}
+  {{/each}}
 
   {{#if showSubmitButton}}
     <div class="btn-group">

--- a/app/components/pipeline-start/component.js
+++ b/app/components/pipeline-start/component.js
@@ -5,61 +5,26 @@ import MAX_NUM_OF_PARAMETERS_ALLOWED from 'screwdriver-ui/utils/constants';
 export default Component.extend({
   direction: 'down',
 
-  hasParameters: computed(
-    'pipelineParameters',
-    'jobParameters',
-    function hasParameters() {
-      return (
-        Object.keys(this.pipelineParameters).length > 0 ||
-        Object.keys(this.jobParameters).length > 0
-      );
-    }
-  ),
+  hasParameters: computed('buildParameters', function hasParameters() {
+    return Object.keys(this.buildParameters).length > 0;
+  }),
 
   hasLargeNumberOfParameters: computed(
-    'pipelineParameters',
-    'jobParameters',
+    'buildParameters',
     function hasLargeNumberOfParameters() {
-      const paramCount =
-        Object.keys(this.pipelineParameters).length +
-        Object.values(this.jobParameters).reduce((count, parameters) => {
-          if (count) {
-            return count + Object.keys(parameters).length;
-          }
-
-          return Object.keys(parameters).length;
-        }, 0);
-
-      return paramCount > MAX_NUM_OF_PARAMETERS_ALLOWED;
+      return (
+        Object.keys(this.buildParameters).length > MAX_NUM_OF_PARAMETERS_ALLOWED
+      );
     }
   ),
 
   init() {
     this._super(...arguments);
-
-    this.setProperties({
-      pipelineParameters: this.getDefaultPipelineParameters(),
-      jobParameters: this.getDefaultJobParameters()
-    });
+    this.set('buildParameters', this.getDefaultBuildParameters());
   },
 
-  getDefaultPipelineParameters() {
+  getDefaultBuildParameters() {
     return this.getWithDefault('pipeline.parameters', {});
-  },
-
-  getDefaultJobParameters() {
-    const jobs = this.getWithDefault('pipeline.jobs', []);
-    const parameters = {};
-
-    jobs.forEach(job => {
-      const jobParameters = job.permutations[0].parameters; // TODO: Revisit while supporting matrix job
-
-      if (jobParameters) {
-        parameters[job.name] = jobParameters;
-      }
-    });
-
-    return parameters;
   },
 
   startArgs: computed('prNum', 'jobs', {
@@ -107,8 +72,7 @@ export default Component.extend({
 
     resetForm() {
       this.setProperties({
-        pipelineParameters: this.getDefaultPipelineParameters(),
-        jobParameters: this.getDefaultJobParameters(),
+        buildParameters: this.getDefaultBuildParameters(),
         direction: 'down',
         isShowingModal: false
       });

--- a/app/components/pipeline-start/template.hbs
+++ b/app/components/pipeline-start/template.hbs
@@ -18,8 +18,7 @@
         {{pipeline-parameterized-build
           pipeline=pipeline
           showSubmitButton=true
-          buildPipelineParameters=pipelineParameters
-          buildJobParameters=jobParameters
+          buildParameters=buildParameters
           onSave=(action "startBuild")
           onClose=(action "toggleModal")}}
       {{/modal-dialog}}
@@ -41,8 +40,7 @@
         {{pipeline-parameterized-build
           pipeline=pipeline
           showSubmitButton=true
-          buildPipelineParameters=pipelineParameters
-          buildJobParameters=jobParameters
+          buildParameters=buildParameters
           onSave=(action "startBuild")
           onClose=(action dd.closeDropdown)}}
       {{/dd.menu}}

--- a/app/components/pipeline-workflow/template.hbs
+++ b/app/components/pipeline-workflow/template.hbs
@@ -42,8 +42,7 @@
         {{#if (get-length tooltipData.selectedEvent.meta.parameters)}}
           {{#pipeline-parameterized-build
             pipeline=pipeline
-            buildPipelineParameters=tooltipData.pipelineParameters
-            buildJobParameters=tooltipData.jobParameters
+            buildParameters=tooltipData.selectedEvent.meta.parameters
             as |parameterizedBuild| }}
             <div class="form-group form-horizontal">
               <label class="control-label col-md-4">Reason:</label>
@@ -89,8 +88,7 @@
       {{else if (get-length tooltipData.selectedEvent.meta.parameters)}}
         {{#pipeline-parameterized-build
           pipeline=pipeline
-          buildPipelineParameters=buildPipelineParameters
-          buildJobParameters=buildJobParameters
+          buildParameters=buildParameters
           as |parameterizedBuild| }}
           <div class="row">
             <div class="col-xs-6">

--- a/app/components/validator-job/template.hbs
+++ b/app/components/validator-job/template.hbs
@@ -40,28 +40,6 @@
     </ul>
   </span>
 </div>
-<div class="parameters" title="These are the job-level parameters that the user has defined.">
-  <span class="label">Parameters:</span>
-  <span class="value">
-    <ul>
-      {{#each-in job.parameters as |name value|}}
-        {{#if value.length}}
-          <li><span class="name">{{name}}: </span><span class="value">{{value}}</span></li>
-        {{else}}
-          <li>
-            <span class="name">{{name}}: </span>
-            <ul>
-              <li><span class="value">{{value.value}}</span></li>
-              <li><span class="description">{{value.description}}</span></li>
-            </ul>
-          </li>
-        {{/if}}
-      {{else}}
-        <li>None defined</li>
-      {{/each-in}}
-    </ul>
-  </span>
-</div>
 {{#unless template}}
   <div class="description" title="This is the description of the job">
     <span class="label">Description:</span>

--- a/tests/integration/components/pipeline-parameterized-build/component-test.js
+++ b/tests/integration/components/pipeline-parameterized-build/component-test.js
@@ -10,7 +10,7 @@ module(
 
     test('it renders inline', async function (assert) {
       this.setProperties({
-        buildPipelineParameters: {
+        buildParameters: {
           p1: '1',
           p2: '2'
         },
@@ -18,7 +18,7 @@ module(
       });
 
       await render(hbs`{{pipeline-parameterized-build
-      buildPipelineParameters=buildPipelineParameters
+      buildParameters=buildParameters
       showSubmitButton=showSubmitButton}}`);
       assert.dom('input').exists({ count: 2 }, 'There are 2 parameters');
       assert
@@ -30,7 +30,7 @@ module(
       // Set any properties with this.set('myProperty', 'value');
       // Handle any actions with this.set('myAction', function(val) { ... });
       this.setProperties({
-        buildPipelineParameters: {
+        buildParameters: {
           p1: '1',
           p2: '2'
         },
@@ -49,7 +49,7 @@ module(
 
       // Template block usage:
       await render(hbs`
-      {{#pipeline-parameterized-build buildPipelineParameters=buildPipelineParameters as |parameterizedBuild| }}
+      {{#pipeline-parameterized-build buildParameters=buildParameters as |parameterizedBuild| }}
         <button class="test-button is-primary" {{action "checkParameters" parameterizedBuild.parameters}}>Test</button>
       {{/pipeline-parameterized-build}}
     `);
@@ -58,7 +58,7 @@ module(
 
     test('it renders as dropdown list', async function (assert) {
       this.setProperties({
-        buildPipelineParameters: {
+        buildParameters: {
           from: 'latest',
           to: ['test', 'stable']
         },
@@ -66,7 +66,7 @@ module(
       });
 
       await render(hbs`{{pipeline-parameterized-build
-      buildPipelineParameters=buildPipelineParameters
+      buildParameters=buildParameters
       showSubmitButton=showSubmitButton}}`);
       assert.dom('.form-group').exists({ count: 2 }, 'There are 2 parameters');
       assert
@@ -82,7 +82,7 @@ module(
 
     test('it renders description', async function (assert) {
       this.setProperties({
-        buildPipelineParameters: {
+        buildParameters: {
           from: {
             value: 'latest',
             description: 'promote from tag'
@@ -97,7 +97,7 @@ module(
       });
 
       await render(hbs`{{pipeline-parameterized-build
-      buildPipelineParameters=buildPipelineParameters
+      buildParameters=buildParameters
       showSubmitButton=showSubmitButton}}`);
       assert.dom('.form-group').exists({ count: 3 }, 'There are 3 parameters');
       assert
@@ -125,7 +125,7 @@ module(
             image: 'test-image'
           }
         },
-        buildPipelineParameters: {
+        buildParameters: {
           from: 'foo',
           to: {
             value: ['bar', 'test', 'stable']
@@ -137,7 +137,7 @@ module(
 
       await render(hbs`{{pipeline-parameterized-build
       pipeline=pipeline
-      buildPipelineParameters=buildPipelineParameters
+      buildParameters=buildParameters
       showSubmitButton=showSubmitButton}}`);
       assert.dom('.form-group').exists({ count: 3 }, 'There are 3 parameters');
       assert

--- a/tests/mock/jobs.js
+++ b/tests/mock/jobs.js
@@ -9,8 +9,7 @@ export default () =>
         name: 'main',
         pipelineId: '4',
         state: 'ENABLED',
-        archived: false,
-        permutations: [{}]
+        archived: false
       },
       {
         id: '12346',
@@ -18,8 +17,7 @@ export default () =>
         name: 'publish',
         pipelineId: '4',
         state: 'ENABLED',
-        archived: false,
-        permutations: [{}]
+        archived: false
       },
       {
         id: '12347',
@@ -27,8 +25,7 @@ export default () =>
         name: 'PR-42:main',
         pipelineId: '4',
         state: 'ENABLED',
-        archived: false,
-        permutations: [{}]
+        archived: false
       },
       {
         id: '12348',
@@ -36,8 +33,7 @@ export default () =>
         name: 'PR-42:publish',
         pipelineId: '4',
         state: 'ENABLED',
-        archived: false,
-        permutations: [{}]
+        archived: false
       },
       {
         id: '12349',
@@ -45,8 +41,7 @@ export default () =>
         name: 'PR-43:main',
         pipelineId: '4',
         state: 'ENABLED',
-        archived: false,
-        permutations: [{}]
+        archived: false
       }
     ],
     true
@@ -66,32 +61,28 @@ export function metricJobs() {
         name: 'prod',
         pipelineId: 4,
         state: 'ENABLED',
-        archived: false,
-        permutations: [{}]
+        archived: false
       },
       {
         id: 158,
         name: 'beta',
         pipelineId: 4,
         state: 'ENABLED',
-        archived: false,
-        permutations: [{}]
+        archived: false
       },
       {
         id: 157,
         name: 'publish',
         pipelineId: 4,
         state: 'ENABLED',
-        archived: false,
-        permutations: [{}]
+        archived: false
       },
       {
         id: 156,
         name: 'main',
         pipelineId: 4,
         state: 'ENABLED',
-        archived: false,
-        permutations: [{}]
+        archived: false
       }
     ],
     true


### PR DESCRIPTION
## Context
Since the tooltip is not displayed due to the change of https://github.com/screwdriver-cd/ui/pull/754, revert it.

## Objective
The most recent UI changes were:
* https://github.com/screwdriver-cd/ui/pull/754
* https://github.com/screwdriver-cd/ui/pull/757

When I investigated in the local environment, the commit by https://github.com/screwdriver-cd/ui/pull/754 was the cause of the tooltip not being displayed.
It's not good if the tooltip isn't displayed, so let me revert your changes.

In the investigation, I reverted the commits https://github.com/screwdriver-cd/ui/pull/754 and https://github.com/screwdriver-cd/ui/pull/757 respectively to see which commit was the cause and whether it happened accidentally due to both changes.

## References


## License
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
