### PR TITLE
fix: Tooltip broken in the workflow graph for pipelines with out parameters

### DIFF
--- a/app/components/pipeline-workflow/component.js
+++ b/app/components/pipeline-workflow/component.js
@@ -196,11 +196,16 @@ export default Component.extend({
       // Find root nodes to determine position of tooltip
       if (job && edges && !/^~/.test(job.name)) {
         const selectedEvent = get(this, 'selectedEventObj');
+        const eventParameters = getWithDefault(
+          selectedEvent,
+          'meta.parameters',
+          {}
+        );
         const pipelineParameters = {};
         const jobParameters = {};
 
         // Segregate pipeline level and job level parameters
-        Object.entries(selectedEvent.meta.parameters).forEach(
+        Object.entries(eventParameters).forEach(
           ([propertyName, propertyVal]) => {
             const keys = Object.keys(propertyVal);
 


### PR DESCRIPTION
## Context

Changes made in https://github.com/screwdriver-cd/ui/pull/754 broke the tooltip on workflow graph nodes

## Objective

This PR delivers the fix to display tooltips on workflow graph nodes for pipelines without parameters

## References
https://github.com/screwdriver-cd/ui/pull/754
https://github.com/screwdriver-cd/ui/pull/758

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
