### PR TITLE
fix: Pipeline search panel UX

### DIFF
--- a/app/components/pipeline-search-panel/styles.scss
+++ b/app/components/pipeline-search-panel/styles.scss
@@ -4,6 +4,16 @@
   justify-content: center;
   flex-wrap: wrap;
 
+  .name {
+    text-align: left;
+    width: 30%;
+  }
+
+  .branch {
+    width: 25%;
+    text-align: right;
+  }
+
   .search-pipeline-searchbar {
     display: flex;
     width: 88%;

--- a/app/components/pipeline-search-panel/styles.scss
+++ b/app/components/pipeline-search-panel/styles.scss
@@ -11,7 +11,7 @@
 
   .branch {
     width: 25%;
-    text-align: right;
+    text-align: left;
   }
 
   .search-pipeline-searchbar {

--- a/app/components/pipeline-search-panel/template.hbs
+++ b/app/components/pipeline-search-panel/template.hbs
@@ -12,7 +12,8 @@
   <div class="searched-pipelines">
     {{#each searchedPipelines as |pipeline|}}
       <div class="searched-pipeline">
-        <span>{{pipeline.name}}</span>
+        <span class="name">{{#highlight-terms query}}{{#link-to "pipeline" pipeline.id}}{{pipeline.name}}{{/link-to}}{{/highlight-terms}}</span>
+        <span class="branch"><a href={{branch-url-encode pipeline.hubUrl}}>{{fa-icon "code-fork"}}{{pipeline.branch}}</a></span>
         <span onclick={{action "selectSearchedPipeline" pipeline.id}} class="add-pipeline-button">
           {{inline-svg "add" class="img"}}
         </span>

--- a/app/components/pipeline-search-panel/template.hbs
+++ b/app/components/pipeline-search-panel/template.hbs
@@ -12,7 +12,7 @@
   <div class="searched-pipelines">
     {{#each searchedPipelines as |pipeline|}}
       <div class="searched-pipeline">
-        <span class="name">{{#highlight-terms query}}{{#link-to "pipeline" pipeline.id}}{{pipeline.appId}}{{/link-to}}{{/highlight-terms}}</span>
+        <span class="name">{{#highlight-terms query}}{{#link-to "pipeline" pipeline.id}}{{pipeline.name}}{{/link-to}}{{/highlight-terms}}</span>
         <span class="branch"><a href={{branch-url-encode pipeline.hubUrl}}>{{fa-icon "code-fork"}}{{pipeline.branch}}</a></span>
         <span onclick={{action "selectSearchedPipeline" pipeline.id}} class="add-pipeline-button">
           {{inline-svg "add" class="img"}}

--- a/app/components/pipeline-search-panel/template.hbs
+++ b/app/components/pipeline-search-panel/template.hbs
@@ -12,7 +12,7 @@
   <div class="searched-pipelines">
     {{#each searchedPipelines as |pipeline|}}
       <div class="searched-pipeline">
-        <span class="name">{{#highlight-terms query}}{{#link-to "pipeline" pipeline.id}}{{pipeline.name}}{{/link-to}}{{/highlight-terms}}</span>
+        <span class="name">{{#highlight-terms query}}{{#link-to "pipeline" pipeline.id}}{{pipeline.appId}}{{/link-to}}{{/highlight-terms}}</span>
         <span class="branch"><a href={{branch-url-encode pipeline.hubUrl}}>{{fa-icon "code-fork"}}{{pipeline.branch}}</a></span>
         <span onclick={{action "selectSearchedPipeline" pipeline.id}} class="add-pipeline-button">
           {{inline-svg "add" class="img"}}


### PR DESCRIPTION
## Context
When adding multiple pipelines to a collection from Collection page does not display branch and source path info.
current:
<img width="811" alt="Screen Shot 2022-09-20 at 11 44 54 AM" src="https://user-images.githubusercontent.com/104225232/191550303-225780f2-e69f-45f7-80fd-b2c368e861ee.png">


## Objective
Expectation:
<img width="614" alt="Screen Shot 2022-09-22 at 10 38 52 AM" src="https://user-images.githubusercontent.com/104225232/192601926-a7e8601a-f338-41ed-8d05-92b6365711a7.png">


## References
https://github.com/screwdriver-cd/screwdriver/issues/2765

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
