### PR TITLE
feat: PR title on PR build page

### DIFF
--- a/app/components/build-banner/template.hbs
+++ b/app/components/build-banner/template.hbs
@@ -54,7 +54,7 @@
         <a href={{this.event.pr.url}} class="sha pr-url">
           {{svg-jar "github" class="pr-img"}}
           <span class="pr-link">
-            PR#{{this.prNumber}}
+            PR#{{this.prNumber}}: {{this.event.pr.title}}
           </span>
         </a>
       </span>

--- a/app/components/pipeline-pr-list/template.hbs
+++ b/app/components/pipeline-pr-list/template.hbs
@@ -6,12 +6,11 @@
           <span>
             <FaIcon @icon="code-branch" />
           </span>
-          PR-{{this.jobs.0.group}}
+          PR-{{this.jobs.0.group}}:
+          <span class="title">
+            {{this.jobs.0.title}}
+          </span>
         </a>
-        <br />
-        <span class="title">
-          {{this.jobs.0.title}}
-        </span>
         {{#if this.isRunning}}
           <BsButton
             @type="primary"

--- a/tests/integration/components/build-banner/component-test.js
+++ b/tests/integration/components/build-banner/component-test.js
@@ -73,7 +73,8 @@ const prEventMock = EmberObject.create({
     url: 'http://example.com/u/batman'
   },
   pr: {
-    url: 'https://github.com/screwdriver-cd/ui/pull/292'
+    url: 'https://github.com/screwdriver-cd/ui/pull/292',
+    title: 'feat: test pr title'
   },
   pipelineId: '12345',
   groupEventId: '23450',
@@ -237,7 +238,7 @@ module('Integration | Component | build banner', function (hooks) {
     assert
       .dom('.pr .pr-url-holder a')
       .hasAttribute('href', 'https://github.com/screwdriver-cd/ui/pull/292');
-    assert.dom('.pr .pr-url-holder a').hasText('PR#292');
+    assert.dom('.pr .pr-url-holder a').hasText('PR#292: feat: test pr title');
     assert.dom('li.job-name .banner-value').hasText('PR-671');
     assert
       .dom('.commit a')
@@ -297,7 +298,7 @@ module('Integration | Component | build banner', function (hooks) {
     assert
       .dom('.pr .pr-url-holder a')
       .hasAttribute('href', 'https://github.com/screwdriver-cd/ui/pull/292');
-    assert.dom('.pr .pr-url-holder a').hasText('PR#292');
+    assert.dom('.pr .pr-url-holder a').hasText('PR#292: feat: test pr title');
     assert.dom('li.job-name .banner-value').hasText('PR-671');
     assert
       .dom('.commit a')


### PR DESCRIPTION
## Context

feature request :can we have the PR title on pr build page?
## Objective
Display PR title on PR build page.
<img width="347" alt="Screen Shot 2023-02-23 at 10 44 41 AM" src="https://user-images.githubusercontent.com/104225232/220957929-d546c622-e4d2-4504-9f0e-a39da2d26c2c.png">


## References

https://github.com/screwdriver-cd/screwdriver/issues/2836
## License


I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
