### PR TITLE
fix: update pipelines from different tabs

### DIFF
--- a/app/components/collection-view/component.js
+++ b/app/components/collection-view/component.js
@@ -173,7 +173,7 @@ export default Component.extend({
     }
   }),
 
-  collectionPipelines: computed('collection.pipelines', {
+  collectionPipelines: computed('collection.pipelines.[]', {
     get() {
       let viewingId = this.get('collection.id');
 
@@ -219,7 +219,7 @@ export default Component.extend({
       const pipelineLabel = pipelineName ? ` ${pipelineName}` : '';
       const message = `The pipeline${pipelineLabel} has been removed from the ${collectionName} collection.`;
 
-      return this.onRemovePipeline(+pipelineId)
+      return this.onRemovePipeline(+pipelineId, collectionId)
         .then(() => {
           this.store.findRecord('collection', collectionId).then(collection => {
             this.setProperties({

--- a/app/components/collection-view/component.js
+++ b/app/components/collection-view/component.js
@@ -224,6 +224,7 @@ export default Component.extend({
           this.store.findRecord('collection', collectionId).then(collection => {
             this.setProperties({
               removePipelineError: null,
+              reset: true,
               collection,
               pipelineRemovedMessage: message
             });

--- a/app/dashboard/show/controller.js
+++ b/app/dashboard/show/controller.js
@@ -1,51 +1,25 @@
 import { alias } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
-import { getWithDefault, set } from '@ember/object';
 import Controller from '@ember/controller';
 
 export default Controller.extend({
   collection: alias('model.collection'),
   shuttle: service(),
   actions: {
-    async removePipeline(pipelineId) {
-      const collectionId = this.get('collection.id');
-      try {
-        await this.shuttle.removePipeline(collectionId, pipelineId);
-        const collection = await this.store.findRecord('collection', collectionId);
-
-        return collection;
-      }
-      catch (e) {
-
-       return e;
-      }
+    removePipeline(pipelineId, collectionId) {
+      return this.shuttle.removePipeline(collectionId, pipelineId);
     },
-    async removeMultiplePipelines(removedPipelineIds) {
-      const collectionId = this.get('collection.id');
-
-      try {
-        await this.shuttle.removeMultiplePipelines(collectionId, removedPipelineIds);
-        const collection = await this.store.findRecord('collection', collectionId);
-
-        return collection;
-      }
-      catch (e) {
-        return e;
-      }
+    removeMultiplePipelines(removedPipelineIds, collectionId) {
+      return this.shuttle.removeMultiplePipelines(
+        collectionId,
+        removedPipelineIds
+      );
     },
     onDeleteCollection() {
       this.transitionToRoute('home');
     },
-    async addMultipleToCollection(addedPipelineIds, collectionId) {
-      try {
-        await this.shuttle.updateCollection(collectionId, addedPipelineIds);
-        const collection = await this.store.findRecord('collection', collectionId);
-
-        return collection;
-      }
-      catch (e) {
-        return e;
-      }
+    addMultipleToCollection(addedPipelineIds, collectionId) {
+      return this.shuttle.updateCollection(collectionId, addedPipelineIds);
     }
   }
 });

--- a/app/dashboard/show/controller.js
+++ b/app/dashboard/show/controller.js
@@ -13,10 +13,11 @@ export default Controller.extend({
         await this.shuttle.removePipeline(collectionId, pipelineId);
         const collection = await this.store.findRecord('collection', collectionId);
 
-        return collection.save();
+        return collection;
       }
       catch (e) {
-        return e;
+
+       return e;
       }
     },
     async removeMultiplePipelines(removedPipelineIds) {
@@ -26,7 +27,7 @@ export default Controller.extend({
         await this.shuttle.removeMultiplePipelines(collectionId, removedPipelineIds);
         const collection = await this.store.findRecord('collection', collectionId);
 
-        return collection.save();
+        return collection;
       }
       catch (e) {
         return e;
@@ -40,7 +41,7 @@ export default Controller.extend({
         await this.shuttle.updateCollection(collectionId, addedPipelineIds);
         const collection = await this.store.findRecord('collection', collectionId);
 
-        return collection.save();
+        return collection;
       }
       catch (e) {
         return e;

--- a/app/dashboard/show/controller.js
+++ b/app/dashboard/show/controller.js
@@ -7,50 +7,44 @@ export default Controller.extend({
   collection: alias('model.collection'),
   shuttle: service(),
   actions: {
-    removePipeline(pipelineId) {
+    async removePipeline(pipelineId) {
       const collectionId = this.get('collection.id');
+      try {
+        await this.shuttle.removePipeline(collectionId, pipelineId);
+        const collection = await this.store.findRecord('collection', collectionId);
 
-      return this.store
-        .findRecord('collection', collectionId)
-        .then(collection => {
-          const pipelineIds = getWithDefault(collection, 'pipelineIds', []);
-
-          set(
-            collection,
-            'pipelineIds',
-            pipelineIds.filter(id => id !== pipelineId)
-          );
-
-          this.shuttle.removePipeline(collectionId, pipelineId);
-        });
+        return collection.save();
+      }
+      catch (e) {
+        return e;
+      }
     },
-    removeMultiplePipelines(removedPipelineIds) {
+    async removeMultiplePipelines(removedPipelineIds) {
       const collectionId = this.get('collection.id');
 
-      return this.store
-        .findRecord('collection', collectionId)
-        .then(collection => {
-          const pipelineIds = getWithDefault(collection, 'pipelineIds', []);
+      try {
+        await this.shuttle.removeMultiplePipelines(collectionId, removedPipelineIds);
+        const collection = await this.store.findRecord('collection', collectionId);
 
-          set(
-            collection,
-            'pipelineIds',
-            pipelineIds.filter(id => !removedPipelineIds.includes(id))
-          );
-
-          this.shuttle.removeMultiplePipelines(collectionId, removedPipelineIds);
-        });
+        return collection.save();
+      }
+      catch (e) {
+        return e;
+      }
     },
     onDeleteCollection() {
       this.transitionToRoute('home');
     },
-    addMultipleToCollection(addedPipelineIds, collectionId) {
-      return this.store
-        .findRecord('collection', collectionId)
-        .then(collection => {
+    async addMultipleToCollection(addedPipelineIds, collectionId) {
+      try {
+        await this.shuttle.updateCollection(collectionId, addedPipelineIds);
+        const collection = await this.store.findRecord('collection', collectionId);
 
-          this.shuttle.updateCollection(collectionId, addedPipelineIds);
-        });
+        return collection.save();
+      }
+      catch (e) {
+        return e;
+      }
     }
   }
 });

--- a/app/dashboard/show/controller.js
+++ b/app/dashboard/show/controller.js
@@ -21,7 +21,7 @@ export default Controller.extend({
             pipelineIds.filter(id => id !== pipelineId)
           );
 
-          return collection.save();
+          this.shuttle.removePipelines(collectionId, pipelineId);
         });
     },
     removeMultiplePipelines(removedPipelineIds) {
@@ -38,7 +38,7 @@ export default Controller.extend({
             pipelineIds.filter(id => !removedPipelineIds.includes(id))
           );
 
-          return collection.save();
+          this.shuttle.removePipelines(collectionId, removedPipelineIds);
         });
     },
     onDeleteCollection() {
@@ -48,7 +48,6 @@ export default Controller.extend({
       return this.store
         .findRecord('collection', collectionId)
         .then(collection => {
-          const pipelineIds = collection.get('pipelineIds');
 
           this.shuttle.updateCollection(collectionId, addedPipelineIds);
         });

--- a/app/dashboard/show/controller.js
+++ b/app/dashboard/show/controller.js
@@ -21,7 +21,7 @@ export default Controller.extend({
             pipelineIds.filter(id => id !== pipelineId)
           );
 
-          this.shuttle.removePipelines(collectionId, pipelineId);
+          this.shuttle.removePipeline(collectionId, pipelineId);
         });
     },
     removeMultiplePipelines(removedPipelineIds) {
@@ -38,7 +38,7 @@ export default Controller.extend({
             pipelineIds.filter(id => !removedPipelineIds.includes(id))
           );
 
-          this.shuttle.removePipelines(collectionId, removedPipelineIds);
+          this.shuttle.removeMultiplePipelines(collectionId, removedPipelineIds);
         });
     },
     onDeleteCollection() {

--- a/app/dashboard/show/controller.js
+++ b/app/dashboard/show/controller.js
@@ -1,9 +1,11 @@
 import { alias } from '@ember/object/computed';
+import { inject as service } from '@ember/service';
 import { getWithDefault, set } from '@ember/object';
 import Controller from '@ember/controller';
 
 export default Controller.extend({
   collection: alias('model.collection'),
+  shuttle: service(),
   actions: {
     removePipeline(pipelineId) {
       const collectionId = this.get('collection.id');
@@ -48,11 +50,7 @@ export default Controller.extend({
         .then(collection => {
           const pipelineIds = collection.get('pipelineIds');
 
-          collection.set('pipelineIds', [
-            ...new Set([...pipelineIds, ...addedPipelineIds])
-          ]);
-
-          return collection.save();
+          this.shuttle.updateCollection(collectionId, addedPipelineIds);
         });
     }
   }

--- a/app/shuttle/service.js
+++ b/app/shuttle/service.js
@@ -349,5 +349,13 @@ export default Service.extend({
     const url = `/pipelines?${query}`;
 
     return this.fetchFromApi(method, url);
+  },
+
+  async updateCollection(collectionId, pipelineIds) {
+    const method = 'put';
+    const query = decodeURIComponent($.param({ ids: pipelineIds}));
+    const url = `/collections/${collectionId}/pipelines?${query}`;
+
+    return this.fetchFromApi(method, url);
   }
 });

--- a/app/shuttle/service.js
+++ b/app/shuttle/service.js
@@ -353,7 +353,7 @@ export default Service.extend({
 
   async updateCollection(collectionId, pipelineIds) {
     const method = 'put';
-    const query = $.param({ ids: pipelineIds });
+    const query = decodeURIComponent($.param({ ids: pipelineIds }));
     const url = `/collections/${collectionId}/pipelines?${query}`;
 
     return this.fetchFromApi(method, url);
@@ -368,7 +368,7 @@ export default Service.extend({
 
   async removeMultiplePipelines(collectionId, pipelineIds) {
     const method = 'delete';
-    const query = $.param({ ids: pipelineIds });
+    const query = decodeURIComponent($.param({ ids: pipelineIds }));
     const url = `/collections/${collectionId}/pipelines?${query}`;
 
     return this.fetchFromApi(method, url);

--- a/app/shuttle/service.js
+++ b/app/shuttle/service.js
@@ -353,15 +353,22 @@ export default Service.extend({
 
   async updateCollection(collectionId, pipelineIds) {
     const method = 'put';
-    const query = decodeURIComponent($.param({ ids: pipelineIds}));
+    const query = decodeURIComponent($.param({ ids: pipelineIds }));
     const url = `/collections/${collectionId}/pipelines?${query}`;
 
     return this.fetchFromApi(method, url);
   },
 
-  async removePipelines(collectionId, pipelineIds) {
+  async removePipeline(collectionId, pipelineId) {
     const method = 'delete';
-    const query = decodeURIComponent($.param({ ids: pipelineIds}));
+    const url = `/collections/${collectionId}/pipelines?ids[]=${pipelineId}`;
+
+    return this.fetchFromApi(method, url);
+  },
+
+  async removeMultiplePipelines(collectionId, pipelineIds) {
+    const method = 'delete';
+    const query = decodeURIComponent($.param({ ids: pipelineIds }));
     const url = `/collections/${collectionId}/pipelines?${query}`;
 
     return this.fetchFromApi(method, url);

--- a/app/shuttle/service.js
+++ b/app/shuttle/service.js
@@ -353,7 +353,7 @@ export default Service.extend({
 
   async updateCollection(collectionId, pipelineIds) {
     const method = 'put';
-    const query = decodeURIComponent($.param({ ids: pipelineIds }));
+    const query = $.param({ ids: pipelineIds });
     const url = `/collections/${collectionId}/pipelines?${query}`;
 
     return this.fetchFromApi(method, url);
@@ -368,7 +368,7 @@ export default Service.extend({
 
   async removeMultiplePipelines(collectionId, pipelineIds) {
     const method = 'delete';
-    const query = decodeURIComponent($.param({ ids: pipelineIds }));
+    const query = $.param({ ids: pipelineIds });
     const url = `/collections/${collectionId}/pipelines?${query}`;
 
     return this.fetchFromApi(method, url);

--- a/app/shuttle/service.js
+++ b/app/shuttle/service.js
@@ -357,5 +357,13 @@ export default Service.extend({
     const url = `/collections/${collectionId}/pipelines?${query}`;
 
     return this.fetchFromApi(method, url);
+  },
+
+  async removePipelines(collectionId, pipelineIds) {
+    const method = 'delete';
+    const query = decodeURIComponent($.param({ ids: pipelineIds}));
+    const url = `/collections/${collectionId}/pipelines?${query}`;
+
+    return this.fetchFromApi(method, url);
   }
 });

--- a/app/shuttle/service.js
+++ b/app/shuttle/service.js
@@ -353,8 +353,12 @@ export default Service.extend({
 
   async updateCollection(collectionId, pipelineIds) {
     const method = 'put';
-    const query = decodeURIComponent($.param({ ids: pipelineIds }));
-    const url = `/collections/${collectionId}/pipelines?${query}`;
+    const pipelineIdsEntries = pipelineIds.map(pipelineId => [
+      'ids[]',
+      pipelineId
+    ]);
+    const pipelineIdsQuery = new URLSearchParams(pipelineIdsEntries);
+    const url = `/collections/${collectionId}/pipelines?${pipelineIdsQuery}`;
 
     return this.fetchFromApi(method, url);
   },
@@ -368,8 +372,13 @@ export default Service.extend({
 
   async removeMultiplePipelines(collectionId, pipelineIds) {
     const method = 'delete';
-    const query = decodeURIComponent($.param({ ids: pipelineIds }));
-    const url = `/collections/${collectionId}/pipelines?${query}`;
+    const pipelineIdsEntries = pipelineIds.map(pipelineId => [
+      'ids[]',
+      pipelineId
+    ]);
+    const pipelineIdsQuery = new URLSearchParams(pipelineIdsEntries);
+
+    const url = `/collections/${collectionId}/pipelines?${pipelineIdsQuery}`;
 
     return this.fetchFromApi(method, url);
   }

--- a/tests/unit/dashboard/show/controller-test.js
+++ b/tests/unit/dashboard/show/controller-test.js
@@ -4,6 +4,7 @@ import { setupTest } from 'ember-qunit';
 import EmberObject, { get } from '@ember/object';
 import sinonTest from 'ember-sinon-qunit/test-support/test';
 import sinon from 'sinon';
+import Service from '@ember/service';
 import { settled } from '@ember/test-helpers';
 import injectSessionStub from '../../../helpers/inject-session';
 
@@ -21,6 +22,19 @@ module('Unit | Controller | dashboard/show', function (hooks) {
   test('it calls removePipeline', async function (assert) {
     injectSessionStub(this);
     const controller = this.owner.lookup('controller:dashboard/show');
+
+    const shuttleStub = Service.extend({
+      removePipeline(collectionId, pipelineId) {
+        assert.ok(true, 'relovePipeline called');
+        assert.equal(pipelineId, 3);
+        assert.equal(collectionId, 1);
+
+        return resolve({});
+      }
+    });
+
+    this.owner.unregister('service:shuttle');
+    this.owner.register('service:shuttle', shuttleStub);
 
     let pipelineIds = [1, 2, 3];
 

--- a/tests/unit/dashboard/show/controller-test.js
+++ b/tests/unit/dashboard/show/controller-test.js
@@ -3,6 +3,8 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import EmberObject, { get } from '@ember/object';
 import sinonTest from 'ember-sinon-qunit/test-support/test';
+import sinon from 'sinon';
+import { settled } from '@ember/test-helpers';
 import injectSessionStub from '../../../helpers/inject-session';
 
 module('Unit | Controller | dashboard/show', function (hooks) {
@@ -16,7 +18,7 @@ module('Unit | Controller | dashboard/show', function (hooks) {
     assert.ok(controller);
   });
 
-  test('it calls removePipeline', function (assert) {
+  test('it calls removePipeline', async function (assert) {
     injectSessionStub(this);
     const controller = this.owner.lookup('controller:dashboard/show');
 
@@ -49,8 +51,20 @@ module('Unit | Controller | dashboard/show', function (hooks) {
       }
     });
 
+    const removePipelineActionStub = sinon.spy(
+      controller.actions,
+      'removePipeline'
+    );
+
+    await settled();
+
     // Remove pipeline with id 3 from collection with id 1
-    controller.send('removePipeline', 3);
+    controller.send('removePipeline', 3, 1);
+
+    assert.ok(
+      removePipelineActionStub.calledOnce,
+      'action removePipeline called once'
+    );
   });
 
   sinonTest('it calls onDeleteCollection', function (assert) {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Fix: adding pipelines to collections from different browser tabs is overwriting collection data.

https://user-images.githubusercontent.com/15989893/213005924-c9bdac9d-b905-4d55-b2d3-df849e1b6615.mp4


## Objective
<!-- What does this PR fix? What intentional changes will this PR make? -->

Using new API call, instead of UI asks the backend to store what the pipeline to a given collection, UI will just pass the necessary pipeline ids to either delete or add, to avoid override the data in the backend. 


## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
Collection https://github.com/screwdriver-cd/screwdriver/issues/2765

Backend PR: https://github.com/screwdriver-cd/screwdriver/pull/2797

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
