### PR TITLE
feat: upgrade node version to 14

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -10,7 +10,7 @@ shared:
 
 jobs:
   main:
-    image: node:12
+    image: node:14
     environment:
       COVERAGE: "true"
       SD_SONAR_OPTS: "-Dsonar.sources=app -Dsonar.javascript.lcov.reportPaths=coverage/lcov.info"
@@ -24,7 +24,7 @@ jobs:
 
   # Publish the package to GitHub and build docker image
   publish:
-    image: node:12
+    image: node:14
     annotations:
       screwdriver.cd/ram: TURBO
     environment:
@@ -49,7 +49,7 @@ jobs:
     template: sd/dind@latest
   # Deploy to our beta environment and run tests
   beta:
-    image: node:12
+    image: node:14
     steps:
       - setup-ci: git clone https://github.com/screwdriver-cd/toolbox.git ci
       - get-tag: ./ci/git-latest.sh
@@ -70,7 +70,7 @@ jobs:
 
   # Deploy to our prod environment and run tests
   prod:
-    image: node:12
+    image: node:14
     steps:
       - setup-ci: git clone https://github.com/screwdriver-cd/toolbox.git ci
       - get-tag: ./ci/git-latest.sh


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Currently, we run on `node:12`, our `setup_chrome.sh` used to work, see [success build](https://cd.screwdriver.cd/pipelines/7/builds/834390/steps/install-browsers), but no longer works, see [failure build](https://cd.screwdriver.cd/pipelines/7/builds/835493/steps/install-browsers)

The error message show as below:
```
15:31:07 $ ./bin/setup_chrome.sh
15:31:09 OK
15:31:09 Ign:1 http://deb.debian.org/debian stretch InRelease
15:31:09 Get:2 http://security.debian.org/debian-security stretch/updates InRelease [59.1 kB]
15:31:09 Get:3 http://dl.google.com/linux/chrome/deb stable InRelease [1811 B]
15:31:09 Get:4 http://deb.debian.org/debian stretch-updates InRelease [93.6 kB]
15:31:09 Get:5 http://deb.debian.org/debian stretch Release [118 kB]
15:31:09 Get:6 http://deb.debian.org/debian stretch Release.gpg [3177 B]
15:31:09 Get:7 http://dl.google.com/linux/chrome/deb stable/main amd64 Packages [1093 B]
15:31:10 Get:8 http://security.debian.org/debian-security stretch/updates/main amd64 Packages [782 kB]
15:31:10 Get:9 http://deb.debian.org/debian stretch/main amd64 Packages [7080 kB]
15:31:11 Fetched 8138 kB in 1s (5188 kB/s)
15:31:11 Reading package lists...
15:31:12 Reading package lists...
15:31:12 Building dependency tree...
15:31:12 Reading state information...
15:31:12 Some packages could not be installed. This may mean that you have
15:31:12 requested an impossible situation or if you are using the unstable
15:31:12 distribution that some required packages have not yet been created
15:31:12 or been moved out of Incoming.
15:31:12 The following information may help to resolve the situation:
15:31:12 
15:31:12 The following packages have unmet dependencies:
15:31:12  google-chrome-stable : Depends: libgbm1 (>= 17.1.0~rc2) but 13.0.6-1+b2 is to be installed
15:31:12                         Recommends: libu2f-udev but it is not installable
15:31:12                         Recommends: libvulkan1 but it is not going to be installed
15:31:12 E: Unable to correct problems, you have held broken packages.
```

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
1. The most straightforward approach is to upgrade the docker image version. 
2. Modify the [setup_chrome.sh](https://github.com/screwdriver-cd/ui/blob/c75174e45f2a062111e5729d92cce1fd6375e99f/bin/setup_chrome.sh#L4) to resolve the dependencies issue of `libgbm1 (>= 17.1.0~rc2) but 13.0.6-1+b2 is to be installed`

This PR takes 1) approach.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
- https://www.google.com/linuxrepositories
- https://askubuntu.com/a/792442
- https://askubuntu.com/a/510186

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
