### PR TITLE
fix(2838): Templates & Commands the table CSS looks like plain table

### DIFF
--- a/app/components/tc-collection-list/component.js
+++ b/app/components/tc-collection-list/component.js
@@ -32,6 +32,8 @@ export default Component.extend({
     this._super(...arguments);
 
     this.set('data', this.refinedModel);
+
+    this.theme.table = 'table table-condensed table-sm collection-list';
   },
   filteredModel: computed(
     'filteringNamespace',

--- a/app/components/tc-collection-list/styles.scss
+++ b/app/components/tc-collection-list/styles.scss
@@ -1,7 +1,6 @@
 & {
   .row,
-  .collection-table,
-  .lt-body-wrap {
+  .collection-table {
     margin-top: 15px;
   }
 
@@ -47,6 +46,8 @@
   }
 
   .collection-list {
+    margin-top: 15px;
+
     th {
       padding: 10px;
       color: $grey-600;


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Ember Upgrade has turned the table on the templates / commands page into a plain table.
https://github.com/screwdriver-cd/ui/pull/844#issuecomment-1457403847

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
The class structure has changed due to the change in the table library, so modify the CSS so that it is applied.

![image](https://user-images.githubusercontent.com/59165943/223370586-dae9b0fe-cc09-442c-abac-2eb5192b8e28.png)

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
[issue](https://github.com/screwdriver-cd/screwdriver/issues/2838)

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
