### PR TITLE
fix(2644): Include stale parameters from the event when a build is restarted after the parameter(s) removed in SD config

### DIFF
--- a/app/components/pipeline-workflow/component.js
+++ b/app/components/pipeline-workflow/component.js
@@ -103,27 +103,38 @@ export default Component.extend({
   },
 
   mergeDefaultAndEventParameters(defaultParameters = {}, eventParameters) {
+    const defaultParameterNames = Object.keys(defaultParameters);
     const mergedParameters = copy(defaultParameters, true);
-    const parameterNames = Object.keys(eventParameters);
 
     if (eventParameters) {
-      parameterNames.forEach(parameterName => {
-        const parameterValue =
-          mergedParameters[parameterName].value ||
-          mergedParameters[parameterName];
-        const eventParameterValue =
-          eventParameters[parameterName].value ||
-          eventParameters[parameterName];
+      Object.entries(eventParameters).forEach(
+        ([eventParameterName, eventParameterDefinition]) => {
+          if (defaultParameterNames.includes(eventParameterName)) {
+            const defaultParameterValue =
+              mergedParameters[eventParameterName].value ||
+              mergedParameters[eventParameterName];
 
-        if (Array.isArray(parameterValue)) {
-          parameterValue.removeObject(eventParameterValue);
-          parameterValue.unshift(eventParameterValue);
-        } else if (mergedParameters[parameterName].value) {
-          mergedParameters[parameterName].value = eventParameterValue;
-        } else {
-          mergedParameters[parameterName] = eventParameterValue;
+            const eventParameterValue =
+              eventParameterDefinition.value || eventParameterDefinition;
+
+            if (Array.isArray(defaultParameterValue)) {
+              defaultParameterValue.removeObject(eventParameterValue);
+              defaultParameterValue.unshift(eventParameterValue);
+            } else if (mergedParameters[eventParameterName].value) {
+              mergedParameters[eventParameterName].value = eventParameterValue;
+            } else {
+              mergedParameters[eventParameterName] = eventParameterValue;
+            }
+          } else if (typeof eventParameters[eventParameterName] === 'object') {
+            mergedParameters[eventParameterName] = copy(
+              eventParameterDefinition,
+              true
+            );
+          } else {
+            mergedParameters[eventParameterName] = eventParameterDefinition;
+          }
         }
-      });
+      );
     }
 
     return mergedParameters;


### PR DESCRIPTION
## Context

A build cannot be restarted from an event when one or more parameters from that event has been removed in the latest screwdriver configuration.

The logic which merges event parameters on top of default parameters for the new build, assumes definition for all the parameters of the event still exists in the latest screwdriver config. This results in Javascript error which prevent users from restarting the builds.

## Objective

While merging the parameters include all the parameters from the event even if those parameters have been removed in the latest screwdriver config.

## References

https://github.com/screwdriver-cd/screwdriver/issues/2644

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
