### PR TITLE
fix(2732): reload job state after restore job state

### DIFF
--- a/app/pipeline/events/controller.js
+++ b/app/pipeline/events/controller.js
@@ -650,8 +650,8 @@ export default Controller.extend(ModelReloaderMixin, {
     setJobState(id, state, stateChangeMessage) {
       this.jobService
         .setJobState(id, state, stateChangeMessage || ' ')
-        .catch(error => this.set('errorMessage', error));
-      this.reload();
+        .catch(error => this.set('errorMessage', error))
+        .finally(() => this.reload());
     }
   },
   willDestroy() {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Follow up of PR https://github.com/screwdriver-cd/ui/pull/806 .
When API response is delayed, job icon state may not be restored.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Reload job state after restore original job state.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

https://github.com/screwdriver-cd/ui/pull/806

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
