### PR TITLE
feat(2580): Disable actions that allow user to manually start an event/build

### DIFF
--- a/app/components/pipeline-list-view/component.js
+++ b/app/components/pipeline-list-view/component.js
@@ -5,6 +5,7 @@ import { inject as service } from '@ember/service';
 import { toCustomLocaleString } from 'screwdriver-ui/utils/time-range';
 import Table from 'ember-light-table';
 import isEqual from 'lodash.isequal';
+import { isActivePipeline } from 'screwdriver-ui/utils/pipeline';
 
 export default Component.extend({
   store: service(),
@@ -173,9 +174,9 @@ export default Component.extend({
         Object.keys(this.getWithDefault('pipelineParameters', {})).length > 0 ||
         Object.keys(this.getWithDefault('jobParameters', {})).length > 0;
 
-      let manualStartEnabled = true;
+      let manualStartEnabled = isActivePipeline(this.get('pipeline'));
 
-      if (annotations) {
+      if (manualStartEnabled && annotations) {
         manualStartEnabled =
           'screwdriver.cd/manualStartEnabled' in annotations
             ? annotations['screwdriver.cd/manualStartEnabled']

--- a/app/components/pipeline-pr-list/component.js
+++ b/app/components/pipeline-pr-list/component.js
@@ -2,6 +2,8 @@ import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { computed, set, get } from '@ember/object';
 import { isActiveBuild } from 'screwdriver-ui/utils/build';
+import { isActivePipeline } from 'screwdriver-ui/utils/pipeline';
+
 export default Component.extend({
   store: service(),
   classNameBindings: ['highlighted'],
@@ -59,6 +61,12 @@ export default Component.extend({
       });
 
       return isActive;
+    }
+  }),
+
+  isStartButtonDisabled: computed('pipeline.state', {
+    get() {
+      return !isActivePipeline(this.get('pipeline'));
     }
   }),
 

--- a/app/components/pipeline-pr-list/template.hbs
+++ b/app/components/pipeline-pr-list/template.hbs
@@ -11,7 +11,7 @@
         {{#if isRunning}}
           {{#bs-button type="primary" class="stopButton" onClick=(action stopPRBuilds jobs)}}Stop{{/bs-button}}
         {{else}}
-          {{#bs-button type="primary" class="startButton" onClick=(action startBuild jobs.0.group jobs)}}Start{{/bs-button}}
+          {{#bs-button type="primary" class="startButton" disabled=isStartButtonDisabled onClick=(action startBuild jobs.0.group jobs)}}Start{{/bs-button}}
         {{/if}}
       </div>
       <div class="date greyOut">Opened {{jobs.0.createTimeExact}}</div>

--- a/app/components/pipeline-start/template.hbs
+++ b/app/components/pipeline-start/template.hbs
@@ -2,7 +2,7 @@
   {{#if hasLargeNumberOfParameters}}
     {{#if (not prNum)}}
       <div class="btn-group">
-        <button {{action "startBuild"}} class="btn start-button" title="Start a new event from latest commit">Start</button>
+        {{#bs-button onClick=(action "startBuild") class="btn start-button" disabled=isStartButtonDisabled title="Start a new event from latest commit"}}Start{{/bs-button}}
         <button class="btn start-with-parameters-button" onClick={{action "toggleModal"}}>{{fa-icon (concat "caret-" direction)}}</button>
       </div>
     {{/if}}
@@ -17,7 +17,7 @@
         <h3>Are you sure to start?</h3>
         {{pipeline-parameterized-build
           pipeline=pipeline
-          showSubmitButton=true
+          showSubmitButton=(eq isStartButtonDisabled false)
           buildPipelineParameters=pipelineParameters
           buildJobParameters=jobParameters
           onSave=(action "startBuild")
@@ -30,7 +30,7 @@
       closeOnMenuClick=false as |dd|}}
       <div class="btn-group">
         {{#if (not prNum)}}
-          <button {{action "startBuild"}} class="start-button btn" title="Start a new event from latest commit">Start</button>
+          {{#bs-button onClick=(action "startBuild") class="start-button btn" disabled=isStartButtonDisabled title="Start a new event from latest commit"}}Start{{/bs-button}}
         {{/if}}
         {{#dd.button class="start-with-parameters-button"
           onClick=(action "toggleDropdown" dd.toggleDropdown)}}
@@ -40,7 +40,7 @@
       {{#dd.menu class="start-with-parameters-menu"}}
         {{pipeline-parameterized-build
           pipeline=pipeline
-          showSubmitButton=true
+          showSubmitButton=(eq isStartButtonDisabled false)
           buildPipelineParameters=pipelineParameters
           buildJobParameters=jobParameters
           onSave=(action "startBuild")

--- a/tests/integration/components/pipeline-list-view/component-test.js
+++ b/tests/integration/components/pipeline-list-view/component-test.js
@@ -8,7 +8,12 @@ import wait from 'ember-test-helpers/wait';
 module('Integration | Component | pipeline list view', function (hooks) {
   setupRenderingTest(hooks);
 
+  const PIPELINE = {
+    state: 'ACTIVE'
+  };
+
   test('it renders', async function (assert) {
+    set(this, 'pipeline', PIPELINE);
     set(this, 'jobsDetails', [
       {
         jobId: 1,
@@ -68,6 +73,7 @@ module('Integration | Component | pipeline list view', function (hooks) {
     });
 
     await render(hbs`{{pipeline-list-view
+      pipeline=pipeline
       jobsDetails=jobsDetails
       updateListViewJobs=updateListViewJobs
       refreshListViewJobs=refreshListViewJobs
@@ -88,6 +94,7 @@ module('Integration | Component | pipeline list view', function (hooks) {
   });
 
   test('it renders then resets jobDetails', async function (assert) {
+    set(this, 'pipeline', PIPELINE);
     set(this, 'jobsDetails', [
       {
         jobId: 1,
@@ -150,6 +157,7 @@ module('Integration | Component | pipeline list view', function (hooks) {
     await render(hbs`
       {{#if showPipelineListView}}
         {{pipeline-list-view
+          pipeline=pipeline
           jobsDetails=jobsDetails
           updateListViewJobs=updateListViewJobs
           refreshListViewJobs=refreshListViewJobs
@@ -168,6 +176,7 @@ module('Integration | Component | pipeline list view', function (hooks) {
   });
 
   test('it renders with duration', async function (assert) {
+    set(this, 'pipeline', PIPELINE);
     set(this, 'jobsDetails', [
       {
         jobId: 1,
@@ -201,6 +210,7 @@ module('Integration | Component | pipeline list view', function (hooks) {
     });
 
     await render(hbs`{{pipeline-list-view
+      pipeline=pipeline
       jobsDetails=jobsDetails
       updateListViewJobs=updateListViewJobs
       refreshListViewJobs=refreshListViewJobs
@@ -223,6 +233,7 @@ module('Integration | Component | pipeline list view', function (hooks) {
   });
 
   test('it renders and build running', async function (assert) {
+    set(this, 'pipeline', PIPELINE);
     set(this, 'jobsDetails', [
       {
         jobId: 1,
@@ -255,6 +266,7 @@ module('Integration | Component | pipeline list view', function (hooks) {
     });
 
     await render(hbs`{{pipeline-list-view
+      pipeline=pipeline
       jobsDetails=jobsDetails
       updateListViewJobs=updateListViewJobs
       refreshListViewJobs=refreshListViewJobs
@@ -277,6 +289,7 @@ module('Integration | Component | pipeline list view', function (hooks) {
   });
 
   test('it renders and build created', async function (assert) {
+    set(this, 'pipeline', PIPELINE);
     set(this, 'jobsDetails', [
       {
         jobId: 1,
@@ -309,6 +322,7 @@ module('Integration | Component | pipeline list view', function (hooks) {
     });
 
     await render(hbs`{{pipeline-list-view
+      pipeline=pipeline
       jobsDetails=jobsDetails
       updateListViewJobs=updateListViewJobs
       refreshListViewJobs=refreshListViewJobs
@@ -331,6 +345,7 @@ module('Integration | Component | pipeline list view', function (hooks) {
   });
 
   test('it renders and build queued', async function (assert) {
+    set(this, 'pipeline', PIPELINE);
     set(this, 'jobsDetails', [
       {
         jobId: 1,
@@ -363,6 +378,7 @@ module('Integration | Component | pipeline list view', function (hooks) {
     });
 
     await render(hbs`{{pipeline-list-view
+      pipeline=pipeline
       jobsDetails=jobsDetails
       updateListViewJobs=updateListViewJobs
       refreshListViewJobs=refreshListViewJobs
@@ -385,6 +401,7 @@ module('Integration | Component | pipeline list view', function (hooks) {
   });
 
   test('it renders and build blocked', async function (assert) {
+    set(this, 'pipeline', PIPELINE);
     set(this, 'jobsDetails', [
       {
         jobId: 1,
@@ -417,6 +434,7 @@ module('Integration | Component | pipeline list view', function (hooks) {
     });
 
     await render(hbs`{{pipeline-list-view
+      pipeline=pipeline
       jobsDetails=jobsDetails
       updateListViewJobs=updateListViewJobs
       refreshListViewJobs=refreshListViewJobs
@@ -439,6 +457,7 @@ module('Integration | Component | pipeline list view', function (hooks) {
   });
 
   test('it renders and build frozen', async function (assert) {
+    set(this, 'pipeline', PIPELINE);
     set(this, 'jobsDetails', [
       {
         jobId: 1,
@@ -471,6 +490,7 @@ module('Integration | Component | pipeline list view', function (hooks) {
     });
 
     await render(hbs`{{pipeline-list-view
+      pipeline=pipeline
       jobsDetails=jobsDetails
       updateListViewJobs=updateListViewJobs
       refreshListViewJobs=refreshListViewJobs
@@ -493,6 +513,7 @@ module('Integration | Component | pipeline list view', function (hooks) {
   });
 
   test('it renders and not started', async function (assert) {
+    set(this, 'pipeline', PIPELINE);
     set(this, 'jobsDetails', [
       {
         jobId: 1,
@@ -525,6 +546,7 @@ module('Integration | Component | pipeline list view', function (hooks) {
     });
 
     await render(hbs`{{pipeline-list-view
+      pipeline=pipeline
       jobsDetails=jobsDetails
       updateListViewJobs=updateListViewJobs
       refreshListViewJobs=refreshListViewJobs
@@ -546,6 +568,7 @@ module('Integration | Component | pipeline list view', function (hooks) {
   });
 
   test('it renders and aborted', async function (assert) {
+    set(this, 'pipeline', PIPELINE);
     set(this, 'jobsDetails', [
       {
         jobId: 1,
@@ -578,6 +601,7 @@ module('Integration | Component | pipeline list view', function (hooks) {
     });
 
     await render(hbs`{{pipeline-list-view
+      pipeline=pipeline
       jobsDetails=jobsDetails
       updateListViewJobs=updateListViewJobs
       refreshListViewJobs=refreshListViewJobs

--- a/tests/integration/components/pipeline-pr-list/component-test.js
+++ b/tests/integration/components/pipeline-pr-list/component-test.js
@@ -6,7 +6,8 @@ import hbs from 'htmlbars-inline-precompile';
 import Pretender from 'pretender';
 
 const mockPipelineData = {
-  id: 3709
+  id: 3709,
+  state: 'ACTIVE'
 };
 
 let server;
@@ -189,6 +190,8 @@ module('Integration | Component | pipeline pr list', function (hooks) {
     assert.dom('.view .view .detail').exists({ count: 2 });
     assert.dom('.title').hasText('update readme');
     assert.dom('.by').hasText('anonymous');
+    assert.dom('.view .startButton').exists();
+    assert.dom('.view .startButton').doesNotHaveAttribute('disabled');
   });
 
   test('it renders start build for restricted PR pipeline', async function (assert) {
@@ -221,6 +224,7 @@ module('Integration | Component | pipeline pr list', function (hooks) {
     assert.dom('.title').hasText('update readme');
     assert.dom('.by').hasText('anonymous');
     assert.dom('.view .startButton').exists({ count: 1 });
+    assert.dom('.view .startButton').doesNotHaveAttribute('disabled');
   });
 
   test('it renders PR stop button', async function (assert) {
@@ -271,6 +275,62 @@ module('Integration | Component | pipeline pr list', function (hooks) {
       stopPRBuilds=stopPRBuilds}}`);
 
     assert.dom('.stopButton').exists({ count: 1 });
+    assert.dom('.view .startButton').doesNotExist();
+    assert.dom('.view .view .detail').exists({ count: 1 });
+    assert.dom('.title').hasText('update readme');
+    assert.dom('.by').hasText('anonymous');
+  });
+
+  test('it renders disabled PR start button for inactive pipeline', async function (assert) {
+    const jobs = [
+      EmberObject.create({
+        id: 'abcd',
+        name: 'PR-1234:main',
+        createTimeWords: 'now',
+        title: 'update readme',
+        username: 'anonymous',
+        builds: [
+          {
+            id: '1235',
+            status: 'SUCCESS',
+            endTime: null
+          }
+        ]
+      })
+    ];
+
+    const workflowgraph = {
+      nodes: [
+        { name: '~pr' },
+        { name: '~commit' },
+        { id: 1, name: 'main', displayName: 'myname' },
+        { id: 2, name: 'A' }
+      ],
+      edges: [
+        { src: '~pr', dest: 'main' },
+        { src: '~commit', dest: 'main' },
+        { src: 'main', dest: 'A' }
+      ]
+    };
+
+    this.set('jobsMock', jobs);
+    this.set('isRestricted', true);
+    this.set('startBuild', Function.prototype);
+    this.set('stopPRBuilds', Function.prototype);
+    this.set('workflowGraphMock', workflowgraph);
+    this.set('pipelineMock', { ...mockPipelineData, state: 'INACTIVE' });
+
+    await render(hbs`{{pipeline-pr-list
+      jobs=jobsMock
+      pipeline=pipelineMock
+      isRestricted=isRestricted
+      startBuild=startBuild
+      workflowGraph=workflowGraphMock
+      stopPRBuilds=stopPRBuilds}}`);
+
+    assert.dom('.stopButton').doesNotExist();
+    assert.dom('.view .startButton').exists({ count: 1 });
+    assert.dom('.view .startButton').hasAttribute('disabled');
     assert.dom('.view .view .detail').exists({ count: 1 });
     assert.dom('.title').hasText('update readme');
     assert.dom('.by').hasText('anonymous');


### PR DESCRIPTION
## Context
Child pipelines are marked Inactive when the associated SCM URLs have been removed from the external configuration. No new events/builds should be allowed for such inactive child pipelines.

Backend API https://github.com/screwdriver-cd/screwdriver/pull/2724 now fails creation of new events for inactive pipelines.

## Objective
This PR disables all the action in the UI which submits a request to the Backend API to create a new event.
Here is the page level breakdown of UI changes...

### Job list view 

1.  Disable 'Start' and 'Restart' buttons/icons under 'ACTIONS' column against each job listed in the table
<img width="1366" alt="image" src="https://user-images.githubusercontent.com/2124590/201741277-afa8555b-6514-4677-8fca-c7fca5bccb10.png">

### Pull Requests card list view

1. Disable 'Start' button

<img width="1366" alt="image" src="https://user-images.githubusercontent.com/2124590/201741446-c365c855-b916-4cbf-ab2a-3681c68cc038.png">

### Pipeline Events view

1. Disable 'Start' button for pipeline with parameters
2. Hide 'Submit' button in the 'START PIPELINE WITH PARAMETERS' drop down menu
3. Hide 'Submit' button in the 'START PIPELINE WITH PARAMETERS' modal (when pipeline has large number of parameters)

<img width="1364" alt="image" src="https://user-images.githubusercontent.com/2124590/201742280-0faa5ffa-900a-4c39-bbe0-4be5427754e9.png">

<img width="550" alt="image" src="https://user-images.githubusercontent.com/2124590/201742908-83b5ea7b-6b4d-4f0c-8f40-117aa4b45746.png">




## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
