### PR TITLE
fix: prevent label overflow behind event list

### DIFF
--- a/app/components/pipeline-graph-nav/styles.scss
+++ b/app/components/pipeline-graph-nav/styles.scss
@@ -83,7 +83,7 @@
   }
 
   .col {
-    flex: 1 0 calc(100% / 8);
+    flex: 1 0 calc(100% / 12);
     padding-left: 10px;
     border-right: 1px solid $grey-500;
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Introducing `branch name`(https://github.com/screwdriver-cd/ui/pull/781) accidentally caused label overflows

## Objective

Before:
![image](https://user-images.githubusercontent.com/15989893/167209132-972d48e2-a636-48e1-9917-804eddad0cbb.png)

After:
![image](https://user-images.githubusercontent.com/15989893/167208997-b20b25b1-63fd-44c2-9cb1-0838a7a7e0ef.png)

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
