### PR TITLE
fix: Hide stop button for unknown event

### DIFF
--- a/app/components/pipeline-event-row/template.hbs
+++ b/app/components/pipeline-event-row/template.hbs
@@ -11,7 +11,7 @@
         {{/if}}
         {{#if event.label}}<div class="label">{{event.label}}</div>{{/if}}
       {{/if}}
-      {{#if event.isRunning}}
+      {{#if (and event.isRunning (not-eq event.status "UNKNOWN"))}}
         {{#bs-button onClick=(action stopEvent) class="stopButton" title="Stop all builds for this event"}}Stop{{/bs-button}}
       {{else}}
         {{#if (eq event.type "pr")}}

--- a/app/components/pipeline-event-row/template.hbs
+++ b/app/components/pipeline-event-row/template.hbs
@@ -11,7 +11,7 @@
         {{/if}}
         {{#if event.label}}<div class="label">{{event.label}}</div>{{/if}}
       {{/if}}
-      {{#if event.isRunning }}
+      {{#if (and event.isRunning (not-eq event.status "UNKNOWN")) }}
         {{#bs-button onClick=(action stopEvent) class="stopButton" title="Stop all builds for this event"}}Stop{{/bs-button}}
       {{else}}
         {{#if (eq event.type "pr")}}

--- a/app/components/pipeline-event-row/template.hbs
+++ b/app/components/pipeline-event-row/template.hbs
@@ -11,7 +11,7 @@
         {{/if}}
         {{#if event.label}}<div class="label">{{event.label}}</div>{{/if}}
       {{/if}}
-      {{#if (and event.isRunning (not-eq event.status "UNKNOWN"))}}
+      {{#if event.isRunning }}
         {{#bs-button onClick=(action stopEvent) class="stopButton" title="Stop all builds for this event"}}Stop{{/bs-button}}
       {{else}}
         {{#if (eq event.type "pr")}}

--- a/app/components/pipeline-event-row/template.hbs
+++ b/app/components/pipeline-event-row/template.hbs
@@ -11,7 +11,7 @@
         {{/if}}
         {{#if event.label}}<div class="label">{{event.label}}</div>{{/if}}
       {{/if}}
-      {{#if (and event.isRunning (not-eq event.status "UNKNOWN")) }}
+      {{#if (and event.isRunning (not-eq event.status "UNKNOWN"))}}
         {{#bs-button onClick=(action stopEvent) class="stopButton" title="Stop all builds for this event"}}Stop{{/bs-button}}
       {{else}}
         {{#if (eq event.type "pr")}}

--- a/tests/integration/components/pipeline-event-row/component-test.js
+++ b/tests/integration/components/pipeline-event-row/component-test.js
@@ -51,7 +51,8 @@ const event = {
     { jobId: 1, id: 4, status: 'SUCCESS' },
     { jobId: 2, id: 5, status: 'SUCCESS' },
     { jobId: 3, id: 6, status: 'FAILURE' }
-  ]
+  ],
+  isRunning: false
 };
 
 module('Integration | Component | pipeline event row', function (hooks) {
@@ -89,6 +90,86 @@ module('Integration | Component | pipeline event row', function (hooks) {
 
     assert.dom('.SUCCESS').exists({ count: 1 });
     assert.dom('.status .fa-check-circle-o').exists({ count: 1 });
+    assert.dom('.commit').hasText('#abc123 Last successful');
+    assert.dom('.message').hasText('this was a test');
+    assert.dom('svg').exists({ count: 1 });
+    assert.dom('.graph-node').exists({ count: 4 });
+    assert.dom('.graph-edge').exists({ count: 3 });
+    assert.dom('.by').hasText('Started and committed by: batman');
+    assert.dom('.date').hasText('Started 06/30/2021, 04:39 PM');
+    assert.dom('.last-successful').exists({ count: 1 });
+    assert.dom('.latest-commit').exists({ count: 1 });
+  });
+
+  test('it renders with running pipeline event', async function (assert) {
+    this.actions.eventClick = () => {
+      assert.ok(true);
+    };
+
+    this.set('stopPRBuilds', Function.prototype);
+    this.set('stopEvent', Function.prototype);
+
+    let eventMock = EmberObject.create(copy(event, true));
+
+    eventMock.isRunning = true;
+
+    this.set('event', eventMock);
+    this.set('latestCommit', {
+      sha: 'sha3'
+    });
+
+    await render(hbs`{{pipeline-event-row
+      event=event
+      startPRBuild=startPRBuild
+      stopEvent=stopEvent
+      selectedEvent=3
+      latestCommit=latestCommit
+      lastSuccessful=3
+    }}`);
+
+    assert.dom('.SUCCESS').exists({ count: 1 });
+    assert.dom('.stopButton').exists({ count: 1 });
+    assert.dom('.status .fa-check-circle-o').exists({ count: 1 });
+    assert.dom('.commit').hasText('#abc123 Last successful Stop');
+    assert.dom('.message').hasText('this was a test');
+    assert.dom('svg').exists({ count: 1 });
+    assert.dom('.graph-node').exists({ count: 4 });
+    assert.dom('.graph-edge').exists({ count: 3 });
+    assert.dom('.by').hasText('Started and committed by: batman');
+    assert.dom('.date').hasText('Started 06/30/2021, 04:39 PM');
+    assert.dom('.last-successful').exists({ count: 1 });
+    assert.dom('.latest-commit').exists({ count: 1 });
+  });
+
+  test('it renders with unknown pipeline event', async function (assert) {
+    this.actions.eventClick = () => {
+      assert.ok(true);
+    };
+
+    this.set('stopPRBuilds', Function.prototype);
+    this.set('stopEvent', Function.prototype);
+
+    let eventMock = EmberObject.create(copy(event, true));
+
+    eventMock.status = 'UNKNOWN';
+
+    this.set('event', eventMock);
+    this.set('latestCommit', {
+      sha: 'sha3'
+    });
+
+    await render(hbs`{{pipeline-event-row
+      event=event
+      startPRBuild=startPRBuild
+      stopEvent=stopEvent
+      selectedEvent=3
+      latestCommit=latestCommit
+      lastSuccessful=3
+    }}`);
+
+    assert.dom('.UNKNOWN').exists({ count: 1 });
+    assert.dom('.status').exists({ count: 1 });
+    assert.dom('.stopButton').doesNotExist();
     assert.dom('.commit').hasText('#abc123 Last successful');
     assert.dom('.message').hasText('this was a test');
     assert.dom('svg').exists({ count: 1 });

--- a/tests/integration/components/pipeline-event-row/component-test.js
+++ b/tests/integration/components/pipeline-event-row/component-test.js
@@ -72,7 +72,10 @@ module('Integration | Component | pipeline event row', function (hooks) {
     this.set('stopPRBuilds', Function.prototype);
     this.set('stopEvent', Function.prototype);
 
-    const eventMock = EmberObject.create(copy(event, true));
+    let eventMock = EmberObject.create(copy(event, true));
+
+    eventMock.isRunning = false;
+    eventMock.status = 'SUCCESS';
 
     this.set('event', eventMock);
     this.set('latestCommit', {
@@ -89,6 +92,7 @@ module('Integration | Component | pipeline event row', function (hooks) {
     }}`);
 
     assert.dom('.SUCCESS').exists({ count: 1 });
+    assert.dom('.stopButton').doesNotExist();
     assert.dom('.status .fa-check-circle-o').exists({ count: 1 });
     assert.dom('.commit').hasText('#abc123 Last successful');
     assert.dom('.message').hasText('this was a test');
@@ -171,8 +175,8 @@ module('Integration | Component | pipeline event row', function (hooks) {
     }}`);
 
     assert.dom('.UNKNOWN').exists({ count: 1 });
-    assert.dom('.status').exists({ count: 1 });
     assert.dom('.stopButton').doesNotExist();
+    assert.dom('.status').exists({ count: 1 });
     assert.dom('.commit').hasText('#abc123 Last successful');
     assert.dom('.message').hasText('this was a test');
     assert.dom('svg').exists({ count: 1 });

--- a/tests/integration/components/pipeline-event-row/component-test.js
+++ b/tests/integration/components/pipeline-event-row/component-test.js
@@ -112,6 +112,7 @@ module('Integration | Component | pipeline event row', function (hooks) {
     let eventMock = EmberObject.create(copy(event, true));
 
     eventMock.isRunning = true;
+    eventMock.status = 'RUNNING';
 
     this.set('event', eventMock);
     this.set('latestCommit', {
@@ -127,9 +128,10 @@ module('Integration | Component | pipeline event row', function (hooks) {
       lastSuccessful=3
     }}`);
 
-    assert.dom('.SUCCESS').exists({ count: 1 });
+    assert.dom('.RUNNING').exists({ count: 1 });
     assert.dom('.stopButton').exists({ count: 1 });
-    assert.dom('.status .fa-check-circle-o').exists({ count: 1 });
+    assert.dom('.status').exists({ count: 1 });
+    assert.dom('.fa-spinner').exists({ count: 1 });
     assert.dom('.commit').hasText('#abc123 Last successful Stop');
     assert.dom('.message').hasText('this was a test');
     assert.dom('svg').exists({ count: 1 });
@@ -151,6 +153,7 @@ module('Integration | Component | pipeline event row', function (hooks) {
 
     let eventMock = EmberObject.create(copy(event, true));
 
+    eventMock.isRunning = false;
     eventMock.status = 'UNKNOWN';
 
     this.set('event', eventMock);

--- a/tests/integration/components/pipeline-event-row/component-test.js
+++ b/tests/integration/components/pipeline-event-row/component-test.js
@@ -153,7 +153,7 @@ module('Integration | Component | pipeline event row', function (hooks) {
 
     let eventMock = EmberObject.create(copy(event, true));
 
-    eventMock.isRunning = false;
+    eventMock.isRunning = true;
     eventMock.status = 'UNKNOWN';
 
     this.set('event', eventMock);


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

When the event status becomes UNKNOWN for some reason, for example, if there is no build at the trigger destination, a stop button is placed for the target event.

The Stop button is confusing to the user because no build is actually running.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Hides the STOP button for events in the UNKNOWN state.

Before:

![スクリーンショット 2022-01-13 13 23 02](https://user-images.githubusercontent.com/32473622/149265666-20d262ac-204b-47ab-ac79-2ea0ffacbdd9.png)

After:
![スクリーンショット 2022-01-13 13 22 05](https://user-images.githubusercontent.com/32473622/149265689-0fb4bbf9-d78a-4fbc-bd32-fefcf2faebc6.png)

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
