### PR TITLE
fix: Modify toggle text to work in both directions

### DIFF
--- a/app/components/command-header/styles.scss
+++ b/app/components/command-header/styles.scss
@@ -17,7 +17,7 @@
     vertical-align: middle;
   }
 
-  .x-toggle-component {
+  .trusted-toggle {
     display: inline-flex;
     font-size: 0.5em;
     float: right;
@@ -25,5 +25,6 @@
 
   .x-toggle-container {
     font-size: 0.75rem;
+    margin-right: 7px;
   }
 }

--- a/app/components/command-header/template.hbs
+++ b/app/components/command-header/template.hbs
@@ -8,15 +8,15 @@
   {{/if}}
   {{#if isAdmin}}
     <a href="#" {{action "setCommandToRemove" command}} class="remove">{{fa-icon "trash" title="Delete command"}}</a>
+    <label class="trusted-toggle">
     {{x-toggle
       size="medium"
       theme="light"
-      showLabels=true
       value=trusted
-      offLabel=null
-      onLabel="Trust?"
       onToggle=(action "updateTrust" command.namespace command.name)
     }}
+    Trust?
+    </label>
   {{else}}
     {{#if scmUrl}}
       <a href="#" {{action "setCommandToRemove" command}} class="remove">{{fa-icon "trash" title="Delete command"}}</a>

--- a/app/components/command-header/template.hbs
+++ b/app/components/command-header/template.hbs
@@ -9,13 +9,13 @@
   {{#if isAdmin}}
     <a href="#" {{action "setCommandToRemove" command}} class="remove">{{fa-icon "trash" title="Delete command"}}</a>
     <label class="trusted-toggle">
-    {{x-toggle
-      size="medium"
-      theme="light"
-      value=trusted
-      onToggle=(action "updateTrust" command.namespace command.name)
-    }}
-    Trust?
+      {{x-toggle
+        size="medium"
+        theme="light"
+        value=trusted
+        onToggle=(action "updateTrust" command.namespace command.name)
+      }}
+      Trust?
     </label>
   {{else}}
     {{#if scmUrl}}

--- a/app/components/tc-collection-list/styles.scss
+++ b/app/components/tc-collection-list/styles.scss
@@ -92,6 +92,11 @@
   }
 
   .x-toggle-component {
-    padding: 10px;
+    padding-right: 3px;
+  }
+
+  .trusted-toggle {
+    display: flex;
+    padding: 10px 10px 10px 0px;
   }
 }

--- a/app/components/tc-collection-list/template.hbs
+++ b/app/components/tc-collection-list/template.hbs
@@ -17,13 +17,13 @@
   <div class="row">
     <div class="col-sm-1">
       <label class="trusted-toggle">
-      {{x-toggle
-        size="small"
-        theme="material"
-        value=trustedOnly
-        onToggle=(action "toggleTrustedOnly")
-      }}
-      Trusted
+        {{x-toggle
+          size="small"
+          theme="material"
+          value=trustedOnly
+          onToggle=(action "toggleTrustedOnly")
+        }}
+        Trusted
       </label>
     </div>
 

--- a/app/components/tc-collection-list/template.hbs
+++ b/app/components/tc-collection-list/template.hbs
@@ -16,15 +16,15 @@
 
   <div class="row">
     <div class="col-sm-1">
+      <label class="trusted-toggle">
       {{x-toggle
         size="small"
         theme="material"
-        showLabels=true
         value=trustedOnly
-        offLabel=null
-        onLabel="Trusted"
         onToggle=(action "toggleTrustedOnly")
       }}
+      Trusted
+      </label>
     </div>
 
     <div class="col-sm-3">

--- a/app/components/template-header/styles.scss
+++ b/app/components/template-header/styles.scss
@@ -45,7 +45,7 @@
     vertical-align: middle;
   }
 
-  .x-toggle-component {
+  .trusted-toggle {
     display: inline-flex;
     font-size: 0.5em;
     float: right;
@@ -53,5 +53,6 @@
 
   .x-toggle-container {
     font-size: 0.75rem;
+    margin-right: 7px;
   }
 }

--- a/app/components/template-header/template.hbs
+++ b/app/components/template-header/template.hbs
@@ -8,15 +8,15 @@
   {{/if}}
   {{#if isAdmin}}
     <a href="#" {{action "setTemplateToRemove" template}} class="remove">{{fa-icon "trash" title="Delete template"}}</a>
+    <label class="trusted-toggle">
     {{x-toggle
       size="medium"
       theme="light"
-      showLabels=true
       value=trusted
-      offLabel=null
-      onLabel="Trust?"
       onToggle=(action "updateTrust" template.fullName)
     }}
+    Trust?
+    </label>
   {{else}}
     {{#if scmUrl}}
       <a href="#" {{action "setTemplateToRemove" template}} class="remove">{{fa-icon "trash" title="Delete template"}}</a>

--- a/app/components/template-header/template.hbs
+++ b/app/components/template-header/template.hbs
@@ -9,13 +9,13 @@
   {{#if isAdmin}}
     <a href="#" {{action "setTemplateToRemove" template}} class="remove">{{fa-icon "trash" title="Delete template"}}</a>
     <label class="trusted-toggle">
-    {{x-toggle
-      size="medium"
-      theme="light"
-      value=trusted
-      onToggle=(action "updateTrust" template.fullName)
-    }}
-    Trust?
+      {{x-toggle
+        size="medium"
+        theme="light"
+        value=trusted
+        onToggle=(action "updateTrust" template.fullName)
+      }}
+      Trust?
     </label>
   {{else}}
     {{#if scmUrl}}

--- a/app/pipeline/metrics/template.hbs
+++ b/app/pipeline/metrics/template.hbs
@@ -41,16 +41,14 @@
     onToggle=(action (mut isUTC))
   }}
 
-  <div class="chart-control filters-selection">
+  <label class="chart-control filters-selection">
     {{x-toggle
       size="small"
       theme="material"
-      showLabels=true
       value=successOnly
-      offLabel=null
-      onLabel="Success Only"
       onToggle=(action "toggleSuccessOnly")}}
-  </div>
+      <div class="success-only">Success Only</div>
+  </label>
 </div>
 
 <div class="chart-pipeline-info">
@@ -116,14 +114,14 @@
   {{/if}}
   <div class="chart-c3">
     <p class="chart-title">Events</p>
+    <label class="toggle-trend">
     {{x-toggle
       size="small"
       theme="material"
-      showLabels=true
       value=inTrendlineView
-      offLabel=null
-      onLabel="Trendline View"
       onToggle=(action "toggleTrendlineView")}}
+      <div class="trendline-view">Trendline View</div>
+    </label>
     <ul class="list-inline chart-legend">
       {{#each eventLegend as |lg|}}
         <li

--- a/app/pipeline/metrics/template.hbs
+++ b/app/pipeline/metrics/template.hbs
@@ -47,7 +47,7 @@
       theme="material"
       value=successOnly
       onToggle=(action "toggleSuccessOnly")}}
-      <div class="success-only">Success Only</div>
+    <div class="success-only">Success Only</div>
   </label>
 </div>
 
@@ -115,11 +115,11 @@
   <div class="chart-c3">
     <p class="chart-title">Events</p>
     <label class="toggle-trend">
-    {{x-toggle
-      size="small"
-      theme="material"
-      value=inTrendlineView
-      onToggle=(action "toggleTrendlineView")}}
+      {{x-toggle
+        size="small"
+        theme="material"
+        value=inTrendlineView
+        onToggle=(action "toggleTrendlineView")}}
       <div class="trendline-view">Trendline View</div>
     </label>
     <ul class="list-inline chart-legend">

--- a/app/styles/chart.scss
+++ b/app/styles/chart.scss
@@ -42,10 +42,6 @@
   justify-content: flex-start;
   align-items: center;
 
-  label {
-    margin: 0;
-  }
-
   .title {
     margin-right: 5px;
   }
@@ -106,7 +102,26 @@
 }
 
 .filters-selection {
+  padding-left: 7px;
   margin-left: auto;
+  display: flex;
+  cursor: pointer;
+}
+
+.success-only {
+  margin-left: 7px;
+}
+
+.toggle-trend {
+  display: flex;
+  cursor: pointer;
+  float: right;
+}
+
+.trendline-view {
+  font-weight: normal;
+  font-size: 0.85em;
+  margin-top: -1em;
 }
 
 .chart-c3,


### PR DESCRIPTION
## Context
Currently, toggles move toward On when the texts are tapped, but not toward Off.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
The following four toggles are modified to move in both directions when the toggle texts are tapped.
<!-- What does this PR fix? What intentional changes will this PR make? -->
`Template/Command Search Page`

<img width="155" alt="スクリーンショット 2022-08-10 18 28 11" src="https://user-images.githubusercontent.com/22903716/184576899-71b70441-973a-4180-ac04-01f28a67ece8.png">

`Template/Command Description Page`

<img width="263" alt="スクリーンショット 2022-08-12 15 44 02" src="https://user-images.githubusercontent.com/22903716/184577216-77ae0e2b-586d-4a6b-b535-25ff8493b1f2.png">

`Metrics Page 1`

<img width="406" alt="スクリーンショット_2022-08-12_18_09_51" src="https://user-images.githubusercontent.com/22903716/184577622-bbcfe7d6-6c8b-4532-b631-517b20aa7498.png">

`Metrics Page 2`

<img width="990" alt="スクリーンショット 2022-08-15 11 32 46" src="https://user-images.githubusercontent.com/22903716/184577652-081bb702-eb3b-4de4-a25c-c59516e2ce0e.png">

## References
https://knownasilya.github.io/ember-toggle/
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
