### PR TITLE
feat: Add user pref timestamp build details page and build logs

### DIFF
--- a/app/components/build-banner/component.js
+++ b/app/components/build-banner/component.js
@@ -3,8 +3,10 @@ import { alias } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { isActiveBuild, isPRJob } from 'screwdriver-ui/utils/build';
+import { getTimestamp } from '../../utils/timestamp-format';
 
 export default Component.extend({
+  userSettings: service(),
   classNames: ['build-banner', 'row'],
   classNameBindings: ['buildStatus'],
   coverage: service(),
@@ -49,6 +51,15 @@ export default Component.extend({
       }
 
       return 'Restart';
+    }
+  }),
+  buildCreateTime: computed('buildCreate', {
+    get() {
+      let createTime = 'n/a';
+
+      createTime = getTimestamp(this.userSettings, this.buildCreate);
+
+      return createTime;
     }
   }),
 

--- a/app/components/build-banner/template.hbs
+++ b/app/components/build-banner/template.hbs
@@ -49,7 +49,7 @@
     <span class="banner-label">Duration</span>
   </li>
   <li class="created">
-    <span class="banner-value" title={{buildCreate}}>{{moment-format buildCreate "YYYY-MM-DD HH:mm:ss"}}</span>
+    <span class="banner-value" title={{buildCreate}}>{{buildCreateTime.content}}</span>
     <span class="banner-label">Create Time</span>
   </li>
   <li class="user">

--- a/app/components/build-log/component.js
+++ b/app/components/build-log/component.js
@@ -10,6 +10,7 @@ const timeTypes = ['datetime', 'datetimeUTC', 'elapsedBuild', 'elapsedStep'];
 export default Component.extend({
   logService: service('build-logs'),
   store: service(),
+  userSettings: service(),
   classNames: ['build-log'],
   classNameBindings: ['fullScreen:fullScreen', 'lineWrap:lineWrap'],
   fullScreen: false,
@@ -221,10 +222,19 @@ export default Component.extend({
     }
   }),
 
-  init() {
+  async init() {
     this._super(...arguments);
 
-    const timeFormat = localStorage.getItem('screwdriver.logs.timeFormat');
+    const userPreferredTimeStampFormat =
+      await this.userSettings.getTimestampFormat();
+
+    let timeFormat;
+
+    if (userPreferredTimeStampFormat === 'UTC') {
+      timeFormat = 'datetimeUTC';
+    } else {
+      timeFormat = localStorage.getItem('screwdriver.logs.timeFormat');
+    }
 
     if (timeFormat && timeTypes.includes(timeFormat)) {
       set(this, 'timeFormat', timeFormat);

--- a/tests/integration/components/build-banner/component-test.js
+++ b/tests/integration/components/build-banner/component-test.js
@@ -6,6 +6,7 @@ import { render, settled, click } from '@ember/test-helpers';
 import test from 'ember-sinon-qunit/test-support/test';
 import { resolve, Promise as EmberPromise } from 'rsvp';
 import Service from '@ember/service';
+import { toCustomLocaleString } from 'screwdriver-ui/utils/time-range';
 
 const coverageService = Service.extend({
   getCoverageInfo() {
@@ -141,7 +142,9 @@ module('Integration | Component | build banner', function (hooks) {
       changeBuild=(action changeB)
     }}`);
 
-    const expectedTime = '11/04/2016, 04:08 PM';
+    const expectedTime = toCustomLocaleString(
+      new Date('2016-11-04T20:08:41.238Z')
+    );
 
     assert.dom('li.job-name a').hasAttribute('href', '/pipelines/12345/pulls');
     assert.dom('li.job-name .banner-value').hasText('PR-671');
@@ -225,7 +228,9 @@ module('Integration | Component | build banner', function (hooks) {
       prEvents=prEvents
       reloadBuild=(action reloadCb)
     }}`);
-    const expectedTime = '11/04/2016, 04:08 PM';
+    const expectedTime = toCustomLocaleString(
+      new Date('2016-11-04T20:08:41.238Z')
+    );
 
     assert
       .dom('.pr .pr-url-holder a')
@@ -283,7 +288,9 @@ module('Integration | Component | build banner', function (hooks) {
       prEvents=prEvents
       reloadBuild=(action reloadCb)
     }}`);
-    const expectedTime = '11/04/2016, 04:08 PM';
+    const expectedTime = toCustomLocaleString(
+      new Date('2016-11-04T20:08:41.238Z')
+    );
 
     assert
       .dom('.pr .pr-url-holder a')

--- a/tests/integration/components/build-banner/component-test.js
+++ b/tests/integration/components/build-banner/component-test.js
@@ -1,5 +1,4 @@
 import EmberObject from '@ember/object';
-import moment from 'moment';
 import hbs from 'htmlbars-inline-precompile';
 import { module } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
@@ -142,9 +141,7 @@ module('Integration | Component | build banner', function (hooks) {
       changeBuild=(action changeB)
     }}`);
 
-    const expectedTime = moment('2016-11-04T20:08:41.238Z').format(
-      'YYYY-MM-DD HH:mm:ss'
-    );
+    const expectedTime = '11/04/2016, 04:08 PM';
 
     assert.dom('li.job-name a').hasAttribute('href', '/pipelines/12345/pulls');
     assert.dom('li.job-name .banner-value').hasText('PR-671');
@@ -228,9 +225,7 @@ module('Integration | Component | build banner', function (hooks) {
       prEvents=prEvents
       reloadBuild=(action reloadCb)
     }}`);
-    const expectedTime = moment('2016-11-04T20:08:41.238Z').format(
-      'YYYY-MM-DD HH:mm:ss'
-    );
+    const expectedTime = '11/04/2016, 04:08 PM';
 
     assert
       .dom('.pr .pr-url-holder a')
@@ -288,9 +283,7 @@ module('Integration | Component | build banner', function (hooks) {
       prEvents=prEvents
       reloadBuild=(action reloadCb)
     }}`);
-    const expectedTime = moment('2016-11-04T20:08:41.238Z').format(
-      'YYYY-MM-DD HH:mm:ss'
-    );
+    const expectedTime = '11/04/2016, 04:08 PM';
 
     assert
       .dom('.pr .pr-url-holder a')

--- a/tests/integration/components/build-banner/component-test.js
+++ b/tests/integration/components/build-banner/component-test.js
@@ -559,7 +559,7 @@ module('Integration | Component | build banner', function (hooks) {
     });
     this.set('eventMock', prEventMock);
     this.set('buildStepsMock', coverageStepsMock);
-    this.set('buildMetaMock', buildMetaMock);
+    this.set('buildMetaMock', {}); // empty as build step is not finished
     this.set('prEvents', new EmberPromise(resolves => resolves([])));
     this.set('isButtonDisabledLoaded', true);
     this.set('jobDisabled', new EmberPromise(resolves => resolves(false)));

--- a/tests/integration/components/build-banner/component-test.js
+++ b/tests/integration/components/build-banner/component-test.js
@@ -107,7 +107,7 @@ module('Integration | Component | build banner', function (hooks) {
   });
 
   test('it renders', async function (assert) {
-    assert.expect(12);
+    assert.expect(13);
     this.owner.setupRouter();
 
     this.set('reloadCb', () => {
@@ -169,7 +169,7 @@ module('Integration | Component | build banner', function (hooks) {
   });
 
   test('it renders events list link if event is not pr', async function (assert) {
-    assert.expect(3);
+    assert.expect(4);
     this.owner.setupRouter();
 
     this.set('reloadCb', () => {
@@ -202,7 +202,7 @@ module('Integration | Component | build banner', function (hooks) {
   });
 
   test('it renders pr link if pr url info is available', async function (assert) {
-    assert.expect(12);
+    assert.expect(13);
 
     this.set('reloadCb', () => {
       assert.ok(true);
@@ -257,7 +257,7 @@ module('Integration | Component | build banner', function (hooks) {
   });
 
   test('it renders prCommit dropdown if event type is pr', async function (assert) {
-    assert.expect(16);
+    assert.expect(17);
 
     this.set('reloadCb', () => {
       assert.ok(true);
@@ -392,7 +392,7 @@ module('Integration | Component | build banner', function (hooks) {
   });
 
   test('it renders a stop button for running job when authenticated', async function (assert) {
-    assert.expect(4);
+    assert.expect(5);
     this.set('willRender', () => {
       assert.ok(true);
     });
@@ -426,7 +426,7 @@ module('Integration | Component | build banner', function (hooks) {
   });
 
   test('it renders a stop button for running disabled job when authenticated', async function (assert) {
-    assert.expect(5);
+    assert.expect(6);
     this.set('willRender', () => {
       assert.ok(true);
     });
@@ -461,7 +461,7 @@ module('Integration | Component | build banner', function (hooks) {
   });
 
   test('it renders a stop button for blocked job when authenticated', async function (assert) {
-    assert.expect(4);
+    assert.expect(5);
     this.set('willRender', () => {
       assert.ok(true);
     });
@@ -552,7 +552,7 @@ module('Integration | Component | build banner', function (hooks) {
       { name: 'sd-teardown-screwdriver-coverage-bookend' }
     ];
 
-    assert.expect(7);
+    assert.expect(8);
 
     this.set('reloadCb', () => {
       assert.ok(true);
@@ -730,7 +730,7 @@ module('Integration | Component | build banner', function (hooks) {
       { name: 'sd-teardown-screwdriver-coverage-bookend' }
     ];
 
-    assert.expect(3);
+    assert.expect(4);
 
     this.set('reloadCb', () => {
       assert.ok(true);


### PR DESCRIPTION
## Context
To update the createTime in the build details page. 

## Objective
update the createTime in the build details page to also be controlled by user pref for time format.

## References


## License
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
