### PR TITLE
feat(2539): Add job enable or disable toggle on pipeline tooltip

### DIFF
--- a/app/components/pipeline-workflow/template.hbs
+++ b/app/components/pipeline-workflow/template.hbs
@@ -23,6 +23,7 @@
       stopBuild=stopBuild
       showTooltip=showTooltip
       showTooltipPosition=showTooltipPosition
+      setJobStatus=setJobStatus
       confirmStartBuild=(action "confirmStartBuild")
     }}
   {{/workflow-graph-d3}}

--- a/app/components/workflow-tooltip/component.js
+++ b/app/components/workflow-tooltip/component.js
@@ -1,11 +1,12 @@
 import Component from '@ember/component';
-import { get } from '@ember/object';
+import { get, computed } from '@ember/object';
 import { equal } from '@ember/object/computed';
 
 export default Component.extend({
   classNames: 'workflow-tooltip',
   classNameBindings: ['showTooltip', 'left'],
   showTooltip: false,
+  showToggleModal: false,
   left: equal('showTooltipPosition', 'left'),
 
   didUpdateAttrs() {
@@ -24,6 +25,32 @@ export default Component.extend({
 
       el.style.top = `${top}px`;
       el.style.left = `${left}px`;
+    }
+  },
+  jobState: computed('tooltipData.job.isDisabled', function jobState() {
+    const isDisabled = get(this, 'tooltipData.job.isDisabled');
+
+    return isDisabled ? 'ENABLED' : 'DISABLED';
+  }),
+  actions: {
+    toggleJob(jobId, toggleJobName) {
+      const state = this.jobState;
+
+      this.set('toggleJobName', toggleJobName);
+      this.set(
+        'stateChange',
+        state[0].toUpperCase() + state.slice(1, -1).toLowerCase()
+      );
+
+      this.set('jobId', jobId);
+      this.set('showToggleModal', true);
+    },
+    updateMessage(message) {
+      const { jobId, jobState } = this;
+
+      this.setJobStatus(jobId, jobState, message || ' ');
+      this.set('showToggleModal', false);
+      this.set('showTooltip', false);
     }
   }
 });

--- a/app/components/workflow-tooltip/template.hbs
+++ b/app/components/workflow-tooltip/template.hbs
@@ -12,21 +12,27 @@
       {{/if}}
     {{/if}}
     {{#link-to "pipeline.metrics" (query-params jobId=tooltipData.job.id)}}Go to build metrics{{/link-to}}
-    {{#if displayRestartButton}}
-      {{#if (eq tooltipData.job.status "DISABLED")}}
-        <p>{{tooltipData.job.stateChangeMessage}}</p>
-      {{else if tooltipData.job.manualStartDisabled}}
-        <p>Disabled manually starting</p>
-      {{else}}
-        {{#if (eq isPrChainJob false)}}
-          <a {{action confirmStartBuild}}>{{if tooltipData.job.status "Restart" "Start"}} pipeline from here</a>
+
+    {{#if tooltipData.job.isDisabled}}
+      <p>{{tooltipData.job.stateChangeMessage}}</p>
+      <a {{action "toggleJob" tooltipData.job.id tooltipData.job.name true}}>Enable this job</a>
+    {{else}}
+      {{#if displayRestartButton}}
+        {{#if tooltipData.job.manualStartDisabled}}
+          <p>Disabled manually starting</p>
         {{else}}
-          {{#if (eq prBuildExists true)}}
+          {{#if (eq isPrChainJob false)}}
             <a {{action confirmStartBuild}}>{{if tooltipData.job.status "Restart" "Start"}} pipeline from here</a>
+          {{else}}
+            {{#if (eq prBuildExists true)}}
+              <a {{action confirmStartBuild}}>{{if tooltipData.job.status "Restart" "Start"}} pipeline from here</a>
+            {{/if}}
           {{/if}}
         {{/if}}
       {{/if}}
+      <a {{action "toggleJob" tooltipData.job.id tooltipData.job.name false}}>Disable this job</a>
     {{/if}}
+
     {{#if tooltipData.displayStop}}
       <a {{action stopBuild tooltipData.selectedEvent tooltipData.job}}>Stop build</a>
     {{/if}}
@@ -36,3 +42,4 @@
   {{/if}}
   {{yield}}
 </div>
+{{job-toggle-modal showToggleModal=showToggleModal updateMessage=(action "updateMessage") name=toggleJobName stateChange=stateChange}}

--- a/app/components/workflow-tooltip/template.hbs
+++ b/app/components/workflow-tooltip/template.hbs
@@ -15,7 +15,7 @@
 
     {{#if tooltipData.job.isDisabled}}
       <p>{{tooltipData.job.stateChangeMessage}}</p>
-      <a {{action "toggleJob" tooltipData.job.id tooltipData.job.name true}}>Enable this job</a>
+      <a {{action "toggleJob" tooltipData.job.id tooltipData.job.name}}>Enable this job</a>
     {{else}}
       {{#if displayRestartButton}}
         {{#if tooltipData.job.manualStartDisabled}}
@@ -30,7 +30,7 @@
           {{/if}}
         {{/if}}
       {{/if}}
-      <a {{action "toggleJob" tooltipData.job.id tooltipData.job.name false}}>Disable this job</a>
+      <a {{action "toggleJob" tooltipData.job.id tooltipData.job.name}}>Disable this job</a>
     {{/if}}
 
     {{#if tooltipData.displayStop}}

--- a/app/pipeline/controller.js
+++ b/app/pipeline/controller.js
@@ -16,6 +16,15 @@ export default Controller.extend({
       }
 
       return collection.save();
+    },
+    setJobStatus(id, state, stateChangeMessage) {
+      const job = this.store.peekRecord('job', id);
+
+      job.set('state', state);
+      job.set('stateChangeMessage', stateChangeMessage);
+      job
+        .save()
+        .catch(error => this.set('errorMessage', error.errors[0].detail || ''));
     }
   }
 });

--- a/app/pipeline/events/controller.js
+++ b/app/pipeline/events/controller.js
@@ -1,4 +1,4 @@
-import Controller from '@ember/controller';
+import Controller, { inject } from '@ember/controller';
 import { computed, get } from '@ember/object';
 import { alias } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
@@ -175,6 +175,7 @@ export async function updateEvents(page) {
 }
 
 export default Controller.extend(ModelReloaderMixin, {
+  pipelineController: inject('pipeline'),
   shuttle: service(),
   lastRefreshed: moment(),
   expandedEventsGroup: {},
@@ -627,6 +628,15 @@ export default Controller.extend(ModelReloaderMixin, {
       } catch (e) {
         this.set('syncAdmins', 'failure');
       }
+    },
+    setJobStatus(id, state, stateChangeMessage) {
+      this.pipelineController.send(
+        'setJobStatus',
+        id,
+        state,
+        stateChangeMessage
+      );
+      this.reload();
     }
   },
   willDestroy() {

--- a/app/pipeline/events/template.hbs
+++ b/app/pipeline/events/template.hbs
@@ -61,6 +61,7 @@
       selected=selected
       startDetachedBuild=(action "startDetachedBuild")
       stopBuild=(action "stopBuild")
+      setJobStatus=(action "setJobStatus")
       authenticated=session.isAuthenticated
     }}
 

--- a/app/pipeline/options/controller.js
+++ b/app/pipeline/options/controller.js
@@ -1,8 +1,9 @@
-import Controller from '@ember/controller';
+import Controller, { inject } from '@ember/controller';
 import { reads } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 
 export default Controller.extend({
+  pipelineController: inject('pipeline'),
   session: service(),
   errorMessage: '',
   isSaving: false,
@@ -10,13 +11,12 @@ export default Controller.extend({
   jobs: reads('model.jobs'),
   actions: {
     setJobStatus(id, state, stateChangeMessage) {
-      const job = this.store.peekRecord('job', id);
-
-      job.set('state', state);
-      job.set('stateChangeMessage', stateChangeMessage);
-      job
-        .save()
-        .catch(error => this.set('errorMessage', error.errors[0].detail || ''));
+      this.pipelineController.send(
+        'setJobStatus',
+        id,
+        state,
+        stateChangeMessage
+      );
     },
     removePipeline() {
       this.pipeline

--- a/app/utils/graph-tools.js
+++ b/app/utils/graph-tools.js
@@ -1,4 +1,4 @@
-import { get } from '@ember/object';
+import { get, getWithDefault } from '@ember/object';
 import DS from 'ember-data';
 
 const STATUS_MAP = {
@@ -226,10 +226,11 @@ const decorateGraph = ({ inputGraph, builds, jobs, start }) => {
 
     if (jobsAvailable) {
       const j = job(jobs, jobId);
-      const jobIsDisabled = j ? get(j, 'isDisabled') : null;
+
+      n.isDisabled = j ? getWithDefault(j, 'isDisabled', false) : false;
 
       // Set build status to disabled if job is disabled
-      if (jobIsDisabled) {
+      if (n.isDisabled) {
         const state = get(j, 'state');
         const stateWithCapitalization =
           state[0].toUpperCase() + state.substring(1).toLowerCase();

--- a/tests/integration/components/workflow-tooltip/component-test.js
+++ b/tests/integration/components/workflow-tooltip/component-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | workflow tooltip', function (hooks) {
@@ -9,7 +9,8 @@ module('Integration | Component | workflow tooltip', function (hooks) {
   test('it renders', async function (assert) {
     await render(hbs`{{workflow-tooltip}}`);
 
-    assert.dom(this.element).hasText('Go to build metrics');
+    assert.dom('a:nth-of-type(1)').hasText('Go to build metrics');
+    assert.dom('a:nth-of-type(2)').hasText('Disable this job');
 
     // Template block usage:
     await render(hbs`
@@ -34,9 +35,10 @@ module('Integration | Component | workflow tooltip', function (hooks) {
 
     await render(hbs`{{workflow-tooltip tooltipData=data}}`);
 
-    assert.dom('.content a').exists({ count: 2 });
-    assert.dom('a:first-child').hasText('Go to build details');
-    assert.dom('a:last-child').hasText('Go to build metrics');
+    assert.dom('.content a').exists({ count: 3 });
+    assert.dom('a:nth-of-type(1)').hasText('Go to build details');
+    assert.dom('a:nth-of-type(2)').hasText('Go to build metrics');
+    assert.dom('a:nth-of-type(3)').hasText('Disable this job');
   });
 
   test('it renders remote trigger link', async function (assert) {
@@ -102,9 +104,12 @@ module('Integration | Component | workflow tooltip', function (hooks) {
       confirmStartBuild="confirmStartBuild"
     }}`);
 
-    assert.dom('.content a').exists({ count: 2 });
-    assert.dom('a:first-child').hasText('Go to build details');
-    assert.dom('p:last-child').hasText('Disabled manually starting');
+    assert.dom('.content a').exists({ count: 3 });
+    assert.dom('.content p').exists({ count: 1 });
+    assert.dom('a:nth-of-type(1)').hasText('Go to build details');
+    assert.dom('a:nth-of-type(2)').hasText('Go to build metrics');
+    assert.dom('a:nth-of-type(3)').hasText('Disable this job');
+    assert.dom('p:nth-of-type(1)').hasText('Disabled manually starting');
   });
 
   test('it renders start link', async function (assert) {
@@ -127,9 +132,11 @@ module('Integration | Component | workflow tooltip', function (hooks) {
       isPrChainJob=isPrChainJob
     }}`);
 
-    assert.dom('.content a').exists({ count: 3 });
-    assert.dom('a:first-child').hasText('Go to build details');
-    assert.dom('a:last-child').hasText('Start pipeline from here');
+    assert.dom('.content a').exists({ count: 4 });
+    assert.dom('a:nth-of-type(1)').hasText('Go to build details');
+    assert.dom('a:nth-of-type(2)').hasText('Go to build metrics');
+    assert.dom('a:nth-of-type(3)').hasText('Start pipeline from here');
+    assert.dom('a:nth-of-type(4)').hasText('Disable this job');
   });
 
   test('it renders restart link', async function (assert) {
@@ -153,9 +160,67 @@ module('Integration | Component | workflow tooltip', function (hooks) {
       isPrChainJob=isPrChainJob
     }}`);
 
+    assert.dom('.content a').exists({ count: 4 });
+    assert.dom('a:nth-of-type(1)').hasText('Go to build details');
+    assert.dom('a:nth-of-type(2)').hasText('Go to build metrics');
+    assert.dom('a:nth-of-type(3)').hasText('Restart pipeline from here');
+    assert.dom('a:nth-of-type(4)').hasText('Disable this job');
+  });
+
+  test('it renders disable link', async function (assert) {
+    const data = {
+      job: {
+        buildId: 1234,
+        name: 'batmobile',
+        isDisabled: false
+      }
+    };
+
+    this.set('data', data);
+    this.set('confirmStartBuild', () => {});
+    this.set('isPrChainJob', false);
+
+    await render(hbs`{{
+      workflow-tooltip
+      tooltipData=data
+      displayRestartButton=true
+      confirmStartBuild="confirmStartBuild"
+      isPrChainJob=isPrChainJob
+    }}`);
+
+    assert.dom('.content a').exists({ count: 4 });
+    assert.dom('a:nth-of-type(1)').hasText('Go to build details');
+    assert.dom('a:nth-of-type(2)').hasText('Go to build metrics');
+    assert.dom('a:nth-of-type(3)').hasText('Start pipeline from here');
+    assert.dom('a:nth-of-type(4)').hasText('Disable this job');
+  });
+
+  test('it renders enable link', async function (assert) {
+    const data = {
+      job: {
+        buildId: 1234,
+        name: 'batmobile',
+        status: 'DISABLED',
+        isDisabled: true
+      }
+    };
+
+    this.set('data', data);
+    this.set('confirmStartBuild', () => {});
+    this.set('isPrChainJob', false);
+
+    await render(hbs`{{
+      workflow-tooltip
+      tooltipData=data
+      displayRestartButton=true
+      confirmStartBuild="confirmStartBuild"
+      isPrChainJob=isPrChainJob
+    }}`);
+
     assert.dom('.content a').exists({ count: 3 });
-    assert.dom('a:first-child').hasText('Go to build details');
-    assert.dom('a:last-child').hasText('Restart pipeline from here');
+    assert.dom('a:nth-of-type(1)').hasText('Go to build details');
+    assert.dom('a:nth-of-type(2)').hasText('Go to build metrics');
+    assert.dom('a:nth-of-type(3)').hasText('Enable this job');
   });
 
   test('it hides restart link if no build exists in PRChain', async function (assert) {
@@ -181,9 +246,10 @@ module('Integration | Component | workflow tooltip', function (hooks) {
       prBuildExists=prBuildExists
     }}`);
 
-    assert.dom('.content a').exists({ count: 2 });
-    assert.dom('a:first-child').hasText('Go to build details');
-    assert.dom('a:last-child').hasText('Go to build metrics');
+    assert.dom('.content a').exists({ count: 3 });
+    assert.dom('a:nth-of-type(1)').hasText('Go to build details');
+    assert.dom('a:nth-of-type(2)').hasText('Go to build metrics');
+    assert.dom('a:nth-of-type(3)').hasText('Disable this job');
   });
 
   test('it renders stop frozen build link', async function (assert) {
@@ -207,9 +273,11 @@ module('Integration | Component | workflow tooltip', function (hooks) {
       action="action"
     }}`);
 
-    assert.dom('.content a').exists({ count: 3 });
-    assert.dom('a:first-child').hasText('Go to build details');
-    assert.dom('a:last-child').hasText('Stop frozen build');
+    assert.dom('.content a').exists({ count: 4 });
+    assert.dom('a:nth-of-type(1)').hasText('Go to build details');
+    assert.dom('a:nth-of-type(2)').hasText('Go to build metrics');
+    assert.dom('a:nth-of-type(3)').hasText('Disable this job');
+    assert.dom('a:nth-of-type(4)').hasText('Stop frozen build');
   });
 
   test('it shows restart link if build exists in PRChain', async function (assert) {
@@ -235,9 +303,11 @@ module('Integration | Component | workflow tooltip', function (hooks) {
       prBuildExists=prBuildExists
     }}`);
 
-    assert.dom('.content a').exists({ count: 3 });
-    assert.dom('a:first-child').hasText('Go to build details');
-    assert.dom('a:last-child').hasText('Restart pipeline from here');
+    assert.dom('.content a').exists({ count: 4 });
+    assert.dom('a:nth-of-type(1)').hasText('Go to build details');
+    assert.dom('a:nth-of-type(2)').hasText('Go to build metrics');
+    assert.dom('a:nth-of-type(3)').hasText('Restart pipeline from here');
+    assert.dom('a:nth-of-type(4)').hasText('Disable this job');
   });
 
   test('it should update position and hidden status', async function (assert) {
@@ -258,5 +328,55 @@ module('Integration | Component | workflow tooltip', function (hooks) {
 
     assert.dom('.workflow-tooltip').hasNoClass('show-tooltip');
     assert.dom('.workflow-tooltip').hasNoClass('left');
+  });
+
+  test('it shows job toggle modal when click disable link', async function (assert) {
+    const data = {
+      job: {
+        buildId: 1234,
+        name: 'batmobile',
+        isDisabled: false
+      }
+    };
+
+    this.set('data', data);
+
+    await render(hbs`{{
+      workflow-tooltip
+      tooltipData=data
+    }}`);
+
+    assert.dom('.content a').exists({ count: 3 });
+    assert.dom('a:nth-of-type(3)').hasText('Disable this job');
+
+    await click('a:nth-of-type(3)');
+
+    assert.dom('.toggle-modal').exists({ count: 1 });
+    assert.dom('.modal-title').hasText('Disable the "batmobile" job?');
+  });
+
+  test('it shows job toggle modal when click enable link', async function (assert) {
+    const data = {
+      job: {
+        buildId: 1234,
+        name: 'batmobile',
+        isDisabled: true
+      }
+    };
+
+    this.set('data', data);
+
+    await render(hbs`{{
+      workflow-tooltip
+      tooltipData=data
+    }}`);
+
+    assert.dom('.content a').exists({ count: 3 });
+    assert.dom('a:nth-of-type(3)').hasText('Enable this job');
+
+    await click('a:nth-of-type(3)');
+
+    assert.dom('.toggle-modal').exists({ count: 1 });
+    assert.dom('.modal-title').hasText('Enable the "batmobile" job?');
   });
 });

--- a/tests/unit/utils/graph-tools-test.js
+++ b/tests/unit/utils/graph-tools-test.js
@@ -250,6 +250,8 @@ module('Unit | Utility | graph tools', function () {
       { id: 1 },
       {
         id: 2,
+        isDisabled: true,
+        state: 'DISABLED',
         permutations: [
           { annotations: { 'screwdriver.cd/manualStartEnabled': true } }
         ]
@@ -268,23 +270,51 @@ module('Unit | Utility | graph tools', function () {
     ];
     const expectedOutput = {
       nodes: [
-        { name: '~pr', pos: { x: 0, y: 0 } },
-        { name: '~commit', pos: { x: 0, y: 1 } },
-        { name: 'main', id: 1, pos: { x: 1, y: 0 } },
+        {
+          name: '~pr',
+          isDisabled: false,
+          pos: { x: 0, y: 0 }
+        },
+        {
+          name: '~commit',
+          isDisabled: false,
+          pos: { x: 0, y: 1 }
+        },
+        {
+          name: 'main',
+          id: 1,
+          isDisabled: false,
+          pos: { x: 1, y: 0 }
+        },
         {
           name: 'A',
           id: 2,
-          pos: { x: 2, y: 0 },
-          manualStartDisabled: false
+          isDisabled: true,
+          manualStartDisabled: false,
+          stateChangeMessage: 'Disabled',
+          status: 'DISABLED',
+          pos: { x: 2, y: 0 }
         },
-        { name: 'B', id: 3, pos: { x: 2, y: 1 }, manualStartDisabled: true },
+        {
+          name: 'B',
+          id: 3,
+          isDisabled: false,
+          manualStartDisabled: true,
+          pos: { x: 2, y: 1 }
+        },
         {
           name: 'C',
           id: 4,
-          pos: { x: 3, y: 0 },
-          manualStartDisabled: false
+          isDisabled: false,
+          manualStartDisabled: false,
+          pos: { x: 3, y: 0 }
         },
-        { name: 'D', id: 5, pos: { x: 4, y: 0 } }
+        {
+          name: 'D',
+          id: 5,
+          isDisabled: false,
+          pos: { x: 4, y: 0 }
+        }
       ],
       edges: [
         { src: '~pr', dest: 'main', from: { x: 0, y: 0 }, to: { x: 1, y: 0 } },
@@ -296,7 +326,13 @@ module('Unit | Utility | graph tools', function () {
         },
         { src: 'main', dest: 'A', from: { x: 1, y: 0 }, to: { x: 2, y: 0 } },
         { src: 'main', dest: 'B', from: { x: 1, y: 0 }, to: { x: 2, y: 1 } },
-        { src: 'A', dest: 'C', from: { x: 2, y: 0 }, to: { x: 3, y: 0 } },
+        {
+          src: 'A',
+          dest: 'C',
+          status: 'DISABLED',
+          from: { x: 2, y: 0 },
+          to: { x: 3, y: 0 }
+        },
         { src: 'B', dest: 'D', from: { x: 2, y: 1 }, to: { x: 4, y: 0 } },
         { src: 'C', dest: 'D', from: { x: 3, y: 0 }, to: { x: 4, y: 0 } }
       ],


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

User cannot toggle to disable or enable jobs while looking a pipeline graph.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

This PR appends a job state toggle to pipeline tooltip as the following.

![toggle](https://user-images.githubusercontent.com/43719835/166193491-29a758e7-92b1-45fa-bb62-2121ce94f711.jpg)

Clicking this toggle will bring up a confirmation modal, similar to the option page.

![modal](https://user-images.githubusercontent.com/43719835/166193632-49a8e096-15a4-4dfd-9089-b005cfa5df73.png)

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

Issues
- Feat: https://github.com/screwdriver-cd/screwdriver/issues/2539 
- Fix: https://github.com/screwdriver-cd/screwdriver/issues/2633

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
