### PR TITLE
fix: When CONTAINER in build banner is long, it overlaps with TEMPLATE

### DIFF
--- a/app/components/build-banner/styles.scss
+++ b/app/components/build-banner/styles.scss
@@ -29,6 +29,7 @@ li {
   padding: 5px 10px;
   min-width: 120px;
   vertical-align: top;
+  overflow-wrap: break-word;
 
   span {
     display: block;


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
as is:
<img width="979" alt="image" src="https://user-images.githubusercontent.com/59165943/224240825-d4b34beb-5848-4144-a44a-ba6239ff0c57.png">

to be:
<img width="944" alt="image" src="https://user-images.githubusercontent.com/59165943/224240883-e3dd8bbc-f915-4d42-ab97-a12434bbc639.png">


## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
