### PR TITLE
fix(2732): Show error message when unauthorized users change job state

### DIFF
--- a/app/components/pipeline-options/component.js
+++ b/app/components/pipeline-options/component.js
@@ -16,6 +16,8 @@ export default Component.extend({
   sync: service('sync'),
   // Clearing a cache
   cache: service('cache'),
+  // Update the job status
+  jobService: service('job'),
   shuttle: service(),
   errorMessage: '',
   scmUrl: '',
@@ -234,7 +236,9 @@ export default Component.extend({
     updateMessage(message) {
       const { state, jobId } = this;
 
-      this.setJobStatus(jobId, state, message || ' ');
+      this.jobService
+        .setJobState(jobId, state, message || ' ')
+        .catch(error => this.set('errorMessage', error));
       this.set('showToggleModal', false);
     },
     showRemoveButtons() {

--- a/app/components/pipeline-workflow/template.hbs
+++ b/app/components/pipeline-workflow/template.hbs
@@ -25,7 +25,7 @@
       stopBuild=stopBuild
       showTooltip=showTooltip
       showTooltipPosition=showTooltipPosition
-      setJobStatus=setJobStatus
+      setJobState=setJobState
       confirmStartBuild=(action "confirmStartBuild")
     }}
   {{/workflow-graph-d3}}

--- a/app/components/workflow-tooltip/component.js
+++ b/app/components/workflow-tooltip/component.js
@@ -52,7 +52,7 @@ export default Component.extend({
     updateMessage(message) {
       const { originalJobId, jobState } = this;
 
-      this.setJobStatus(originalJobId, jobState, message || ' ');
+      this.setJobState(originalJobId, jobState, message || ' ');
       this.set('showToggleModal', false);
       this.set('showTooltip', false);
     }

--- a/app/job/service.js
+++ b/app/job/service.js
@@ -1,0 +1,38 @@
+import Service, { inject as service } from '@ember/service';
+import { Promise as EmberPromise } from 'rsvp';
+
+export default Service.extend({
+  store: service(),
+
+  /**
+   * Update the job state
+   * @method setJobState
+   * @param   {Number}  id                   Job id
+   * @param   {String}  state                Job state to be changed ('ENABLED' or 'DISABLED')
+   * @param   {String}  stateChangeMessage   Job state update message
+   * @return  {Promise}                      Resolve nothing if success otherwise reject with error message
+   */
+  setJobState(id, state, stateChangeMessage) {
+    const job = this.store.peekRecord('job', id);
+    const originalState = job.get('state');
+    const originalStateChangeMessage = job.get('stateChangeMessage');
+
+    job.set('state', state);
+    job.set('stateChangeMessage', stateChangeMessage);
+
+    return new EmberPromise((resolve, reject) => {
+      job
+        .save()
+        .then(() => resolve())
+        .catch(error => {
+          // Restore the original job state
+          job.set('state', originalState);
+          job.set('stateChangeMessage', originalStateChangeMessage);
+
+          return reject(
+            error.errors[0].detail || 'Could not change the job state.'
+          );
+        });
+    });
+  }
+});

--- a/app/pipeline/controller.js
+++ b/app/pipeline/controller.js
@@ -16,15 +16,6 @@ export default Controller.extend({
       }
 
       return collection.save();
-    },
-    setJobStatus(id, state, stateChangeMessage) {
-      const job = this.store.peekRecord('job', id);
-
-      job.set('state', state);
-      job.set('stateChangeMessage', stateChangeMessage);
-      job
-        .save()
-        .catch(error => this.set('errorMessage', error.errors[0].detail || ''));
     }
   }
 });

--- a/app/pipeline/events/controller.js
+++ b/app/pipeline/events/controller.js
@@ -1,4 +1,4 @@
-import Controller, { inject } from '@ember/controller';
+import Controller from '@ember/controller';
 import { computed, get } from '@ember/object';
 import { alias } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
@@ -175,8 +175,9 @@ export async function updateEvents(page) {
 }
 
 export default Controller.extend(ModelReloaderMixin, {
-  pipelineController: inject('pipeline'),
   shuttle: service(),
+  // Update the job status
+  jobService: service('job'),
   lastRefreshed: moment(),
   expandedEventsGroup: {},
   shouldReload(model) {
@@ -646,13 +647,10 @@ export default Controller.extend(ModelReloaderMixin, {
         this.set('syncAdmins', 'failure');
       }
     },
-    setJobStatus(id, state, stateChangeMessage) {
-      this.pipelineController.send(
-        'setJobStatus',
-        id,
-        state,
-        stateChangeMessage
-      );
+    setJobState(id, state, stateChangeMessage) {
+      this.jobService
+        .setJobState(id, state, stateChangeMessage || ' ')
+        .catch(error => this.set('errorMessage', error));
       this.reload();
     }
   },

--- a/app/pipeline/events/template.hbs
+++ b/app/pipeline/events/template.hbs
@@ -62,7 +62,7 @@
       selected=selected
       startDetachedBuild=(action "startDetachedBuild")
       stopBuild=(action "stopBuild")
-      setJobStatus=(action "setJobStatus")
+      setJobState=(action "setJobState")
       authenticated=session.isAuthenticated
     }}
 

--- a/app/pipeline/options/controller.js
+++ b/app/pipeline/options/controller.js
@@ -1,23 +1,14 @@
-import Controller, { inject } from '@ember/controller';
+import Controller from '@ember/controller';
 import { reads } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 
 export default Controller.extend({
-  pipelineController: inject('pipeline'),
   session: service(),
   errorMessage: '',
   isSaving: false,
   pipeline: reads('model.pipeline'),
   jobs: reads('model.jobs'),
   actions: {
-    setJobStatus(id, state, stateChangeMessage) {
-      this.pipelineController.send(
-        'setJobStatus',
-        id,
-        state,
-        stateChangeMessage
-      );
-    },
     removePipeline() {
       this.pipeline
         .destroyRecord()

--- a/app/pipeline/options/template.hbs
+++ b/app/pipeline/options/template.hbs
@@ -6,7 +6,6 @@
   pipeline=pipeline
   jobs=jobs
   errorMessage=errorMessage
-  setJobStatus=(action "setJobStatus")
   onRemovePipeline=(action "removePipeline")
   isSaving=isSaving
   onUpdatePipeline=(action "updatePipeline")

--- a/tests/integration/components/pipeline-options/component-test.js
+++ b/tests/integration/components/pipeline-options/component-test.js
@@ -309,20 +309,6 @@ module('Integration | Component | pipeline options', function (hooks) {
     this.set('showToggleModal', false);
     this.set('mockJobs', A([main]));
     this.set('username', 'tkyi');
-    this.set('setJobStatsMock', (id, state, name, message) => {
-      assert.equal(id, '1234');
-      assert.equal(message, ' ');
-      assert.equal(name, 'tkyi');
-      assert.equal(state, 'DISABLED');
-
-      main.set('state', state);
-      main.set('stateChanger', 'tkyi');
-      main.set('stateChangeMessage', ' ');
-      main.set('isDisabled', state === 'DISABLED');
-
-      this.set('state', state);
-      this.set('showToggleModal', false);
-    });
 
     this.owner.unregister('service:store');
     this.owner.register('service:store', storeStub);
@@ -330,7 +316,6 @@ module('Integration | Component | pipeline options', function (hooks) {
     await render(hbs`{{pipeline-options
       username=username
       pipeline=mockPipeline
-      setJobStatus=setJobStatsMock
       jobs=mockJobs
       showToggleModal=showToggleModal
     }}`);
@@ -355,7 +340,7 @@ module('Integration | Component | pipeline options', function (hooks) {
       name: 'main',
       state: 'ENABLED',
       stateChanger: 'tkyi',
-      stateChangeMessage: 'testing',
+      stateChangeMessage: 'foo',
       isDisabled: false
     });
 
@@ -370,23 +355,35 @@ module('Integration | Component | pipeline options', function (hooks) {
 
     this.set('mockJobs', A([main]));
     this.set('username', 'tkyi');
-    this.set('setJobStatsMock', (id, state) => {
-      assert.equal(id, '1234');
-      assert.equal(state, 'DISABLED');
 
-      main.set('isDisabled', state === 'DISABLED');
+    const jobServiceStub = Service.extend({
+      setJobState: (id, state, message) => {
+        assert.equal(id, '1234');
+        assert.equal(state, 'DISABLED');
+        assert.equal(message, 'testing');
+
+        main.set('state', state);
+        main.set('stateChanger', 'tkyi');
+        main.set('stateChangeMessage', 'testing');
+        main.set('isDisabled', true);
+
+        return Promise.resolve();
+      }
     });
+
+    this.owner.unregister('service:job');
+    this.owner.register('service:job', jobServiceStub);
 
     await render(hbs`{{pipeline-options
       username=username
       pipeline=mockPipeline
-      setJobStatus=setJobStatsMock
       jobs=mockJobs
     }}`);
 
     assert.dom('.x-toggle-container').hasClass('x-toggle-container-checked');
 
     await click('.x-toggle-btn');
+    await fillIn('.message input', 'testing');
     await click('.toggle-form__create');
 
     assert.dom('section.jobs h4').hasText('main');
@@ -403,6 +400,8 @@ module('Integration | Component | pipeline options', function (hooks) {
     const main = EmberObject.create({
       id: '1234',
       name: 'main',
+      state: 'DISABLED',
+      stateChangeMessage: 'testing',
       isDisabled: true
     });
 
@@ -415,16 +414,27 @@ module('Integration | Component | pipeline options', function (hooks) {
       })
     );
     this.set('mockJobs', A([main]));
-    this.set('setJobStatsMock', (id, state) => {
-      assert.equal(id, '1234');
-      assert.equal(state, 'ENABLED');
 
-      main.set('isDisabled', state === 'DISABLED');
+    const jobServiceStub = Service.extend({
+      setJobState: (id, state, message) => {
+        assert.equal(id, '1234');
+        assert.equal(state, 'ENABLED');
+        assert.equal(message, ' ');
+
+        main.set('state', state);
+        main.set('stateChanger', 'tkyi');
+        main.set('stateChangeMessage', ' ');
+        main.set('isDisabled', false);
+
+        return Promise.resolve();
+      }
     });
+
+    this.owner.unregister('service:job');
+    this.owner.register('service:job', jobServiceStub);
 
     await render(hbs`{{pipeline-options
       pipeline=mockPipeline
-      setJobStatus=setJobStatsMock
       jobs=mockJobs
     }}`);
 
@@ -438,6 +448,50 @@ module('Integration | Component | pipeline options', function (hooks) {
     await click('.toggle-form__create');
 
     assert.dom('.x-toggle-container').hasClass('x-toggle-container-checked');
+  });
+
+  test('it fails to handle job enabling', async function (assert) {
+    const main = EmberObject.create({
+      id: '1234',
+      name: 'main',
+      state: 'DISABLED',
+      stateChangeMessage: 'testing',
+      isDisabled: true
+    });
+
+    this.set(
+      'mockPipeline',
+      EmberObject.create({
+        appId: 'foo/bar',
+        scmUri: 'github.com:84604643:master',
+        id: 'abc1234'
+      })
+    );
+    this.set('mockJobs', A([main]));
+
+    const jobServiceStub = Service.extend({
+      setJobState: () => reject('Error message')
+    });
+
+    this.owner.unregister('service:job');
+    this.owner.register('service:job', jobServiceStub);
+
+    await render(hbs`{{pipeline-options
+      pipeline=mockPipeline
+      jobs=mockJobs
+    }}`);
+
+    assert.dom('section.jobs h4').hasText('main');
+    assert
+      .dom('section.jobs p')
+      .hasText('Toggle to disable or enable the job.');
+    assert.dom('.x-toggle-container').hasNoClass('x-toggle-container-checked');
+
+    await click('.x-toggle-btn');
+    await click('.toggle-form__create');
+
+    assert.dom('.x-toggle-container').hasNoClass('x-toggle-container-checked');
+    assert.dom('.alert > span').hasText('Error message');
   });
 
   test('it handles filterEventsForNobuilds enabling', async function (assert) {

--- a/tests/unit/job/service-test.js
+++ b/tests/unit/job/service-test.js
@@ -1,0 +1,69 @@
+import EmberObject from '@ember/object';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import Service from '@ember/service';
+import sinon from 'sinon';
+
+let job;
+
+const storeServiceStub = Service.extend({
+  peekRecord() {
+    return job;
+  }
+});
+
+module('Unit | Service | job', function (hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.owner.unregister('service:store');
+    this.owner.register('service:store', storeServiceStub);
+  });
+
+  test('it exists', function (assert) {
+    const service = this.owner.lookup('service:job');
+
+    assert.ok(service);
+  });
+
+  test('it handles updating job state', function (assert) {
+    job = EmberObject.create({
+      id: 1234,
+      state: 'DISABLED',
+      stateChangeMessage: 'foo',
+      save: sinon.stub().resolves()
+    });
+
+    const service = this.owner.lookup('service:job');
+    const p = service.setJobState(1234, 'ENABLED', 'testing');
+
+    p.then(() => {
+      assert.equal(job.state, 'ENABLED');
+      assert.equal(job.stateChangeMessage, 'testing');
+      assert.ok(job.save.calledOnce);
+    });
+  });
+
+  test('it fails updating job state', function (assert) {
+    const error = {
+      errors: [{ detail: 'test message' }]
+    };
+
+    job = EmberObject.create({
+      id: 1234,
+      state: 'DISABLED',
+      stateChangeMessage: 'foo',
+      save: sinon.stub().rejects(error)
+    });
+
+    const service = this.owner.lookup('service:job');
+    const p = service.setJobState(1234, 'ENABLED', 'testing');
+
+    p.catch(message => {
+      assert.equal(job.state, 'DISABLED');
+      assert.equal(job.stateChangeMessage, 'foo');
+      assert.equal(message, 'test message');
+      assert.ok(job.save.calledOnce);
+    });
+  });
+});

--- a/tests/unit/pipeline/options/controller-test.js
+++ b/tests/unit/pipeline/options/controller-test.js
@@ -16,38 +16,6 @@ module('Unit | Controller | pipeline/options', function (hooks) {
     server.shutdown();
   });
 
-  test('it handles updating job state', function (assert) {
-    server.put('http://localhost:8080/v4/jobs/1234', () => [
-      200,
-      {},
-      JSON.stringify({ id: 1234 })
-    ]);
-
-    let controller = this.owner.lookup('controller:pipeline/options');
-
-    run(() => {
-      controller.store.push({
-        data: {
-          id: '1234',
-          type: 'job',
-          attributes: {
-            status: 'DISABLED'
-          }
-        }
-      });
-
-      controller.send('setJobStatus', '1234', 'ENABLED', 'testing');
-    });
-
-    return settled().then(() => {
-      const [request] = server.handledRequests;
-      const payload = JSON.parse(request.requestBody);
-
-      assert.equal(payload.state, 'ENABLED');
-      assert.equal(payload.stateChangeMessage, 'testing');
-    });
-  });
-
   test('it handles deleting pipelines', function (assert) {
     assert.expect(2);
     server.delete('http://localhost:8080/v4/pipelines/abc1234', () => [


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Fix the following issue.
- https://github.com/screwdriver-cd/screwdriver/issues/2732

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

- Show an error message when user without permission change job state.
- Preserve the visual of job state

Option page:
![options](https://user-images.githubusercontent.com/43719835/182990438-85cbf595-eb28-419d-8acc-eeca49178e75.jpg)

Pipeline tooltip:
![tooltip](https://user-images.githubusercontent.com/43719835/182990452-2a94d3bb-fd60-4baf-a324-389c41438173.jpg)

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

https://github.com/screwdriver-cd/screwdriver/issues/2732

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
