### PR TITLE
fix: update for Build History column

### DIFF
--- a/app/components/collection-table-row/template.hbs
+++ b/app/components/collection-table-row/template.hbs
@@ -20,6 +20,15 @@
   {{fa-icon "code-fork"}}
   <span title={{branch}}>{{branch}}</span>
 </td>
+<td class="start">
+  {{lastEventInfo.startTime}}
+</td>
+<td class="duration">
+  {{lastEventInfo.durationText}}
+</td>
+<td class="last-run">
+  <span title={{lastRun}}> {{lastRun}}</span>
+</td>
 <td class="status">
   {{#link-to "pipeline" pipeline.id title=pipeline.scmRepo.name}}
     {{fa-icon lastEventInfo.icon class=lastEventInfo.statusColor}}
@@ -33,15 +42,6 @@
   {{else}}
     Loading events
   {{/if}}
-</td>
-<td class="start">
-  {{lastEventInfo.startTime}}
-</td>
-<td class="duration">
-  {{lastEventInfo.durationText}}
-</td>
-<td class="last-run">
-  <span title={{lastRun}}> {{lastRun}}</span>
 </td>
 <td class="history">
   {{#if hasBothEventsAndLatestEventInfo}}

--- a/app/components/collection-view/styles.scss
+++ b/app/components/collection-view/styles.scss
@@ -211,14 +211,12 @@
   }
 
   .history {
-    display: flex;
+    width: 12%;
+    max-width: 200px;
     align-items: center;
     cursor: pointer;
 
     .icon-wrapper {
-      display: flex;
-      flex-direction: column;
-
       .fa {
         line-height: 0;
       }

--- a/app/components/collection-view/template.hbs
+++ b/app/components/collection-view/template.hbs
@@ -156,7 +156,6 @@
                 <p rowspan="1">Name</p>
               </th>
               <th class="branch" rowspan="1">Branch</th>
-              <th class="status" rowspan="1">Status</th>
               <th class="start" rowspan="1">Start Date</th>
               <th class="duration" rowspan="1">Duration</th>
               <th class="last-run" rowspan="1" onclick={{action "setSortBy" (if (eq (get sortBy 0) "createTime:desc") "createTime:asc" "createTime:desc")}}>
@@ -171,6 +170,7 @@
                   {{/if}}
                 </span>
               </th>
+              <th class="status" rowspan="1">Status</th>
               <th class="history" rowspan="1" onclick={{action "setSortBy" (if (eq (get sortBy 0) "failedBuildCount:desc") "failedBuildCount:asc" "failedBuildCount:desc")}}>
                 Build History
                 <span class="icon-wrapper">


### PR DESCRIPTION
## Context

Build History column doesn't match with other column on Dashboard collection.

## Objective
Before:
![image](https://user-images.githubusercontent.com/15989893/187537543-bdfa23e3-580c-4ca7-bfd1-016cf420bdc9.png)

After
<img width="1354" alt="Screen Shot 2022-08-30 at 3 21 47 PM" src="https://user-images.githubusercontent.com/104225232/187525282-3b99a23c-764e-4fae-ae81-48cacba47f0e.png">


## References

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
