### PR TITLE
fix: sorting issues for collection page

### DIFF
--- a/app/components/collection-table-row/template.hbs
+++ b/app/components/collection-table-row/template.hbs
@@ -21,7 +21,11 @@
   <span title={{branch}}>{{branch}}</span>
 </td>
 <td class="last-run">
-  {{lastEventInfo.startTime}}
+  {{#if (eq lastEventInfo.createTime 0)}}
+    --/--/----
+  {{else}}
+    {{lastEventInfo.startTime}}
+  {{/if}}
 </td>
 <td class="duration">
   {{lastEventInfo.durationText}}

--- a/app/components/collection-table-row/template.hbs
+++ b/app/components/collection-table-row/template.hbs
@@ -21,11 +21,7 @@
   <span title={{branch}}>{{branch}}</span>
 </td>
 <td class="last-run">
-  {{#if (eq lastEventInfo.createTime 0)}}
-    --/--/----
-  {{else}}
-    {{lastEventInfo.startTime}}
-  {{/if}}
+  {{lastEventInfo.startTime}}
 </td>
 <td class="duration">
   {{lastEventInfo.durationText}}

--- a/app/components/collection-view/component.js
+++ b/app/components/collection-view/component.js
@@ -121,10 +121,10 @@ export default Component.extend({
       collectionPipelinesArray.forEach(p => {
         const { lastRunEvent } = p;
 
-        if (lastRunEvent && lastRunEvent.status !== 'build-empty') {
-          knownStatusPipelines.push(p);
-        } else {
+        if (lastRunEvent && lastRunEvent.status === 'build-empty') {
           unknownStatusPipelines.push(p);
+        } else {
+          knownStatusPipelines.push(p);
         }
       });
 

--- a/app/components/collection-view/component.js
+++ b/app/components/collection-view/component.js
@@ -121,10 +121,10 @@ export default Component.extend({
       collectionPipelinesArray.forEach(p => {
         const { lastRunEvent } = p;
 
-        if (lastRunEvent.status === 'build-empty') {
-          unknownStatusPipelines.push(p);
-        } else {
+        if (lastRunEvent && lastRunEvent.status !== 'build-empty') {
           knownStatusPipelines.push(p);
+        } else {
+          unknownStatusPipelines.push(p);
         }
       });
 

--- a/app/components/collection-view/component.js
+++ b/app/components/collection-view/component.js
@@ -114,26 +114,39 @@ export default Component.extend({
     'sortOrder',
     function sortedPipelines() {
       let sorted;
+      const unknownStatusPipelines = [];
+      const knownStatusPipelines = [];
       const collectionPipelinesArray = this.collectionPipelines.toArray();
 
+      collectionPipelinesArray.forEach(p => {
+        const { lastRunEvent } = p;
+
+        if (lastRunEvent.status === 'build-empty') {
+          unknownStatusPipelines.push(p);
+        } else {
+          knownStatusPipelines.push(p);
+        }
+      });
+
       if (this.sortBy === 'lastRunStatus') {
-        sorted = collectionPipelinesArray.sort(sortByLastRunStatus);
+        sorted = knownStatusPipelines.sort(sortByLastRunStatus);
       } else if (this.sortBy === 'pipelineName') {
-        sorted = collectionPipelinesArray.sort(sortByName);
+        sorted = knownStatusPipelines.sort(sortByName);
       } else if (this.sortBy === 'lastRun') {
-        sorted = collectionPipelinesArray.sort(sortByLastRun);
+        sorted = knownStatusPipelines.sort(sortByLastRun);
       } else if (this.sortBy === 'history') {
-        sorted = collectionPipelinesArray.sort(sortByHistory);
+        sorted = knownStatusPipelines.sort(sortByHistory);
       } else if (this.sortBy === 'branch') {
-        sorted = collectionPipelinesArray.sort(sortByBranch);
+        sorted = knownStatusPipelines.sort(sortByBranch);
       } else if (this.sortBy === 'duration') {
-        sorted = collectionPipelinesArray.sort(sortByDuration);
-      }
-      if (this.sortOrder === 'asc') {
-        return sorted;
+        sorted = knownStatusPipelines.sort(sortByDuration);
       }
 
-      return sorted.reverse();
+      if (this.sortOrder === 'desc') {
+        sorted = sorted.reverse();
+      }
+
+      return sorted.concat(unknownStatusPipelines);
     }
   ),
   sortByText: computed('sortBy', {

--- a/app/components/collection-view/template.hbs
+++ b/app/components/collection-view/template.hbs
@@ -155,10 +155,12 @@
                 {{/if}}
                 Name
                 <span class="icon-wrapper">
-                  {{#if (eq sortOrder "desc")}}
-                    <i class="fa fa-sort-asc"></i>
-                  {{else if (eq sortOrder "asc")}}
-                    <i class="fa fa-sort-desc"></i>
+                  {{#if (eq sortBy "pipelineName")}}
+                    {{#if (eq sortOrder "desc")}}
+                      <i class="fa fa-sort-asc"></i>
+                    {{else}}
+                      <i class="fa fa-sort-desc"></i>
+                    {{/if}}
                   {{else}}
                     <i class="fa fa-sort"></i>
                   {{/if}}
@@ -167,10 +169,12 @@
               <th class="branch" rowspan="1" onclick={{action "setSortBy" "branch" (if (eq sortOrder "desc") "asc" "desc")}} >
                 Branch
                 <span class="icon-wrapper">
-                  {{#if (eq sortOrder "desc")}}
-                    <i class="fa fa-sort-asc"></i>
-                  {{else if (eq sortOrder "asc")}}
-                    <i class="fa fa-sort-desc"></i>
+                  {{#if (eq sortBy "branch")}}
+                    {{#if (eq sortOrder "desc")}}
+                      <i class="fa fa-sort-asc"></i>
+                    {{else}}
+                      <i class="fa fa-sort-desc"></i>
+                    {{/if}}
                   {{else}}
                     <i class="fa fa-sort"></i>
                   {{/if}}
@@ -179,10 +183,12 @@
               <th class="last-run" rowspan="1" onclick={{action "setSortBy" "lastRun" (if (eq sortOrder "desc") "asc" "desc")}}>
                 Last run
                 <span class="icon-wrapper">
-                  {{#if (eq sortOrder "desc")}}
-                    <i class="fa fa-sort-asc"></i>
-                  {{else if (eq sortOrder "asc")}}
-                    <i class="fa fa-sort-desc"></i>
+                  {{#if (eq sortBy "lastRun")}}
+                    {{#if (eq sortOrder "desc")}}
+                      <i class="fa fa-sort-asc"></i>
+                    {{else}}
+                      <i class="fa fa-sort-desc"></i>
+                    {{/if}}
                   {{else}}
                     <i class="fa fa-sort"></i>
                   {{/if}}
@@ -191,10 +197,12 @@
               <th class="duration" rowspan="1" onclick={{action "setSortBy" "duration" (if (eq sortOrder "desc") "asc" "desc")}} >
                 Duration
                 <span class="icon-wrapper">
-                  {{#if (eq sortOrder "desc")}}
-                    <i class="fa fa-sort-asc"></i>
-                  {{else if (eq sortOrder "asc")}}
-                    <i class="fa fa-sort-desc"></i>
+                  {{#if (eq sortBy "duration")}}
+                    {{#if (eq sortOrder "desc")}}
+                      <i class="fa fa-sort-asc"></i>
+                    {{else}}
+                      <i class="fa fa-sort-desc"></i>
+                    {{/if}}
                   {{else}}
                     <i class="fa fa-sort"></i>
                   {{/if}}
@@ -203,10 +211,12 @@
               <th class="status" rowspan="1" onclick={{action "setSortBy" "lastRunStatus" (if (eq sortOrder "desc") "asc" "desc")}} >
                 Status
                 <span class="icon-wrapper">
-                  {{#if (eq sortOrder "desc")}}
-                    <i class="fa fa-sort-asc"></i>
-                  {{else if (eq sortOrder "asc")}}
-                    <i class="fa fa-sort-desc"></i>
+                  {{#if (eq sortBy "lastRunStatus")}}
+                    {{#if (eq sortOrder "desc")}}
+                      <i class="fa fa-sort-asc"></i>
+                    {{else}}
+                      <i class="fa fa-sort-desc"></i>
+                    {{/if}}
                   {{else}}
                     <i class="fa fa-sort"></i>
                   {{/if}}
@@ -218,10 +228,12 @@
                   sort on number of failed builds
                 {{/bs-tooltip}}
                 <span class="icon-wrapper">
-                  {{#if (eq sortOrder "desc")}}
-                    <i class="fa fa-sort-asc"></i>
-                  {{else if (eq sortOrder "asc")}}
-                    <i class="fa fa-sort-desc"></i>
+                  {{#if (eq sortBy "history")}}
+                    {{#if (eq sortOrder "desc")}}
+                      <i class="fa fa-sort-asc"></i>
+                    {{else}}
+                      <i class="fa fa-sort-desc"></i>
+                    {{/if}}
                   {{else}}
                     <i class="fa fa-sort"></i>
                   {{/if}}

--- a/app/utils/metric.js
+++ b/app/utils/metric.js
@@ -75,7 +75,7 @@ const formatMetrics = metrics => {
     return {
       eventsInfo: [],
       lastEventInfo: {
-        startTime: '--/--/----',
+        startTime: 0,
         statusColor: 'build-empty',
         status: 'build-empty',
         durationText: '--',
@@ -83,8 +83,8 @@ const formatMetrics = metrics => {
         icon: 'question-circle',
         commitMessage: 'No events have been run for this pipeline',
         commitUrl: '#',
-        createTime: '--/--/----',
-        duration: '--'
+        createTime: 0,
+        duration: 0
       }
     };
   }
@@ -114,7 +114,7 @@ const formatMetrics = metrics => {
     commitMessage: lastEvent.commit.message,
     commitUrl: lastEvent.commit.url,
     createTime: moment(lastEvent.createTime).format(),
-    duration: lastEvent.duration
+    duration: lastEvent.duration || 0
   };
 
   return { eventsInfo, lastEventInfo };

--- a/app/utils/metric.js
+++ b/app/utils/metric.js
@@ -75,7 +75,7 @@ const formatMetrics = metrics => {
     return {
       eventsInfo: [],
       lastEventInfo: {
-        startTime: 0,
+        startTime: '--/--/----',
         statusColor: 'build-empty',
         status: 'build-empty',
         durationText: '--',


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
1) Current sorting breaks on unknown `status` for the collection page
2) Break down the collection into `knownStatus` and `unknownStatus` pipelines, and latter remain at the bottom of the list when sorting.

3) Fix up/down arrow when another column was selected

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
![image](https://user-images.githubusercontent.com/15989893/207730661-97d54b74-2129-4ad0-afd7-44ca52a91b40.png)

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
