### PR TITLE
fix: Create pipeline not showing all templates

### DIFF
--- a/app/components/pipeline-create-form/component.js
+++ b/app/components/pipeline-create-form/component.js
@@ -43,6 +43,10 @@ export default Component.extend({
     }
   }),
 
+  searchInputMatcher: function matcher(template, term) {
+    return `${template.name} ${template.namespace}`.indexOf(term);
+  },
+
   hasAutoDeployEnabled: computed({
     get() {
       const { session } = this;

--- a/app/components/pipeline-create-form/template.hbs
+++ b/app/components/pipeline-create-form/template.hbs
@@ -53,11 +53,11 @@
             options=templates
             selected=selectedTemplate
             onchange=(action "selectTemplate")
-            searchField="name"
+            matcher=searchInputMatcher
             searchEnabled=true
             noMatchesMessage=messageForSearching
             as |template| }}
-            {{template.name}}
+            {{template.name}} {{template.namespace}}
           {{/power-select}}
         </div>
 

--- a/app/components/pipeline-create-form/template.hbs
+++ b/app/components/pipeline-create-form/template.hbs
@@ -57,7 +57,7 @@
             searchEnabled=true
             noMatchesMessage=messageForSearching
             as |template| }}
-            {{template.name}} {{template.namespace}}
+            {{template.name}}
           {{/power-select}}
         </div>
 


### PR DESCRIPTION
## Context
UI is not searching in template namespace.

## Objective
Searching for a template name should match both namespace & name.

<img width="984" alt="Screen Shot 2022-12-06 at 10 45 48 AM" src="https://user-images.githubusercontent.com/104225232/206269258-571eb62a-829a-491a-a776-e13bf291ba98.png">



## References
https://github.com/screwdriver-cd/screwdriver/issues/2282

## License
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
