### PR TITLE
fix(2728): gray out the Restart button for jobs that are disabled on the build details page

### DIFF
--- a/app/components/build-banner/component.js
+++ b/app/components/build-banner/component.js
@@ -72,6 +72,23 @@ export default Component.extend({
     }
   }),
 
+  isButtonDisabledLoaded: false,
+  isButtonDisabled: computed('buildStatus', 'jobDisabled', {
+    get() {
+      if (this.buildAction === 'Restart') {
+        return this.jobDisabled.then(jobDisabled => {
+          this.set('isButtonDisabledLoaded', true);
+
+          return jobDisabled;
+        });
+      }
+
+      this.set('isButtonDisabledLoaded', true);
+
+      return false;
+    }
+  }),
+
   overrideCoverageInfo() {
     const { buildMeta } = this;
 

--- a/app/components/build-banner/template.hbs
+++ b/app/components/build-banner/template.hbs
@@ -80,7 +80,9 @@
   </li>
   <li class="call-to-action button-right">
     {{#if isAuthenticated}}
-      {{#bs-button onClick=(action "buildButtonClick")}}{{buildAction}}{{/bs-button}}
+      {{#bs-button onClick=(action "buildButtonClick") disabled=(or (await isButtonDisabled) (not isButtonDisabledLoaded))}}
+        {{buildAction}}
+      {{/bs-button}}
     {{/if}}
   </li>
 </ul>

--- a/app/pipeline/build/controller.js
+++ b/app/pipeline/build/controller.js
@@ -21,6 +21,23 @@ export default Controller.extend({
   stepList: mapBy('build.steps', 'name'),
   isShowingModal: false,
   errorMessage: '',
+  jobDisabled: computed('model.job', {
+    get() {
+      const job = this.get('model.job');
+      const jobsPromise = this.get('model.pipeline.jobs');
+
+      return jobsPromise.then(jobs => {
+        if (this.get('model.event.type') === 'pr') {
+          const originalJob = jobs.find(j => j.id === job.prParentJobId);
+
+          return originalJob ? originalJob.isDisabled : false;
+        }
+
+        return job.isDisabled;
+      });
+    }
+  }),
+
   prEvents: computed('model.{event.pr.url,pipeline.id}', {
     get() {
       if (this.get('model.event.type') === 'pr') {

--- a/app/pipeline/build/template.hbs
+++ b/app/pipeline/build/template.hbs
@@ -13,6 +13,7 @@
   buildMeta=build.meta
   jobName=job.name
   jobId=job.id
+  jobDisabled=jobDisabled
   annotations=job.annotations
   pipelineId=pipeline.id
   pipelineName=pipeline.name

--- a/tests/integration/components/build-banner/component-test.js
+++ b/tests/integration/components/build-banner/component-test.js
@@ -321,6 +321,42 @@ module('Integration | Component | build banner', function (hooks) {
   });
 
   test('it renders a restart button for completed jobs when authenticated', async function (assert) {
+    assert.expect(4);
+
+    const reloadBuildSpy = this.spy();
+
+    this.set('buildStepsMock', buildStepsMock);
+    this.set('reloadCb', reloadBuildSpy);
+    this.set('externalStart', () => {
+      assert.ok(true);
+    });
+    this.set('eventMock', prEventMock);
+    this.set('prEvents', new EmberPromise(resolves => resolves([])));
+    this.set('isButtonDisabledLoaded', true);
+    this.set('jobDisabled', new EmberPromise(resolves => resolves(false)));
+
+    await render(hbs`{{build-banner
+      buildContainer="node:6"
+      duration="5 seconds"
+      buildStatus="ABORTED"
+      buildStart="2016-11-04T20:09:41.238Z"
+      buildSteps=buildStepsMock
+      jobName="PR-671"
+      jobDisabled=jobDisabled
+      isAuthenticated=true
+      event=eventMock
+      prEvents=prEvents
+      onStart=(action externalStart)
+      reloadBuild=(action reloadCb)
+    }}`);
+
+    assert.dom('button').hasText('Restart');
+    assert.dom('.clicks-disabled').doesNotExist();
+    assert.notOk(reloadBuildSpy.called);
+    await click('button');
+  });
+
+  test('it renders a disabled restart button for completed disabled jobs when authenticated', async function (assert) {
     assert.expect(3);
 
     const reloadBuildSpy = this.spy();
@@ -332,6 +368,8 @@ module('Integration | Component | build banner', function (hooks) {
     });
     this.set('eventMock', prEventMock);
     this.set('prEvents', new EmberPromise(resolves => resolves([])));
+    this.set('isButtonDisabledLoaded', true);
+    this.set('jobDisabled', new EmberPromise(resolves => resolves(true)));
 
     await render(hbs`{{build-banner
       buildContainer="node:6"
@@ -340,6 +378,7 @@ module('Integration | Component | build banner', function (hooks) {
       buildStart="2016-11-04T20:09:41.238Z"
       buildSteps=buildStepsMock
       jobName="PR-671"
+      jobDisabled=jobDisabled
       isAuthenticated=true
       event=eventMock
       prEvents=prEvents
@@ -348,8 +387,8 @@ module('Integration | Component | build banner', function (hooks) {
     }}`);
 
     assert.dom('button').hasText('Restart');
+    assert.dom('button').hasAttribute('disabled');
     assert.notOk(reloadBuildSpy.called);
-    await click('button');
   });
 
   test('it renders a stop button for running job when authenticated', async function (assert) {
@@ -364,6 +403,8 @@ module('Integration | Component | build banner', function (hooks) {
     this.set('buildStepsMock', buildStepsMock);
     this.set('eventMock', prEventMock);
     this.set('prEvents', new EmberPromise(resolves => resolves([])));
+    this.set('isButtonDisabledLoaded', true);
+    this.set('jobDisabled', new EmberPromise(resolves => resolves(false)));
 
     await render(hbs`{{build-banner
       buildContainer="node:6"
@@ -372,6 +413,7 @@ module('Integration | Component | build banner', function (hooks) {
       buildStart="2016-11-04T20:09:41.238Z"
       buildSteps=buildStepsMock
       jobName="main"
+      jobDisabled=jobDisabled
       isAuthenticated=true
       event=eventMock
       prEvents=prEvents
@@ -380,6 +422,41 @@ module('Integration | Component | build banner', function (hooks) {
     }}`);
 
     assert.dom('button').hasText('Stop');
+    await click('button');
+  });
+
+  test('it renders a stop button for running disabled job when authenticated', async function (assert) {
+    assert.expect(5);
+    this.set('willRender', () => {
+      assert.ok(true);
+    });
+
+    this.set('externalStop', () => {
+      assert.ok(true);
+    });
+    this.set('buildStepsMock', buildStepsMock);
+    this.set('eventMock', prEventMock);
+    this.set('prEvents', new EmberPromise(resolves => resolves([])));
+    this.set('isButtonDisabledLoaded', true);
+    this.set('jobDisabled', new EmberPromise(resolves => resolves(true)));
+
+    await render(hbs`{{build-banner
+      buildContainer="node:6"
+      duration="5 seconds"
+      buildStatus="RUNNING"
+      buildStart="2016-11-04T20:09:41.238Z"
+      buildSteps=buildStepsMock
+      jobName="main"
+      jobDisabled=jobDisabled
+      isAuthenticated=true
+      event=eventMock
+      prEvents=prEvents
+      onStop=(action externalStop)
+      reloadBuild=(action willRender)
+    }}`);
+
+    assert.dom('button').hasText('Stop');
+    assert.dom('.clicks-disabled').doesNotExist();
     await click('button');
   });
 
@@ -395,6 +472,8 @@ module('Integration | Component | build banner', function (hooks) {
     this.set('buildStepsMock', buildStepsMock);
     this.set('eventMock', prEventMock);
     this.set('prEvents', new EmberPromise(resolves => resolves([])));
+    this.set('isButtonDisabledLoaded', true);
+    this.set('jobDisabled', new EmberPromise(resolves => resolves(false)));
 
     await render(hbs`{{build-banner
       buildContainer="node:6"
@@ -403,6 +482,7 @@ module('Integration | Component | build banner', function (hooks) {
       buildStart="2016-11-04T20:09:41.238Z"
       buildSteps=buildStepsMock
       jobName="main"
+      jobDisabled=jobDisabled
       isAuthenticated=true
       event=eventMock
       prEvents=prEvents
@@ -433,6 +513,7 @@ module('Integration | Component | build banner', function (hooks) {
     this.set('buildStepsMock', coverageStepsMock);
     this.set('buildMetaMock', buildMetaMock);
     this.set('prEvents', new EmberPromise(resolves => resolves([])));
+    this.set('jobDisabled', new EmberPromise(resolves => resolves(false)));
 
     await render(hbs`{{build-banner
       buildContainer="node:6"
@@ -443,6 +524,7 @@ module('Integration | Component | build banner', function (hooks) {
       buildStart="2016-11-04T20:09:41.238Z"
       buildSteps=buildStepsMock
       jobId=1
+      jobDisabled=jobDisabled
       jobName="main"
       isAuthenticated=true
       event=eventMock
@@ -479,6 +561,8 @@ module('Integration | Component | build banner', function (hooks) {
     this.set('buildStepsMock', coverageStepsMock);
     this.set('buildMetaMock', buildMetaMock);
     this.set('prEvents', new EmberPromise(resolves => resolves([])));
+    this.set('isButtonDisabledLoaded', true);
+    this.set('jobDisabled', new EmberPromise(resolves => resolves(false)));
 
     await render(hbs`{{build-banner
       buildContainer="node:6"
@@ -489,6 +573,7 @@ module('Integration | Component | build banner', function (hooks) {
       buildStart="2016-11-04T20:09:41.238Z"
       buildSteps=buildStepsMock
       jobId=1
+      jobDisabled=jobDisabled
       jobName="main"
       isAuthenticated=true
       event=eventMock
@@ -533,6 +618,7 @@ module('Integration | Component | build banner', function (hooks) {
     this.set('buildStepsMock', coverageStepsMock);
     this.set('buildMetaMock', buildMetaMock);
     this.set('prEvents', new EmberPromise(resolves => resolves([])));
+    this.set('jobDisabled', new EmberPromise(resolves => resolves(false)));
 
     await render(hbs`{{build-banner
       buildContainer="node:6"
@@ -543,6 +629,7 @@ module('Integration | Component | build banner', function (hooks) {
       buildSteps=buildStepsMock
       buildMeta=buildMetaMock
       jobId=1
+      jobDisabled=jobDisabled
       jobName="main"
       isAuthenticated=true
       event=eventMock
@@ -579,6 +666,7 @@ module('Integration | Component | build banner', function (hooks) {
     this.set('buildStepsMock', coverageStepsMock);
     this.set('buildMetaMock', buildMetaMock);
     this.set('prEvents', new EmberPromise(resolves => resolves([])));
+    this.set('jobDisabled', new EmberPromise(resolves => resolves(false)));
 
     await render(hbs`{{build-banner
       buildContainer="node:6"
@@ -589,6 +677,7 @@ module('Integration | Component | build banner', function (hooks) {
       buildSteps=buildStepsMock
       buildMeta=buildMetaMock
       jobId=1
+      jobDisabled=jobDisabled
       jobName="main"
       isAuthenticated=true
       event=eventMock
@@ -613,6 +702,7 @@ module('Integration | Component | build banner', function (hooks) {
     this.set('eventMock', prEventMock);
     this.set('buildStepsMock', buildStepsMock);
     this.set('prEvents', new EmberPromise(resolves => resolves([])));
+    this.set('jobDisabled', new EmberPromise(resolves => resolves(false)));
 
     await render(hbs`{{build-banner
       buildContainer="node:6"
@@ -622,6 +712,7 @@ module('Integration | Component | build banner', function (hooks) {
       buildStart="2016-11-04T20:09:41.238Z"
       buildSteps=buildStepsMock
       jobId=1
+      jobDisabled=jobDisabled
       jobName="main"
       isAuthenticated=true
       event=eventMock
@@ -647,6 +738,8 @@ module('Integration | Component | build banner', function (hooks) {
     this.set('eventMock', prEventMock);
     this.set('buildStepsMock', coverageStepsMock);
     this.set('prEvents', new EmberPromise(resolves => resolves([])));
+    this.set('isButtonDisabledLoaded', true);
+    this.set('jobDisabled', new EmberPromise(resolves => resolves(false)));
 
     await render(hbs`{{build-banner
       buildContainer="node:6"
@@ -656,6 +749,7 @@ module('Integration | Component | build banner', function (hooks) {
       buildStart="2016-11-04T20:09:41.238Z"
       buildSteps=buildStepsMock
       jobId=1
+      jobDisabled=jobDisabled
       jobName="main"
       isAuthenticated=true
       event=eventMock


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
As per the comment in https://github.com/screwdriver-cd/models/pull/555#pullrequestreview-1047094026, it would be preferable to have a UI where disabled jobs cannot be Restarted from the Build Details page.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Fix the Restart button to be grayed out on the build details page of a disable job.
- While waiting for `model.pipeline.jobs` to fetch, isButtonDisabledLoaded is false and the Restart button is grayed out regardless of its state.
  - The time to wait for this fetch does not occur when transitioning from tooltip, but occurs slightly when the build detail page is accessed directly.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
