### PR TITLE
fix: Even in PR workflow-graph job states show up

### DIFF
--- a/app/components/pipeline-workflow/template.hbs
+++ b/app/components/pipeline-workflow/template.hbs
@@ -9,6 +9,7 @@
     selectedEventObjStatus=selectedEventObj.status
     builds=selectedEventObj.builds
     jobs=jobs
+    prJobs=prJobs
     workflowGraph=selectedEventObj.workflowGraph
     startFrom=selectedEventObj.startFrom
     causeMessage=selectedEventObj.causeMessage

--- a/app/components/workflow-graph-d3/component.js
+++ b/app/components/workflow-graph-d3/component.js
@@ -38,7 +38,10 @@ export default Component.extend({
         const builds = getWithDefault(this, 'builds', []);
 
         const { startFrom } = this;
-        const jobs = getWithDefault(this, 'jobs', []);
+
+        const prJobs = getWithDefault(this, 'prJobs', []);
+        const jobs = getWithDefault(this, 'jobs', []).concat(prJobs);
+
         const workflowGraph = getWithDefault(this, 'workflowGraph', {
           nodes: [],
           edges: []

--- a/app/pipeline/events/controller.js
+++ b/app/pipeline/events/controller.js
@@ -242,6 +242,23 @@ export default Controller.extend(ModelReloaderMixin, {
       return jobs.filter(j => !isPRJob(j.get('name')));
     }
   }),
+  prJobs: computed('model.jobs', {
+    get() {
+      const jobs = this.getWithDefault('model.jobs', []);
+      const prJobs = jobs.filter(j => isPRJob(j.get('name')));
+
+      prJobs.forEach(prJob => {
+        const originalJob = jobs.find(j => j.id === prJob.prParentJobId);
+
+        if (originalJob) {
+          prJob.state = originalJob.state;
+          prJob.isDisabled = originalJob.isDisabled;
+        }
+      });
+
+      return prJobs;
+    }
+  }),
   jobIds: computed('pipeline.jobs', {
     get() {
       return this.get('pipeline.jobs')

--- a/app/pipeline/events/template.hbs
+++ b/app/pipeline/events/template.hbs
@@ -57,6 +57,7 @@
       completeWorkflowGraph=completeWorkflowGraph
       workflowGraph=pipeline.workflowGraph
       jobs=jobs
+      prJobs=prJobs
       selectedEventObj=selectedEventObj
       selected=selected
       startDetachedBuild=(action "startDetachedBuild")


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
In PR workflow-graph, the job state display is not working, so it is not possible to see if a job that is not running is disabled or not.

![pr-state-before](https://user-images.githubusercontent.com/59165943/178200121-9281d3f0-e7f9-47ee-8fad-84e5323500f1.png)

Modify it as shown in the following image.
![pr-state-after](https://user-images.githubusercontent.com/59165943/178200263-e66a26e1-815b-4e3d-afbf-4b58717090d9.png)

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
- Set PR job information as `prJobs` to determine the state of PR jobs.
- Get the original job from `prParentJobId` and set the state of the original job as the state of the PR job.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
