### PR TITLE
fix: Last run column sort correction

### DIFF
--- a/app/components/collection-view/template.hbs
+++ b/app/components/collection-view/template.hbs
@@ -167,12 +167,12 @@
                   {{/if}}
                 </span>
               </th>
-              <th class="last-run" rowspan="1" onclick={{action "setSortBy" (if (eq (get sortBy 0) "lastRunEvent.startTime:desc") "lastRunEvent.startTime:asc" "lastRunEvent.startTime:desc")}}>
+              <th class="last-run" rowspan="1" onclick={{action "setSortBy" (if (eq (get sortBy 0) "lastRunEvent.createTime:desc") "lastRunEvent.createTime:asc" "lastRunEvent.createTime:desc")}}>
                 Last run
                 <span class="icon-wrapper">
-                  {{#if (eq (get sortBy 0) "lastRunEvent.startTime:asc")}}
+                  {{#if (eq (get sortBy 0) "lastRunEvent.createTime:asc")}}
                     <i class="fa fa-sort-asc"></i>
-                  {{else if (eq (get sortBy 0) "lastRunEvent.startTime:desc")}}
+                  {{else if (eq (get sortBy 0) "lastRunEvent.createTime:desc")}}
                     <i class="fa fa-sort-desc"></i>
                   {{else}}
                     <i class="fa fa-sort"></i>

--- a/app/utils/metric.js
+++ b/app/utils/metric.js
@@ -1,3 +1,5 @@
+import moment from 'moment';
+
 const getIcon = status => {
   switch (status) {
     case 'queued':
@@ -79,7 +81,8 @@ const formatMetrics = metrics => {
         sha: 'Not available',
         icon: 'question-circle',
         commitMessage: 'No events have been run for this pipeline',
-        commitUrl: '#'
+        commitUrl: '#',
+        createTime: '--/--/----'
       }
     };
   }
@@ -106,7 +109,8 @@ const formatMetrics = metrics => {
     sha: getSha(lastEvent.sha),
     icon: getIcon(lastEvent.status.toLowerCase()),
     commitMessage: lastEvent.commit.message,
-    commitUrl: lastEvent.commit.url
+    commitUrl: lastEvent.commit.url,
+    createTime: moment(lastEvent.createTime).format()
   };
 
   return { eventsInfo, lastEventInfo };


### PR DESCRIPTION
## Context

last run column sorting is not working as expected.
## Objective 
To fix last run column sorting.
sorting in descending order
<img width="706" alt="Screen Shot 2022-11-08 at 12 18 36 PM" src="https://user-images.githubusercontent.com/104225232/200632477-f0c9ca26-ab08-4d21-a263-c7b8e385fc55.png">
 
sorting in ascending order
<img width="659" alt="Screen Shot 2022-11-08 at 12 19 32 PM" src="https://user-images.githubusercontent.com/104225232/200632507-4a1e913d-b006-4e37-a09b-c70b82cab9e0.png">

## References


## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
