### PR TITLE
feat: Add template details page

### DIFF
--- a/app/build/model.js
+++ b/app/build/model.js
@@ -66,6 +66,7 @@ export default DS.Model.extend({
   stats: DS.attr(),
   statusMessage: DS.attr('string', { defaultValue: null }),
   steps: DS.attr(),
+  templateId: DS.attr('number'),
   startTimeWords: computed('startTime', {
     get() {
       return `${durationText.call(this, 'startTime', 'now')} ago`;

--- a/app/components/build-banner/component.js
+++ b/app/components/build-banner/component.js
@@ -68,7 +68,7 @@ export default Component.extend({
     }
   }),
 
-  getTemplate: computed('build', {
+  getTemplate: computed('templateId', {
     get() {
       const templateId = this.get('templateId');
 

--- a/app/components/build-banner/component.js
+++ b/app/components/build-banner/component.js
@@ -68,18 +68,18 @@ export default Component.extend({
     }
   }),
 
-  getTemplate: computed('templateId', {
+  template: computed('templateId', {
     get() {
       const templateId = this.get('templateId');
 
       return ObjectPromiseProxy.create({
-        promise: this.shuttle.getTemlateDetails(templateId).then(template => {
+        promise: this.shuttle.getTemplateDetails(templateId).then(template => {
           const { namespace, name, version } = template;
 
           return {
-            link: `/templates/${namespace}/${name}/${version}`,
             name,
-            version
+            version,
+            namespace
           };
         })
       });

--- a/app/components/build-banner/component.js
+++ b/app/components/build-banner/component.js
@@ -3,7 +3,11 @@ import { alias } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { isActiveBuild, isPRJob } from 'screwdriver-ui/utils/build';
+import PromiseProxyMixin from '@ember/object/promise-proxy-mixin';
+import ObjectProxy from '@ember/object/proxy';
 import { getTimestamp } from '../../utils/timestamp-format';
+
+const ObjectPromiseProxy = ObjectProxy.extend(PromiseProxyMixin);
 
 export default Component.extend({
   userSettings: service(),
@@ -66,9 +70,19 @@ export default Component.extend({
 
   getTemplate: computed('build', {
     get() {
-      const template = this.shuttle.getTemlateDetails(7633);
+      const templateId = this.get('templateId');
 
-      return template;
+      return ObjectPromiseProxy.create({
+        promise: this.shuttle.getTemlateDetails(templateId).then(template => {
+          const { namespace, name, version } = template;
+
+          return {
+            link: `/templates/${namespace}/${name}/${version}`,
+            name,
+            version
+          };
+        })
+      });
     }
   }),
 

--- a/app/components/build-banner/component.js
+++ b/app/components/build-banner/component.js
@@ -7,6 +7,7 @@ import { getTimestamp } from '../../utils/timestamp-format';
 
 export default Component.extend({
   userSettings: service(),
+  shuttle: service(),
   classNames: ['build-banner', 'row'],
   classNameBindings: ['buildStatus'],
   coverage: service(),
@@ -60,6 +61,14 @@ export default Component.extend({
       createTime = getTimestamp(this.userSettings, this.buildCreate);
 
       return createTime;
+    }
+  }),
+
+  getTemplate: computed('build', {
+    get() {
+      const template = this.shuttle.getTemlateDetails(7633);
+
+      return template;
     }
   }),
 

--- a/app/components/build-banner/template.hbs
+++ b/app/components/build-banner/template.hbs
@@ -79,7 +79,7 @@
     <span class="banner-label">Container</span>
   </li>
   <li class="template-info">
-    <span class="banner-value">{{buildContainer}}</span>
+    <span class="banner-value">{{getTemplate}}</span>
     <span class="banner-label">Template</span>
   </li>
   <li class="call-to-action button-right">

--- a/app/components/build-banner/template.hbs
+++ b/app/components/build-banner/template.hbs
@@ -78,6 +78,10 @@
     <span class="banner-value">{{buildContainer}}</span>
     <span class="banner-label">Container</span>
   </li>
+  <li class="template-info">
+    <span class="banner-value">{{buildContainer}}</span>
+    <span class="banner-label">Template</span>
+  </li>
   <li class="call-to-action button-right">
     {{#if isAuthenticated}}
       {{#bs-button onClick=(action "buildButtonClick") disabled=(or (await isButtonDisabled) (not isButtonDisabledLoaded))}}
@@ -85,4 +89,5 @@
       {{/bs-button}}
     {{/if}}
   </li>
-</ul>
+</ul> 
+      

--- a/app/components/build-banner/template.hbs
+++ b/app/components/build-banner/template.hbs
@@ -79,7 +79,7 @@
     <span class="banner-label">Container</span>
   </li>
   <li class="template-info">
-    <span class="banner-value">{{getTemplate}}</span>
+    <span class="banner-value"><a href={{getTemplate.content.link}}>{{getTemplate.content.name}}:{{getTemplate.content.version}}</a></span>
     <span class="banner-label">Template</span>
   </li>
   <li class="call-to-action button-right">

--- a/app/components/build-banner/template.hbs
+++ b/app/components/build-banner/template.hbs
@@ -79,10 +79,12 @@
     <span class="banner-label">Container</span>
   </li>
   {{#if templateId}}
-    <li class="template-info">
-      <span class="banner-value"><a href={{getTemplate.content.link}}>{{getTemplate.content.name}}:{{getTemplate.content.version}}</a></span>
-      <span class="banner-label">Template</span>
-    </li>
+    {{#if template.content}}
+      <li class="template-info">
+        {{#link-to "templates.detail" template.content.namespace template.content.name template.content.version}}<span class="banner-value">{{template.content.name}}:{{template.content.version}}</span>{{/link-to}}
+        <span class="banner-label">Template</span>
+      </li>
+    {{/if}}
   {{/if}}
   <li class="call-to-action button-right">
     {{#if isAuthenticated}}

--- a/app/components/build-banner/template.hbs
+++ b/app/components/build-banner/template.hbs
@@ -78,10 +78,12 @@
     <span class="banner-value">{{buildContainer}}</span>
     <span class="banner-label">Container</span>
   </li>
-  <li class="template-info">
-    <span class="banner-value"><a href={{getTemplate.content.link}}>{{getTemplate.content.name}}:{{getTemplate.content.version}}</a></span>
-    <span class="banner-label">Template</span>
-  </li>
+  {{#if templateId}}
+    <li class="template-info">
+      <span class="banner-value"><a href={{getTemplate.content.link}}>{{getTemplate.content.name}}:{{getTemplate.content.version}}</a></span>
+      <span class="banner-label">Template</span>
+    </li>
+  {{/if}}
   <li class="call-to-action button-right">
     {{#if isAuthenticated}}
       {{#bs-button onClick=(action "buildButtonClick") disabled=(or (await isButtonDisabled) (not isButtonDisabledLoaded))}}

--- a/app/pipeline/build/template.hbs
+++ b/app/pipeline/build/template.hbs
@@ -1,4 +1,5 @@
 {{build-banner
+  build=build
   buildContainer=build.buildContainer
   duration=build.totalDuration
   blockDuration=build.blockedDuration
@@ -22,6 +23,7 @@
   event=event
   prEvents=prEvents
   prNumber=job.prNumber
+  templateId=build.templateId
   onStart=(action "startBuild")
   onStop=(action "stopBuild")
   reloadBuild=(action "reload")

--- a/app/pipeline/build/template.hbs
+++ b/app/pipeline/build/template.hbs
@@ -1,5 +1,4 @@
 {{build-banner
-  build=build
   buildContainer=build.buildContainer
   duration=build.totalDuration
   blockDuration=build.blockedDuration

--- a/app/shuttle/service.js
+++ b/app/shuttle/service.js
@@ -384,18 +384,18 @@ export default Service.extend({
   },
 
   /**
-   * getTemlateDetails
+   * getTemplateDetails
    * @param {Number} templateId template id
-   * @return {Promise} temlate details
+   * @return {Promise} template details
    */
-  async getTemlateDetails(templateId) {
+  async getTemplateDetails(templateId) {
     const method = 'get';
     const url = `/template/${templateId}`;
 
     try {
-      const temlateDetails = await this.fetchFromApi(method, url);
+      const templateDetails = await this.fetchFromApi(method, url);
 
-      return temlateDetails;
+      return templateDetails;
     } catch (e) {
       return {};
     }

--- a/app/shuttle/service.js
+++ b/app/shuttle/service.js
@@ -391,13 +391,8 @@ export default Service.extend({
   async getTemplateDetails(templateId) {
     const method = 'get';
     const url = `/template/${templateId}`;
+    const templateDetails = await this.fetchFromApi(method, url);
 
-    try {
-      const templateDetails = await this.fetchFromApi(method, url);
-
-      return templateDetails;
-    } catch (e) {
-      return {};
-    }
+    return templateDetails;
   }
 });

--- a/app/shuttle/service.js
+++ b/app/shuttle/service.js
@@ -381,5 +381,23 @@ export default Service.extend({
     const url = `/collections/${collectionId}/pipelines?${pipelineIdsQuery}`;
 
     return this.fetchFromApi(method, url);
+  },
+
+  /**
+   * getTemlateDetails
+   * @param {Number} templateId template id
+   * @return {Promise} temlate details
+   */
+  async getTemlateDetails(templateId) {
+    const method = 'get';
+    const url = `/template/${templateId}`;
+
+    try {
+      const temlateDetails = await this.fetchFromApi(method, url);
+
+      return temlateDetails;
+    } catch (e) {
+      return {};
+    }
   }
 });

--- a/tests/integration/components/build-banner/component-test.js
+++ b/tests/integration/components/build-banner/component-test.js
@@ -107,7 +107,7 @@ module('Integration | Component | build banner', function (hooks) {
   });
 
   test('it renders', async function (assert) {
-    assert.expect(13);
+    assert.expect(14);
     this.owner.setupRouter();
 
     this.set('reloadCb', () => {
@@ -165,6 +165,8 @@ module('Integration | Component | build banner', function (hooks) {
     assert.dom('.created .banner-value').hasText(expectedTime);
     assert.dom('.user .banner-value').hasText('Bruce W');
     assert.dom('.docker-container .banner-value').hasText('node:6');
+    // template info doesnot exists because we haven't passed yet
+    assert.dom('.template-info .banner-value').doesNotExist();
     assert.dom('button').doesNotExist();
   });
 
@@ -760,5 +762,88 @@ module('Integration | Component | build banner', function (hooks) {
     return settled().then(() => {
       assert.dom('button').hasText('Stop');
     });
+  });
+
+  test('it renders template info if user is using template', async function (assert) {
+    assert.expect(15);
+    this.owner.setupRouter();
+
+    this.set('reloadCb', () => {
+      assert.ok(true);
+    });
+
+    this.set('changeB', () => {
+      assert.ok(true);
+    });
+
+    this.set('prEvents', new EmberPromise(resolves => resolves([])));
+
+    this.set('buildStepsMock', buildStepsMock);
+    this.set('eventMock', prEventMock);
+    const shuttleStub = Service.extend({
+      // eslint-disable-next-line no-unused-vars
+      getTemplateDetails(templateId) {
+        assert.ok(true, 'getTemplateDetails called');
+        assert.equal(templateId, 9333);
+
+        return resolve({
+          namespace: 'nodejs',
+          name: 'test',
+          version: '2.0'
+        });
+      },
+      getUserSetting() {
+        return resolve({});
+      }
+    });
+
+    this.owner.unregister('service:shuttle');
+    this.owner.register('service:shuttle', shuttleStub);
+    await render(hbs`{{build-banner
+      buildContainer="node:6"
+      duration="11 seconds"
+      blockDuration="4 seconds"
+      imagePullDuration="5 seconds"
+      buildDuration="2 seconds"
+      buildStatus="RUNNING"
+      buildCreate="2016-11-04T20:08:41.238Z"
+      buildStart="2016-11-04T20:09:41.238Z"
+      buildSteps=buildStepsMock
+      jobId=1
+      jobName="PR-671"
+      isAuthenticated=false
+      event=eventMock
+      pipelineId=12345
+      prEvents=prEvents
+      templateId=9333
+      reloadBuild=(action reloadCb)
+      changeBuild=(action changeB)
+    }}`);
+
+    const expectedTime = toCustomLocaleString(
+      new Date('2016-11-04T20:08:41.238Z')
+    );
+
+    assert.dom('li.job-name a').hasAttribute('href', '/pipelines/12345/pulls');
+    assert.dom('li.job-name .banner-value').hasText('PR-671');
+    assert
+      .dom('.commit a')
+      .hasAttribute(
+        'href',
+        'http://example.com/batcave/batmobile/commit/abcdef1029384'
+      );
+    assert.dom('.commit a').hasText('#abcdef1');
+    assert
+      .dom('.duration .banner-value')
+      .hasAttribute(
+        'title',
+        'Total duration: 11 seconds, Blocked time: 4 seconds, Image pull time: 5 seconds, Build time: 2 seconds'
+      );
+    assert.dom('.duration > a').hasText('See build metrics');
+    assert.dom('.created .banner-value').hasText(expectedTime);
+    assert.dom('.user .banner-value').hasText('Bruce W');
+    assert.dom('.docker-container .banner-value').hasText('node:6');
+    assert.dom('.template-info .banner-value').hasText('test:2.0');
+    assert.dom('button').doesNotExist();
   });
 });


### PR DESCRIPTION
## Context

If users use a template inside their sd.yaml for jobs, the build details page should show something similar as we do for the container images.


## Objective
<img width="1292" alt="Screen Shot 2023-02-16 at 11 35 32 AM 1" src="https://user-images.githubusercontent.com/104225232/219451753-af3c1c3f-de8a-4936-9d5b-4d9e37f81a2e.png">


## References
https://github.com/screwdriver-cd/screwdriver/issues/2822

## License


I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
