### PR TITLE
fix: pipeline search ui link-to syntax issue

### DIFF
--- a/app/components/pipeline-search-panel/template.hbs
+++ b/app/components/pipeline-search-panel/template.hbs
@@ -16,7 +16,7 @@
     {{#each this.searchedPipelines as |pipeline|}}
       <div class="searched-pipeline">
         <span class="name">
-          <LinkTo @route="pipeline" >
+          <LinkTo @route="pipeline" @model={{this.pipeline.id}}>
             {{pipeline.name}}
           </LinkTo>
         </span>


### PR DESCRIPTION
## Context

Syntax pipeline syntax error on Pipeline search panel.
<img width="1137" alt="Screen Shot 2023-02-21 at 12 29 02 PM" src="https://user-images.githubusercontent.com/104225232/220418162-c645352d-60b5-4c44-a6a2-8198738761ea.png">

## Objective

Fix this pipeline search panel syntax error.
## References


## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
