### PR TITLE
feat: prompt users with no-admin info, and allow users to sync

### DIFF
--- a/app/pipeline/events/controller.js
+++ b/app/pipeline/events/controller.js
@@ -250,7 +250,7 @@ export default Controller.extend(ModelReloaderMixin, {
   }),
   hasAdmins: computed('pipeline.admins', 'numberOfAdmins', {
     get() {
-      const admins = this.get('pipeline.admins');
+      const admins = this.getWithDefault('pipeline.admins', {});
 
       return Object.keys(admins).length;
     }

--- a/app/pipeline/events/controller.js
+++ b/app/pipeline/events/controller.js
@@ -209,6 +209,7 @@ export default Controller.extend(ModelReloaderMixin, {
   jobId: '',
   session: service(),
   stop: service('event-stop'),
+  sync: service(),
   init() {
     this._super(...arguments);
     this.startReloading();
@@ -245,6 +246,13 @@ export default Controller.extend(ModelReloaderMixin, {
       return this.get('pipeline.jobs')
         .filter(j => !isPRJob(j.get('name')))
         .map(j => j.id);
+    }
+  }),
+  hasAdmins: computed('pipeline.admins', 'numberOfAdmins', {
+    get() {
+      const admins = this.get('pipeline.admins');
+
+      return Object.keys(admins).length;
     }
   }),
   jobsDetails: [],
@@ -604,6 +612,21 @@ export default Controller.extend(ModelReloaderMixin, {
           );
         })
         .finally(() => jobs.forEach(j => j.hasMany('builds').reload()));
+    },
+
+    async syncAdmins() {
+      this.set('syncAdmins', 'init');
+
+      try {
+        const syncPath = '';
+
+        await this.sync.syncRequests(this.get('pipeline.id'), syncPath);
+        this.set('syncAdmins', 'success');
+
+        await this.get('pipeline').reload();
+      } catch (e) {
+        this.set('syncAdmins', 'failure');
+      }
     }
   },
   willDestroy() {

--- a/app/pipeline/events/template.hbs
+++ b/app/pipeline/events/template.hbs
@@ -9,6 +9,24 @@
 
 {{info-message message=errorMessage type="warning" icon="exclamation-triangle" scmContext=pipeline.scmContext}}
 
+{{#unless hasAdmins}}
+  {{#bs-alert type="warning" dismissible=false}}
+    <p>This repo has no admins, click <span class="text-info" onclick={{action "syncAdmins"}}>here</span> to sync from git repo, you must be an admin to do so.</p>
+  {{/bs-alert}}
+{{/unless}}
+
+{{#if (eq syncAdmins "success")}}
+  {{#bs-alert type="success"}}
+    <p>Good job, pipeline's admins are in sync</p>
+  {{/bs-alert}}
+{{/if}}
+
+{{#if (eq syncAdmins "failure")}}
+  {{#bs-alert type="danger"}}
+    <p>Something went wrong, please try syncing again</p>
+  {{/bs-alert}}
+{{/if}}
+
 <div class="row">
   <div class="col-xs-12 col-md-9 separator partial-view">
     {{pipeline-graph-nav


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Periodic jobs will not run due to invalid credentials. It is caused by users either have not login for X days or being deactivated. Resulting git users are out of sync, this feature prompts users on the UI to click **sync** with the latest git repo admins.

## Objective
![image](https://user-images.githubusercontent.com/15989893/158692921-542792c3-09eb-4a95-9db5-fb36b733c969.png)
<!-- What does this PR fix? What intentional changes will this PR make? -->

One can manually produce the scenario by running the following SQL queries

```
// check admins field
SELECT name, id, admins from pipelines where id=1234;

// manually set the admins to be empty
UPDATE pipelines SET admins='{}' WHERE id=1234;

// test the feature and run the sql to check admins field being updated
SELECT name, id, admins from pipelines where id=1234;
```

## References
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
