### PR TITLE
fix(2765): update pipelines from different tabs

### DIFF
--- a/app/components/collection-view/component.js
+++ b/app/components/collection-view/component.js
@@ -173,7 +173,7 @@ export default Component.extend({
     }
   }),
 
-  collectionPipelines: computed('collection.pipelines', {
+  collectionPipelines: computed('collection.pipelines.[]', {
     get() {
       let viewingId = this.get('collection.id');
 
@@ -219,7 +219,7 @@ export default Component.extend({
       const pipelineLabel = pipelineName ? ` ${pipelineName}` : '';
       const message = `The pipeline${pipelineLabel} has been removed from the ${collectionName} collection.`;
 
-      return this.onRemovePipeline(+pipelineId)
+      return this.onRemovePipeline(+pipelineId, collectionId)
         .then(() => {
           this.store.findRecord('collection', collectionId).then(collection => {
             this.setProperties({

--- a/app/dashboard/show/controller.js
+++ b/app/dashboard/show/controller.js
@@ -1,51 +1,25 @@
 import { alias } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
-import { getWithDefault, set } from '@ember/object';
 import Controller from '@ember/controller';
 
 export default Controller.extend({
   collection: alias('model.collection'),
   shuttle: service(),
   actions: {
-    async removePipeline(pipelineId) {
-      const collectionId = this.get('collection.id');
-      try {
-        await this.shuttle.removePipeline(collectionId, pipelineId);
-        const collection = await this.store.findRecord('collection', collectionId);
-
-        return collection;
-      }
-      catch (e) {
-
-       return e;
-      }
+    removePipeline(pipelineId, collectionId) {
+      return this.shuttle.removePipeline(collectionId, pipelineId);
     },
-    async removeMultiplePipelines(removedPipelineIds) {
-      const collectionId = this.get('collection.id');
-
-      try {
-        await this.shuttle.removeMultiplePipelines(collectionId, removedPipelineIds);
-        const collection = await this.store.findRecord('collection', collectionId);
-
-        return collection;
-      }
-      catch (e) {
-        return e;
-      }
+    removeMultiplePipelines(removedPipelineIds, collectionId) {
+      return this.shuttle.removeMultiplePipelines(
+        collectionId,
+        removedPipelineIds
+      );
     },
     onDeleteCollection() {
       this.transitionToRoute('home');
     },
-    async addMultipleToCollection(addedPipelineIds, collectionId) {
-      try {
-        await this.shuttle.updateCollection(collectionId, addedPipelineIds);
-        const collection = await this.store.findRecord('collection', collectionId);
-
-        return collection;
-      }
-      catch (e) {
-        return e;
-      }
+    addMultipleToCollection(addedPipelineIds, collectionId) {
+      return this.shuttle.updateCollection(collectionId, addedPipelineIds);
     }
   }
 });

--- a/app/shuttle/service.js
+++ b/app/shuttle/service.js
@@ -353,8 +353,12 @@ export default Service.extend({
 
   async updateCollection(collectionId, pipelineIds) {
     const method = 'put';
-    const query = decodeURIComponent($.param({ ids: pipelineIds }));
-    const url = `/collections/${collectionId}/pipelines?${query}`;
+    const pipelineIdsEntries = pipelineIds.map(pipelineId => [
+      'ids[]',
+      pipelineId
+    ]);
+    const pipelineIdsQuery = new URLSearchParams(pipelineIdsEntries);
+    const url = `/collections/${collectionId}/pipelines?${pipelineIdsQuery}`;
 
     return this.fetchFromApi(method, url);
   },
@@ -368,8 +372,13 @@ export default Service.extend({
 
   async removeMultiplePipelines(collectionId, pipelineIds) {
     const method = 'delete';
-    const query = decodeURIComponent($.param({ ids: pipelineIds }));
-    const url = `/collections/${collectionId}/pipelines?${query}`;
+    const pipelineIdsEntries = pipelineIds.map(pipelineId => [
+      'ids[]',
+      pipelineId
+    ]);
+    const pipelineIdsQuery = new URLSearchParams(pipelineIdsEntries);
+
+    const url = `/collections/${collectionId}/pipelines?${pipelineIdsQuery}`;
 
     return this.fetchFromApi(method, url);
   }


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Fix: adding pipelines to collections from different browser tabs is overwriting collection data.

https://user-images.githubusercontent.com/15989893/213005924-c9bdac9d-b905-4d55-b2d3-df849e1b6615.mp4


## Objective
<!-- What does this PR fix? What intentional changes will this PR make? -->

1. use `URLSearchParams` instead of jquery $.param
2. code clean up, that pass in collectionId instead of lookup
3. use [] notation on computed property as dependencies
4. remove unnecessary `findRecord` inside collection-view/component.js to avoid extra fetch


## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
Collection https://github.com/screwdriver-cd/screwdriver/issues/2765

Backend PR: https://github.com/screwdriver-cd/screwdriver/pull/2797

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
