### PR TITLE
fix: remove displayJobNameLength feature

### DIFF
--- a/app/components/pipeline-options/template.hbs
+++ b/app/components/pipeline-options/template.hbs
@@ -278,23 +278,6 @@
         <li>
           <div class="row">
             <div class="col-xs-10">
-              <h4>Display Name Length</h4>
-              <p>Setup your own preferred job name length to display on the workflow graph (range: 20 - 99)</p>
-            </div>
-            <div class="col-xs-2 right">
-              <input type="number"
-                class="display-job-name"
-                min={{minDisplayLength}}
-                max={{maxDisplayLength}}
-                placeholder={{minDisplayLength}}
-                value={{desiredJobNameLength}}
-                onchange={{action "updateJobNameLength" value="target.value"}}>
-            </div>
-          </div>
-        </li>
-        <li>
-          <div class="row">
-            <div class="col-xs-10">
               <h4>Show PR Jobs</h4>
               <p>Show or Hide jobs that are triggered from Pull Request</p>
             </div>

--- a/app/preference/pipeline/model.js
+++ b/app/preference/pipeline/model.js
@@ -1,7 +1,5 @@
 import Model, { attr } from '@ember-data/model';
 
 export default class PreferencePipelineModel extends Model {
-  @attr('number', { defaultValue: 20 }) displayJobNameLength;
-
   @attr('boolean', { defaultValue: true }) showPRJobs;
 }


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
`displayJobNameLength` is updated in https://github.com/screwdriver-cd/data-schema/pull/504, and currently blocks users to use set/unset show PR Job feature

## Objective
This PR removes `displayJobNameLength` to unblock users
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/data-schema/pull/504#issuecomment-1224728898
## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
