### PR TITLE
fix: fix toggle text cursor

### DIFF
--- a/app/components/command-header/styles.scss
+++ b/app/components/command-header/styles.scss
@@ -19,6 +19,7 @@
 
   .trusted-toggle {
     display: inline-flex;
+    cursor: pointer;
     font-size: 0.5em;
     float: right;
   }

--- a/app/components/tc-collection-list/styles.scss
+++ b/app/components/tc-collection-list/styles.scss
@@ -98,5 +98,6 @@
   .trusted-toggle {
     display: flex;
     padding: 10px 10px 10px 0px;
+    cursor: pointer;
   }
 }

--- a/app/components/template-header/styles.scss
+++ b/app/components/template-header/styles.scss
@@ -47,6 +47,7 @@
 
   .trusted-toggle {
     display: inline-flex;
+    cursor: pointer;
     font-size: 0.5em;
     float: right;
   }


### PR DESCRIPTION
## Context
Because of #813, the cursor no longer becomes a pointer when hovering over some toggle texts.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
Toggle texts of `Template/Command Search Page` and `Template/Command Description Page` are fixed.
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
