### PR TITLE
fix: add string case for provider for validator

### DIFF
--- a/app/components/validator-job/template.hbs
+++ b/app/components/validator-job/template.hbs
@@ -154,16 +154,38 @@
     </ul>
   </span>
 </div>
+
 <div class="provider" title="This is the AWS cloud provider you have added to the job for AWS Native builds.">
   <span class="label">Provider:</span>
-  <span class="value">
-    <ul>
-      {{#each-in job.provider as |name value|}}
-        <li><span class="name">{{name}}: </span><span class="value">{{value}}</span></li>
-      {{else}}
-        <li>None defined</li>
-      {{/each-in}}
-    </ul>
-  </span>
+  {{#if job.provider}}
+    {{#if (is-object job.provider)}}
+      <span class="value">
+        <ul>
+          {{#each-in job.provider as |name value|}}
+            <li>
+              <span class="name">{{name}}: </span>
+              {{#if (is-object value)}}
+                <ul>
+                  {{#each-in value as |n v|}}
+                    <li>
+                      <span class="name">{{n}}: </span>
+                      <span class="value">{{v}}</span>
+                    </li>
+                  {{/each-in}}
+                </ul>
+              {{else}}
+                <span class="value">{{value}}</span>
+              {{/if}}
+            </li>
+          {{/each-in}}
+        </ul>
+      </span>
+    {{else}}
+      <span class="value">{{job.provider}}</span>
+    {{/if}}
+  {{else}}
+    <li>None defined</li>
+  {{/if}}
 </div>
+
 {{yield}}

--- a/app/helpers/is-object.js
+++ b/app/helpers/is-object.js
@@ -1,0 +1,13 @@
+import { helper } from '@ember/component/helper';
+import { typeOf } from '@ember/utils';
+
+/**
+ * return whether inupt is a string or not
+ * @param  {[String]}  value  Any string
+ * @return {Boolean}
+ */
+export function isObject([value] /* , hash */) {
+  return typeOf(value) === 'object';
+}
+
+export default helper(isObject);


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
`provider` can either be a string or an object. Validator should handle for both cases.

## Objective
String case:

```
jobs:
  main:
    image: node:12
    steps:
      - echo: echo step
    provider: git@github.com:tkyi/mytest.git#master:provider.yaml
```

![image](https://user-images.githubusercontent.com/15989893/160003520-c2e269ff-5b97-4abc-a266-e05b8467eefb.png)

Object case:
```
jobs:
  main:
    requires: [~pr, ~commit]
    image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
    provider:
      name: aws
      region: us-west-2
      accountId: 123456789012
      vpc:
        vpcId: vpc-0123abc
        securityGroupIds:
          - sg-0123abc
        subnetIds:
          - subnet-0123abc
          - subnet-0123def
          - subnet-0123ghi
      role: arn:aws:iam::123456789012:role/screwdriver-integration-role
      executor: sls
      launcherImage: screwdrivercd/launcher:v6.0.149
      launcherVersion: v6.0.149
    steps:
      - init: npm install
      - test: npm test

```

![image](https://user-images.githubusercontent.com/15989893/160003529-a66a622b-203b-4725-9cd2-fcd88181a847.png)

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
- https://docs.screwdriver.cd/cluster-management/aws-integration#job-provider-configuration
- https://api.emberjs.com/ember/3.16/functions/@ember%2Futils/typeOf
## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
