### PR TITLE
fix: Last run column 

### DIFF
--- a/app/components/collection-table-row/component.js
+++ b/app/components/collection-table-row/component.js
@@ -3,12 +3,6 @@ import { computed, getWithDefault } from '@ember/object';
 import { and } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 import { formatMetrics } from 'screwdriver-ui/utils/metric';
-import PromiseProxyMixin from '@ember/object/promise-proxy-mixin';
-import ObjectProxy from '@ember/object/proxy';
-import templateHelper from 'screwdriver-ui/utils/template';
-
-const ObjectPromiseProxy = ObjectProxy.extend(PromiseProxyMixin);
-const { getLastUpdatedTime } = templateHelper;
 
 export default Component.extend({
   store: service(),
@@ -33,25 +27,6 @@ export default Component.extend({
     const { branch, rootDir } = this.pipeline.scmRepo;
 
     return rootDir ? `${branch}#${rootDir}` : branch;
-  }),
-  lastRun: computed('pipeline', function get() {
-    return ObjectPromiseProxy.create({
-      promise: this.pipeline.get('metrics').then(metrics => {
-        let lastRun = 'n/a';
-
-        const { lastEventInfo } = formatMetrics(metrics);
-
-        if (lastEventInfo) {
-          const { createTime } = lastEventInfo;
-
-          lastRun = getLastUpdatedTime({
-            createTime
-          });
-        }
-
-        return lastRun;
-      })
-    });
   }),
   showRemoveButton: computed(
     'isOrganizing',

--- a/app/components/collection-table-row/component.js
+++ b/app/components/collection-table-row/component.js
@@ -3,7 +3,11 @@ import { computed, getWithDefault } from '@ember/object';
 import { and } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 import { formatMetrics } from 'screwdriver-ui/utils/metric';
+import PromiseProxyMixin from '@ember/object/promise-proxy-mixin';
+import ObjectProxy from '@ember/object/proxy';
 import templateHelper from 'screwdriver-ui/utils/template';
+
+const ObjectPromiseProxy = ObjectProxy.extend(PromiseProxyMixin);
 const { getLastUpdatedTime } = templateHelper;
 
 export default Component.extend({
@@ -32,13 +36,21 @@ export default Component.extend({
 
     return rootDir ? `${branch}#${rootDir}` : branch;
   }),
-  lastRun: computed('lastRun', function get() {
-    const { createTime } = this.pipeline;
-    const lastRun = getLastUpdatedTime({
-      createTime
-    });
+  lastRun: computed('pipeline', function get() {
+    return ObjectPromiseProxy.create({
+      promise: this.pipeline.get('metrics').then(metrics => {
+        let lastRun = 'n/a';
+        const lastRunBuild = metrics.lastObject.builds.lastObject;
 
-    return lastRun;
+        const { createTime } = lastRunBuild;
+
+        lastRun = getLastUpdatedTime({
+          createTime
+        });
+
+        return lastRun;
+      })
+    });
   }),
   showRemoveButton: computed(
     'isOrganizing',

--- a/app/components/collection-table-row/component.js
+++ b/app/components/collection-table-row/component.js
@@ -38,13 +38,16 @@ export default Component.extend({
     return ObjectPromiseProxy.create({
       promise: this.pipeline.get('metrics').then(metrics => {
         let lastRun = 'n/a';
-        const lastRunBuild = metrics.lastObject.builds.lastObject;
 
-        const { createTime } = lastRunBuild;
+        const lastRunBuild = metrics.lastObject?.builds?.lastObject;
 
-        lastRun = getLastUpdatedTime({
-          createTime
-        });
+        if (lastRunBuild) {
+          const { createTime } = lastRunBuild;
+
+          lastRun = getLastUpdatedTime({
+            createTime
+          });
+        }
 
         return lastRun;
       })

--- a/app/components/collection-table-row/component.js
+++ b/app/components/collection-table-row/component.js
@@ -39,10 +39,10 @@ export default Component.extend({
       promise: this.pipeline.get('metrics').then(metrics => {
         let lastRun = 'n/a';
 
-        const lastRunBuild = metrics.lastObject?.builds?.lastObject;
+        const { lastEventInfo } = formatMetrics(metrics);
 
-        if (lastRunBuild) {
-          const { createTime } = lastRunBuild;
+        if (lastEventInfo) {
+          const { createTime } = lastEventInfo;
 
           lastRun = getLastUpdatedTime({
             createTime

--- a/app/components/collection-table-row/template.hbs
+++ b/app/components/collection-table-row/template.hbs
@@ -27,7 +27,7 @@
   {{lastEventInfo.durationText}}
 </td>
 <td class="last-run">
-  <span title={{lastRun}}> {{lastRun}}</span>
+  <span title={{lastRun}}> {{lastRun.content}}</span>
 </td>
 <td class="status">
   {{#link-to "pipeline" pipeline.id title=pipeline.scmRepo.name}}

--- a/app/components/collection-table-row/template.hbs
+++ b/app/components/collection-table-row/template.hbs
@@ -20,14 +20,11 @@
   {{fa-icon "code-fork"}}
   <span title={{branch}}>{{branch}}</span>
 </td>
-<td class="start">
+<td class="last-run">
   {{lastEventInfo.startTime}}
 </td>
 <td class="duration">
   {{lastEventInfo.durationText}}
-</td>
-<td class="last-run">
-  <span title={{lastRun}}> {{lastRun.content}}</span>
 </td>
 <td class="status">
   {{#link-to "pipeline" pipeline.id title=pipeline.scmRepo.name}}

--- a/app/components/collection-view/template.hbs
+++ b/app/components/collection-view/template.hbs
@@ -158,12 +158,12 @@
               <th class="branch" rowspan="1">Branch</th>
               <th class="start" rowspan="1">Start Date</th>
               <th class="duration" rowspan="1">Duration</th>
-              <th class="last-run" rowspan="1" onclick={{action "setSortBy" (if (eq (get sortBy 0) "createTime:desc") "createTime:asc" "createTime:desc")}}>
+              <th class="last-run" rowspan="1" onclick={{action "setSortBy" (if (eq (get sortBy 0) "lastRunJob.createTime:desc") "lastRunJob.createTime:asc" "lastRunJob.createTime:desc")}}>
                 Last Run Job
                 <span class="icon-wrapper">
-                  {{#if (eq (get sortBy 0) "createTime:asc")}}
+                  {{#if (eq (get sortBy 0) "lastRunJob.createTime:asc")}}
                     <i class="fa fa-sort-asc"></i>
-                  {{else if (eq (get sortBy 0) "createTime:desc")}}
+                  {{else if (eq (get sortBy 0) "lastRunJob.createTime:desc")}}
                     <i class="fa fa-sort-desc"></i>
                   {{else}}
                     <i class="fa fa-sort"></i>

--- a/app/components/collection-view/template.hbs
+++ b/app/components/collection-view/template.hbs
@@ -167,20 +167,19 @@
                   {{/if}}
                 </span>
               </th>
-              <th class="start" rowspan="1">Start Date</th>
-              <th class="duration" rowspan="1">Duration</th>
-              <th class="last-run" rowspan="1" onclick={{action "setSortBy" (if (eq (get sortBy 0) "lastRunEvent.createTime:desc") "lastRunEvent.createTime:asc" "lastRunEvent.createTime:desc")}}>
-                Last Run
+              <th class="last-run" rowspan="1" onclick={{action "setSortBy" (if (eq (get sortBy 0) "lastRunEvent.startTime:desc") "lastRunEvent.startTime:asc" "lastRunEvent.startTime:desc")}}>
+                Last run
                 <span class="icon-wrapper">
-                  {{#if (eq (get sortBy 0) "lastRunEvent.createTime:asc")}}
+                  {{#if (eq (get sortBy 0) "lastRunEvent.startTime:asc")}}
                     <i class="fa fa-sort-asc"></i>
-                  {{else if (eq (get sortBy 0) "lastRunEvent.createTime:desc")}}
+                  {{else if (eq (get sortBy 0) "lastRunEvent.startTime:desc")}}
                     <i class="fa fa-sort-desc"></i>
                   {{else}}
                     <i class="fa fa-sort"></i>
                   {{/if}}
                 </span>
               </th>
+              <th class="duration" rowspan="1">Duration</th>
               <th class="status" rowspan="1" onclick={{action "setSortBy" (if (eq (get sortBy 0) "lastRunJob.status:desc") "lastRunJob.status:asc" "lastRunJob.status:desc")}} >
                 Status
                 <span class="icon-wrapper">

--- a/app/components/collection-view/template.hbs
+++ b/app/components/collection-view/template.hbs
@@ -169,12 +169,12 @@
               </th>
               <th class="start" rowspan="1">Start Date</th>
               <th class="duration" rowspan="1">Duration</th>
-              <th class="last-run" rowspan="1" onclick={{action "setSortBy" (if (eq (get sortBy 0) "lastRunJob.createTime:desc") "lastRunJob.createTime:asc" "lastRunJob.createTime:desc")}}>
-                Last Run Job
+              <th class="last-run" rowspan="1" onclick={{action "setSortBy" (if (eq (get sortBy 0) "lastRunEvent.createTime:desc") "lastRunEvent.createTime:asc" "lastRunEvent.createTime:desc")}}>
+                Last Run
                 <span class="icon-wrapper">
-                  {{#if (eq (get sortBy 0) "lastRunJob.createTime:asc")}}
+                  {{#if (eq (get sortBy 0) "lastRunEvent.createTime:asc")}}
                     <i class="fa fa-sort-asc"></i>
-                  {{else if (eq (get sortBy 0) "lastRunJob.createTime:desc")}}
+                  {{else if (eq (get sortBy 0) "lastRunEvent.createTime:desc")}}
                     <i class="fa fa-sort-desc"></i>
                   {{else}}
                     <i class="fa fa-sort"></i>

--- a/app/components/pipeline-card/styles.scss
+++ b/app/components/pipeline-card/styles.scss
@@ -168,12 +168,12 @@
     .duration-badge {
       display: flex;
       justify-content: center;
-      margin-right: 10px;
     }
 
-    .start-time-badge {
+    .last-run-badge {
       display: flex;
       justify-content: center;
+      margin-right: 10px;      
     }
   }
 

--- a/app/components/pipeline-card/template.hbs
+++ b/app/components/pipeline-card/template.hbs
@@ -40,13 +40,13 @@
     </p>
   </div>
   <div class="time-metrics">
+    <div class="last-run-badge">
+      <span class="badge-label">last run</span>
+      <span class="badge-info">{{lastEventInfo.startTime}}</span>
+    </div>
     <div class="duration-badge">
       <span class="badge-label">duration</span>
       <span class="badge-info">{{lastEventInfo.durationText}}</span>
-    </div>
-    <div class="start-time-badge">
-      <span class="badge-label">start Date</span>
-      <span class="badge-info">{{lastEventInfo.startTime}}</span>
     </div>
   </div>
 

--- a/app/pipeline/model.js
+++ b/app/pipeline/model.js
@@ -73,5 +73,16 @@ export default DS.Model.extend({
 
       return failedBuildCount;
     }
+  }),
+  lastRunJob: computed('metrics.[]', {
+    get() {
+      let lastRun;
+
+      this.metrics.toArray().forEach(event => {
+        lastRun = event.builds.lastObject;
+      });
+
+      return lastRun;
+    }
   })
 });

--- a/app/pipeline/model.js
+++ b/app/pipeline/model.js
@@ -77,15 +77,9 @@ export default DS.Model.extend({
   }),
   lastRunEvent: computed('metrics.[]', {
     get() {
-      let lastRun = 'n/a';
+      const { lastEventInfo } = formatMetrics(this.metrics);
 
-      this.metrics.toArray().forEach(metrics => {
-        const { lastEventInfo } = formatMetrics(metrics);
-
-        lastRun = lastEventInfo;
-      });
-
-      return lastRun;
+      return lastEventInfo;
     }
   })
 });

--- a/app/pipeline/model.js
+++ b/app/pipeline/model.js
@@ -76,7 +76,7 @@ export default DS.Model.extend({
   }),
   lastRunJob: computed('metrics.[]', {
     get() {
-      let lastRun;
+      let lastRun = 'n/a';
 
       this.metrics.toArray().forEach(event => {
         lastRun = event.builds.lastObject;

--- a/app/pipeline/model.js
+++ b/app/pipeline/model.js
@@ -1,6 +1,7 @@
 import { alias } from '@ember/object/computed';
 import { computed, getWithDefault } from '@ember/object';
 import DS from 'ember-data';
+import { formatMetrics } from 'screwdriver-ui/utils/metric';
 
 export default DS.Model.extend({
   admins: DS.attr(),
@@ -74,14 +75,16 @@ export default DS.Model.extend({
       return failedBuildCount;
     }
   }),
-  lastRunJob: computed('metrics.[]', {
+  lastRunEvent: computed('metrics.[]', {
     get() {
       let lastRun = 'n/a';
 
-      this.metrics.toArray().forEach(event => {
-        lastRun = event.builds.lastObject;
-      });
+      this.metrics.toArray().forEach(metrics => {
+        const { lastEventInfo } = formatMetrics(metrics);
 
+       lastRun = lastEventInfo;
+      });
+      
       return lastRun;
     }
   })

--- a/app/pipeline/model.js
+++ b/app/pipeline/model.js
@@ -82,9 +82,9 @@ export default DS.Model.extend({
       this.metrics.toArray().forEach(metrics => {
         const { lastEventInfo } = formatMetrics(metrics);
 
-       lastRun = lastEventInfo;
+        lastRun = lastEventInfo;
       });
-      
+
       return lastRun;
     }
   })

--- a/app/utils/metric.js
+++ b/app/utils/metric.js
@@ -79,7 +79,8 @@ const formatMetrics = metrics => {
         sha: 'Not available',
         icon: 'question-circle',
         commitMessage: 'No events have been run for this pipeline',
-        commitUrl: '#'
+        commitUrl: '#',
+        createTime: 'n/a'
       }
     };
   }
@@ -106,7 +107,8 @@ const formatMetrics = metrics => {
     sha: getSha(lastEvent.sha),
     icon: getIcon(lastEvent.status.toLowerCase()),
     commitMessage: lastEvent.commit.message,
-    commitUrl: lastEvent.commit.url
+    commitUrl: lastEvent.commit.url,
+    createTime: lastEvent.createTime
   };
 
   return { eventsInfo, lastEventInfo };

--- a/app/utils/metric.js
+++ b/app/utils/metric.js
@@ -79,8 +79,7 @@ const formatMetrics = metrics => {
         sha: 'Not available',
         icon: 'question-circle',
         commitMessage: 'No events have been run for this pipeline',
-        commitUrl: '#',
-        createTime: 'n/a'
+        commitUrl: '#'
       }
     };
   }
@@ -107,8 +106,7 @@ const formatMetrics = metrics => {
     sha: getSha(lastEvent.sha),
     icon: getIcon(lastEvent.status.toLowerCase()),
     commitMessage: lastEvent.commit.message,
-    commitUrl: lastEvent.commit.url,
-    createTime: lastEvent.createTime
+    commitUrl: lastEvent.commit.url
   };
 
   return { eventsInfo, lastEventInfo };

--- a/tests/integration/components/collection-table-row/component-test.js
+++ b/tests/integration/components/collection-table-row/component-test.js
@@ -63,7 +63,7 @@ module('Integration | Component | collection table row', function (hooks) {
   });
 
   test('it renders', async function (assert) {
-    assert.expect(13);
+    assert.expect(12);
     this.owner.setupRouter();
     await render(hbs`
       {{collection-table-row
@@ -89,9 +89,8 @@ module('Integration | Component | collection table row', function (hooks) {
     assert
       .dom('td.status a:nth-of-type(2)')
       .hasAttribute('href', lastEventInfo.commitUrl);
-    assert.dom('td.start').hasText(lastEventInfo.startTime);
+    assert.dom('td.last-run').hasText(lastEventInfo.startTime);
     assert.dom('td.duration').hasText(lastEventInfo.durationText);
-    assert.dom('td.last-run').hasText('0 seconds ago'); // '0 seconds ago' because no last run event data available
     assert.dom('td.history').exists({ count: 1 });
     assert.dom('td.collection-pipeline__remove').exists({ count: 1 });
 

--- a/tests/integration/components/collection-table-row/component-test.js
+++ b/tests/integration/components/collection-table-row/component-test.js
@@ -91,7 +91,7 @@ module('Integration | Component | collection table row', function (hooks) {
       .hasAttribute('href', lastEventInfo.commitUrl);
     assert.dom('td.start').hasText(lastEventInfo.startTime);
     assert.dom('td.duration').hasText(lastEventInfo.durationText);
-    assert.dom('td.last-run').hasText('n/a'); // 'n/a' because no metrics data available
+    assert.dom('td.last-run').hasText('0 seconds ago'); // '0 seconds ago' because no last run event data available
     assert.dom('td.history').exists({ count: 1 });
     assert.dom('td.collection-pipeline__remove').exists({ count: 1 });
 

--- a/tests/integration/components/collection-table-row/component-test.js
+++ b/tests/integration/components/collection-table-row/component-test.js
@@ -8,8 +8,6 @@ import sinon from 'sinon';
 import $ from 'jquery';
 import wait from 'ember-test-helpers/wait';
 import Pretender from 'pretender';
-import templateHelper from 'screwdriver-ui/utils/template';
-const { getLastUpdatedTime } = templateHelper;
 
 let server;
 const hasEmptyMetrics = () => [
@@ -93,11 +91,7 @@ module('Integration | Component | collection table row', function (hooks) {
       .hasAttribute('href', lastEventInfo.commitUrl);
     assert.dom('td.start').hasText(lastEventInfo.startTime);
     assert.dom('td.duration').hasText(lastEventInfo.durationText);
-    assert.dom('td.last-run').hasText(
-      getLastUpdatedTime({
-        createTime: mockPipeline.createTime
-      })
-    );
+    assert.dom('td.last-run').hasText('n/a'); // 'n/a' because no metrics data available
     assert.dom('td.history').exists({ count: 1 });
     assert.dom('td.collection-pipeline__remove').exists({ count: 1 });
 

--- a/tests/integration/components/collection-view/component-test.js
+++ b/tests/integration/components/collection-view/component-test.js
@@ -635,9 +635,8 @@ module('Integration | Component | collection view', function (hooks) {
     assert.dom('th.app-id').hasText('Alias/ Name');
     assert.dom('th.branch').hasText('Branch');
     assert.dom('th.status').hasText('Status');
-    assert.dom('th.start').hasText('Start Date');
+    assert.dom('th.last-run').hasText('Last run');
     assert.dom('th.duration').hasText('Duration');
-    assert.dom('th.last-run').hasText('Last Run');
     assert.dom('th.history').exists({ count: 1 });
 
     assert.dom('.collection-pipeline').exists({ count: 4 });
@@ -747,9 +746,8 @@ module('Integration | Component | collection view', function (hooks) {
     assert.dom('th.app-id').hasText('Name');
     assert.dom('th.branch').hasText('Branch');
     assert.dom('th.status').hasText('Status');
-    assert.dom('th.start').hasText('Start Date');
+    assert.dom('th.last-run').hasText('Last run');
     assert.dom('th.duration').hasText('Duration');
-    assert.dom('th.last-run').hasText('Last Run');
     assert.dom('th.history').exists({ count: 1 });
 
     assert.dom('.collection-pipeline').exists({ count: 4 });

--- a/tests/integration/components/collection-view/component-test.js
+++ b/tests/integration/components/collection-view/component-test.js
@@ -637,7 +637,7 @@ module('Integration | Component | collection view', function (hooks) {
     assert.dom('th.status').hasText('Status');
     assert.dom('th.start').hasText('Start Date');
     assert.dom('th.duration').hasText('Duration');
-    assert.dom('th.last-run').hasText('Last Run Job');
+    assert.dom('th.last-run').hasText('Last Run');
     assert.dom('th.history').exists({ count: 1 });
 
     assert.dom('.collection-pipeline').exists({ count: 4 });
@@ -749,7 +749,7 @@ module('Integration | Component | collection view', function (hooks) {
     assert.dom('th.status').hasText('Status');
     assert.dom('th.start').hasText('Start Date');
     assert.dom('th.duration').hasText('Duration');
-    assert.dom('th.last-run').hasText('Last Run Job');
+    assert.dom('th.last-run').hasText('Last Run');
     assert.dom('th.history').exists({ count: 1 });
 
     assert.dom('.collection-pipeline').exists({ count: 4 });

--- a/tests/integration/components/pipeline-card/component-test.js
+++ b/tests/integration/components/pipeline-card/component-test.js
@@ -99,7 +99,7 @@ module('Integration | Component | pipeline card', function (hooks) {
       .dom('.duration-badge span:nth-of-type(2)')
       .hasText(lastEventInfo.durationText);
     assert
-      .dom('.start-time-badge span:nth-of-type(2)')
+      .dom('.last-run-badge span:nth-of-type(2)')
       .hasText(lastEventInfo.startTime);
     assert.dom('.events-thumbnail-wrapper').exists({ count: 1 });
   });


### PR DESCRIPTION
## Context
Last run job column's data is not correct.

## Objective
Display correct data in Last run job column in collection.
card view:
<img width="986" alt="Screen Shot 2022-10-27 at 1 19 35 PM" src="https://user-images.githubusercontent.com/104225232/198357075-5777188b-3f3e-4edb-ace0-07e121b2ef4b.png">
List view:
<img width="988" alt="Screen Shot 2022-10-27 at 1 20 37 PM" src="https://user-images.githubusercontent.com/104225232/198357123-263356f1-fe5b-4c9c-bc1e-befbd1d09055.png">


## References
https://github.com/screwdriver-cd/screwdriver/issues/2765

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
