### PR TITLE
fix(2573): Unify checkbox expansion behavior on pipeline creation page

### DIFF
--- a/app/components/pipeline-create-form/component.js
+++ b/app/components/pipeline-create-form/component.js
@@ -12,7 +12,7 @@ const SEPARATOR = '  '; // 2 spaces
 export default Component.extend({
   selectedTemplate: {},
   templates: [],
-  manualYamlCreation: false,
+  automaticYamlCreation: false,
   scmService: service('scm'),
   template: service(),
   results: '',
@@ -107,7 +107,7 @@ export default Component.extend({
           autoKeysGeneration: this.autoKeysGeneration
         };
 
-        if (!this.manualYamlCreation) {
+        if (this.automaticYamlCreation) {
           payload.yaml = this.yaml;
         }
 

--- a/app/components/pipeline-create-form/template.hbs
+++ b/app/components/pipeline-create-form/template.hbs
@@ -35,13 +35,13 @@
 
 <section>
   <h5 class="bold">Create screwdriver.yaml file</h5>
-  <h5>Choose a template to automatically generate the screwdriver.yaml file for your project or select to create the file manually.</h5>
+  <h5>Create the screwdriver.yaml file manually or choose a template to automatically generate the file for your project.</h5>
   <div>
     {{input class="create-screwdriver-yaml-later" type="checkbox" checked=manualYamlCreation}}
-    <label class="normal-weight">I will create the <span class="select-screwdriver-yaml">screwdriver.yaml {{fa-icon "question-circle"}}</span> later</label>
+    <label class="normal-weight">I choose a template to automatically generate the <span class="select-screwdriver-yaml">screwdriver.yaml {{fa-icon "question-circle"}}</span></label>
 
     <div>
-      {{#unless manualYamlCreation}}
+      {{#if manualYamlCreation}}
         <label class="normal-weight">Start with a <span class="select-template">template {{fa-icon "question-circle"}}</span></label>
 
         <div class="templates-dropdown">
@@ -71,7 +71,7 @@
             What are <a href="https://docs.screwdriver.cd/user-guide/templates" target="_blank" rel="noopener">templates</a>?
           {{/bs-tooltip}}
         </div>
-      {{/unless}}
+      {{/if}}
     </div>
   </div>
 

--- a/app/components/pipeline-create-form/template.hbs
+++ b/app/components/pipeline-create-form/template.hbs
@@ -37,11 +37,11 @@
   <h5 class="bold">Create screwdriver.yaml file</h5>
   <h5>Create the screwdriver.yaml file manually or choose a template to automatically generate the file for your project.</h5>
   <div>
-    {{input class="create-screwdriver-yaml-later" type="checkbox" checked=manualYamlCreation}}
+    {{input class="autogenerate-screwdriver-yaml" type="checkbox" checked=automaticYamlCreation}}
     <label class="normal-weight">I choose a template to automatically generate the <span class="select-screwdriver-yaml">screwdriver.yaml {{fa-icon "question-circle"}}</span></label>
 
     <div>
-      {{#if manualYamlCreation}}
+      {{#if automaticYamlCreation}}
         <label class="normal-weight">Start with a <span class="select-template">template {{fa-icon "question-circle"}}</span></label>
 
         <div class="templates-dropdown">

--- a/tests/acceptance/create-page-test.js
+++ b/tests/acceptance/create-page-test.js
@@ -193,7 +193,7 @@ module('Acceptance | create', function (hooks) {
     assert.dom('.alert > span').hasText('something conflicting');
   });
 
-  test('Create Screwdriver.yaml', async function (assert) {
+  test('Generate Screwdriver.yaml automatically', async function (assert) {
     server.post('http://localhost:8080/v4/pipelines', () => [
       409,
       { 'Content-Type': 'application/json' },
@@ -215,13 +215,14 @@ module('Acceptance | create', function (hooks) {
 
     await fillIn('.text-input', 'git@github.com:foo/bar.git');
     await triggerEvent('.text-input', 'keyup');
+    await click('input.autogenerate-screwdriver-yaml');
 
     assert.dom('.select-template').hasText('template');
     assert.dom('.templates-dropdown').exists();
     assert.dom('.ace_editor').exists();
   });
 
-  test('Create Screwdriver.yaml later', async function (assert) {
+  test('Create Screwdriver.yaml manually', async function (assert) {
     server.post('http://localhost:8080/v4/pipelines', () => [
       409,
       { 'Content-Type': 'application/json' },
@@ -243,7 +244,6 @@ module('Acceptance | create', function (hooks) {
 
     await fillIn('.text-input', 'git@github.com:foo/bar.git');
     await triggerEvent('.text-input', 'keyup');
-    await click('input.create-screwdriver-yaml-later');
 
     assert.dom('.templates-dropdown').doesNotExist();
     assert.dom('.ace_editor').doesNotExist();

--- a/tests/integration/components/create-pipeline/component-test.js
+++ b/tests/integration/components/create-pipeline/component-test.js
@@ -55,6 +55,7 @@ module('Integration | Component | create-pipeline', function (hooks) {
       hbs`{{create-pipeline showCreatePipeline=showCreatePipeline}}`
     );
 
+    await click('.autogenerate-screwdriver-yaml');
     await click('.ember-basic-dropdown-trigger');
     assert
       .dom('.ember-power-select-group-name')


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
The expansion of the checkboxes on the create pipeline page is not consistent.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Modify the behavior of the pipeline creation page so that when a checkbox is checked, the form to automatically generate the screwdriver.yaml is displayed.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
Related to https://github.com/screwdriver-cd/screwdriver/issues/2573
## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
