### PR TITLE
fix: file name with ampersand error

### DIFF
--- a/app/components/artifact-tree/component.js
+++ b/app/components/artifact-tree/component.js
@@ -79,7 +79,7 @@ export default Component.extend({
 
     showArtifactPreview(treeData) {
       const { href } = treeData.a_attr;
-      const artifactPath = href.split('artifacts/')[1];
+      const artifactPath = href.split('artifacts/').lastObject;
 
       this.setProperties({
         href,

--- a/app/components/artifact-tree/component.js
+++ b/app/components/artifact-tree/component.js
@@ -79,7 +79,8 @@ export default Component.extend({
 
     showArtifactPreview(treeData) {
       const { href } = treeData.a_attr;
-      const artifactPath = href.split('artifacts/').lastObject;
+      const pathArray = href.split('artifacts/');
+      const artifactPath = pathArray[pathArray.length - 1];
 
       this.setProperties({
         href,


### PR DESCRIPTION
## Context

If an artifact has a filename with an ampersand in it,UI shows an error .
## Objective

<img width="1271" alt="Screen Shot 2023-02-24 at 11 30 21 AM" src="https://user-images.githubusercontent.com/104225232/221932091-2b2a92e1-8cf6-4a28-966d-3b35c88bf02a.png">



## References

https://github.com/screwdriver-cd/screwdriver/issues/2839
## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
