### PR TITLE
fix: Display message when manually executing jobs for non-latest events

### DIFF
--- a/app/components/pipeline-workflow/template.hbs
+++ b/app/components/pipeline-workflow/template.hbs
@@ -38,11 +38,14 @@
       <h3>Are you sure to start?</h3>
       <p>
         Job: <code>{{tooltipData.job.name}}</code><br>
-        Commit:<code>{{selectedEventObj.truncatedMessage}}</code>
+        Commit: <code>{{selectedEventObj.truncatedMessage}}</code>
         <a class={{if (eq selectedEventObj.sha latestCommit.sha) "latest-commit"}} href={{selectedEventObj.commit.url}}>
           #{{selectedEventObj.truncatedSha}}
         </a>
       </p>
+      {{#if (not-eq selectedEventObj.sha latestCommit.sha)}}
+        <p>{{fa-icon "exclamation-circle"}} This is not the latest commit.</p>
+      {{/if}}
       {{#if (eq tooltipData.job.status "FROZEN")}}
         {{#if (get-length tooltipData.selectedEvent.meta.parameters)}}
           {{#pipeline-parameterized-build

--- a/app/components/pipeline-workflow/template.hbs
+++ b/app/components/pipeline-workflow/template.hbs
@@ -43,7 +43,7 @@
           #{{selectedEventObj.truncatedSha}}
         </a>
       </p>
-      {{#if (not-eq selectedEventObj.sha latestCommit.sha)}}
+      {{#if (and (not-eq selectedEventObj.type "pr") (not-eq selectedEventObj.sha latestCommit.sha))}}
         <p>{{fa-icon "exclamation-circle"}} This is not the latest commit.</p>
       {{/if}}
       {{#if (eq tooltipData.job.status "FROZEN")}}

--- a/tests/integration/components/pipeline-workflow/component-test.js
+++ b/tests/integration/components/pipeline-workflow/component-test.js
@@ -179,6 +179,7 @@ module('Integration | Component | pipeline workflow', function (hooks) {
     );
 
     assert.dom('.latest-commit').exists({ count: 1 });
+    assert.dom('.fa-exclamation-circle').doesNotExist({ count: 1 });
   });
 
   test('it renders without latest-commit', async function (assert) {
@@ -204,5 +205,6 @@ module('Integration | Component | pipeline workflow', function (hooks) {
     );
 
     assert.dom('.latest-commit').doesNotExist();
+    assert.dom('.fa-exclamation-circle').exists({ count: 1 });
   });
 });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Currently, when manually running a job, sha is highlighted in blue if the latest event is selected.

![latest-modal](https://user-images.githubusercontent.com/59165943/178951461-d715c9c1-4568-433d-b211-830e3aee0eba.png)

This indication alone may cause the user to unintentionally run a job from a non-latest sha event.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Displays a message when executing a job from a non-latest sha event.

![not-latest-modal](https://user-images.githubusercontent.com/59165943/178952589-a9f38cd6-7173-47ff-89c5-9cb4431fe531.png)

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
