### PR TITLE
fix: emphasize non-latest sha warning when manually executing jobs

### DIFF
--- a/app/components/pipeline-workflow/template.hbs
+++ b/app/components/pipeline-workflow/template.hbs
@@ -42,10 +42,11 @@
         <a class={{if (eq selectedEventObj.sha latestCommit.sha) "latest-commit"}} href={{selectedEventObj.commit.url}}>
           #{{selectedEventObj.truncatedSha}}
         </a>
+        {{#if (and (not-eq selectedEventObj.type "pr") (not-eq selectedEventObj.sha latestCommit.sha))}}
+          <br>
+          <div class="commit-warning alert alert-warning">{{fa-icon "exclamation-triangle"}} This is <strong>NOT</strong> the latest commit.</div>
+        {{/if}}
       </p>
-      {{#if (and (not-eq selectedEventObj.type "pr") (not-eq selectedEventObj.sha latestCommit.sha))}}
-        <p>{{fa-icon "exclamation-circle"}} This is not the latest commit.</p>
-      {{/if}}
       {{#if (eq tooltipData.job.status "FROZEN")}}
         {{#if (get-length tooltipData.selectedEvent.meta.parameters)}}
           {{#pipeline-parameterized-build

--- a/app/styles/screwdriver-modal-styles.scss
+++ b/app/styles/screwdriver-modal-styles.scss
@@ -24,6 +24,12 @@
 
   p {
     padding: 0 7px;
+    .commit-warning {
+      margin-top: 2px;
+      margin-bottom: 5px;
+      display: inline-block;
+      padding: 2px 2px 2px 2px;
+    }
   }
 
   .right {

--- a/app/styles/screwdriver-modal-styles.scss
+++ b/app/styles/screwdriver-modal-styles.scss
@@ -26,7 +26,7 @@
     padding: 0 7px;
     .commit-warning {
       margin-top: 2px;
-      margin-bottom: 5px;
+      margin-bottom: 0px;
       display: inline-block;
       padding: 2px 2px 2px 2px;
     }

--- a/tests/integration/components/pipeline-workflow/component-test.js
+++ b/tests/integration/components/pipeline-workflow/component-test.js
@@ -179,7 +179,7 @@ module('Integration | Component | pipeline workflow', function (hooks) {
     );
 
     assert.dom('.latest-commit').exists({ count: 1 });
-    assert.dom('.fa-exclamation-circle').doesNotExist({ count: 1 });
+    assert.dom('.fa-exclamation-triangle').doesNotExist({ count: 1 });
   });
 
   test('it renders without latest-commit', async function (assert) {
@@ -205,6 +205,6 @@ module('Integration | Component | pipeline workflow', function (hooks) {
     );
 
     assert.dom('.latest-commit').doesNotExist();
-    assert.dom('.fa-exclamation-circle').exists({ count: 1 });
+    assert.dom('.fa-exclamation-triangle').exists({ count: 1 });
   });
 });


### PR DESCRIPTION
## Context
#800 displays a message when executing a job from a non-latest sha event. However, the message is quiet and can be missed.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
Make the message more conspicuous.
<!-- What does this PR fix? What intentional changes will this PR make? -->
<img width="347" alt="スクリーンショット 2022-07-28 17 34 47" src="https://user-images.githubusercontent.com/22903716/181464728-0f502290-d806-420a-af58-120da1e8fda9.png">

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
#800
## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
