### PR TITLE
fix: Make search field case insensitive and trim space

### DIFF
--- a/app/components/pipeline-create-form/component.js
+++ b/app/components/pipeline-create-form/component.js
@@ -45,8 +45,9 @@ export default Component.extend({
 
   searchInputMatcher: function matcher(template, term) {
     const searchString = term.trim().toLowerCase();
+    const text = `${template.name} ${template.namespace}`.toLowerCase();
 
-    return `${template.name} ${template.namespace}`.indexOf(searchString);
+    return text.indexOf(searchString);
   },
 
   hasAutoDeployEnabled: computed({

--- a/app/components/pipeline-create-form/component.js
+++ b/app/components/pipeline-create-form/component.js
@@ -44,7 +44,9 @@ export default Component.extend({
   }),
 
   searchInputMatcher: function matcher(template, term) {
-    return `${template.name} ${template.namespace}`.indexOf(term);
+    const searchString = term.trim().toLowerCase();
+
+    return `${template.name} ${template.namespace}`.indexOf(searchString);
   },
 
   hasAutoDeployEnabled: computed({


### PR DESCRIPTION
## Context
To fix the search option.

## Objective
Make the search case insensitive and trim the whitespace at the beginning and end of the word.

## References

https://github.com/screwdriver-cd/screwdriver/issues/2282
## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
