### PR TITLE
fix: Deselect pipelines update count

### DIFF
--- a/app/components/collection-view/component.js
+++ b/app/components/collection-view/component.js
@@ -228,7 +228,7 @@ export default Component.extend({
       this.set('selectedPipelines', newSelectedPipelines);
     },
     deselectPipeline(pipelineId) {
-      const idx = this.selectedPipelines.indexOf(pipelineId);
+      const idx = this.selectedPipelines.indexOf(parseInt(pipelineId, 10));
       const newSelectedPipelines = this.selectedPipelines.slice(0);
 
       if (idx !== -1) {

--- a/app/components/collection-view/component.js
+++ b/app/components/collection-view/component.js
@@ -224,7 +224,7 @@ export default Component.extend({
     selectPipeline(pipelineId) {
       const newSelectedPipelines = this.selectedPipelines.slice(0);
 
-      newSelectedPipelines.push(pipelineId);
+      newSelectedPipelines.push(parseInt(pipelineId, 10));
       this.set('selectedPipelines', newSelectedPipelines);
     },
     deselectPipeline(pipelineId) {


### PR DESCRIPTION
## Context
Select is not working properly while unselect some pipelines in a collection.

## Objective
To fix select option.

## References

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
