### PR TITLE
fix: Pipeline collection table show non-intuitive cursor when hover over headers

### DIFF
--- a/app/components/collection-view/styles.scss
+++ b/app/components/collection-view/styles.scss
@@ -4,6 +4,10 @@
   height: calc(100vh - 56px);
   width: 100%;
 
+  table {
+    cursor: default;
+  }
+
   button {
     border: none;
 
@@ -202,6 +206,7 @@
   .last-run {
     width: 12%;
     max-width: 200px;
+    cursor: pointer;
 
     .icon-wrapper {
       .fa {
@@ -213,6 +218,7 @@
   .history {
     display: flex;
     align-items: center;
+    cursor: pointer;
 
     .icon-wrapper {
       display: flex;


### PR DESCRIPTION
## Context

Pipeline collection table show non-intuitive cursor when hover over headers
## Objective
When mouse hover over Last Run Job and Build History table header, mouse cursor should be a hand to indicate sorting, while other headers should be the default instead of text
## References
https://github.com/screwdriver-cd/screwdriver/issues/2746

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
