### PR TITLE
fix(2838): Problems caused by ember upgrade

### DIFF
--- a/app/components/build-step-collection/styles.scss
+++ b/app/components/build-step-collection/styles.scss
@@ -13,6 +13,10 @@
     }
   }
 
+  li.nav-item {
+    padding: 10px;
+  }
+
   ul {
     list-style: none;
     padding: 0;

--- a/app/components/collection-table-row/styles.scss
+++ b/app/components/collection-table-row/styles.scss
@@ -28,4 +28,8 @@
     overflow: hidden;
     text-overflow: ellipsis;
   }
+
+  p {
+    margin: 0 0 10px;
+  }
 }

--- a/app/components/metrics/chart/template.hbs
+++ b/app/components/metrics/chart/template.hbs
@@ -5,7 +5,7 @@
 
   {{#if @legends}}
     {{#if @legends.left}}
-      <ul class="list-inline chart-legend pull-left">
+      <ul class="list-inline chart-legend float-left">
         {{#each @legends.left as |leg|}}
           <li style={{leg.style}}>
             {{leg.name}}
@@ -15,7 +15,7 @@
     {{/if}}
 
     {{#if @legends.right}}
-      <ul class="list-inline chart-legend pull-right">
+      <ul class="list-inline chart-legend float-right">
         {{#each @legends.right as |leg|}}
           <li style={{leg.style}}>
             {{leg.name}}

--- a/app/components/pipeline-events-row-group/template.hbs
+++ b/app/components/pipeline-events-row-group/template.hbs
@@ -4,7 +4,7 @@
       {{#if (not-eq this.events.length 1)}}
         <a
           onclick={{action "toggleExpanded"}}
-          class="pull-right expand-collapse"
+          class="float-right expand-collapse"
         >
           {{#if (eq this.isExpanded true)}}
             Collapse

--- a/app/components/tc-collection-list/component.js
+++ b/app/components/tc-collection-list/component.js
@@ -93,6 +93,7 @@ export default Component.extend({
   columns: computed(() => [
     {
       title: 'Name',
+      propertyName: 'name',
       component: 'tcCollectionLinker',
       resizable: true,
       width: '20%',
@@ -108,6 +109,7 @@ export default Component.extend({
     },
     {
       title: 'Namespace',
+      propertyName: 'namespace',
       component: 'tcCollectionNamespaceLinker',
       resizable: true,
       width: '15%',

--- a/app/components/tc-collection-list/template.hbs
+++ b/app/components/tc-collection-list/template.hbs
@@ -6,7 +6,7 @@
       title="More Information"
       target="_blank"
       rel="noopener"
-      class="link pull-right"
+      class="link float-right"
     >
       {{this.collectionType}} Docs
       <FaIcon @icon="question-circle" />
@@ -22,7 +22,7 @@
     <b>
       Screwdriver {{this.collectionType}}
     </b>
-    <span class="pull-right">
+    <span class="float-right">
       <span class="text-uppercase total">
         Total
       </span>
@@ -125,5 +125,6 @@
     @showCurrentPageNumberSelect={{false}}
     @multipleColumnsSorting={{false}}
     @noDataToShowMsg="Sorry! No result is found."
+    @pageSize={{this.refinedModel.length}}
   />
 </section>

--- a/app/components/token-list/style.scss
+++ b/app/components/token-list/style.scss
@@ -11,10 +11,10 @@
 
   section {
     border-radius: 5px 5px 0 0;
-    border: 1px solid $sd-separator;
   }
 
-  tbody tr, tfoot tr {
+  tbody tr,
+  tfoot tr {
     border: 1px solid $sd-text-light;
   }
 
@@ -58,26 +58,27 @@
       color: $sd-text-med;
     }
   }
-  
-  .token-name, .token-description {
+
+  .token-name,
+  .token-description {
     width: 30%;
     max-width: 200px;
   }
 
-  .name, .description {
+  .name,
+  .description {
     width: 30%;
     max-width: 200px;
-    input{
+    input {
       max-width: 200px;
     }
   }
 
-  .last-used, .actions {
+  .last-used,
+  .actions {
     width: 20%;
     max-width: 100px;
   }
-
-
 
   .add {
     cursor: pointer;

--- a/app/components/token-list/style.scss
+++ b/app/components/token-list/style.scss
@@ -11,6 +11,7 @@
 
   section {
     border-radius: 5px 5px 0 0;
+    padding: 25px;
   }
 
   tbody tr,

--- a/app/pipeline/secrets/template.hbs
+++ b/app/pipeline/secrets/template.hbs
@@ -17,6 +17,7 @@
   @onRefreshToken={{action "refreshPipelineToken"}}
   @tokenName="Pipeline"
   @tokenScope="this pipeline"
+  style="padding: 25px;"
 />
 
 {{outlet}}

--- a/app/pipeline/secrets/template.hbs
+++ b/app/pipeline/secrets/template.hbs
@@ -17,7 +17,6 @@
   @onRefreshToken={{action "refreshPipelineToken"}}
   @tokenName="Pipeline"
   @tokenScope="this pipeline"
-  style="padding: 25px;"
 />
 
 {{outlet}}

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -185,7 +185,11 @@ body {
   font-weight: $weight-normal;
 }
 
-$ember-power-select-border-color: #64A5ED;
+html {
+  font-size: 14px;
+}
+
+$ember-power-select-border-color: #64a5ed;
 $ember-power-select-border-radius: 0;
 
 @import 'ember-power-select';

--- a/app/styles/user-settings.scss
+++ b/app/styles/user-settings.scss
@@ -10,18 +10,19 @@
     border-radius: 5px 5px 0 0;
     border: 1px solid $sd-separator;
     margin-bottom: 20px;
+    padding: 0px !important;
 
     ul {
       list-style: none;
       padding: 0;
       margin: 0;
     }
-  
+
     li {
       font-size: 14px;
       padding: 15px 10px;
       border-bottom: 1px solid $sd-separator;
-  
+
       &:last-child {
         border-width: 0;
       }
@@ -58,7 +59,6 @@
     width: 100%;
   }
 
-
   .text-input {
     box-sizing: border-box;
     margin-top: 10px;
@@ -66,7 +66,7 @@
     height: 45px;
     width: 100%;
     border-radius: 2px;
-    border: 2px solid $sd-text-med;;
+    border: 2px solid $sd-text-med;
     font-size: 16px;
     padding-left: 10px;
     color: $sd-text;
@@ -103,7 +103,7 @@
       width: calc(100% - 15px);
     }
   }
-  
+
   .blue-button {
     @include transition(all, 50ms);
     border: none;
@@ -155,13 +155,13 @@
 
   .column-tabs-view {
     overflow: auto;
-  
+
     .nav-tabs {
       position: sticky;
       top: 0;
       background: $sd-white;
       z-index: 1;
-  
+
       & > li {
         width: 18%;
         float: none;
@@ -170,10 +170,10 @@
         text-align: center;
         font-weight: bold;
         border-bottom: 2px solid $grey-400;
-  
+
         & > a {
           color: #555555;
-          
+
           &,
           &:hover {
             border: none !important;
@@ -181,7 +181,7 @@
             background: none !important;
           }
         }
-  
+
         &.active,
         &:hover {
           border-bottom: 2px solid $brand-600;

--- a/tests/integration/components/metrics/chart/component-test.js
+++ b/tests/integration/components/metrics/chart/component-test.js
@@ -152,8 +152,8 @@ module('Integration | Component | metrics/chart', function (hooks) {
     assert.dom('.chart-c3').exists({ count: 1 });
     assert.dom('.chart-title').exists({ count: 1 });
     assert.dom('.chart-title').hasText(chartTitle, 'has chart title');
-    assert.dom('.pull-left').hasText('Downtime (MIN)', 'has left legend');
-    assert.dom('.pull-right').hasText('Build Count', 'has right legend');
+    assert.dom('.float-left').hasText('Downtime (MIN)', 'has left legend');
+    assert.dom('.float-right').hasText('Build Count', 'has right legend');
     assert.dom('.reset-button').exists({ count: 1 });
     assert.dom('.c3-text').exists({ count: 1 });
     assert


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Fix some display issues caused by Ember upgrade in https://github.com/screwdriver-cd/ui/pull/844.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
- Overall
  - Font looks a bit large.
    - [In bootstrap4, the default font size is `16px`](https://getbootstrap.com/docs/4.6/content/typography/#global-settings), so set `14px` in the root as before.
  - Display position of the part using `pull-{right,left}`
    - [`pull-{right,left}` is obsolete in bootstrap4](https://getbootstrap.com/docs/4.1/migration/#utilities).
    - e.g. before:
![image](https://user-images.githubusercontent.com/59165943/222666228-37f519bd-7043-4c43-b4b4-407437752890.png)
after:
![image](https://user-images.githubusercontent.com/59165943/222666328-ba90637a-2e1c-4238-8e9c-55a571bfc0cb.png)

- Templates/Commands list page
  - There are more than that, but only 10 are shown.
    - Since default page size is 10, set `pageSize` to the number that should be displayed.
  - Cannot sort by `Name` and `Namespace`.
    - In `ember-models-table`, If `propertyName` isn't provided, sorting and filtering options for current column are ignored.
- Collections page
  - The display position of the `Name` value is biased upward on the table.
- Build details page
  - Steps and Artifacts tabs are small
before:
![image](https://user-images.githubusercontent.com/59165943/222668803-b9c91eaa-aaed-46a1-9508-2ca1bb04b2ca.png)
after:
![image](https://user-images.githubusercontent.com/59165943/222668875-d15be83d-5c5f-42da-9b1f-69e14511bd94.png)

- Pipeline secrets page
  - Display corruption on access tokens section.
    - To be precise, this is not due to Ember Upgrade, but to https://github.com/screwdriver-cd/ui/pull/868.
    - Fix the Access Token section of the Pipeline Secrets page so that the User Settings page is not affected.
      - padding must function properly.
      - No unnatural borders should appear.
        - Since the border is [defined as a user-preference](https://github.com/screwdriver-cd/ui/blob/e4faaa9b8b399c77fc9011afbe322dc19219defa/app/styles/user-settings.scss#L11), removing it from the component will not affect the User Setting page.

before:
![image](https://user-images.githubusercontent.com/59165943/222667638-6580313f-c5a8-4aac-b5f9-0df72130f70d.png)
after:
![image](https://user-images.githubusercontent.com/59165943/222667753-cc7efc98-c390-4e48-b49f-03837e618cc9.png)

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

- [issue](https://github.com/screwdriver-cd/screwdriver/issues/2838)
- [ember-models-table docs](https://onechiporenko.github.io/ember-models-table/v.3/docs/classes/Utils.ModelsTableColumn.html)


## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
