### PR TITLE
feat(2605) Option to display all screwdriver jobs in a chronological order

### DIFF
--- a/app/components/pipeline-events-list/component.js
+++ b/app/components/pipeline-events-list/component.js
@@ -1,4 +1,4 @@
-import { computed, get, set } from '@ember/object';
+import { computed, get, set, getWithDefault } from '@ember/object';
 import Component from '@ember/component';
 import { scheduleOnce } from '@ember/runloop';
 import { inject as service } from '@ember/service';
@@ -7,7 +7,30 @@ import moment from 'moment';
 
 export default Component.extend({
   router: service(),
+  shuttle: service(),
   errorMessage: '',
+  isGroupedEvents: computed('pipeline', {
+    get() {
+      const isGroupedEvents = getWithDefault(
+        this.pipeline,
+        'settings.groupedEvents',
+        false
+      );
+
+      console.log('isGroupedEvents', isGroupedEvents);
+
+      return isGroupedEvents;
+    }
+  }),
+  eventsList: computed('events.[]', {
+    get() {
+      this.shuttle.getLatestCommitEvent(this.get('pipeline.id')).then(event => {
+        this.set('latestCommit', event);
+      });
+
+      return get(this, 'events');
+    }
+  }),
   groups: computed('events.[]', {
     get() {
       const events = get(this, 'events');
@@ -30,6 +53,7 @@ export default Component.extend({
   }),
   init() {
     this._super(...arguments);
+
     scheduleOnce('afterRender', this, 'updateEvents', this.eventsPage + 1);
   },
   actions: {
@@ -43,12 +67,19 @@ export default Component.extend({
       set(this, 'selected', id);
 
       if (eventType !== 'pr') {
-        const currentEvent = this.groups.find(g => g.find(e => e.id === id))[0];
-        const { pipelineId } = currentEvent;
-        const expandedEventsGroup = get(this, 'expandedEventsGroup') || {};
+        let currentEvent;
 
-        expandedEventsGroup[currentEvent.groupEventId] = true;
-        set(this, 'expandedEventsGroup', expandedEventsGroup);
+        if (this.isGroupedEvents === true) {
+          currentEvent = this.groups.find(g => g.find(e => e.id === id))[0];
+          const expandedEventsGroup = get(this, 'expandedEventsGroup') || {};
+
+          expandedEventsGroup[currentEvent.groupEventId] = true;
+          set(this, 'expandedEventsGroup', expandedEventsGroup);
+        } else {
+          currentEvent = this.eventsList.findBy('id', id);
+        }
+
+        const { pipelineId } = currentEvent;
 
         this.router.transitionTo('pipeline.events.show', pipelineId, id);
       }

--- a/app/components/pipeline-events-list/component.js
+++ b/app/components/pipeline-events-list/component.js
@@ -17,8 +17,6 @@ export default Component.extend({
         false
       );
 
-      console.log('isGroupedEvents', isGroupedEvents);
-
       return isGroupedEvents;
     }
   }),

--- a/app/components/pipeline-events-list/component.js
+++ b/app/components/pipeline-events-list/component.js
@@ -14,7 +14,7 @@ export default Component.extend({
       const isGroupedEvents = getWithDefault(
         this,
         'pipeline.settings.groupedEvents',
-        false
+        true
       );
 
       return isGroupedEvents;

--- a/app/components/pipeline-events-list/component.js
+++ b/app/components/pipeline-events-list/component.js
@@ -12,8 +12,8 @@ export default Component.extend({
   isGroupedEvents: computed('pipeline', {
     get() {
       const isGroupedEvents = getWithDefault(
-        this.pipeline,
-        'settings.groupedEvents',
+        this,
+        'pipeline.settings.groupedEvents',
         false
       );
 

--- a/app/components/pipeline-events-list/template.hbs
+++ b/app/components/pipeline-events-list/template.hbs
@@ -1,19 +1,35 @@
 <div>
-  {{#each groups as |group|}}
-    {{pipeline-events-row-group
-      pipeline=pipeline
-      expandedEventsGroup=expandedEventsGroup
-      events=group
-      selectedEvent=selectedEvent
-      latestCommit=latestCommit
-      lastSuccessful=lastSuccessful
-      startPRBuild=(action "startPRBuild")
-      stopEvent=(action "stopEvent")
-      eventClick=(action "eventClick")
-    }}
+  {{#if isGroupedEvents}}
+    {{#each groups as |group|}}
+      {{pipeline-events-row-group
+        pipeline=pipeline
+        expandedEventsGroup=expandedEventsGroup
+        events=group
+        selectedEvent=selectedEvent
+        latestCommit=latestCommit
+        lastSuccessful=lastSuccessful
+        startPRBuild=(action "startPRBuild")
+        stopEvent=(action "stopEvent")
+        eventClick=(action "eventClick")
+      }}
+    {{else}}
+      <div class="alert">No events have been run for this pipeline</div>
+    {{/each}}
   {{else}}
-    <div class="alert">No events have been run for this pipeline</div>
-  {{/each}}
+    {{#each eventsList as |event|}}
+      {{pipeline-event-row
+        event=event
+        selectedEvent=selectedEvent
+        latestCommit=latestCommit
+        lastSuccessful=lastSuccessful
+        startPRBuild=(action "startPRBuild")
+        stopEvent=(action "stopEvent")
+        eventClick=(action "eventClick")
+      }}
+    {{else}}
+      <div class="alert">No events have been run for this pipeline</div>
+    {{/each}}
+  {{/if}}
 </div>
 
 {{yield}}

--- a/app/components/pipeline-options/component.js
+++ b/app/components/pipeline-options/component.js
@@ -313,6 +313,17 @@ export default Component.extend({
         );
 
       this.set('showPRJobs', showPRJobs);
+    },
+    async updatePipelineGroupedEvents(groupedEvents) {
+      try {
+        const pipelineId = this.get('pipeline.id');
+
+        await this.shuttle.updatePipelineSettings(pipelineId, {
+          groupedEvents
+        });
+      } finally {
+        this.set('groupedEvents', groupedEvents);
+      }
     }
   }
 });

--- a/app/components/pipeline-options/template.hbs
+++ b/app/components/pipeline-options/template.hbs
@@ -188,6 +188,31 @@
 
   <div class="col-xs-12 col-md-8">
     <section class="preference">
+      <h3>Pipeline Preference</h3>
+      <ul>
+        <li>
+          <div class="row">
+            <div class="col-xs-10">
+              <h4>Group Events</h4>
+              <p>Setup your pipeline preference to group events or not</p>
+            </div>
+            <div class="col-xs-2 right" title="Toggle to {{if groupedEvents "group" "ungroup"}} the pipeline">
+              {{x-toggle
+                size="small"
+                value=groupedEvents
+                onLabel="groupedEvents:true"
+                offLabel="groupedEvents::false"
+                onToggle=(action "updatePipelineGroupedEvents")
+              }}
+            </div>
+          </div>
+        </li>
+      </ul>
+    </section>
+  </div>
+
+  <div class="col-xs-12 col-md-8">
+    <section class="preference">
       <h3>User Preference</h3>
       <ul>
         <li>

--- a/app/components/pipeline-options/template.hbs
+++ b/app/components/pipeline-options/template.hbs
@@ -1,3 +1,4 @@
+
 {{info-message message=errorMessage type="warning" icon="exclamation-triangle"}}
 
 <div class="row">
@@ -194,7 +195,7 @@
           <div class="row">
             <div class="col-xs-10">
               <h4>Group Events</h4>
-              <p>Setup your pipeline preference to group events or not</p>
+              <p>Setup your pipeline preference to group events or not. {{fa-icon "question-circle" title="When grouping is enabled, events which share a common accesstor will be grouped together"}}</p>
             </div>
             <div class="col-xs-2 right" title="Toggle to {{if groupedEvents "group" "ungroup"}} the pipeline">
               {{x-toggle

--- a/app/pipeline/events/show/route.js
+++ b/app/pipeline/events/show/route.js
@@ -1,6 +1,6 @@
 import Route from '@ember/routing/route';
 import { debounce, later } from '@ember/runloop';
-import { action } from '@ember/object';
+import { action, getWithDefault } from '@ember/object';
 import { inject as service } from '@ember/service';
 import ENV from 'screwdriver-ui/config/environment';
 
@@ -49,15 +49,23 @@ export default class PipelineEventsShowRoute extends Route {
 
       pipelineEventsController.paginateEvents.pushObject(event);
     } else {
-      const { groupEventId } = desiredEvent;
+      const { settings } = pipelineEventsController.pipeline;
+      const isGroupedEvents = getWithDefault(settings, 'groupedEvents', false);
 
-      const expandedEventsGroup =
-        pipelineEventsController.expandedEventsGroup || {};
+      if (isGroupedEvents === true) {
+        const { groupEventId } = desiredEvent;
 
-      if (expandedEventsGroup[groupEventId] === undefined) {
-        expandedEventsGroup[groupEventId] = true;
+        const expandedEventsGroup =
+          pipelineEventsController.expandedEventsGroup || {};
+
+        if (expandedEventsGroup[groupEventId] === undefined) {
+          expandedEventsGroup[groupEventId] = true;
+        }
+        pipelineEventsController.set(
+          'expandedEventsGroup',
+          expandedEventsGroup
+        );
       }
-      pipelineEventsController.set('expandedEventsGroup', expandedEventsGroup);
     }
 
     pipelineEventsController.set('selected', eventId);

--- a/app/pipeline/events/show/route.js
+++ b/app/pipeline/events/show/route.js
@@ -49,8 +49,11 @@ export default class PipelineEventsShowRoute extends Route {
 
       pipelineEventsController.paginateEvents.pushObject(event);
     } else {
-      const { settings } = pipelineEventsController.pipeline;
-      const isGroupedEvents = getWithDefault(settings, 'groupedEvents', false);
+      const isGroupedEvents = getWithDefault(
+        pipelineEventsController,
+        'settings.groupedEvents',
+        false
+      );
 
       if (isGroupedEvents === true) {
         const { groupEventId } = desiredEvent;

--- a/app/pipeline/events/show/route.js
+++ b/app/pipeline/events/show/route.js
@@ -52,7 +52,7 @@ export default class PipelineEventsShowRoute extends Route {
       const isGroupedEvents = getWithDefault(
         pipelineEventsController,
         'settings.groupedEvents',
-        false
+        true
       );
 
       if (isGroupedEvents === true) {

--- a/app/pipeline/model.js
+++ b/app/pipeline/model.js
@@ -22,7 +22,13 @@ export default DS.Model.extend({
   secrets: DS.hasMany('secret', { async: true }),
   tokens: DS.hasMany('token', { async: true }),
   metrics: DS.hasMany('metric', { async: true }),
-  settings: DS.attr(),
+  settings: DS.attr({
+    defaultValue() {
+      return {
+        groupedEvents: true
+      };
+    }
+  }),
 
   appId: alias('scmRepo.name'),
   branch: computed('scmRepo.{branch,rootDir}', {

--- a/app/shuttle/service.js
+++ b/app/shuttle/service.js
@@ -161,6 +161,10 @@ export default Service.extend({
       newSetting = { ...newSetting, public: settings.publicPipeline };
     }
 
+    if (typeof settings.groupedEvents === 'boolean') {
+      newSetting = { ...newSetting, groupedEvents: settings.groupedEvents };
+    }
+
     const data = { settings: newSetting };
 
     return this.fetchFromApi(method, url, data);


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
![image](https://user-images.githubusercontent.com/15989893/144934826-238a2678-b179-4ddf-a1cc-64ba36161f51.png)

## Objective
Provide an option for user to set event display at pipeline level, whether is _grouped events_ or not
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
- https://github.com/screwdriver-cd/screwdriver/issues/2605
- https://github.com/screwdriver-cd/ui/pull/658/files

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
