### PR TITLE
fix: Delete pipelines in a collection

### DIFF
--- a/app/components/collection-view/component.js
+++ b/app/components/collection-view/component.js
@@ -224,7 +224,7 @@ export default Component.extend({
     selectPipeline(pipelineId) {
       const newSelectedPipelines = this.selectedPipelines.slice(0);
 
-      newSelectedPipelines.push(pipelineId);
+      newSelectedPipelines.push(parseInt(pipelineId, 10));
       this.set('selectedPipelines', newSelectedPipelines);
     },
     deselectPipeline(pipelineId) {


### PR DESCRIPTION
## Context
When user selects one or more pipelines from the collection and try to remove it, nothing happens.

## Objective
User should able to delete one or more pipelines from collection.

## References
https://github.com/screwdriver-cd/screwdriver/issues/2794

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
