### PR TITLE
fix(2713): spelling error for rename pipeline

### DIFF
--- a/app/components/pipeline-options/template.hbs
+++ b/app/components/pipeline-options/template.hbs
@@ -189,7 +189,7 @@
 
   <div class="col-xs-12 col-md-8">
     <section class="preference">
-      <h3>Pipeline Preference</h3>
+      <h3>Pipeline Preferences</h3>
       <ul>
         <li>
           <div class="row">
@@ -244,7 +244,7 @@
         <li>
           <div class="row">
             <div class="col-xs-10">
-              <h4>Re-name pipeline</h4>
+              <h4>Rename pipeline</h4>
               <p>Setup your own preferred pipeline name in the dashboard list view.</p>
             </div>
             <div class="col-xs-2 right">

--- a/tests/integration/components/pipeline-options/component-test.js
+++ b/tests/integration/components/pipeline-options/component-test.js
@@ -599,7 +599,7 @@ module('Integration | Component | pipeline options', function (hooks) {
 
     assert
       .dom('section.preference li:nth-of-type(4) h4')
-      .hasText('Re-name pipeline');
+      .hasText('Rename pipeline');
     assert
       .dom('section.preference li:nth-of-type(4) p')
       .hasText(


### PR DESCRIPTION
## Context

Re-name should be rename.

## Objective

This PR fixes some spelling issues.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2713

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
