### PR TITLE
feat(1577): feat filter events for no builds [2]

### DIFF
--- a/app/components/pipeline-options/component.js
+++ b/app/components/pipeline-options/component.js
@@ -1,11 +1,11 @@
-import $ from 'jquery';
-import { inject as service } from '@ember/service';
-import { not, or } from '@ember/object/computed';
-import { computed, getWithDefault, set } from '@ember/object';
-import { debounce } from '@ember/runloop';
 import Component from '@ember/component';
+import { computed, getWithDefault, set } from '@ember/object';
+import { not, or } from '@ember/object/computed';
+import { debounce } from '@ember/runloop';
+import { inject as service } from '@ember/service';
+import $ from 'jquery';
 import ENV from 'screwdriver-ui/config/environment';
-import { parse, getCheckoutUrl } from 'screwdriver-ui/utils/git';
+import { getCheckoutUrl, parse } from 'screwdriver-ui/utils/git';
 
 const { MINIMUM_JOBNAME_LENGTH, MAXIMUM_JOBNAME_LENGTH, DOWNTIME_JOBS } =
   ENV.APP;
@@ -48,6 +48,7 @@ export default Component.extend({
   minDisplayLength: MINIMUM_JOBNAME_LENGTH,
   maxDisplayLength: MAXIMUM_JOBNAME_LENGTH,
   showEventTriggers: false,
+  filterEventsForNoBuilds: false,
   sortedJobs: computed('jobs', function filterThenSortJobs() {
     const prRegex = /PR-\d+:.*/;
 
@@ -90,6 +91,10 @@ export default Component.extend({
 
     let showEventTriggers = this.get('pipeline.settings.showEventTriggers');
 
+    let filterEventsForNoBuilds = this.get(
+      'pipeline.settings.filterEventsForNoBuilds'
+    );
+
     if (typeof privateRepo !== 'boolean') {
       privateRepo = false;
     }
@@ -106,11 +111,16 @@ export default Component.extend({
       showEventTriggers = false;
     }
 
+    if (typeof filterEventsForNoBuilds !== 'boolean') {
+      filterEventsForNoBuilds = false;
+    }
+
     this.setProperties({
       privateRepo,
       publicPipeline,
       groupedEvents,
-      showEventTriggers
+      showEventTriggers,
+      filterEventsForNoBuilds
     });
 
     let desiredJobNameLength = MINIMUM_JOBNAME_LENGTH;
@@ -320,6 +330,23 @@ export default Component.extend({
         pipeline.set('settings.showEventTriggers', showEventTriggers);
 
         this.set('showEventTriggers', showEventTriggers);
+      }
+    },
+
+    async updateFilterEventsForNoBuilds(filterEventsForNoBuilds) {
+      const pipeline = this.get('pipeline');
+
+      try {
+        await this.shuttle.updatePipelineSettings(pipeline.id, {
+          filterEventsForNoBuilds
+        });
+      } finally {
+        pipeline.set(
+          'settings.filterEventsForNoBuilds',
+          filterEventsForNoBuilds
+        );
+
+        this.set('filterEventsForNoBuilds', filterEventsForNoBuilds);
       }
     },
 

--- a/app/components/pipeline-options/component.js
+++ b/app/components/pipeline-options/component.js
@@ -310,13 +310,15 @@ export default Component.extend({
     },
 
     async updatePipelineShowTriggers(showEventTriggers) {
-      try {
-        const pipelineId = this.get('pipeline.id');
+      const pipeline = this.get('pipeline');
 
-        await this.shuttle.updatePipelineSettings(pipelineId, {
+      try {
+        await this.shuttle.updatePipelineSettings(pipeline.id, {
           showEventTriggers
         });
       } finally {
+        pipeline.set('settings.showEventTriggers', showEventTriggers);
+
         this.set('showEventTriggers', showEventTriggers);
       }
     },

--- a/app/components/pipeline-options/template.hbs
+++ b/app/components/pipeline-options/template.hbs
@@ -235,8 +235,7 @@
               {{x-toggle
                 size="small"
                 value=filterEventsForNoBuilds
-                onLabel="filterEventsForNoBuilds:true"
-                offLabel="filterEventsForNoBuilds::false"
+                showLabels=false
                 onToggle=(action "updateFilterEventsForNoBuilds")
               }}
             </div>

--- a/app/components/pipeline-options/template.hbs
+++ b/app/components/pipeline-options/template.hbs
@@ -229,7 +229,7 @@
           <div class="row">
             <div class="col-xs-10">
               <h4>Filter Events For No Builds</h4>
-              <p>Setup your pipeline preference to filter events for no builds</p>
+              <p>Setup your pipeline preference to not show events with no builds</p>
             </div>
             <div class="col-xs-2 right" title="Toggle to {{if filterEventsForNoBuilds "filter" "unfilter"}} events for no builds">
               {{x-toggle

--- a/app/components/pipeline-options/template.hbs
+++ b/app/components/pipeline-options/template.hbs
@@ -225,6 +225,23 @@
             </div>
           </div>
         </li>
+        <li>
+          <div class="row">
+            <div class="col-xs-10">
+              <h4>Filter Events For No Builds</h4>
+              <p>Setup your pipeline preference to filter events for no builds</p>
+            </div>
+            <div class="col-xs-2 right" title="Toggle to {{if filterEventsForNoBuilds "filter" "unfilter"}} events for no builds">
+              {{x-toggle
+                size="small"
+                value=filterEventsForNoBuilds
+                onLabel="filterEventsForNoBuilds:true"
+                offLabel="filterEventsForNoBuilds::false"
+                onToggle=(action "updateFilterEventsForNoBuilds")
+              }}
+            </div>
+          </div>
+        </li>
       </ul>
     </section>
   </div>

--- a/app/pipeline/events/route.js
+++ b/app/pipeline/events/route.js
@@ -1,9 +1,9 @@
-import { inject as service } from '@ember/service';
+import { getWithDefault } from '@ember/object';
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+import RSVP from 'rsvp';
 import ENV from 'screwdriver-ui/config/environment';
 import getErrorMessage from 'screwdriver-ui/utils/error-messages';
-import { getWithDefault } from '@ember/object';
-import RSVP from 'rsvp';
 
 export default Route.extend({
   shuttle: service(),
@@ -33,6 +33,11 @@ export default Route.extend({
       showDownstreamTriggers: getWithDefault(
         this.pipeline,
         'settings.showEventTriggers',
+        false
+      ),
+      isFilteredEventsForNoBuilds: getWithDefault(
+        this.pipeline,
+        'settings.filterEventsForNoBuilds',
         false
       )
     });

--- a/app/shuttle/service.js
+++ b/app/shuttle/service.js
@@ -1,8 +1,7 @@
 import { computed, getWithDefault } from '@ember/object';
 import Service, { inject as service } from '@ember/service';
-import ENV from 'screwdriver-ui/config/environment';
-
 import $ from 'jquery';
+import ENV from 'screwdriver-ui/config/environment';
 
 /**
  * Screwdriver Shuttle Service
@@ -169,6 +168,13 @@ export default Service.extend({
       newSetting = {
         ...newSetting,
         showEventTriggers: settings.showEventTriggers
+      };
+    }
+
+    if (typeof settings.filterEventsForNoBuilds === 'boolean') {
+      newSetting = {
+        ...newSetting,
+        filterEventsForNoBuilds: settings.filterEventsForNoBuilds
       };
     }
 


### PR DESCRIPTION
## Context
Add a setting to the pipeline preference to hide many empty events, such as skip ci, or events that have no jobs to start from the event list. (the latest events are not hidden)

Also, fixed a bug that the setting is not reflected immediately when changing the setting of Show Triggers of pipeline preference.

data-schema PR is [here](https://github.com/screwdriver-cd/data-schema/pull/482).

## Objective
Added "Filter events for no builds" to pipeline preference:
<img width="723" alt="スクリーンショット 2022-03-02 20 01 07" src="https://user-images.githubusercontent.com/23443081/156349389-fce9c29c-d670-4f6b-b1a0-aecb881ade85.png">

filterEventsForNoBuilds OFF:
<img width="331" alt="スクリーンショット 2022-03-02 20 04 25" src="https://user-images.githubusercontent.com/23443081/156350058-8da0808f-1686-4fae-bacd-9bef9ac96dab.png">

filterEventsForNoBuilds ON:
<img width="329" alt="スクリーンショット 2022-03-02 20 04 09" src="https://user-images.githubusercontent.com/23443081/156350108-32a5c1bc-d3e8-4d74-b645-439ee088b10f.png">


## References
- https://github.com/screwdriver-cd/screwdriver/issues/1577
  - adding a toggle switch on a pipeline or an option page to filter empty events.

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
