### PR TITLE
feat(2805): make label clickable if contains links

### DIFF
--- a/app/components/pipeline-graph-nav/template.hbs
+++ b/app/components/pipeline-graph-nav/template.hbs
@@ -87,7 +87,7 @@
         {{#if selectedEventObj.label}}
           <div class="col">
             <span class="title">Label</span><br>
-            <span class="customize-label" title={{selectedEventObj.label}}>{{linkify selectedEventObj.label urlLength=30}}</span>
+            <span class="customize-label" title={{selectedEventObj.label}}>{{linkify selectedEventObj.label target="_blank" rel="nofollow" urlLength=30}}</span>
           </div>
         {{/if}}
       </div>

--- a/app/components/pipeline-graph-nav/template.hbs
+++ b/app/components/pipeline-graph-nav/template.hbs
@@ -87,7 +87,7 @@
         {{#if selectedEventObj.label}}
           <div class="col">
             <span class="title">Label</span><br>
-            <span class="customize-label" title={{selectedEventObj.label}}>{{selectedEventObj.label}}</span>
+            <span class="customize-label" title={{selectedEventObj.label}}>{{linkify selectedEventObj.label urlLength=30}}</span>
           </div>
         {{/if}}
       </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -27570,6 +27570,57 @@
         "ember-cli-babel": "^7.2.0"
       }
     },
+    "ember-linkify": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/ember-linkify/-/ember-linkify-4.1.2.tgz",
+      "integrity": "sha512-T18llhORCfhXWRqeUHDrtM76H8scyLFL4q4h5s+MKSE4ryFQb9fevBgAN8pzOaxpUUEtgIcY6atOUjwpDTXVMg==",
+      "dev": true,
+      "requires": {
+        "ember-cli-babel": "^6.6.0"
+      },
+      "dependencies": {
+        "amd-name-resolver": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/amd-name-resolver/-/amd-name-resolver-1.2.0.tgz",
+          "integrity": "sha512-hlSTWGS1t6/xq5YCed7YALg7tKZL3rkl7UwEZ/eCIkn8JxmM6fU6Qs/1hwtjQqfuYxlffuUcgYEm0f5xP4YKaA==",
+          "dev": true,
+          "requires": {
+            "ensure-posix-path": "^1.0.1"
+          }
+        },
+        "ember-cli-babel": {
+          "version": "6.18.0",
+          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz",
+          "integrity": "sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==",
+          "dev": true,
+          "requires": {
+            "amd-name-resolver": "1.2.0",
+            "babel-plugin-debug-macros": "^0.2.0-beta.6",
+            "babel-plugin-ember-modules-api-polyfill": "^2.6.0",
+            "babel-plugin-transform-es2015-modules-amd": "^6.24.0",
+            "babel-polyfill": "^6.26.0",
+            "babel-preset-env": "^1.7.0",
+            "broccoli-babel-transpiler": "^6.5.0",
+            "broccoli-debug": "^0.6.4",
+            "broccoli-funnel": "^2.0.0",
+            "broccoli-source": "^1.1.0",
+            "clone": "^2.0.0",
+            "ember-cli-version-checker": "^2.1.2",
+            "semver": "^5.5.0"
+          }
+        },
+        "ember-cli-version-checker": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
+          "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
+          "dev": true,
+          "requires": {
+            "resolve": "^1.3.3",
+            "semver": "^5.3.0"
+          }
+        }
+      }
+    },
     "ember-load-initializers": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ember-load-initializers/-/ember-load-initializers-2.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "ember-light-table": "^2.0.0-beta.5",
     "ember-line-clamp": "^1.0.1",
     "ember-link-action": "^0.1.3",
+    "ember-linkify": "^4.1.2",
     "ember-load-initializers": "^2.1.2",
     "ember-local-storage": "^1.7.2",
     "ember-maybe-import-regenerator": "^0.1.6",

--- a/tests/integration/components/pipeline-graph-nav/component-test.js
+++ b/tests/integration/components/pipeline-graph-nav/component-test.js
@@ -492,4 +492,117 @@ module('Integration | Component | pipeline graph nav', function (hooks) {
 
     assert.dom('.latest-commit').exists({ count: 1 });
   });
+
+  test('label does not contain any URLs', async function (assert) {
+    set(this, 'obj', {
+      sha: 'abc123',
+      baseBranch: 'main',
+      truncatedSha: 'abc123',
+      status: 'SUCCESS',
+      commit: {
+        author: { name: 'anonymous' }
+      },
+      createTime: '04/11/2016, 08:09 PM',
+      createTimeExact: '04/11/2016, 08:09 PM',
+      truncatedMessage: 'test message',
+      durationText: '10 seconds',
+      label:
+        'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua'
+    });
+    set(this, 'selected', 2);
+    set(this, 'latestCommit', {
+      sha: 'latestSha'
+    });
+    set(this, 'startBuild', () => {
+      assert.ok(true);
+    });
+    set(this, 'currentEventType', 'pipeline');
+    set(this, 'showDownstreamTriggers', false);
+    set(this, 'setDownstreamTrigger', () => {
+      assert.ok(true);
+    });
+    set(this, 'setShowListView', () => {
+      assert.ok(true);
+    });
+
+    await render(hbs`{{pipeline-graph-nav
+      mostRecent=3
+      latestCommit=latestCommit
+      lastSuccessful=2
+      selectedEvent=2
+      selectedEventObj=obj
+      selected=selected
+      startMainBuild=startBuild
+      startPRBuild=startBuild
+      graphType=currentEventType
+      showDownstreamTriggers=showDownstreamTriggers
+      setDownstreamTrigger=setDownstreamTrigger
+      setShowListView=setShowListView
+    }}`);
+
+    assert
+      .dom('.col .customize-label')
+      .hasText(
+        'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua'
+      );
+  });
+
+  test('label contain URLs', async function (assert) {
+    set(this, 'obj', {
+      sha: 'abc123',
+      baseBranch: 'main',
+      truncatedSha: 'abc123',
+      status: 'SUCCESS',
+      commit: {
+        author: { name: 'anonymous' }
+      },
+      createTime: '04/11/2016, 08:09 PM',
+      createTimeExact: '04/11/2016, 08:09 PM',
+      truncatedMessage: 'test message',
+      durationText: '10 seconds',
+      label:
+        'Lorem ipsum dolor sit amet, https://abc.com consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua'
+    });
+    set(this, 'selected', 2);
+    set(this, 'latestCommit', {
+      sha: 'latestSha'
+    });
+    set(this, 'startBuild', () => {
+      assert.ok(true);
+    });
+    set(this, 'currentEventType', 'pipeline');
+    set(this, 'showDownstreamTriggers', false);
+    set(this, 'setDownstreamTrigger', () => {
+      assert.ok(true);
+    });
+    set(this, 'setShowListView', () => {
+      assert.ok(true);
+    });
+
+    await render(hbs`{{pipeline-graph-nav
+      mostRecent=3
+      latestCommit=latestCommit
+      lastSuccessful=2
+      selectedEvent=2
+      selectedEventObj=obj
+      selected=selected
+      startMainBuild=startBuild
+      startPRBuild=startBuild
+      graphType=currentEventType
+      showDownstreamTriggers=showDownstreamTriggers
+      setDownstreamTrigger=setDownstreamTrigger
+      setShowListView=setShowListView
+    }}`);
+    const compare = (elem, expected) => {
+      const actual = elem.innerHTML.trim();
+
+      assert.strictEqual(actual, expected);
+    };
+    const labelColumn = this.element.querySelector('.col .customize-label');
+
+    compare(
+      labelColumn,
+      'Lorem ipsum dolor sit amet, <a href="https://abc.com">https://abc.com</a> consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua'
+    );
+  });
 });

--- a/tests/integration/components/pipeline-graph-nav/component-test.js
+++ b/tests/integration/components/pipeline-graph-nav/component-test.js
@@ -494,35 +494,36 @@ module('Integration | Component | pipeline graph nav', function (hooks) {
   });
 
   test('label does not contain any URLs', async function (assert) {
-    set(this, 'obj', {
-      sha: 'abc123',
-      baseBranch: 'main',
-      truncatedSha: 'abc123',
-      status: 'SUCCESS',
-      commit: {
-        author: { name: 'anonymous' }
+    this.setProperties({
+      obj: {
+        sha: 'abc123',
+        baseBranch: 'main',
+        truncatedSha: 'abc123',
+        status: 'SUCCESS',
+        commit: {
+          author: { name: 'anonymous' }
+        },
+        createTime: '04/11/2016, 08:09 PM',
+        createTimeExact: '04/11/2016, 08:09 PM',
+        truncatedMessage: 'test message',
+        durationText: '10 seconds',
+        label: 'Yahoo new project, and Version #2.0'
       },
-      createTime: '04/11/2016, 08:09 PM',
-      createTimeExact: '04/11/2016, 08:09 PM',
-      truncatedMessage: 'test message',
-      durationText: '10 seconds',
-      label:
-        'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua'
-    });
-    set(this, 'selected', 2);
-    set(this, 'latestCommit', {
-      sha: 'latestSha'
-    });
-    set(this, 'startBuild', () => {
-      assert.ok(true);
-    });
-    set(this, 'currentEventType', 'pipeline');
-    set(this, 'showDownstreamTriggers', false);
-    set(this, 'setDownstreamTrigger', () => {
-      assert.ok(true);
-    });
-    set(this, 'setShowListView', () => {
-      assert.ok(true);
+      selected: 2,
+      latestCommit: {
+        sha: 'latestSha'
+      },
+      startBuild: () => {
+        assert.ok(true);
+      },
+      currentEventType: 'pipeline',
+      showDownstreamTriggers: false,
+      setDownstreamTrigger: () => {
+        assert.ok(true);
+      },
+      setShowListView: () => {
+        assert.ok(true);
+      }
     });
 
     await render(hbs`{{pipeline-graph-nav
@@ -542,41 +543,40 @@ module('Integration | Component | pipeline graph nav', function (hooks) {
 
     assert
       .dom('.col .customize-label')
-      .hasText(
-        'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua'
-      );
+      .hasText('Yahoo new project, and Version #2.0');
   });
 
   test('label contain URLs', async function (assert) {
-    set(this, 'obj', {
-      sha: 'abc123',
-      baseBranch: 'main',
-      truncatedSha: 'abc123',
-      status: 'SUCCESS',
-      commit: {
-        author: { name: 'anonymous' }
+    this.setProperties({
+      obj: {
+        sha: 'abc123',
+        baseBranch: 'main',
+        truncatedSha: 'abc123',
+        status: 'SUCCESS',
+        commit: {
+          author: { name: 'anonymous' }
+        },
+        createTime: '04/11/2016, 08:09 PM',
+        createTimeExact: '04/11/2016, 08:09 PM',
+        truncatedMessage: 'test message',
+        durationText: '10 seconds',
+        label: 'Yahoo http://yahoo.com, and Version #2.0'
       },
-      createTime: '04/11/2016, 08:09 PM',
-      createTimeExact: '04/11/2016, 08:09 PM',
-      truncatedMessage: 'test message',
-      durationText: '10 seconds',
-      label:
-        'Lorem ipsum dolor sit amet, https://abc.com consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua'
-    });
-    set(this, 'selected', 2);
-    set(this, 'latestCommit', {
-      sha: 'latestSha'
-    });
-    set(this, 'startBuild', () => {
-      assert.ok(true);
-    });
-    set(this, 'currentEventType', 'pipeline');
-    set(this, 'showDownstreamTriggers', false);
-    set(this, 'setDownstreamTrigger', () => {
-      assert.ok(true);
-    });
-    set(this, 'setShowListView', () => {
-      assert.ok(true);
+      selected: 2,
+      latestCommit: {
+        sha: 'latestSha'
+      },
+      startBuild: () => {
+        assert.ok(true);
+      },
+      currentEventType: 'pipeline',
+      showDownstreamTriggers: false,
+      setDownstreamTrigger: () => {
+        assert.ok(true);
+      },
+      setShowListView: () => {
+        assert.ok(true);
+      }
     });
 
     await render(hbs`{{pipeline-graph-nav
@@ -594,15 +594,15 @@ module('Integration | Component | pipeline graph nav', function (hooks) {
       setShowListView=setShowListView
     }}`);
     const compare = (elem, expected) => {
-      const actual = elem.innerHTML.trim();
-
-      assert.strictEqual(actual, expected);
+      assert.strictEqual(elem, expected);
     };
-    const labelColumn = this.element.querySelector('.col .customize-label');
+    const labelColumn = this.element
+      .querySelector('.col .customize-label')
+      .innerHTML.trim();
 
     compare(
       labelColumn,
-      'Lorem ipsum dolor sit amet, <a href="https://abc.com">https://abc.com</a> consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua'
+      'Yahoo <a href="http://yahoo.com" rel="nofollow" target="_blank">http://yahoo.com</a>, and Version #2.0'
     );
   });
 });


### PR DESCRIPTION
## Context
To set hyperlink to 'label' like 'commit' field.

## Objective
Make [label](https://docs.screwdriver.cd/user-guide/metadata#event-labels) more usable, so that users can put links inside `label` content, and instead of showing as text, it shows as hyperlinks

<img width="1179" alt="Screen Shot 2022-12-22 at 12 24 07 PM" src="https://user-images.githubusercontent.com/104225232/209379431-696f79c4-79a9-4a6f-8adf-8661bdcd2d26.png">

## References

https://github.com/screwdriver-cd/screwdriver/issues/2805

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
