### PR TITLE
feat(2465): Show base branch name on pipeline graph nav

### DIFF
--- a/app/components/pipeline-graph-nav/template.hbs
+++ b/app/components/pipeline-graph-nav/template.hbs
@@ -58,11 +58,15 @@
       <div class="event-info">
         <div class="col">
           <span class="title">Commit</span><br>
-          <a class={{if (eq selectedEventObj.sha latestCommit.sha) "latest-commit"}} href={{selectedEventObj.commit.url}}>#{{selectedEventObj.truncatedSha}}</a>
+          <span><a class={{if (eq selectedEventObj.sha latestCommit.sha) "latest-commit"}} href={{selectedEventObj.commit.url}}>#{{selectedEventObj.truncatedSha}}</a></span>
         </div>
         <div class="col">
           <span class="title">Message</span><br>
           <span title={{selectedEventObj.commit.message}}>{{selectedEventObj.truncatedMessage}}</span>
+        </div>
+        <div class="col">
+          <span class="title">Branch</span><br>
+          <span>{{selectedEventObj.baseBranch}}</span>
         </div>
         <div class="col">
           <span class="title">Status</span><br>
@@ -70,15 +74,15 @@
         </div>
         <div class="col">
           <span class="title">Committer</span><br>
-          <a href={{selectedEventObj.commit.author.url}}>{{selectedEventObj.commit.author.name}}</a>
+          <span><a href={{selectedEventObj.commit.author.url}}>{{selectedEventObj.commit.author.name}}</a></span>
         </div>
         <div class="col">
           <span class="title">Start Date</span><br>
-          {{selectedEventObj.createTimeExact}}
+          <span>{{selectedEventObj.createTimeExact}}</span>
         </div>
         <div class="col">
           <span class="title">Duration</span><br>
-          {{selectedEventObj.durationText}}
+          <span>{{selectedEventObj.durationText}}</span>
         </div>
         {{#if selectedEventObj.label}}
           <div class="col">

--- a/app/event/model.js
+++ b/app/event/model.js
@@ -9,6 +9,7 @@ import { SHOULD_RELOAD_NO, SHOULD_RELOAD_YES } from '../mixins/model-reloader';
 
 export default DS.Model.extend(ModelReloaderMixin, {
   buildId: DS.attr('number'),
+  baseBranch: DS.attr('string'),
   causeMessage: DS.attr('string'),
   commit: DS.attr(),
   createTime: DS.attr('date'),

--- a/tests/integration/components/pipeline-graph-nav/component-test.js
+++ b/tests/integration/components/pipeline-graph-nav/component-test.js
@@ -10,11 +10,15 @@ module('Integration | Component | pipeline graph nav', function (hooks) {
   test('it renders', async function (assert) {
     set(this, 'obj', {
       sha: 'abc123',
+      baseBranch: 'main',
       truncatedSha: 'abc123',
       status: 'SUCCESS',
       commit: {
         author: { name: 'anonymous' }
-      }
+      },
+      createTimeExact: '04/11/2016, 08:09 PM',
+      truncatedMessage: 'test message',
+      durationText: '10 seconds'
     });
     set(this, 'selected', 2);
     set(this, 'latestCommit', {
@@ -52,21 +56,32 @@ module('Integration | Component | pipeline graph nav', function (hooks) {
     const $columnTitles = this.element.querySelectorAll(
       '.row .event-info .title'
     );
+    const $columnValues = this.element.querySelectorAll(
+      '.row .event-info .title ~ span'
+    );
     const $links = this.element.querySelectorAll('.row .event-info a');
 
     const compare = (elem, expected) => {
-      assert.equal(
-        (elem.innerText.trim() || elem.innerHTML.trim()).toUpperCase(),
-        expected.toUpperCase()
-      );
+      const actual = elem.innerText.trim() || elem.innerHTML.trim();
+
+      assert.strictEqual(actual, expected);
     };
 
     compare($columnTitles[0], 'COMMIT');
     compare($columnTitles[1], 'MESSAGE');
-    compare($columnTitles[2], 'STATUS');
-    compare($columnTitles[3], 'COMMITTER');
-    compare($columnTitles[4], 'START DATE');
-    compare($columnTitles[5], 'DURATION');
+    compare($columnTitles[2], 'BRANCH');
+    compare($columnTitles[3], 'STATUS');
+    compare($columnTitles[4], 'COMMITTER');
+    compare($columnTitles[5], 'START DATE');
+    compare($columnTitles[6], 'DURATION');
+
+    compare($columnValues[0], '#abc123');
+    compare($columnValues[1], 'test message');
+    compare($columnValues[2], 'main');
+    compare($columnValues[3], 'SUCCESS');
+    compare($columnValues[4], 'anonymous');
+    compare($columnValues[5], '04/11/2016, 08:09 PM');
+    compare($columnValues[6], '10 seconds');
 
     compare($links[0], '#abc123');
     compare($links[1], 'anonymous');

--- a/tests/mock/events.js
+++ b/tests/mock/events.js
@@ -4,6 +4,7 @@ import { assign } from '@ember/polyfills';
 const events = [
   {
     id: '2',
+    baseBranch: 'main',
     causeMessage: 'Merged by batman',
     commit: {
       message: 'Merge pull request #2 from batcave/batmobile',
@@ -34,6 +35,7 @@ const events = [
   },
   {
     id: '3',
+    baseBranch: 'main',
     causeMessage: 'Opened by github:robin',
     commit: {
       message: 'fix bug',
@@ -68,6 +70,7 @@ const events = [
   },
   {
     id: '4',
+    baseBranch: 'main',
     causeMessage: 'Opened by github:robin',
     commit: {
       message: 'fix docs',


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

User cannot know which branch is used when start detached job from a specific branch event.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

This PR adds a base branch name column to the pipeline graph navigation as the following.

![base_branch_name](https://user-images.githubusercontent.com/43719835/164380437-fae4b139-a490-4b5c-8ad8-739a02775fba.jpg)

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

- Issue comment
  - https://github.com/screwdriver-cd/screwdriver/issues/2465#issuecomment-896544388

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
