### PR TITLE
fix: Wording on User Setting to match other settings

### DIFF
--- a/app/user-settings/preferences/template.hbs
+++ b/app/user-settings/preferences/template.hbs
@@ -23,7 +23,7 @@
       <li>
         <div class="row">
           <div class="col-xs-9">
-            <h4>Choose timestamp format</h4>
+            <h4>Timestamp format</h4>
             <p>Choose your preferred timestamp format</p>
           </div>
           <div class="col-xs-3">


### PR DESCRIPTION
## Context

Currently the two titles are:
Display Name Length
Choose Timestamp Format

## Objective
Display Name Length
Timestamp Format

This PR changes titles to:

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2218

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
