### PR TITLE
feat: add sort by failed builds and Last Run Job column to dashboard collection

### DIFF
--- a/app/collection/model.js
+++ b/app/collection/model.js
@@ -5,5 +5,5 @@ export default DS.Model.extend({
   description: DS.attr('string'),
   type: DS.attr('string'),
   pipelineIds: DS.attr(),
-  pipelines: DS.attr()
+  pipelines: DS.hasMany('pipeline', { sync: true })
 });

--- a/app/collection/serializer.js
+++ b/app/collection/serializer.js
@@ -1,7 +1,23 @@
 import { assign } from '@ember/polyfills';
 import DS from 'ember-data';
+import { EmbeddedRecordsMixin } from '@ember-data/serializer/rest';
 
-export default DS.RESTSerializer.extend({
+export default DS.RESTSerializer.extend(EmbeddedRecordsMixin, {
+  attrs: {
+    pipelines: { embedded: 'always' }
+  },
+
+  normalizeResponse(store, typeClass, payload, id, requestType) {
+    if (requestType === 'findRecord') {
+      payload.collection.pipelines.forEach(p => {
+        p.links = {
+          metrics: `/v4/pipelines/${p.id}/metrics?count=20&page=1`
+        };
+      });
+    }
+
+    return this._super(store, typeClass, payload, id, requestType);
+  },
   /**
    * Override the serializeIntoHash method
    * See http://emberjs.com/api/data/classes/DS.RESTSerializer.html#method_serializeIntoHash

--- a/app/components/collection-table-row/component.js
+++ b/app/components/collection-table-row/component.js
@@ -25,6 +25,13 @@ export default Component.extend({
 
     return rootDir ? `${branch}#${rootDir}` : branch;
   }),
+  lastRun: computed('lastRun', function get() {
+    const startTime = this.pipeline.createTime;
+    const timeDifference = Math.abs(new Date() - new Date(startTime).getTime());
+    const days = Math.ceil(timeDifference / (1000 * 3600 * 24));
+
+    return days;
+  }),
   showRemoveButton: computed(
     'isOrganizing',
     'isAuthenticated',
@@ -78,6 +85,7 @@ export default Component.extend({
       lastEventInfo
     });
   },
+
   actions: {
     removePipeline() {
       this.removePipeline(this.pipeline.id, this.pipeline.name);

--- a/app/components/collection-table-row/component.js
+++ b/app/components/collection-table-row/component.js
@@ -68,17 +68,11 @@ export default Component.extend({
     }
   },
   async updateEventMetrics() {
-    const metrics = await this.store
-      .query('metric', {
-        pipelineId: this.pipeline.id,
-        page: 1,
-        count: 20
-      })
-      .catch(() => {
-        this.setProperties({
-          storeQueryError: true
-        });
+    const metrics = await this.pipeline.get('metrics').catch(() => {
+      this.setProperties({
+        storeQueryError: true
       });
+    });
 
     const result = formatMetrics(metrics);
     const { eventsInfo, lastEventInfo } = result;

--- a/app/components/collection-table-row/component.js
+++ b/app/components/collection-table-row/component.js
@@ -3,6 +3,8 @@ import { computed } from '@ember/object';
 import { and } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 import { formatMetrics } from 'screwdriver-ui/utils/metric';
+import templateHelper from 'screwdriver-ui/utils/template';
+const { getLastUpdatedTime } = templateHelper;
 
 export default Component.extend({
   store: service(),
@@ -27,10 +29,11 @@ export default Component.extend({
   }),
   lastRun: computed('lastRun', function get() {
     const startTime = this.pipeline.createTime;
-    const timeDifference = Math.abs(new Date() - new Date(startTime).getTime());
-    const days = Math.ceil(timeDifference / (1000 * 3600 * 24));
+    const lastRun = getLastUpdatedTime({
+      createTime: startTime
+    });
 
-    return days;
+    return lastRun;
   }),
   showRemoveButton: computed(
     'isOrganizing',

--- a/app/components/collection-table-row/component.js
+++ b/app/components/collection-table-row/component.js
@@ -28,9 +28,9 @@ export default Component.extend({
     return rootDir ? `${branch}#${rootDir}` : branch;
   }),
   lastRun: computed('lastRun', function get() {
-    const startTime = this.pipeline.createTime;
+    const { createTime } = this.pipeline;
     const lastRun = getLastUpdatedTime({
-      createTime: startTime
+      createTime
     });
 
     return lastRun;

--- a/app/components/collection-table-row/template.hbs
+++ b/app/components/collection-table-row/template.hbs
@@ -31,7 +31,7 @@
   {{lastEventInfo.durationText}}
 </td>
 <td class="last-run">
-  <span title={{lastRun}}> {{lastRun}} days ago </span>
+  <span title={{lastRun}}> {{lastRun}}</span>
 </td>
 <td class="history">
   {{#if hasBothEventsAndLatestEventInfo}}

--- a/app/components/collection-table-row/template.hbs
+++ b/app/components/collection-table-row/template.hbs
@@ -30,6 +30,9 @@
 <td class="duration">
   {{lastEventInfo.durationText}}
 </td>
+<td class="last-run">
+  <span title={{lastRun}}> {{lastRun}} days ago </span>
+</td>
 <td class="history">
   {{#if hasBothEventsAndLatestEventInfo}}
     {{events-thumbnail

--- a/app/components/collection-view/component.js
+++ b/app/components/collection-view/component.js
@@ -145,6 +145,24 @@ export default Component.extend({
       );
     }
   ),
+  updateFailedBuild() {
+    this.collectionPipelines.forEach(async pipeline => {
+      const metrics = await this.store.query('metric', {
+        pipelineId: pipeline.id,
+        page: 1,
+        count: 20
+      });
+
+      let failedBuildCount = 0;
+
+      metrics.toArray().forEach(event => {
+        if (event.status === 'FAILURE' || event.status === 'ABORTED') {
+          failedBuildCount += 1;
+        }
+      });
+      pipeline.failedBuildCount = failedBuildCount;
+    });
+  },
 
   actions: {
     /**
@@ -207,6 +225,10 @@ export default Component.extend({
         default:
           this.set('sortBy', [option]);
       }
+    },
+    sortByFailedBuilds(option) {
+      this.updateFailedBuild();
+      this.set('sortBy', [option]);
     },
     organize() {
       this.set('isOrganizing', true);

--- a/app/components/collection-view/component.js
+++ b/app/components/collection-view/component.js
@@ -145,24 +145,6 @@ export default Component.extend({
       );
     }
   ),
-  updateFailedBuild() {
-    this.collectionPipelines.forEach(async pipeline => {
-      const metrics = await this.store.query('metric', {
-        pipelineId: pipeline.id,
-        page: 1,
-        count: 20
-      });
-
-      let failedBuildCount = 0;
-
-      metrics.toArray().forEach(event => {
-        if (event.status === 'FAILURE' || event.status === 'ABORTED') {
-          failedBuildCount += 1;
-        }
-      });
-      pipeline.failedBuildCount = failedBuildCount;
-    });
-  },
 
   actions: {
     /**
@@ -227,7 +209,6 @@ export default Component.extend({
       }
     },
     sortByFailedBuilds(option) {
-      this.updateFailedBuild();
       this.set('sortBy', [option]);
     },
     organize() {

--- a/app/components/collection-view/component.js
+++ b/app/components/collection-view/component.js
@@ -208,9 +208,6 @@ export default Component.extend({
           this.set('sortBy', [option]);
       }
     },
-    sortByFailedBuilds(option) {
-      this.set('sortBy', [option]);
-    },
     organize() {
       this.set('isOrganizing', true);
     },

--- a/app/components/collection-view/component.js
+++ b/app/components/collection-view/component.js
@@ -113,6 +113,7 @@ export default Component.extend({
       }
     }
   }),
+
   collectionPipelines: computed('collection.pipelines', {
     get() {
       let viewingId = this.get('collection.id');

--- a/app/components/collection-view/styles.scss
+++ b/app/components/collection-view/styles.scss
@@ -177,8 +177,13 @@
     width: 30%;
     max-width: 200px;
 
-    span {
-      display: inline;
+    .icon-wrapper {
+      display: flex;
+      flex-direction: column;
+
+      .fa {
+        line-height: 0;
+      }
     }
   }
 
@@ -204,8 +209,19 @@
   }
 
   .history {
-    width: 25%;
-    padding: 5px;
+    width: 30%;
+    max-width: 200px;
+    display: flex;
+    align-items: center;
+
+    .icon-wrapper {
+      display: flex;
+      flex-direction: column;
+
+      .fa {
+        line-height: 0;
+      }
+    }
   }
 
   tbody tr:hover {

--- a/app/components/collection-view/styles.scss
+++ b/app/components/collection-view/styles.scss
@@ -173,20 +173,6 @@
     max-width: 200px;
   }
 
-  .last-run {
-    width: 30%;
-    max-width: 200px;
-
-    .icon-wrapper {
-      display: flex;
-      flex-direction: column;
-
-      .fa {
-        line-height: 0;
-      }
-    }
-  }
-
   .status {
     width: 15%;
     min-width: 120px;
@@ -206,6 +192,17 @@
     width: 10%;
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen,
       Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  }
+
+  .last-run {
+    width: 12%;
+    max-width: 200px;
+
+    .icon-wrapper {
+      .fa {
+        line-height: 0;
+      }
+    }
   }
 
   .history {

--- a/app/components/collection-view/styles.scss
+++ b/app/components/collection-view/styles.scss
@@ -209,8 +209,6 @@
   }
 
   .history {
-    width: 30%;
-    max-width: 200px;
     display: flex;
     align-items: center;
 

--- a/app/components/collection-view/styles.scss
+++ b/app/components/collection-view/styles.scss
@@ -173,6 +173,15 @@
     max-width: 200px;
   }
 
+  .last-run {
+    width: 30%;
+    max-width: 200px;
+
+    span {
+      display: inline;
+    }
+  }
+
   .status {
     width: 15%;
     min-width: 120px;
@@ -184,14 +193,14 @@
 
   .start {
     width: 10%;
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell,
-      'Open Sans', 'Helvetica Neue', sans-serif;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen,
+      Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
   }
 
   .duration {
     width: 10%;
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell,
-      'Open Sans', 'Helvetica Neue', sans-serif;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen,
+      Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
   }
 
   .history {

--- a/app/components/collection-view/template.hbs
+++ b/app/components/collection-view/template.hbs
@@ -149,13 +149,15 @@
           <thead>
             <tr>
               <th class="collection-pipeline__choose"></th>
-              <th class="alias" rowspan="1">Alias</th>
               <th class="app-id" rowspan="1">Name</th>
               <th class="branch" rowspan="1">Branch</th>
               <th class="status" rowspan="1">Status</th>
               <th class="start" rowspan="1">Start Date</th>
               <th class="duration" rowspan="1">Duration</th>
-              <th class="last-run" rowspan="1">Last Run Job</th>
+              <th class="last-run" rowspan="1"> Last Run Job
+                <span onclick={{action "setSortBy" "createTime:asc"}}>{{fa-icon "sort-asc" }}</span>
+                <span onclick={{action "setSortBy" "createTime:desc"}}>{{fa-icon "sort-desc" }}</span>
+              </th>
               <th class="history" rowspan="1">Build History</th>
               <th class="collection-pipeline__remove"></th>
             </tr>

--- a/app/components/collection-view/template.hbs
+++ b/app/components/collection-view/template.hbs
@@ -155,10 +155,18 @@
               <th class="start" rowspan="1">Start Date</th>
               <th class="duration" rowspan="1">Duration</th>
               <th class="last-run" rowspan="1"> Last Run Job
-                <span onclick={{action "setSortBy" "createTime:asc"}}>{{fa-icon "sort-asc" }}</span>
-                <span onclick={{action "setSortBy" "createTime:desc"}}>{{fa-icon "sort-desc" }}</span>
+                <span class="icon-wrapper">
+                  <i class="fa fa-sort-asc" onclick={{action "setSortBy" "createTime"}}></i>
+                  <i class="fa fa-sort-desc" onclick={{action "setSortBy" "createTime:desc"}}></i>
+                </span>
               </th>
-              <th class="history" rowspan="1">Build History</th>
+              <th class="history" rowspan="1">
+                 Build History
+                <span class="icon-wrapper">
+                  <i class="fa fa-sort-asc" onclick={{action "sortByFailedBuilds" "failedBuildCount"}}></i>
+                  <i class="fa fa-sort-desc" onclick={{action "sortByFailedBuilds" "failedBuildCount:desc"}}></i>
+                </span>
+              </th>
               <th class="collection-pipeline__remove"></th>
             </tr>
           </thead>
@@ -168,7 +176,7 @@
                   class="collection-pipeline"
                   removePipeline=(action "removePipeline")
                   pipeline=pipeline
-                  isAuthenticated=session.isAuthenticated
+                  isAuthenticated=session.isAuthenticayqted
                   isOrganizing=isOrganizing
                   isDefaultCollection=isDefaultCollection
                   selectPipeline=(action "selectPipeline")

--- a/app/components/collection-view/template.hbs
+++ b/app/components/collection-view/template.hbs
@@ -154,18 +154,28 @@
               <th class="status" rowspan="1">Status</th>
               <th class="start" rowspan="1">Start Date</th>
               <th class="duration" rowspan="1">Duration</th>
-              <th class="last-run" rowspan="1">
+              <th class="last-run" rowspan="1" onclick={{action "setSortBy" (if (eq (get sortBy 0) "createTime:desc") "createTime:asc" "createTime:desc")}}>
                 Last Run Job
                 <span class="icon-wrapper">
-                  <i class="fa fa-sort-asc" onclick={{action "setSortBy" "createTime:asc"}}></i>
-                  <i class="fa fa-sort-desc" onclick={{action "setSortBy" "createTime:desc"}}></i>
+                  {{#if (eq (get sortBy 0) 'createTime:asc')}}
+                    <i class="fa fa-sort-asc"></i>
+                  {{else if (eq (get sortBy 0) 'createTime:desc')}}
+                    <i class="fa fa-sort-desc"></i>
+                  {{else}}
+                    <i class="fa fa-sort"></i>
+                  {{/if}}
                 </span>
               </th>
-              <th class="history" rowspan="1">
+              <th class="history" rowspan="1" onclick={{action "setSortBy" (if (eq (get sortBy 0) "failedBuildCount:desc") "failedBuildCount:asc" "failedBuildCount:desc")}}>
                 Build History
                 <span class="icon-wrapper">
-                  <i class="fa fa-sort-asc" onclick={{action "sortByFailedBuilds" "failedBuildCount:asc"}}></i>
-                  <i class="fa fa-sort-desc" onclick={{action "sortByFailedBuilds" "failedBuildCount:desc"}}></i>
+                  {{#if (eq (get sortBy 0) 'failedBuildCount:asc')}}
+                    <i class="fa fa-sort-asc"></i>
+                  {{else if (eq (get sortBy 0) 'failedBuildCount:desc')}}
+                    <i class="fa fa-sort-desc"></i>
+                  {{else}}
+                    <i class="fa fa-sort"></i>
+                  {{/if}}
                 </span>
               </th>
               <th class="collection-pipeline__remove"></th>

--- a/app/components/collection-view/template.hbs
+++ b/app/components/collection-view/template.hbs
@@ -156,14 +156,14 @@
               <th class="duration" rowspan="1">Duration</th>
               <th class="last-run" rowspan="1"> Last Run Job
                 <span class="icon-wrapper">
-                  <i class="fa fa-sort-asc" onclick={{action "setSortBy" "createTime"}}></i>
+                  <i class="fa fa-sort-asc" onclick={{action "setSortBy" "createTime:asc"}}></i>
                   <i class="fa fa-sort-desc" onclick={{action "setSortBy" "createTime:desc"}}></i>
                 </span>
               </th>
               <th class="history" rowspan="1">
                  Build History
                 <span class="icon-wrapper">
-                  <i class="fa fa-sort-asc" onclick={{action "sortByFailedBuilds" "failedBuildCount"}}></i>
+                  <i class="fa fa-sort-asc" onclick={{action "sortByFailedBuilds" "failedBuildCount:asc"}}></i>
                   <i class="fa fa-sort-desc" onclick={{action "sortByFailedBuilds" "failedBuildCount:desc"}}></i>
                 </span>
               </th>

--- a/app/components/collection-view/template.hbs
+++ b/app/components/collection-view/template.hbs
@@ -157,9 +157,9 @@
               <th class="last-run" rowspan="1" onclick={{action "setSortBy" (if (eq (get sortBy 0) "createTime:desc") "createTime:asc" "createTime:desc")}}>
                 Last Run Job
                 <span class="icon-wrapper">
-                  {{#if (eq (get sortBy 0) 'createTime:asc')}}
+                  {{#if (eq (get sortBy 0) "createTime:asc")}}
                     <i class="fa fa-sort-asc"></i>
-                  {{else if (eq (get sortBy 0) 'createTime:desc')}}
+                  {{else if (eq (get sortBy 0) "createTime:desc")}}
                     <i class="fa fa-sort-desc"></i>
                   {{else}}
                     <i class="fa fa-sort"></i>
@@ -169,9 +169,9 @@
               <th class="history" rowspan="1" onclick={{action "setSortBy" (if (eq (get sortBy 0) "failedBuildCount:desc") "failedBuildCount:asc" "failedBuildCount:desc")}}>
                 Build History
                 <span class="icon-wrapper">
-                  {{#if (eq (get sortBy 0) 'failedBuildCount:asc')}}
+                  {{#if (eq (get sortBy 0) "failedBuildCount:asc")}}
                     <i class="fa fa-sort-asc"></i>
-                  {{else if (eq (get sortBy 0) 'failedBuildCount:desc')}}
+                  {{else if (eq (get sortBy 0) "failedBuildCount:desc")}}
                     <i class="fa fa-sort-desc"></i>
                   {{else}}
                     <i class="fa fa-sort"></i>

--- a/app/components/collection-view/template.hbs
+++ b/app/components/collection-view/template.hbs
@@ -149,11 +149,13 @@
           <thead>
             <tr>
               <th class="collection-pipeline__choose"></th>
+              <th class="alias" rowspan="1">Alias</th>
               <th class="app-id" rowspan="1">Name</th>
               <th class="branch" rowspan="1">Branch</th>
               <th class="status" rowspan="1">Status</th>
               <th class="start" rowspan="1">Start Date</th>
               <th class="duration" rowspan="1">Duration</th>
+              <th class="last-run" rowspan="1">Last Run Job</th>
               <th class="history" rowspan="1">Build History</th>
               <th class="collection-pipeline__remove"></th>
             </tr>

--- a/app/components/collection-view/template.hbs
+++ b/app/components/collection-view/template.hbs
@@ -154,14 +154,15 @@
               <th class="status" rowspan="1">Status</th>
               <th class="start" rowspan="1">Start Date</th>
               <th class="duration" rowspan="1">Duration</th>
-              <th class="last-run" rowspan="1"> Last Run Job
+              <th class="last-run" rowspan="1">
+                Last Run Job
                 <span class="icon-wrapper">
                   <i class="fa fa-sort-asc" onclick={{action "setSortBy" "createTime:asc"}}></i>
                   <i class="fa fa-sort-desc" onclick={{action "setSortBy" "createTime:desc"}}></i>
                 </span>
               </th>
               <th class="history" rowspan="1">
-                 Build History
+                Build History
                 <span class="icon-wrapper">
                   <i class="fa fa-sort-asc" onclick={{action "sortByFailedBuilds" "failedBuildCount:asc"}}></i>
                   <i class="fa fa-sort-desc" onclick={{action "sortByFailedBuilds" "failedBuildCount:desc"}}></i>

--- a/app/components/collection-view/template.hbs
+++ b/app/components/collection-view/template.hbs
@@ -176,7 +176,7 @@
                   class="collection-pipeline"
                   removePipeline=(action "removePipeline")
                   pipeline=pipeline
-                  isAuthenticated=session.isAuthenticayqted
+                  isAuthenticated=session.isAuthenticated
                   isOrganizing=isOrganizing
                   isDefaultCollection=isDefaultCollection
                   selectPipeline=(action "selectPipeline")

--- a/app/components/pipeline-card/component.js
+++ b/app/components/pipeline-card/component.js
@@ -62,17 +62,11 @@ export default Component.extend({
     }
   },
   async updateEventMetrics() {
-    const metrics = await this.store
-      .query('metric', {
-        pipelineId: this.pipeline.id,
-        page: 1,
-        count: 20
-      })
-      .catch(() => {
-        this.setProperties({
-          storeQueryError: true
-        });
+    const metrics = await this.pipeline.get('metrics').catch(() => {
+      this.setProperties({
+        storeQueryError: true
       });
+    });
 
     const result = formatMetrics(metrics);
     const { eventsInfo, lastEventInfo } = result;

--- a/app/dashboard/show/route.js
+++ b/app/dashboard/show/route.js
@@ -20,7 +20,7 @@ export default Route.extend(AuthenticatedRouteMixin, {
   },
 
   actions: {
-    error() {
+    error(/* error, transition */) {
       localStorage.removeItem('lastViewedCollectionId');
 
       return this.transitionTo('/404');

--- a/app/pipeline/model.js
+++ b/app/pipeline/model.js
@@ -61,7 +61,7 @@ export default DS.Model.extend({
       return parameters;
     }
   }),
-  failedBuildCount: computed('failedBuildCount', {
+  failedBuildCount: computed('metrics.[]', {
     get() {
       let failedBuildCount = 0;
 

--- a/app/pipeline/model.js
+++ b/app/pipeline/model.js
@@ -60,5 +60,18 @@ export default DS.Model.extend({
 
       return parameters;
     }
+  }),
+  failedBuildCount: computed('failedBuildCount', {
+    get() {
+      let failedBuildCount = 0;
+
+      this.metrics.toArray().forEach(event => {
+        if (['FAILURE', 'ABORTED'].includes(event.status)) {
+          failedBuildCount += 1;
+        }
+      });
+
+      return failedBuildCount;
+    }
   })
 });

--- a/tests/integration/components/collection-table-row/component-test.js
+++ b/tests/integration/components/collection-table-row/component-test.js
@@ -7,6 +7,8 @@ import sinon from 'sinon';
 import $ from 'jquery';
 import wait from 'ember-test-helpers/wait';
 import Pretender from 'pretender';
+import templateHelper from 'screwdriver-ui/utils/template';
+const { getLastUpdatedTime } = templateHelper;
 
 let server;
 const hasEmptyMetrics = () => [
@@ -22,7 +24,8 @@ const mockPipeline = EmberObject.create({
     rootDir: '',
     url: 'https://github.com/screwdriver-cd/ui/tree/master'
   },
-  branch: 'master'
+  branch: 'master',
+  createTime: Date.now()
 });
 const lastEventInfo = EmberObject.create({
   startTime: '--/--/----',
@@ -60,7 +63,7 @@ module('Integration | Component | collection table row', function (hooks) {
   });
 
   test('it renders', async function (assert) {
-    assert.expect(12);
+    assert.expect(13);
     this.owner.setupRouter();
     await render(hbs`
       {{collection-table-row
@@ -88,6 +91,11 @@ module('Integration | Component | collection table row', function (hooks) {
       .hasAttribute('href', lastEventInfo.commitUrl);
     assert.dom('td.start').hasText(lastEventInfo.startTime);
     assert.dom('td.duration').hasText(lastEventInfo.durationText);
+    assert.dom('td.last-run').hasText(
+      getLastUpdatedTime({
+        createTime: mockPipeline.createTime
+      })
+    );
     assert.dom('td.history').exists({ count: 1 });
     assert.dom('td.collection-pipeline__remove').exists({ count: 1 });
 

--- a/tests/integration/components/collection-table-row/component-test.js
+++ b/tests/integration/components/collection-table-row/component-test.js
@@ -8,6 +8,7 @@ import $ from 'jquery';
 import wait from 'ember-test-helpers/wait';
 import Pretender from 'pretender';
 import templateHelper from 'screwdriver-ui/utils/template';
+import { mockMetricsPromise as makeMetricsMock } from 'screwdriver-ui/tests/mock/metrics';
 const { getLastUpdatedTime } = templateHelper;
 
 let server;
@@ -16,6 +17,8 @@ const hasEmptyMetrics = () => [
   { 'Content-Type': 'application/json' },
   JSON.stringify([])
 ];
+
+const metricsMock = makeMetricsMock();
 const mockPipeline = EmberObject.create({
   id: 1,
   scmRepo: {
@@ -25,6 +28,7 @@ const mockPipeline = EmberObject.create({
     url: 'https://github.com/screwdriver-cd/ui/tree/master'
   },
   branch: 'master',
+  metrics: metricsMock,
   createTime: Date.now()
 });
 const lastEventInfo = EmberObject.create({

--- a/tests/integration/components/collection-table-row/component-test.js
+++ b/tests/integration/components/collection-table-row/component-test.js
@@ -1,4 +1,5 @@
 import EmberObject from '@ember/object';
+import { Promise as EmberPromise } from 'rsvp';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, click, waitFor } from '@ember/test-helpers';
@@ -8,7 +9,6 @@ import $ from 'jquery';
 import wait from 'ember-test-helpers/wait';
 import Pretender from 'pretender';
 import templateHelper from 'screwdriver-ui/utils/template';
-import { mockMetricsPromise as makeMetricsMock } from 'screwdriver-ui/tests/mock/metrics';
 const { getLastUpdatedTime } = templateHelper;
 
 let server;
@@ -17,8 +17,6 @@ const hasEmptyMetrics = () => [
   { 'Content-Type': 'application/json' },
   JSON.stringify([])
 ];
-
-const metricsMock = makeMetricsMock();
 const mockPipeline = EmberObject.create({
   id: 1,
   scmRepo: {
@@ -28,7 +26,7 @@ const mockPipeline = EmberObject.create({
     url: 'https://github.com/screwdriver-cd/ui/tree/master'
   },
   branch: 'master',
-  metrics: metricsMock,
+  metrics: EmberPromise.resolve([]),
   createTime: Date.now()
 });
 const lastEventInfo = EmberObject.create({

--- a/tests/integration/components/collection-view/component-test.js
+++ b/tests/integration/components/collection-view/component-test.js
@@ -1,4 +1,4 @@
-import { resolve, reject, Promise as EmberPromise } from 'rsvp';
+import { resolve, reject } from 'rsvp';
 import EmberObject from '@ember/object';
 import { module, test, todo } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
@@ -7,234 +7,26 @@ import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
 import Service from '@ember/service';
 import $ from 'jquery';
-import { copy } from 'ember-copy';
-import { mockMetricsPromise as makeMetricsMock } from 'screwdriver-ui/tests/mock/metrics';
 import injectSessionStub from '../../../helpers/inject-session';
 import injectScmServiceStub from '../../../helpers/inject-scm';
+import { mockPipelinesPromise as makePipelinePromise } from '../../../mock/pipeline';
 
-/**
- * Return a promise based collection mock
- *
- * @returns Promise
- */
-function mockCollectionPromise() {
-  return new EmberPromise(emberResolve =>
-    emberResolve(
-      copy(
-        {
-          id: 1,
-          name: 'My Pipelines',
-          description: 'Default Collection',
-          type: 'default',
-          pipelines: [
-            {
-              id: 1,
-              scmUri: 'github.com:12345678:master',
-              createTime: '2017-01-05T00:55:46.775Z',
-              admins: {
-                username: true
-              },
-              workflow: ['main'],
-              scmRepo: {
-                name: 'screwdriver-cd/screwdriver',
-                branch: 'master',
-                url: 'https://github.com/screwdriver-cd/screwdriver/tree/master'
-              },
-              scmContext: 'github:github.com',
-              annotations: {},
-              lastEventId: 12,
-              lastBuilds: [
-                {
-                  id: 123,
-                  status: 'SUCCESS',
-                  // Most recent build
-                  createTime: '2017-09-05T04:02:20.890Z'
-                }
-              ]
-            },
-            {
-              id: 2,
-              scmUri: 'github.com:87654321:master',
-              createTime: '2017-01-05T00:55:46.775Z',
-              admins: {
-                username: true
-              },
-              workflow: ['main', 'publish'],
-              scmRepo: {
-                name: 'screwdriver-cd/ui',
-                branch: 'master',
-                url: 'https://github.com/screwdriver-cd/ui/tree/master'
-              },
-              scmContext: 'github:github.com',
-              annotations: {},
-              prs: {
-                open: 2,
-                failing: 1
-              }
-            },
-            {
-              id: 3,
-              scmUri: 'github.com:54321876:master',
-              createTime: '2017-01-05T00:55:46.775Z',
-              admins: {
-                username: true
-              },
-              workflow: ['main'],
-              scmRepo: {
-                name: 'screwdriver-cd/models',
-                branch: 'master',
-                url: 'https://github.com/screwdriver-cd/models/tree/master'
-              },
-              scmContext: 'bitbucket:bitbucket.org',
-              annotations: {},
-              lastEventId: 23,
-              lastBuilds: [
-                {
-                  id: 125,
-                  status: 'FAILURE',
-                  // 2nd most recent build
-                  createTime: '2017-09-05T04:01:41.789Z'
-                }
-              ]
-            },
-            {
-              id: 4,
-              scmUri: 'github.com:54321879:master:lib',
-              createTime: '2017-01-05T00:55:46.775Z',
-              admins: {
-                username: true
-              },
-              workflow: ['main'],
-              scmRepo: {
-                name: 'screwdriver-cd/zzz',
-                branch: 'master',
-                url: 'https://github.com/screwdriver-cd/zzz/tree/master',
-                rootDir: 'lib'
-              },
-              scmContext: 'bitbucket:bitbucket.org',
-              annotations: {},
-              lastEventId: 23,
-              lastBuilds: [
-                {
-                  id: 125,
-                  status: 'UNSTABLE',
-                  createTime: '2017-09-05T04:01:41.789Z'
-                }
-              ]
-            }
-          ],
-          pipelineIds: [1, 2, 3, 4]
-        },
-        true
-      )
-    )
-  );
-}
-
-const mockDefaultCollection = mockCollectionPromise();
+const mockPipeline = makePipelinePromise();
+const mockDefaultCollection = EmberObject.create({
+  id: 1,
+  name: 'My Pipelines',
+  description: 'Default Collection',
+  type: 'default',
+  pipelines: mockPipeline,
+  pipelineIds: [1, 2, 3, 4]
+});
 
 const mockNormalCollection = EmberObject.create({
   id: 1,
   name: 'My Pipelines',
   description: 'Normal Collection',
   type: 'normal',
-  pipelines: [
-    {
-      id: 1,
-      scmUri: 'github.com:12345678:master',
-      createTime: '2017-01-05T00:55:46.775Z',
-      admins: {
-        username: true
-      },
-      workflow: ['main'],
-      scmRepo: {
-        name: 'screwdriver-cd/screwdriver',
-        branch: 'master',
-        url: 'https://github.com/screwdriver-cd/screwdriver/tree/master'
-      },
-      scmContext: 'github:github.com',
-      annotations: {},
-      lastEventId: 12,
-      lastBuilds: [
-        {
-          id: 123,
-          status: 'SUCCESS',
-          // Most recent build
-          createTime: '2017-09-05T04:02:20.890Z'
-        }
-      ]
-    },
-    {
-      id: 2,
-      scmUri: 'github.com:87654321:master',
-      createTime: '2017-01-05T00:55:46.775Z',
-      admins: {
-        username: true
-      },
-      workflow: ['main', 'publish'],
-      scmRepo: {
-        name: 'screwdriver-cd/ui',
-        branch: 'master',
-        url: 'https://github.com/screwdriver-cd/ui/tree/master'
-      },
-      scmContext: 'github:github.com',
-      annotations: {},
-      prs: {
-        open: 2,
-        failing: 1
-      }
-    },
-    {
-      id: 3,
-      scmUri: 'github.com:54321876:master',
-      createTime: '2017-01-05T00:55:46.775Z',
-      admins: {
-        username: true
-      },
-      workflow: ['main'],
-      scmRepo: {
-        name: 'screwdriver-cd/models',
-        branch: 'master',
-        url: 'https://github.com/screwdriver-cd/models/tree/master'
-      },
-      scmContext: 'bitbucket:bitbucket.org',
-      annotations: {},
-      lastEventId: 23,
-      lastBuilds: [
-        {
-          id: 125,
-          status: 'FAILURE',
-          // 2nd most recent build
-          createTime: '2017-09-05T04:01:41.789Z'
-        }
-      ]
-    },
-    {
-      id: 4,
-      scmUri: 'github.com:54321879:master:lib',
-      createTime: '2017-01-05T00:55:46.775Z',
-      admins: {
-        username: true
-      },
-      workflow: ['main'],
-      scmRepo: {
-        name: 'screwdriver-cd/zzz',
-        branch: 'master',
-        url: 'https://github.com/screwdriver-cd/zzz/tree/master',
-        rootDir: 'lib'
-      },
-      scmContext: 'bitbucket:bitbucket.org',
-      annotations: {},
-      lastEventId: 23,
-      lastBuilds: [
-        {
-          id: 125,
-          status: 'UNSTABLE',
-          createTime: '2017-09-05T04:01:41.789Z'
-        }
-      ]
-    }
-  ],
+  pipelines: mockPipeline,
   pipelineIds: [1, 2, 3, 4]
 });
 
@@ -294,7 +86,31 @@ const mockCollections = [
   }
 ];
 
-const mockMetrics = makeMetricsMock();
+const mockMetrics = [
+  {
+    id: 3,
+    createTime: '2020-10-06T17:57:53.388Z',
+    causeMessage: 'Manually started by klu909',
+    sha: '9af92ba134322',
+    commit: {
+      message: '3',
+      url: 'https://github.com/batman/foo/commit/9af92ba134322'
+    },
+    duration: 14,
+    status: 'SUCCESS'
+  },
+  {
+    id: 2,
+    createTime: '2020-10-06T17:47:55.089Z',
+    sha: '9af92ba134321',
+    commit: {
+      message: '2',
+      url: 'https://github.com/batman/foo/commit/9af92ba134321'
+    },
+    duration: 14,
+    status: 'SUCCESS'
+  }
+];
 
 const onRemovePipelineSpy = sinon.spy();
 const addMultipleToCollectionSpy = sinon.spy();
@@ -452,7 +268,6 @@ module('Integration | Component | collection view', function (hooks) {
     assert.dom('th.status').hasText('Status');
     assert.dom('th.start').hasText('Start Date');
     assert.dom('th.duration').hasText('Duration');
-    assert.dom('th.last-run').hasText('Last Run Job');
     assert.dom('th.history').exists({ count: 1 });
 
     assert.dom('.collection-pipeline').exists({ count: 4 });

--- a/tests/integration/components/collection-view/component-test.js
+++ b/tests/integration/components/collection-view/component-test.js
@@ -1,4 +1,4 @@
-import { resolve, reject } from 'rsvp';
+import { resolve, reject, Promise as EmberPromise } from 'rsvp';
 import EmberObject from '@ember/object';
 import { module, test, todo } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
@@ -7,113 +7,131 @@ import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
 import Service from '@ember/service';
 import $ from 'jquery';
+import { copy } from 'ember-copy';
+import { mockMetricsPromise as makeMetricsMock } from 'screwdriver-ui/tests/mock/metrics';
 import injectSessionStub from '../../../helpers/inject-session';
 import injectScmServiceStub from '../../../helpers/inject-scm';
 
-const mockDefaultCollection = EmberObject.create({
-  id: 1,
-  name: 'My Pipelines',
-  description: 'Default Collection',
-  type: 'default',
-  pipelines: [
-    {
-      id: 1,
-      scmUri: 'github.com:12345678:master',
-      createTime: '2017-01-05T00:55:46.775Z',
-      admins: {
-        username: true
-      },
-      workflow: ['main'],
-      scmRepo: {
-        name: 'screwdriver-cd/screwdriver',
-        branch: 'master',
-        url: 'https://github.com/screwdriver-cd/screwdriver/tree/master'
-      },
-      scmContext: 'github:github.com',
-      annotations: {},
-      lastEventId: 12,
-      lastBuilds: [
+/**
+ * Return a promise based collection mock
+ *
+ * @returns Promise
+ */
+function mockCollectionPromise() {
+  return new EmberPromise(emberResolve =>
+    emberResolve(
+      copy(
         {
-          id: 123,
-          status: 'SUCCESS',
-          // Most recent build
-          createTime: '2017-09-05T04:02:20.890Z'
-        }
-      ]
-    },
-    {
-      id: 2,
-      scmUri: 'github.com:87654321:master',
-      createTime: '2017-01-05T00:55:46.775Z',
-      admins: {
-        username: true
-      },
-      workflow: ['main', 'publish'],
-      scmRepo: {
-        name: 'screwdriver-cd/ui',
-        branch: 'master',
-        url: 'https://github.com/screwdriver-cd/ui/tree/master'
-      },
-      scmContext: 'github:github.com',
-      annotations: {},
-      prs: {
-        open: 2,
-        failing: 1
-      }
-    },
-    {
-      id: 3,
-      scmUri: 'github.com:54321876:master',
-      createTime: '2017-01-05T00:55:46.775Z',
-      admins: {
-        username: true
-      },
-      workflow: ['main'],
-      scmRepo: {
-        name: 'screwdriver-cd/models',
-        branch: 'master',
-        url: 'https://github.com/screwdriver-cd/models/tree/master'
-      },
-      scmContext: 'bitbucket:bitbucket.org',
-      annotations: {},
-      lastEventId: 23,
-      lastBuilds: [
-        {
-          id: 125,
-          status: 'FAILURE',
-          // 2nd most recent build
-          createTime: '2017-09-05T04:01:41.789Z'
-        }
-      ]
-    },
-    {
-      id: 4,
-      scmUri: 'github.com:54321879:master:lib',
-      createTime: '2017-01-05T00:55:46.775Z',
-      admins: {
-        username: true
-      },
-      workflow: ['main'],
-      scmRepo: {
-        name: 'screwdriver-cd/zzz',
-        branch: 'master',
-        url: 'https://github.com/screwdriver-cd/zzz/tree/master',
-        rootDir: 'lib'
-      },
-      scmContext: 'bitbucket:bitbucket.org',
-      annotations: {},
-      lastEventId: 23,
-      lastBuilds: [
-        {
-          id: 125,
-          status: 'UNSTABLE',
-          createTime: '2017-09-05T04:01:41.789Z'
-        }
-      ]
-    }
-  ],
-  pipelineIds: [1, 2, 3, 4]
-});
+          id: 1,
+          name: 'My Pipelines',
+          description: 'Default Collection',
+          type: 'default',
+          pipelines: [
+            {
+              id: 1,
+              scmUri: 'github.com:12345678:master',
+              createTime: '2017-01-05T00:55:46.775Z',
+              admins: {
+                username: true
+              },
+              workflow: ['main'],
+              scmRepo: {
+                name: 'screwdriver-cd/screwdriver',
+                branch: 'master',
+                url: 'https://github.com/screwdriver-cd/screwdriver/tree/master'
+              },
+              scmContext: 'github:github.com',
+              annotations: {},
+              lastEventId: 12,
+              lastBuilds: [
+                {
+                  id: 123,
+                  status: 'SUCCESS',
+                  // Most recent build
+                  createTime: '2017-09-05T04:02:20.890Z'
+                }
+              ]
+            },
+            {
+              id: 2,
+              scmUri: 'github.com:87654321:master',
+              createTime: '2017-01-05T00:55:46.775Z',
+              admins: {
+                username: true
+              },
+              workflow: ['main', 'publish'],
+              scmRepo: {
+                name: 'screwdriver-cd/ui',
+                branch: 'master',
+                url: 'https://github.com/screwdriver-cd/ui/tree/master'
+              },
+              scmContext: 'github:github.com',
+              annotations: {},
+              prs: {
+                open: 2,
+                failing: 1
+              }
+            },
+            {
+              id: 3,
+              scmUri: 'github.com:54321876:master',
+              createTime: '2017-01-05T00:55:46.775Z',
+              admins: {
+                username: true
+              },
+              workflow: ['main'],
+              scmRepo: {
+                name: 'screwdriver-cd/models',
+                branch: 'master',
+                url: 'https://github.com/screwdriver-cd/models/tree/master'
+              },
+              scmContext: 'bitbucket:bitbucket.org',
+              annotations: {},
+              lastEventId: 23,
+              lastBuilds: [
+                {
+                  id: 125,
+                  status: 'FAILURE',
+                  // 2nd most recent build
+                  createTime: '2017-09-05T04:01:41.789Z'
+                }
+              ]
+            },
+            {
+              id: 4,
+              scmUri: 'github.com:54321879:master:lib',
+              createTime: '2017-01-05T00:55:46.775Z',
+              admins: {
+                username: true
+              },
+              workflow: ['main'],
+              scmRepo: {
+                name: 'screwdriver-cd/zzz',
+                branch: 'master',
+                url: 'https://github.com/screwdriver-cd/zzz/tree/master',
+                rootDir: 'lib'
+              },
+              scmContext: 'bitbucket:bitbucket.org',
+              annotations: {},
+              lastEventId: 23,
+              lastBuilds: [
+                {
+                  id: 125,
+                  status: 'UNSTABLE',
+                  createTime: '2017-09-05T04:01:41.789Z'
+                }
+              ]
+            }
+          ],
+          pipelineIds: [1, 2, 3, 4]
+        },
+        true
+      )
+    )
+  );
+}
+
+const mockDefaultCollection = mockCollectionPromise();
 
 const mockNormalCollection = EmberObject.create({
   id: 1,
@@ -276,31 +294,7 @@ const mockCollections = [
   }
 ];
 
-const mockMetrics = [
-  {
-    id: 3,
-    createTime: '2020-10-06T17:57:53.388Z',
-    causeMessage: 'Manually started by klu909',
-    sha: '9af92ba134322',
-    commit: {
-      message: '3',
-      url: 'https://github.com/batman/foo/commit/9af92ba134322'
-    },
-    duration: 14,
-    status: 'SUCCESS'
-  },
-  {
-    id: 2,
-    createTime: '2020-10-06T17:47:55.089Z',
-    sha: '9af92ba134321',
-    commit: {
-      message: '2',
-      url: 'https://github.com/batman/foo/commit/9af92ba134321'
-    },
-    duration: 14,
-    status: 'SUCCESS'
-  }
-];
+const mockMetrics = makeMetricsMock();
 
 const onRemovePipelineSpy = sinon.spy();
 const addMultipleToCollectionSpy = sinon.spy();

--- a/tests/integration/components/collection-view/component-test.js
+++ b/tests/integration/components/collection-view/component-test.js
@@ -458,6 +458,7 @@ module('Integration | Component | collection view', function (hooks) {
     assert.dom('th.status').hasText('Status');
     assert.dom('th.start').hasText('Start Date');
     assert.dom('th.duration').hasText('Duration');
+    assert.dom('th.last-run').hasText('Last Run Job');
     assert.dom('th.history').exists({ count: 1 });
 
     assert.dom('.collection-pipeline').exists({ count: 4 });

--- a/tests/integration/components/pipeline-card/component-test.js
+++ b/tests/integration/components/pipeline-card/component-test.js
@@ -7,6 +7,7 @@ import sinon from 'sinon';
 import $ from 'jquery';
 import wait from 'ember-test-helpers/wait';
 import Pretender from 'pretender';
+import { mockMetricsPromise as makeMetricsMock } from 'screwdriver-ui/tests/mock/metrics';
 
 let server;
 const hasEmptyMetrics = () => [
@@ -14,6 +15,8 @@ const hasEmptyMetrics = () => [
   { 'Content-Type': 'application/json' },
   JSON.stringify([])
 ];
+
+const metricsMock = makeMetricsMock();
 const mockPipeline = EmberObject.create({
   id: 1,
   scmRepo: {
@@ -22,7 +25,8 @@ const mockPipeline = EmberObject.create({
     rootDir: '',
     url: 'https://github.com/screwdriver-cd/ui/tree/master'
   },
-  branch: 'master'
+  branch: 'master',
+  metrics: metricsMock
 });
 const lastEventInfo = EmberObject.create({
   startTime: '--/--/----',

--- a/tests/integration/components/pipeline-card/component-test.js
+++ b/tests/integration/components/pipeline-card/component-test.js
@@ -3,11 +3,11 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, click, waitFor } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import { resolve } from 'rsvp';
 import sinon from 'sinon';
 import $ from 'jquery';
 import wait from 'ember-test-helpers/wait';
 import Pretender from 'pretender';
-import { mockMetricsPromise as makeMetricsMock } from 'screwdriver-ui/tests/mock/metrics';
 
 let server;
 const hasEmptyMetrics = () => [
@@ -16,7 +16,6 @@ const hasEmptyMetrics = () => [
   JSON.stringify([])
 ];
 
-const metricsMock = makeMetricsMock();
 const mockPipeline = EmberObject.create({
   id: 1,
   scmRepo: {
@@ -26,7 +25,7 @@ const mockPipeline = EmberObject.create({
     url: 'https://github.com/screwdriver-cd/ui/tree/master'
   },
   branch: 'master',
-  metrics: metricsMock
+  metrics: resolve([])
 });
 const lastEventInfo = EmberObject.create({
   startTime: '--/--/----',

--- a/tests/mock/collections.js
+++ b/tests/mock/collections.js
@@ -1,98 +1,100 @@
+import EmberObject from '@ember/object';
+
 const mockCollections = [
-  {
+  EmberObject.create({
     id: 2,
     name: 'collection1',
     description: 'description1',
     type: 'normal',
     userId: 1,
     pipelineIds: [12742, 12743]
-  },
-  {
+  }),
+  EmberObject.create({
     id: 1,
     name: 'My Pipelines',
     description: 'default collection description',
     type: 'default',
     userId: 1,
     pipelineIds: [12742, 12743]
-  }
+  })
 ];
 
-const mockDefaultCollection = [
-  {
-    id: 1,
-    name: 'My Pipelines',
-    description: 'default collection description',
-    type: 'default',
-    pipelineIds: [12742, 12743],
-    pipelines: [
-      {
-        id: 12742,
-        scmUri: 'github.com:12345678:master',
-        createTime: '2017-01-05T00:55:46.775Z',
-        admins: {
-          username: true
-        },
-        workflow: ['main', 'publish'],
-        scmRepo: {
-          name: 'screwdriver-cd/screwdriver',
-          branch: 'master',
-          url: 'https://github.com/screwdriver-cd/screwdriver/tree/master'
-        },
-        scmContext: 'github:github.com',
-        annotations: {},
-        lastEventId: 12,
-        lastBuilds: [
-          {
-            id: 123,
-            status: 'SUCCESS'
-          },
-          {
-            id: 124,
-            status: 'FAILURE'
-          }
-        ]
+const mockDefaultCollection = {
+  id: 1,
+  name: 'My Pipelines',
+  description: 'default collection description',
+  type: 'default',
+  pipelineIds: [12742, 12743],
+  pipelines: [
+    EmberObject.create({
+      id: 12742,
+      scmUri: 'github.com:12345678:master',
+      createTime: '2017-01-05T00:55:46.775Z',
+      admins: {
+        username: true
       },
-      {
-        id: 12743,
-        scmUri: 'github.com:87654321:master',
-        createTime: '2017-01-05T00:55:46.775Z',
-        admins: {
-          username: true
+      workflow: ['main', 'publish'],
+      scmRepo: {
+        name: 'screwdriver-cd/screwdriver',
+        branch: 'master',
+        url: 'https://github.com/screwdriver-cd/screwdriver/tree/master'
+      },
+      scmContext: 'github:github.com',
+      annotations: {},
+      lastEventId: 12,
+      lastBuilds: [
+        {
+          id: 123,
+          status: 'SUCCESS'
         },
-        workflow: ['main', 'publish'],
-        scmRepo: {
-          name: 'screwdriver-cd/ui',
-          branch: 'master',
-          url: 'https://github.com/screwdriver-cd/ui/tree/master'
-        },
-        scmContext: 'github:github.com',
-        annotations: {},
-        prs: {
-          open: 2,
-          failing: 1
+        {
+          id: 124,
+          status: 'FAILURE'
         }
+      ]
+    }),
+    EmberObject.create({
+      id: 12743,
+      scmUri: 'github.com:87654321:master',
+      createTime: '2017-01-05T00:55:46.775Z',
+      admins: {
+        username: true
+      },
+      workflow: ['main', 'publish'],
+      scmRepo: {
+        name: 'screwdriver-cd/ui',
+        branch: 'master',
+        url: 'https://github.com/screwdriver-cd/ui/tree/master'
+      },
+      scmContext: 'github:github.com',
+      annotations: {},
+      prs: {
+        open: 2,
+        failing: 1
       }
-    ]
-  }
-];
+    })
+  ]
+};
 
-const mockCollection = [
-  {
-    ...mockDefaultCollection[0],
-    id: 2,
-    name: 'collection1',
-    description: 'description1',
-    type: 'normal'
-  }
-];
+const mockCollection = {
+  ...mockDefaultCollection,
+  id: 2,
+  name: 'collection1',
+  description: 'description1',
+  type: 'normal'
+};
 
-const mockEmptyDefaultCollection = [
-  { ...mockDefaultCollection[0], pipelineIds: [], pipelines: [] }
-];
+const mockEmptyDefaultCollection = {
+  ...mockDefaultCollection,
+  pipelineIds: [],
+  pipelines: []
+};
 
-const mockEmptyCollection = [
-  { ...mockCollection[0], pipelineIds: [], pipelines: [] }
-];
+const mockEmptyCollection = {
+  ...mockCollection,
+  pipelineIds: [],
+  pipelines: []
+};
 
 export const hasCollections = () => [
   200,

--- a/tests/mock/metrics.js
+++ b/tests/mock/metrics.js
@@ -1,4 +1,5 @@
 import { copy } from 'ember-copy';
+import { Promise as EmberPromise } from 'rsvp';
 
 export default () =>
   copy(
@@ -226,6 +227,189 @@ export default () =>
     ],
     true
   );
+
+/**
+ * Return a promise based metrics mock
+ *
+ * @returns Promise
+ */
+export function mockMetricsPromise() {
+  return new EmberPromise(resolve =>
+    resolve(
+      copy(
+        [
+          {
+            id: 631630,
+            createTime: '2021-05-21T18:54:43.093Z',
+            causeMessage: 'Manually started by adong',
+            sha: 'fb3d95d9f73190c1e2eb9561e3c5579f5146c0c9',
+            commit: {
+              author: {
+                avatar: 'https://cd.screwdriver.cd/assets/unknown_user.png',
+                name: 'Alan Dong',
+                username: 'n/a',
+                url: 'https://cd.screwdriver.cd/'
+              },
+              committer: {
+                avatar: 'https://cd.screwdriver.cd/assets/unknown_user.png',
+                name: 'Alan Dong',
+                username: 'n/a',
+                url: 'https://cd.screwdriver.cd/'
+              },
+              message: 'update',
+              url: 'https://github.com/adong/sd-pipeline1/commit/fb3d95d9f73190c1e2eb9561e3c5579f5146c0c9'
+            },
+            duration: 3,
+            queuedTime: 1,
+            imagePullTime: 7,
+            status: 'SUCCESS',
+            builds: [
+              {
+                id: 707350,
+                jobId: 34625,
+                eventId: 631630,
+                createTime: '2021-05-21T18:54:43.281Z',
+                startTime: '2021-05-21T18:54:52.177Z',
+                endTime: '2021-05-21T18:54:55.310Z',
+                duration: 3,
+                status: 'SUCCESS',
+                queuedTime: 1,
+                imagePullTime: 7
+              }
+            ],
+            isDowntimeEvent: false,
+            maxEndTime: '2021-05-21T18:54:55.310Z'
+          },
+          {
+            id: 628914,
+            createTime: '2021-05-06T06:05:11.070Z',
+            causeMessage: 'Manually started by adong',
+            sha: 'fb3d95d9f73190c1e2eb9561e3c5579f5146c0c9',
+            commit: {
+              author: {
+                avatar: 'https://cd.screwdriver.cd/assets/unknown_user.png',
+                name: 'Alan Dong',
+                username: 'n/a',
+                url: 'https://cd.screwdriver.cd/'
+              },
+              committer: {
+                avatar: 'https://cd.screwdriver.cd/assets/unknown_user.png',
+                name: 'Alan Dong',
+                username: 'n/a',
+                url: 'https://cd.screwdriver.cd/'
+              },
+              message: 'update',
+              url: 'https://github.com/adong/sd-pipeline1/commit/fb3d95d9f73190c1e2eb9561e3c5579f5146c0c9'
+            },
+            duration: 3,
+            queuedTime: 2,
+            imagePullTime: 7,
+            status: 'SUCCESS',
+            builds: [
+              {
+                id: 703324,
+                jobId: 34625,
+                eventId: 628914,
+                createTime: '2021-05-06T06:05:11.265Z',
+                startTime: '2021-05-06T06:05:20.802Z',
+                endTime: '2021-05-06T06:05:24.401Z',
+                duration: 3,
+                status: 'SUCCESS',
+                queuedTime: 2,
+                imagePullTime: 7
+              }
+            ],
+            isDowntimeEvent: false,
+            maxEndTime: '2021-05-06T06:05:24.401Z'
+          },
+          {
+            id: 628913,
+            createTime: '2021-05-06T06:02:48.436Z',
+            causeMessage: 'Manually started by adong',
+            sha: 'fb3d95d9f73190c1e2eb9561e3c5579f5146c0c9',
+            commit: {
+              author: {
+                avatar: 'https://cd.screwdriver.cd/assets/unknown_user.png',
+                name: 'Alan Dong',
+                username: 'n/a',
+                url: 'https://cd.screwdriver.cd/'
+              },
+              committer: {
+                avatar: 'https://cd.screwdriver.cd/assets/unknown_user.png',
+                name: 'Alan Dong',
+                username: 'n/a',
+                url: 'https://cd.screwdriver.cd/'
+              },
+              message: 'update',
+              url: 'https://github.com/adong/sd-pipeline1/commit/fb3d95d9f73190c1e2eb9561e3c5579f5146c0c9'
+            },
+            duration: null,
+            queuedTime: 4,
+            imagePullTime: 0,
+            status: 'ABORTED',
+            builds: [
+              {
+                id: 703323,
+                jobId: 34625,
+                eventId: 628913,
+                createTime: '2021-05-06T06:02:48.638Z',
+                duration: null,
+                status: 'ABORTED',
+                queuedTime: 4,
+                imagePullTime: null
+              }
+            ],
+            isDowntimeEvent: false,
+            maxEndTime: null
+          },
+          {
+            id: 621172,
+            createTime: '2021-03-30T02:44:20.219Z',
+            causeMessage: 'Manually started by adong',
+            sha: 'fb3d95d9f73190c1e2eb9561e3c5579f5146c0c9',
+            commit: {
+              author: {
+                avatar: 'https://cd.screwdriver.cd/assets/unknown_user.png',
+                name: 'Alan Dong',
+                username: 'n/a',
+                url: 'https://cd.screwdriver.cd/'
+              },
+              committer: {
+                avatar: 'https://cd.screwdriver.cd/assets/unknown_user.png',
+                name: 'Alan Dong',
+                username: 'n/a',
+                url: 'https://cd.screwdriver.cd/'
+              },
+              message: 'update',
+              url: 'https://github.com/adong/sd-pipeline1/commit/fb3d95d9f73190c1e2eb9561e3c5579f5146c0c9'
+            },
+            duration: 3,
+            queuedTime: 1,
+            imagePullTime: 5,
+            status: 'SUCCESS',
+            builds: [
+              {
+                id: 691444,
+                jobId: 34625,
+                eventId: 621172,
+                createTime: '2021-03-30T02:44:20.403Z',
+                startTime: '2021-03-30T02:44:27.954Z',
+                endTime: '2021-03-30T02:44:31.180Z',
+                duration: 3,
+                status: 'SUCCESS',
+                queuedTime: 1,
+                imagePullTime: 5
+              }
+            ],
+            isDowntimeEvent: false,
+            maxEndTime: '2021-03-30T02:44:31.180Z'
+          }
+        ],
+        true
+      )
+    )
+  );
+}
 
 /**
  * Return mock model for metrics

--- a/tests/mock/pipeline.js
+++ b/tests/mock/pipeline.js
@@ -1,5 +1,6 @@
 import { copy } from 'ember-copy';
 import { assign } from '@ember/polyfills';
+import { Promise as EmberPromise } from 'rsvp';
 
 export const pipeline = {
   id: '4',
@@ -93,3 +94,115 @@ export const hasPipelines = () => [
 ];
 
 export default workflowGraph => assign(copy(pipeline, true), { workflowGraph });
+
+/**
+ * return mock pipeline promise
+ *
+ * @returns promise
+ */
+export function mockPipelinesPromise() {
+  return new EmberPromise(resolve =>
+    resolve(
+      copy(
+        [
+          {
+            id: 1,
+            scmUri: 'github.com:12345678:master',
+            createTime: '2017-01-05T00:55:46.775Z',
+            admins: {
+              username: true
+            },
+            workflow: ['main'],
+            scmRepo: {
+              name: 'screwdriver-cd/screwdriver',
+              branch: 'master',
+              url: 'https://github.com/screwdriver-cd/screwdriver/tree/master'
+            },
+            scmContext: 'github:github.com',
+            annotations: {},
+            lastEventId: 12,
+            lastBuilds: [
+              {
+                id: 123,
+                status: 'SUCCESS',
+                // Most recent build
+                createTime: '2017-09-05T04:02:20.890Z'
+              }
+            ]
+          },
+          {
+            id: 2,
+            scmUri: 'github.com:87654321:master',
+            createTime: '2017-01-05T00:55:46.775Z',
+            admins: {
+              username: true
+            },
+            workflow: ['main', 'publish'],
+            scmRepo: {
+              name: 'screwdriver-cd/ui',
+              branch: 'master',
+              url: 'https://github.com/screwdriver-cd/ui/tree/master'
+            },
+            scmContext: 'github:github.com',
+            annotations: {},
+            prs: {
+              open: 2,
+              failing: 1
+            }
+          },
+          {
+            id: 3,
+            scmUri: 'github.com:54321876:master',
+            createTime: '2017-01-05T00:55:46.775Z',
+            admins: {
+              username: true
+            },
+            workflow: ['main'],
+            scmRepo: {
+              name: 'screwdriver-cd/models',
+              branch: 'master',
+              url: 'https://github.com/screwdriver-cd/models/tree/master'
+            },
+            scmContext: 'bitbucket:bitbucket.org',
+            annotations: {},
+            lastEventId: 23,
+            lastBuilds: [
+              {
+                id: 125,
+                status: 'FAILURE',
+                // 2nd most recent build
+                createTime: '2017-09-05T04:01:41.789Z'
+              }
+            ]
+          },
+          {
+            id: 4,
+            scmUri: 'github.com:54321879:master:lib',
+            createTime: '2017-01-05T00:55:46.775Z',
+            admins: {
+              username: true
+            },
+            workflow: ['main'],
+            scmRepo: {
+              name: 'screwdriver-cd/zzz',
+              branch: 'master',
+              url: 'https://github.com/screwdriver-cd/zzz/tree/master',
+              rootDir: 'lib'
+            },
+            scmContext: 'bitbucket:bitbucket.org',
+            annotations: {},
+            lastEventId: 23,
+            lastBuilds: [
+              {
+                id: 125,
+                status: 'UNSTABLE',
+                createTime: '2017-09-05T04:01:41.789Z'
+              }
+            ]
+          }
+        ],
+        true
+      )
+    )
+  );
+}

--- a/tests/unit/pipeline/events/controller-test.js
+++ b/tests/unit/pipeline/events/controller-test.js
@@ -541,8 +541,6 @@ module('Unit | Controller | pipeline/events', function (hooks) {
 
     controller.set('pipeline', pipeline);
 
-    console.log(controller.get('hasAdmins'), false);
-
     assert.notOk(controller.get('hasAdmins'), 'has no admins');
     assert.deepEqual(
       controller.get('pipeline.admins'),


### PR DESCRIPTION
## Context
Feature addition to dashboard collection to enhance the usability

## Objective
Add sorting criteria based on ascending or descending order for the number of failed builds (number of red bars)
Create a column after Duration, called "Last Run Job", and sorting criteria based on ascending or descending orders.

## References
Refer to: https://github.com/screwdriver-cd/screwdriver/issues/2713
## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
