### PR TITLE
fix: set SD_HAB_ENABLED environment variable for docker-publish

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -44,6 +44,8 @@ jobs:
     requires:
       - main
   docker-publish:
+    environment:
+      SD_HAB_ENABLED: true
     requires: publish
     template: sd/dind@latest
   # Deploy to our beta environment and run tests


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Enable to use bash entry for job  `docker-publish`, need to set `SD_HAB_ENABLED` to true

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
