### PR TITLE
fix: should catch server error when fetching build log

### DIFF
--- a/app/build-logs/service.js
+++ b/app/build-logs/service.js
@@ -57,7 +57,7 @@ export default Service.extend({
               started && jqXHR.getResponseHeader('x-more-data') === 'false';
           })
           .catch(error => {
-            if (error.jqXHR && [403, 404].includes(error.jqXHR.status)) {
+            if (error.jqXHR && [403, 404, 500].includes(error.jqXHR.status)) {
               done = true;
             }
           })

--- a/tests/unit/build-logs/service-test.js
+++ b/tests/unit/build-logs/service-test.js
@@ -2,7 +2,6 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import Service from '@ember/service';
 import Pretender from 'pretender';
-import Ember from 'ember';
 
 let server;
 const now = Date.now();
@@ -49,16 +48,6 @@ const noNewLogs = () => {
       'x-more-data': true
     },
     '[]'
-  ]);
-};
-
-const badLogs = () => {
-  server.get('http://localhost:8080/v4/builds/1/steps/banana/logs/', () => [
-    500,
-    {
-      'Content-Type': 'application/json'
-    },
-    ''
   ]);
 };
 
@@ -169,28 +158,6 @@ module('Unit | Service | build logs', function (hooks) {
       request.url,
       'http://localhost:8080/v4/builds/1/steps/banana/logs?from=0&pages=10&sort=ascending'
     );
-  });
-
-  test('it handles log api failure by treating it as there are more logs', async function (assert) {
-    assert.expect(3);
-    badLogs();
-    const service = this.owner.lookup('service:build-logs');
-
-    try {
-      const { lines, done } = await service.fetchLogs(serviceConfig);
-
-      assert.notOk(done);
-      assert.equal(lines.length, 0);
-
-      const [request] = server.handledRequests;
-
-      assert.equal(
-        request.url,
-        'http://localhost:8080/v4/builds/1/steps/banana/logs?from=0&pages=10&sort=ascending'
-      );
-    } catch (err) {
-      Ember.Logger.error('err', err);
-    }
   });
 
   test('it handles fetching multiple pages', async function (assert) {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
ui calls api repeatedly on status code 500
## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
catch status code 500 when fetching log
## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
