### PR TITLE
fix(2662):Improve the description of the parameter

### DIFF
--- a/app/components/validator-job/template.hbs
+++ b/app/components/validator-job/template.hbs
@@ -51,8 +51,10 @@
           <li>
             <span class="name">{{name}}: </span>
             <ul>
-              <li><span class="value">{{value.value}}</span></li>
-              <li><span class="description">{{value.description}}</span></li>
+              <li><span class="name">value: </span><span class="value">{{value.value}}</span></li>
+              {{#if value.description}}
+                <li><span class="name">description: </span><span class="value">{{value.description}}</span></li>
+              {{/if}}
             </ul>
           </li>
         {{/if}}

--- a/app/components/validator-pipeline/template.hbs
+++ b/app/components/validator-pipeline/template.hbs
@@ -23,8 +23,10 @@
           <li>
             <span class="name">{{name}}: </span>
             <ul>
-              <li><span class="value">{{value.value}}</span></li>
-              <li><span class="description">{{value.description}}</span></li>
+              <li><span class="name">value: </span><span class="value">{{value.value}}</span></li>
+              {{#if value.description}}
+                <li><span class="name">description: </span><span class="value">{{value.description}}</span></li>
+              {{/if}}
             </ul>
           </li>
         {{/if}}


### PR DESCRIPTION
## Context
In the UI of Screwdriver.cd, the parameters value and description are not fully explained.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
We clarified which is the `value` and which is `description`. The following `parameters` are displayed as shown in the image.
```
parameters:
  full-choose:
    value: [ "aaa", "bbb" ]
    description: "ccc"
  choose: [ "aaa", "bbb" ]
  value-only-choose:
    value: [ "aaa", "bbb" ]
  full-default:
    value: "aaa"
    description: "ccc"
  default: "aaa"
  value-only-default:
    value: "aaa"
```
<img width="188" alt="parameter-ui" src="https://user-images.githubusercontent.com/22903716/170907871-f4eef5eb-ce3b-427f-ac8f-ccb37acc866b.png">
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/screwdriver/issues/2662
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
