### PR TITLE
fix: Pipeline alias reset

### DIFF
--- a/app/components/pipeline-options/component.js
+++ b/app/components/pipeline-options/component.js
@@ -155,7 +155,7 @@ export default Component.extend({
       await this.shuttle.updatePipelineSettings(pipeline.id, {
         aliasName
       });
-      this.set('successMessage', 'Pipeline alias-name updated successfully');
+      this.set('successMessage', 'Pipeline alias updated successfully');
     } finally {
       this.set('aliasName', aliasName);
     }
@@ -276,7 +276,7 @@ export default Component.extend({
     async resetPipelineAlias() {
       this.$('input.pipeline-alias-name').val('');
 
-      this.updatePipelineAlias('');
+      this.set('aliasName', '');
     },
     async updateMetricsDowntimeJobs(metricsDowntimeJobs) {
       try {


### PR DESCRIPTION
## Context

To Reset alias name and update success message on save.

## Objective
No API call should involve while hit Reset for alias name.
Success message updated on hit save.
<img width="974" alt="Screen Shot 2022-09-21 at 11 07 16 AM" src="https://user-images.githubusercontent.com/104225232/191541436-414cf5a6-78fd-40df-8650-153ea53a816a.png">


## References
https://github.com/screwdriver-cd/screwdriver/issues/2765

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
