### PR TITLE
fix(2552): Switch from power icon to info icon

### DIFF
--- a/app/components/quickstart-guide/template.hbs
+++ b/app/components/quickstart-guide/template.hbs
@@ -2,7 +2,7 @@
   <div class="quickstart-guide-menu" onclick={{action "openMenu"}}>
     <div class="mini-menu-oval">
       <div class="mini-menu">
-        {{fa-icon "power-off"}}
+        {{fa-icon "info"}}
       </div>
     </div>
   </div>
@@ -12,7 +12,7 @@
   <div class="header">
     <div class="item">
       <div class="icon">
-        {{fa-icon "power-off"}}
+        {{fa-icon "info"}}
       </div>
       <div class="section">
         <span class="title">


### PR DESCRIPTION
## Context

It can be misleading/confusing to use a power off icon for quickstart information during pipeline creation.

## Objective

This PR switches from power icon to info icon.

Before:
<img width="92" alt="Screen Shot 2022-04-20 at 2 24 27 PM" src="https://user-images.githubusercontent.com/3230529/164325456-3b60f0b9-9947-4817-8c60-ff8413a7ab8d.png">

After:
<img width="33" alt="Screen Shot 2022-04-20 at 2 18 57 PM" src="https://user-images.githubusercontent.com/3230529/164325486-e52e0c25-5362-4fd3-9886-a7b83ac0eab9.png">

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2552

## License


I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
