### PR TITLE
fix: Fix build-banner display

### DIFF
--- a/app/components/build-banner/component.js
+++ b/app/components/build-banner/component.js
@@ -12,7 +12,7 @@ const ObjectPromiseProxy = ObjectProxy.extend(PromiseProxyMixin);
 export default Component.extend({
   userSettings: service(),
   shuttle: service(),
-  classNames: ['build-banner', 'row'],
+  classNames: ['build-banner', 'grid'],
   classNameBindings: ['buildStatus'],
   coverage: service(),
   coverageInfo: {},

--- a/app/components/build-banner/styles.scss
+++ b/app/components/build-banner/styles.scss
@@ -79,19 +79,28 @@ li {
   display: none;
 }
 
-.open .dropdown-menu,
+.show .dropdown-menu,
 .commit-list,
 .caret-display,
 .dropdown {
   display: inline-block;
 }
 
-.dropdown-menu {
+.commit-dropdown {
   position: absolute;
-  left: -70px;
+  top: 1.5rem !important;
+  left: -70px !important;
   min-width: 60px;
   max-height: 150px;
   overflow: auto;
+  transform: none !important;
+  padding: 0;
+  > li > a {
+    display: block;
+    padding: 3px 20px;
+    line-height: 1.428571429;
+    white-space: nowrap;
+  }
 }
 
 .pr-item {

--- a/app/components/build-banner/template.hbs
+++ b/app/components/build-banner/template.hbs
@@ -32,12 +32,14 @@
           <dd.toggle>
             <span class="caret caret-display"></span>
           </dd.toggle>
-          <dd.menu as |ddm|>
+          <dd.menu class="commit-dropdown" as |ddm|>
             {{#each (await this.shortenedPrShas) as |prSha|}}
-              <ddm.item class="pr-item">
-                <a onClick={{action "changeCurPr" prSha}}>
-                  {{prSha.index}}. {{prSha.shortenedSha}}
-                </a>
+              <ddm.item>
+                <li class="pr-item">
+                  <a onClick={{action "changeCurPr" prSha}}>
+                    {{prSha.index}}. {{prSha.shortenedSha}}
+                  </a>
+                </li>
               </ddm.item>
             {{/each}}
           </dd.menu>


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Fix following 2 build-banner display bugs.
- [restart button not aligned to the right](https://github.com/screwdriver-cd/screwdriver/issues/2838#issuecomment-1457234861).
- [Build results from previous commits in the same PR can no longer be selected from the UI](https://github.com/screwdriver-cd/screwdriver/issues/2838#issuecomment-1461053310).

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
- fix build-banner layout to align the restart button to the right.
- fix css to show a dropdown menu correct.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/2838

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
