### PR TITLE
feat: Add tooltip on build history column

### DIFF
--- a/app/components/collection-view/template.hbs
+++ b/app/components/collection-view/template.hbs
@@ -173,6 +173,9 @@
               <th class="status" rowspan="1">Status</th>
               <th class="history" rowspan="1" onclick={{action "setSortBy" (if (eq (get sortBy 0) "failedBuildCount:desc") "failedBuildCount:asc" "failedBuildCount:desc")}}>
                 Build History
+                {{#bs-tooltip placement="top" renderInPlace=true}}
+                  sort on number of failed builds
+                {{/bs-tooltip}}
                 <span class="icon-wrapper">
                   {{#if (eq (get sortBy 0) "failedBuildCount:asc")}}
                     <i class="fa fa-sort-asc"></i>


### PR DESCRIPTION
## Context
 To fix Build history column In collection Dashboard.

## Objective

 add a tool tip to show sort on number of failed builds on build history column.
<img width="982" alt="Screen Shot 2022-10-05 at 11 13 25 AM" src="https://user-images.githubusercontent.com/104225232/194096849-d1017d30-d4b3-42bf-8b66-67572fc1db14.png">


## References
https://github.com/screwdriver-cd/screwdriver/issues/2765

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
