### PR TITLE
fix: error message persists even after successful action.

### DIFF
--- a/app/components/pipeline-options/component.js
+++ b/app/components/pipeline-options/component.js
@@ -244,6 +244,12 @@ export default Component.extend({
 
       return this.sync
         .syncRequests(this.get('pipeline.id'), syncPath)
+        .then(() =>
+          this.setProperties({
+            successMessage: 'Pipeline sync successful',
+            errorMessage: ''
+          })
+        )
         .catch(error => this.set('errorMessage', error))
         .finally(() => this.set('isShowingModal', false));
     },


### PR DESCRIPTION
## Context
User clicks Sync Pipeline. Error message is shown even if the Sync is success

## Objective
#2 In the pipeline options page, if user clicks Sync again and if it succeeds, then error message should be cleared.


## References
https://github.com/screwdriver-cd/screwdriver/issues/765

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
