### PR TITLE
fix(2705): restart method when using listView

### DIFF
--- a/app/pipeline/jobs/index/controller.js
+++ b/app/pipeline/jobs/index/controller.js
@@ -218,6 +218,7 @@ export default Controller.extend(ModelReloaderMixin, {
           get(build, 'eventId')
         );
 
+        const buildId = get(build, 'id');
         const parentBuildId = get(build, 'parentBuildId');
         const parentEventId = get(event, 'id');
         const prNum = get(event, 'prNum');
@@ -228,6 +229,7 @@ export default Controller.extend(ModelReloaderMixin, {
         }
 
         eventPayload = {
+          buildId,
           pipelineId,
           startFrom,
           parentBuildId,

--- a/tests/unit/pipeline/jobs/controller-test.js
+++ b/tests/unit/pipeline/jobs/controller-test.js
@@ -111,7 +111,6 @@ module('Unit | Controller | pipeline/jobs/index', function (hooks) {
     const payload = JSON.parse(request.requestBody);
 
     assert.notOk(controller.get('isShowingModal'));
-    console.log(payload);
     assert.deepEqual(payload, {
       buildId: 99,
       pipelineId: '1234',

--- a/tests/unit/pipeline/jobs/controller-test.js
+++ b/tests/unit/pipeline/jobs/controller-test.js
@@ -89,7 +89,7 @@ module('Unit | Controller | pipeline/jobs/index', function (hooks) {
         });
 
         return Promise.resolve(
-          EmberObject.create({ eventId: '10', parentBuildId: '57' })
+          EmberObject.create({ eventId: '10', parentBuildId: '57', id: '99' })
         );
       });
 
@@ -111,7 +111,9 @@ module('Unit | Controller | pipeline/jobs/index', function (hooks) {
     const payload = JSON.parse(request.requestBody);
 
     assert.notOk(controller.get('isShowingModal'));
+    console.log(payload);
     assert.deepEqual(payload, {
+      buildId: 99,
       pipelineId: '1234',
       startFrom: 'name',
       parentBuildId: 57,


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Modify the following Issue with `Case 1`.
https://github.com/screwdriver-cd/screwdriver/issues/2705

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
When restarting a build using the `listView` function, the `buildId` is not sent to the API and the restart behavior is different.
In this PR, add to parameter to send `buildId` at restart.


## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
issue: https://github.com/screwdriver-cd/screwdriver/issues/2705
The API determines whether to restart or not by whether the buildId is present or not. 
https://github.com/screwdriver-cd/screwdriver/blob/8ee441ffbfc2c17e9246cc4c2a40ee1e944c2121/plugins/events/create.js#L39-L56

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
