### PR TITLE
feat(2669): Render Stages in the workflow graph if configured

### DIFF
--- a/app/components/pipeline-events/template.hbs
+++ b/app/components/pipeline-events/template.hbs
@@ -85,6 +85,7 @@
       @setJobState={{action "setJobState"}}
       @authenticated={{this.session.isAuthenticated}}
       @prChainEnabled={{this.prChainEnabled}}
+      @stages={{this.stages}}
     />
   </div>
   <div

--- a/app/components/pipeline-workflow/component.js
+++ b/app/components/pipeline-workflow/component.js
@@ -45,7 +45,7 @@ export default Component.extend({
     }
   ),
 
-  displayRestartButton: computed('authenticated', 'pipeline.state', {
+  canRestartPipeline: computed('authenticated', 'pipeline.state', {
     get() {
       return this.authenticated && isActivePipeline(this.get('pipeline'));
     }

--- a/app/components/pipeline-workflow/template.hbs
+++ b/app/components/pipeline-workflow/template.hbs
@@ -16,13 +16,14 @@
     @graphClicked={{action "graphClicked"}}
     @isSkipped={{this.selectedEventObj.isSkipped}}
     @prChainEnabled={{this.prChainEnabled}}
+    @stages={{this.stages}}
   >
     <WorkflowTooltip
       @pipeline={{this.pipeline}}
       @tooltipData={{this.tooltipData}}
       @isPrChainJob={{this.isPrChainJob}}
       @prBuildExists={{this.prBuildExists}}
-      @displayRestartButton={{this.displayRestartButton}}
+      @canRestartPipeline={{this.canRestartPipeline}}
       @stopBuild={{this.stopBuild}}
       @showTooltip={{this.showTooltip}}
       @showTooltipPosition={{this.showTooltipPosition}}

--- a/app/components/workflow-graph-d3/styles.scss
+++ b/app/components/workflow-graph-d3/styles.scss
@@ -104,3 +104,24 @@ g {
     stroke: $sd-success;
   }
 }
+
+.stage-container {
+  rx: 5;
+  ry: 5;
+}
+
+.stage-info {
+  padding: 10px;
+}
+
+.stage-name {
+  font-weight: bold;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.stage-description {
+  color: $sd-text-med;
+  margin-top: 5px;
+}

--- a/app/components/workflow-tooltip/component.js
+++ b/app/components/workflow-tooltip/component.js
@@ -58,6 +58,17 @@ export default Component.extend({
       return description;
     }
   ),
+  displayRestartButton: computed(
+    'canRestartPipeline',
+
+    'tooltipData.job.stageName',
+    function displayRestartButton() {
+      return (
+        get(this, 'canRestartPipeline') &&
+        !get(this, 'tooltipData.job.stageName')
+      );
+    }
+  ),
   actions: {
     toggleJob(toggleJobName) {
       const state = this.jobState;

--- a/app/job/model.js
+++ b/app/job/model.js
@@ -1,4 +1,4 @@
-import Model, { attr, hasMany } from '@ember-data/model';
+import Model, { attr, hasMany, belongsTo } from '@ember-data/model';
 import { computed, get } from '@ember/object';
 import { alias, match } from '@ember/object/computed';
 import ENV from 'screwdriver-ui/config/environment';
@@ -102,5 +102,6 @@ export default Model.extend({
       this.builds.any(b => isActiveBuild(b.get('status'), b.get('endTime')))
       ? SHOULD_RELOAD_YES
       : SHOULD_RELOAD_NO;
-  }
+  },
+  stage: belongsTo('stage')
 });

--- a/app/pipeline/events/show/route.js
+++ b/app/pipeline/events/show/route.js
@@ -39,8 +39,22 @@ export default class PipelineEventsShowRoute extends Route {
     }
   }
 
+  async model() {
+    const { event_id: eventId } = this.paramsFor(this.routeName);
+    const { pipeline_id: pipelineId } = this.paramsFor('pipeline');
+
+    const stages = await this.store.query('stage', {
+      pipelineId,
+      eventId
+    });
+
+    return { stages };
+  }
+
   async setupController(controller, model) {
     super.setupController(controller, model);
+
+    const { stages } = model;
 
     const { event_id: eventId } = this.paramsFor(this.routeName);
     const pipelineEventsController = this.controllerFor('pipeline.events');
@@ -74,7 +88,10 @@ export default class PipelineEventsShowRoute extends Route {
       }
     }
 
-    pipelineEventsController.set('selected', eventId);
+    pipelineEventsController.setProperties({
+      selected: eventId,
+      stages
+    });
 
     if (eventId !== this.eventId) {
       this.eventId = eventId;

--- a/app/pipeline/events/template.hbs
+++ b/app/pipeline/events/template.hbs
@@ -14,6 +14,7 @@
     @eventsPage={{this.eventsPage}}
     @isShowingModal={{this.isShowingModal}}
     @refresh={{action "refresh"}}
+    @stages={{this.stages}}
 />
 
 {{outlet}}

--- a/app/pipeline/route.js
+++ b/app/pipeline/route.js
@@ -1,6 +1,6 @@
 import RSVP from 'rsvp';
 import Route from '@ember/routing/route';
-import { get, set } from '@ember/object';
+import { set } from '@ember/object';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 import { inject as service } from '@ember/service';
 

--- a/app/shuttle/service.js
+++ b/app/shuttle/service.js
@@ -321,7 +321,7 @@ export default Service.extend({
     const url = `/users/settings`;
     const userSettings = await this.getUserSetting();
 
-    const data = {
+    let data = {
       settings: {
         ...userSettings,
         [pipelineId]: pipelineSettings
@@ -416,5 +416,13 @@ export default Service.extend({
     const data = { badges };
 
     return this.fetchFromApi(method, url, data);
+  },
+
+  // GET /pipelines/{id}/stages
+  async fetchStages(pipelineId) {
+    const method = 'get';
+    const url = `/pipelines/${pipelineId}/stages`;
+
+    return this.fetchFromApi(method, url);
   }
 });

--- a/app/stage/adapter.js
+++ b/app/stage/adapter.js
@@ -1,0 +1,37 @@
+import BaseAdapter from 'screwdriver-ui/application/adapter';
+import { inject as service } from '@ember/service';
+
+export default BaseAdapter.extend({
+  shuttle: service(),
+
+  // eslint-disable-next-line no-unused-vars
+  findHasMany(store, snapshot, url, relationship) {
+    const { id } = snapshot;
+    const type = snapshot.modelName;
+    const finalURL = this.urlPrefix(
+      url,
+      this.buildURL(type, id, snapshot, 'findHasMany')
+    );
+
+    return this.ajax(finalURL, 'GET');
+  },
+
+  // eslint-disable-next-line no-unused-vars
+  handleResponse(status, headers, payload, requestData) {
+    return this._super(...arguments);
+  },
+
+  async queryRecord(store, type, query) {
+    const { pipelineId } = query;
+
+    const data = await this.shuttle.fetchStages(pipelineId);
+
+    return data;
+  },
+
+  query(store, type, query) {
+    const { pipelineId } = query;
+
+    return this.shuttle.fetchStages(pipelineId);
+  }
+});

--- a/app/stage/model.js
+++ b/app/stage/model.js
@@ -1,0 +1,8 @@
+import Model, { attr, hasMany } from '@ember-data/model';
+
+export default Model.extend({
+  name: attr('string'),
+  pipelineId: attr('number'),
+  description: attr('string'),
+  jobs: hasMany('job')
+});

--- a/app/stage/serializer.js
+++ b/app/stage/serializer.js
@@ -1,0 +1,42 @@
+import DS from 'ember-data';
+
+/**
+ * extractPayload
+ * Make the raw payload into Ember Data expected format for RestAdapter
+ * @param  {JSON} payload [raw json data]
+ * @return {JSON}         [data]
+ */
+export function extractPayload(payload) {
+  payload.forEach(stage => {
+    stage.jobs = stage.jobIds;
+    delete stage.jobIds;
+  });
+
+  const data = {
+    stages: payload
+  };
+
+  return data;
+}
+
+export default DS.RESTSerializer.extend({
+  normalizeResponse(store, typeClass, payload, id, requestType) {
+    let data = payload;
+
+    if (['query'].includes(requestType)) {
+      data = extractPayload(payload);
+    }
+
+    return this._super(store, typeClass, data, id, requestType);
+  },
+
+  /**
+   * Override the serializeIntoHash
+   * See http://emberjs.com/api/data/classes/DS.RESTSerializer.html#method_serializeIntoHash
+   * @method serializeIntoHash
+   */
+  // eslint-disable-next-line no-unused-vars
+  serializeIntoHash(hash, typeClass, snapshot) {
+    return this._super(...arguments);
+  }
+});

--- a/app/utils/graph-tools.js
+++ b/app/utils/graph-tools.js
@@ -21,6 +21,8 @@ const STATUS_MAP = {
 };
 const edgeSrcBranchRegExp = new RegExp('^~(pr|commit):/(.+)/$');
 const triggerBranchRegExp = new RegExp('^~(pr|commit):(.+)$');
+const STAGE_SETUP_PATTERN = /^stage@([\w-]+)(?::setup)$/;
+const STAGE_TEARDOWN_PATTERN = /^stage@([\w-]+)(?::teardown)$/;
 
 /**
  * Find a node from the list of nodes
@@ -69,6 +71,162 @@ const prJob = (jobs, prNum, name) =>
  */
 const icon = status =>
   STATUS_MAP[status] ? STATUS_MAP[status].icon : STATUS_MAP.UNKNOWN.icon;
+
+/**
+ * Compiles and returns a list of stages and associated jobs by traversing the event workflow graph
+ * @method  extractEventStages
+ * @param  {Object} graph                            Event workflow graph
+ * @param  {Array|DS.PromiseArray} pipelineStages   List of latest stage metadata associated with the pipeline
+ * @return {Array}                                  List of stage metadata associated with the event
+ */
+const extractEventStages = (graph, pipelineStages) => {
+  const stageToPipelineStageMap = pipelineStages
+    ? pipelineStages.reduce(
+        (obj, stage) => ({
+          ...obj,
+          [stage.name]: stage
+        }),
+        {}
+      )
+    : {};
+  const stageNameToEventStageMap = {};
+  const { nodes } = graph;
+
+  nodes.forEach(n => {
+    const { stageName } = n;
+
+    if (stageName) {
+      let eventStage = stageNameToEventStageMap[stageName];
+
+      if (eventStage === undefined) {
+        const pipelineStage = stageToPipelineStageMap[stageName] || {};
+
+        eventStage = {
+          name: stageName,
+          jobs: [],
+          id: pipelineStage.id,
+          description: pipelineStage.description
+        };
+
+        stageNameToEventStageMap[stageName] = eventStage;
+      }
+      eventStage.jobs.push({ id: n.id });
+    }
+  });
+
+  return Object.values(stageNameToEventStageMap);
+};
+
+/**
+ * Replaces the edges associated with the specified node by creating new edges from the upstream nodes of the specified node
+ * to the downstream nodes of the specified node.
+ * @method  bypassSetupTeardownEdges
+ * @param  {Array} edges       List of edges in the workflow graph
+ * @param  {String} nodeName   Name of the node (job) in the workflow graph. Ex: 'stage@prod:setup', 'stage@canary:teardown'
+ * @return {Array}             List of edges after replacing the edges associated with specified node
+ */
+const bypassSetupTeardownEdges = (edges, nodeName) => {
+  const resultEdges = [];
+
+  const asSrcEdges = [];
+  const asDestEdges = [];
+
+  edges.forEach(e => {
+    if (e.src === nodeName) {
+      asSrcEdges.push(e);
+    } else if (e.dest === nodeName) {
+      asDestEdges.push(e);
+    } else {
+      resultEdges.push(e);
+    }
+  });
+
+  if (asSrcEdges.length > 0 && asDestEdges.length > 0) {
+    asSrcEdges.forEach(asSrcEdge => {
+      const newDest = asSrcEdge.dest;
+
+      asDestEdges.forEach(asDestEdge => {
+        resultEdges.push({ ...asDestEdge, dest: newDest });
+      });
+    });
+  }
+
+  return resultEdges;
+};
+
+/**
+ * Extracts the workflow graph associated with the specified stage.
+ * @method  extractStageGraph
+ * @param  {Object} graph   Event workflow graph
+ * @param  {Object} stage   Stage metadata
+ * @return {Array}          Workflow graph associated with the specified stage
+ */
+const extractStageGraph = (graph, stage) => {
+  const { nodes, edges } = graph;
+  const jobIds = stage.jobs.map(j => parseInt(j.id, 10));
+  const newNodes = [];
+  const newNodesSet = new Set();
+  const newEdges = [];
+
+  nodes.forEach(n => {
+    const { id, name } = n;
+
+    if (jobIds.includes(parseInt(id, 10))) {
+      newNodes.push(n);
+      newNodesSet.add(name);
+    }
+  });
+
+  edges.forEach(e => {
+    const { src, dest } = e;
+
+    if (newNodesSet.has(src) && newNodesSet.has(dest)) {
+      newEdges.push(e);
+    }
+  });
+
+  let xMin;
+
+  let xMax;
+
+  let yMin;
+
+  let yMax;
+
+  newNodes.forEach(n => {
+    xMin = xMin === undefined ? n.pos.x : Math.min(xMin, n.pos.x);
+    xMax = xMax === undefined ? n.pos.x : Math.max(xMax, n.pos.x);
+    yMin = yMin === undefined ? n.pos.y : Math.min(yMin, n.pos.y);
+    yMax = yMax === undefined ? n.pos.y : Math.max(yMax, n.pos.y);
+  });
+
+  return {
+    nodes: newNodes,
+    edges: newEdges,
+    meta: {
+      width: xMax - xMin + 1,
+      height: yMax - yMin + 1
+    }
+  };
+};
+
+const getStagePosition = graph => {
+  const { nodes } = graph;
+
+  let x;
+
+  let y;
+
+  nodes.forEach(n => {
+    x = x === undefined ? n.pos.x : Math.min(x, n.pos.x);
+    y = y === undefined ? n.pos.y : Math.min(y, n.pos.y);
+  });
+
+  return {
+    x,
+    y
+  };
+};
 
 /**
  * Calculate how many nodes are visited in the graph from the given starting point
@@ -190,7 +348,7 @@ const hasProcessedDest = (graph, name) => {
 };
 
 /**
- * Clones and decorates an input graph datastructure into something that can be used to display
+ * Clones and decorates an input graph data structure into something that can be used to display
  * a custom directed graph
  * @method decorateGraph
  * @param  {Object}      inputGraph A directed graph representation { nodes: [], edges: [] }
@@ -199,12 +357,23 @@ const hasProcessedDest = (graph, name) => {
  * @param  {String}   [start]     Node name that indicates what started the graph
  * @param  {Boolean}  [chainPR]   Boolean flag for the chainPR setting
  * @param  {number}   [prNum]     The pull request number
+ * @param  {Array|DS.PromiseArray}  [stages]     A list of stage metadata
  * @return {Object}                 A graph representation with row/column coordinates for drawing, and meta information for scaling
  */
-const decorateGraph = ({ inputGraph, builds, jobs, start, chainPR, prNum }) => {
+const decorateGraph = ({
+  inputGraph,
+  builds,
+  jobs,
+  start,
+  chainPR,
+  prNum,
+  stages
+}) => {
   // deep clone
-  const graph = JSON.parse(JSON.stringify(inputGraph));
-  const { nodes } = graph;
+  const originalGraph = JSON.parse(JSON.stringify(inputGraph));
+  const originalNodes = originalGraph.nodes;
+  const originalEdges = originalGraph.edges;
+
   const buildsAvailable =
     (Array.isArray(builds) ||
       builds instanceof DS.PromiseArray ||
@@ -215,9 +384,41 @@ const decorateGraph = ({ inputGraph, builds, jobs, start, chainPR, prNum }) => {
       jobs instanceof DS.PromiseArray ||
       jobs instanceof DS.PromiseManyArray) &&
     jobs.length;
-  const { edges } = graph;
+  const graph = {};
 
   let y = [0]; // accumulator for column heights
+
+  const setupNodes = [];
+  const teardownNodes = [];
+  const nodes = [];
+
+  // Remove setup and teardown nodes
+  originalNodes.forEach(n => {
+    const jobName = n.name;
+
+    if (STAGE_SETUP_PATTERN.test(jobName)) {
+      setupNodes.push(n);
+    } else if (STAGE_TEARDOWN_PATTERN.test(jobName)) {
+      teardownNodes.push(n);
+    } else {
+      nodes.push(n);
+    }
+  });
+
+  graph.nodes = nodes;
+
+  let edges = originalEdges;
+
+  // Bypass setup/teardown edges
+  setupNodes.forEach(setupNode => {
+    edges = bypassSetupTeardownEdges(edges, setupNode.name);
+  });
+
+  teardownNodes.forEach(teardownNode => {
+    edges = bypassSetupTeardownEdges(edges, teardownNode.name);
+  });
+
+  graph.edges = edges;
 
   nodes.forEach(n => {
     // Set root nodes on left
@@ -326,6 +527,19 @@ const decorateGraph = ({ inputGraph, builds, jobs, start, chainPR, prNum }) => {
     height: Math.max(1, ...y),
     width: Math.max(1, y.length - 1)
   };
+
+  if (stages) {
+    const eventStages = extractEventStages(graph, stages);
+
+    graph.stages = eventStages.map(s => {
+      const stageGraph = extractStageGraph(graph, s);
+
+      s.graph = stageGraph;
+      s.pos = getStagePosition(stageGraph);
+
+      return s;
+    });
+  }
 
   return graph;
 };

--- a/tests/acceptance/pipeline-builds-test.js
+++ b/tests/acceptance/pipeline-builds-test.js
@@ -70,6 +70,12 @@ module('Acceptance | pipeline build', function (hooks) {
       ];
     });
 
+    server.get('http://localhost:8080/v4/pipelines/4/stages', () => [
+      200,
+      { 'Content-Type': 'application/json' },
+      JSON.stringify([])
+    ]);
+
     server.get('http://localhost:8080/v4/jobs/:jobId/builds', request => {
       const jobId = parseInt(request.params.jobId, 10);
 

--- a/tests/integration/components/pipeline-workflow/component-test.js
+++ b/tests/integration/components/pipeline-workflow/component-test.js
@@ -93,7 +93,7 @@ module('Integration | Component | pipeline workflow', function (hooks) {
     this.setProperties({
       obj: frozenBuild,
       builds: [],
-      displayRestartButton: true,
+      canRestartPipeline: true,
       jobs: [
         {
           id: 6,

--- a/tests/integration/components/workflow-graph-d3/component-test.js
+++ b/tests/integration/components/workflow-graph-d3/component-test.js
@@ -246,4 +246,182 @@ module('Integration | Component | workflow graph d3', function (hooks) {
       1
     );
   });
+
+  test('it renders stages when stages are supplied', async function (assert) {
+    const STAGE_INT_DESC =
+      'This stage will deploy the latest application to CI environment and certifies it after the tests are passed.';
+    const STAGE_PROD_DESC =
+      'This stage will deploy the CI certified application to production environment and certifies it after the tests are passed.';
+
+    this.set('workflowGraph', {
+      nodes: [
+        { name: '~pr' },
+        { name: '~commit' },
+        { name: 'component', id: 1 },
+        { name: 'publish', id: 2 },
+        { name: 'ci-deploy', id: 21, stageName: 'integration' },
+        { name: 'ci-test', id: 22, stageName: 'integration' },
+        { name: 'ci-certify', id: 23, stageName: 'integration' },
+        { name: 'prod-deploy', id: 31, stageName: 'production' },
+        { name: 'prod-test', id: 32, stageName: 'production' },
+        { name: 'prod-certify', id: 33, stageName: 'production' }
+      ],
+      edges: [
+        { src: '~pr', dest: 'component' },
+        { src: '~commit', dest: 'component' },
+        { src: 'component', dest: 'publish' },
+        { src: 'publish', dest: 'ci-deploy' },
+        { src: 'ci-deploy', dest: 'ci-test' },
+        { src: 'ci-test', dest: 'ci-certify' },
+        { src: 'ci-certify', dest: 'prod-deploy' },
+        { src: 'prod-deploy', dest: 'prod-test' },
+        { src: 'prod-test', dest: 'prod-certify' }
+      ]
+    });
+
+    this.set('stages', [
+      {
+        id: 7,
+        name: 'integration',
+        jobs: [{ id: 21 }, { id: 22 }, { id: 23 }],
+        description: STAGE_INT_DESC
+      },
+      {
+        id: 8,
+        name: 'production',
+        jobs: [{ id: 31 }, { id: 32 }, { id: 33 }],
+        description: STAGE_PROD_DESC
+      }
+    ]);
+
+    await render(
+      hbs`<WorkflowGraphD3 @workflowGraph={{this.workflowGraph}} @stages={{this.stages}}/>`
+    );
+
+    assert.equal(this.element.querySelectorAll('svg').length, 1);
+    assert.equal(
+      this.element.querySelectorAll('svg > g.graph-node').length,
+      10
+    );
+    assert.equal(
+      this.element.querySelectorAll('svg > path.graph-edge').length,
+      9
+    );
+
+    assert.equal(
+      this.element.querySelectorAll('svg > .stage-container').length,
+      2
+    );
+
+    assert.equal(
+      this.element.querySelectorAll(
+        'svg > .stage-info-wrapper .stage-info .stage-name'
+      ).length,
+      2
+    );
+    assert
+      .dom('svg > .stage-info-wrapper:nth-of-type(1) .stage-info .stage-name')
+      .hasText('integration');
+    assert
+      .dom('svg > .stage-info-wrapper:nth-of-type(2) .stage-info .stage-name')
+      .hasText('production');
+
+    assert.equal(
+      this.element.querySelectorAll(
+        'svg > .stage-info-wrapper .stage-info .stage-description'
+      ).length,
+      2
+    );
+    assert
+      .dom(
+        'svg > .stage-info-wrapper:nth-of-type(1) .stage-info .stage-description'
+      )
+      .hasText(STAGE_INT_DESC);
+    assert
+      .dom(
+        'svg > .stage-info-wrapper:nth-of-type(2) .stage-info .stage-description'
+      )
+      .hasText(STAGE_PROD_DESC);
+  });
+
+  test('it does not render stages for minified case', async function (assert) {
+    const STAGE_INT_DESC =
+      'This stage will deploy the latest application to CI environment and certifies it after the tests are passed.';
+    const STAGE_PROD_DESC =
+      'This stage will deploy the CI certified application to production environment and certifies it after the tests are passed.';
+
+    this.set('workflowGraph', {
+      nodes: [
+        { name: '~pr' },
+        { name: '~commit' },
+        { name: 'component', id: 1 },
+        { name: 'publish', id: 2 },
+        { name: 'ci-deploy', id: 21, stageName: 'integration' },
+        { name: 'ci-test', id: 22, stageName: 'integration' },
+        { name: 'ci-certify', id: 23, stageName: 'integration' },
+        { name: 'prod-deploy', id: 31, stageName: 'production' },
+        { name: 'prod-test', id: 32, stageName: 'production' },
+        { name: 'prod-certify', id: 33, stageName: 'production' }
+      ],
+      edges: [
+        { src: '~pr', dest: 'component' },
+        { src: '~commit', dest: 'component' },
+        { src: 'component', dest: 'publish' },
+        { src: 'publish', dest: 'ci-deploy' },
+        { src: 'ci-deploy', dest: 'ci-test' },
+        { src: 'ci-test', dest: 'ci-certify' },
+        { src: 'ci-certify', dest: 'prod-deploy' },
+        { src: 'prod-deploy', dest: 'prod-test' },
+        { src: 'prod-test', dest: 'prod-certify' }
+      ]
+    });
+
+    this.set('stages', [
+      {
+        id: 7,
+        name: 'integration',
+        jobs: [{ id: 21 }, { id: 22 }, { id: 23 }],
+        description: STAGE_INT_DESC
+      },
+      {
+        id: 8,
+        name: 'production',
+        jobs: [{ id: 31 }, { id: 32 }, { id: 33 }],
+        description: STAGE_PROD_DESC
+      }
+    ]);
+
+    await render(
+      hbs`<WorkflowGraphD3 @workflowGraph={{this.workflowGraph}} @stages={{this.stages}} @minified={{true}}/>`
+    );
+
+    assert.equal(this.element.querySelectorAll('svg').length, 1);
+    assert.equal(
+      this.element.querySelectorAll('svg > g.graph-node').length,
+      10
+    );
+    assert.equal(
+      this.element.querySelectorAll('svg > path.graph-edge').length,
+      9
+    );
+
+    assert.equal(
+      this.element.querySelectorAll('svg > .stage-container').length,
+      0
+    );
+
+    assert.equal(
+      this.element.querySelectorAll(
+        'svg > .stage-info-wrapper .stage-info .stage-name'
+      ).length,
+      0
+    );
+
+    assert.equal(
+      this.element.querySelectorAll(
+        'svg > .stage-info-wrapper .stage-info .stage-description'
+      ).length,
+      0
+    );
+  });
 });

--- a/tests/integration/components/workflow-tooltip/component-test.js
+++ b/tests/integration/components/workflow-tooltip/component-test.js
@@ -138,7 +138,7 @@ module('Integration | Component | workflow tooltip', function (hooks) {
 
     await render(hbs`<WorkflowTooltip
         @tooltipData={{this.data}}
-        @displayRestartButton={{true}}
+        @canRestartPipeline={{true}}
         @confirmStartBuild={{this.confirmStartBuild}}
       />`);
 
@@ -165,7 +165,7 @@ module('Integration | Component | workflow tooltip', function (hooks) {
 
     await render(hbs`<WorkflowTooltip
         @tooltipData={{this.data}}
-        @displayRestartButton={{true}}
+        @canRestartPipeline={{true}}
         @confirmStartBuild={{this.confirmStartBuild}}
         @isPrChainJob={{this.isPrChainJob}}
       />`);
@@ -193,7 +193,7 @@ module('Integration | Component | workflow tooltip', function (hooks) {
 
     await render(hbs`<WorkflowTooltip
         @tooltipData={{this.data}}
-        @displayRestartButton={{true}}
+        @canRestartPipeline={{true}}
         @confirmStartBuild={{this.confirmStartBuild}}
         @isPrChainJob={{this.isPrChainJob}}
       />`);
@@ -220,7 +220,7 @@ module('Integration | Component | workflow tooltip', function (hooks) {
 
     await render(hbs`<WorkflowTooltip
         @tooltipData={{this.data}}
-        @displayRestartButton={{true}}
+        @canRestartPipeline={{true}}
         @confirmStartBuild={{this.confirmStartBuild}}
         @isPrChainJob={{this.isPrChainJob}}
       />`);
@@ -248,7 +248,7 @@ module('Integration | Component | workflow tooltip', function (hooks) {
 
     await render(hbs`<WorkflowTooltip
         @tooltipData={{this.data}}
-        @displayRestartButton={{true}}
+        @canRestartPipeline={{true}}
         @confirmStartBuild={{this.confirmStartBuild}}
         @isPrChainJob={{this.isPrChainJob}}
       />`);
@@ -276,10 +276,65 @@ module('Integration | Component | workflow tooltip', function (hooks) {
 
     await render(hbs`<WorkflowTooltip
         @tooltipData={{this.data}}
-        @displayRestartButton={{true}}
+        @canRestartPipeline={{true}}
         @confirmStartBuild={{this.confirmStartBuild}}
         @isPrChain={{this.isPrChain}}
         @prBuildExists={{this.prBuildExists}}
+      />`);
+
+    assert.dom('.content a').exists({ count: 3 });
+    assert.dom('a:nth-of-type(1)').hasText('Go to build details');
+    assert.dom('a:nth-of-type(2)').hasText('Go to build metrics');
+    assert.dom('a:nth-of-type(3)').hasText('Disable this job');
+  });
+
+  test('it hides start link for stage jobs', async function (assert) {
+    const data = {
+      job: {
+        buildId: 1234,
+        name: 'batmobile',
+        isDisabled: false,
+        stageName: 'integration'
+      }
+    };
+
+    this.set('data', data);
+    this.set('confirmStartBuild', () => {});
+    this.set('isPrChainJob', false);
+
+    await render(hbs`<WorkflowTooltip
+        @tooltipData={{this.data}}
+        @canRestartPipeline={{true}}
+        @confirmStartBuild={{this.confirmStartBuild}}
+        @isPrChainJob={{this.isPrChainJob}}
+      />`);
+
+    assert.dom('.content a').exists({ count: 3 });
+    assert.dom('a:nth-of-type(1)').hasText('Go to build details');
+    assert.dom('a:nth-of-type(2)').hasText('Go to build metrics');
+    assert.dom('a:nth-of-type(3)').hasText('Disable this job');
+  });
+
+  test('it hides restart link for stage jobs', async function (assert) {
+    const data = {
+      job: {
+        buildId: 1234,
+        name: 'batmobile',
+        status: 'SUCCESS',
+        isDisabled: false,
+        stageName: 'integration'
+      }
+    };
+
+    this.set('data', data);
+    this.set('confirmStartBuild', () => {});
+    this.set('isPrChainJob', false);
+
+    await render(hbs`<WorkflowTooltip
+        @tooltipData={{this.data}}
+        @canRestartPipeline={{true}}
+        @confirmStartBuild={{this.confirmStartBuild}}
+        @isPrChainJob={{this.isPrChainJob}}
       />`);
 
     assert.dom('.content a').exists({ count: 3 });
@@ -333,7 +388,7 @@ module('Integration | Component | workflow tooltip', function (hooks) {
 
     await render(hbs`<WorkflowTooltip
         @tooltipData={{this.data}}
-        @displayRestartButton={{true}}
+        @canRestartPipeline={{true}}
         @confirmStartBuild={{this.confirmStartBuild}}
         @isPrChain={{this.isPrChain}}
         @prBuildExists={{this.prBuildExists}}
@@ -460,7 +515,7 @@ module('Integration | Component | workflow tooltip', function (hooks) {
 
     await render(hbs`<WorkflowTooltip
         @tooltipData={{this.data}}
-        @displayRestartButton={{true}}
+        @canRestartPipeline={{true}}
         @confirmStartBuild={{this.confirmStartBuild}}
         @isPrChainJob={{this.isPrChainJob}}
       />`);
@@ -492,7 +547,7 @@ module('Integration | Component | workflow tooltip', function (hooks) {
 
     await render(hbs`<WorkflowTooltip
         @tooltipData={{this.data}}
-        @displayRestartButton={{true}}
+        @canRestartPipeline={{true}}
         @confirmStartBuild={{this.confirmStartBuild}}
         @isPrChainJob={{this.isPrChainJob}}
         @enableHiddenDescription={{this.enableHiddenDescription}}


### PR DESCRIPTION
## Context

Stage represents a group of closely related jobs acting on a specific environment in the pipeline. We need to visualize these groupings in the workflow graph for an event.
Stage will have a name and description (optional).

## Objective

Render stages in the workflow graph

**Examples:**
https://github.com/sagar1312/screwdriver-config/blob/main/stage-with-linear-jobs/screwdriver.yaml
<img width="1238" alt="image" src="https://user-images.githubusercontent.com/2124590/210418328-db784ade-33c3-47a1-ad8c-897f8cf1dd8d.png">

https://github.com/sagar1312/screwdriver-config/blob/main/stage-with-parallel-jobs/screwdriver.yaml
<img width="1250" alt="image" src="https://user-images.githubusercontent.com/2124590/210418376-9f1b5e0d-9139-4d5f-aace-51e8787707ca.png">

https://github.com/sagar1312/screwdriver-config/blob/main/stage-with-linear-jobs-not-in-first-row/screwdriver.yaml
<img width="1235" alt="image" src="https://user-images.githubusercontent.com/2124590/210418635-33093659-dab1-4384-9749-0c05af3a25b4.png">

## References

https://github.com/screwdriver-cd/screwdriver/issues/2669

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
