### PR TITLE
fix: When pipeline alias present, build history looks way too small

### DIFF
--- a/app/components/collection-view/styles.scss
+++ b/app/components/collection-view/styles.scss
@@ -164,8 +164,8 @@
   }
 
   .alias {
-    width: 15%;
-    max-width: 150px;
+    width: 10%;
+    max-width: 100px;
   }
 
   .app-id {


### PR DESCRIPTION
## Context
For pipeline collection view, when both ALIAS and BUILD HISTORY columns exist, Alias column took much space that Build History column is skewed

## Objective
For pipeline collection-list view ,to provide enough space for Build History column on Dashboard.

## References
https://github.com/screwdriver-cd/screwdriver/issues/2745


## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
