### PR TITLE
feat:display build date/time

### DIFF
--- a/app/components/pipeline-list-history-cell/styles.scss
+++ b/app/components/pipeline-list-history-cell/styles.scss
@@ -38,4 +38,8 @@
     width: 0.8em;
     font-size: 1.2em;
   }
+  p {
+    padding: 0;
+    margin: 0;
+  }
 }

--- a/app/components/pipeline-list-history-cell/styles.scss
+++ b/app/components/pipeline-list-history-cell/styles.scss
@@ -38,8 +38,10 @@
     width: 0.8em;
     font-size: 1.2em;
   }
+
   p {
     padding: 0;
     margin: 0;
+    text-align: left;
   }
 }

--- a/app/components/pipeline-list-history-cell/template.hbs
+++ b/app/components/pipeline-list-history-cell/template.hbs
@@ -5,8 +5,8 @@
       <span class="build-status">
         <BsTooltip @placement="top" @renderInPlace={{true}} class="tooltip">
           <p>Build# {{build.id}}</p>
-          <p>Start - {{moment-format build.startTime "DD/MM/YYYY HH:mm"}}</p>
-          <p>End - {{moment-format build.endTime "DD/MM/YYYY HH:mm"}}</p>
+          <p>Start - {{moment-format build.startTime "MM/DD/YYYY HH:mmA"}}</p>
+          <p>End - {{moment-format build.endTime "MM/DD/YYYY HH:mmA"}}</p>
         </BsTooltip>
         <LinkTo @route="pipeline.build" @model={{build.id}} @title={{build.id}}>
           <FaIcon @icon="circle" @fixedWidth="true" class={{build.status}} />

--- a/app/components/pipeline-list-history-cell/template.hbs
+++ b/app/components/pipeline-list-history-cell/template.hbs
@@ -3,12 +3,12 @@
     {{#each this.builds as |build|}}
       {{#if (not-eq build.status "CREATED")}}
       <span class="build-status">
+        <BsTooltip @placement="top" @renderInPlace={{true}} class="tooltip">
+          <p>Build# {{build.id}}</p>
+          <p>Start - {{moment-format build.startTime "DD/MM/YYYY HH:mm"}}</p>
+          <p>End - {{moment-format build.endTime "DD/MM/YYYY HH:mm"}}</p>
+        </BsTooltip>
         <LinkTo @route="pipeline.build" @model={{build.id}} @title={{build.id}}>
-          <BsTooltip @placement="top" @renderInPlace={{true}} class="tooltip">
-            <p>Build# {{build.id}}</p>
-            <p>Start - {{moment-format build.startTime "DD/MM/YYYY HH:mm"}}</p>
-            <p>End - {{moment-format build.endTime "DD/MM/YYYY HH:mm"}}</p>
-          </BsTooltip>
           <FaIcon @icon="circle" @fixedWidth="true" class={{build.status}} />
         </LinkTo>
       </span>

--- a/app/components/pipeline-list-history-cell/template.hbs
+++ b/app/components/pipeline-list-history-cell/template.hbs
@@ -3,6 +3,11 @@
     {{#each this.builds as |build|}}
       {{#if (not-eq build.status "CREATED")}}
         <LinkTo @route="pipeline.build" @model={{build.id}} @title={{build.id}}>
+          <BsTooltip @placement="top" @renderInPlace={{true}}>
+            <p>Build# {{build.id}}</p>
+            <p>Start - {{moment-format build.startTime "DD/MM/YYYY HH:mm"}}</p>
+            <p>End - {{moment-format build.endTime "DD/MM/YYYY HH:mm"}}</p>
+          </BsTooltip>
           <FaIcon @icon="circle" @fixedWidth="true" class={{build.status}} />
         </LinkTo>
       {{else}}

--- a/app/components/pipeline-list-history-cell/template.hbs
+++ b/app/components/pipeline-list-history-cell/template.hbs
@@ -2,14 +2,16 @@
   <div>
     {{#each this.builds as |build|}}
       {{#if (not-eq build.status "CREATED")}}
+      <span class="build-status">
         <LinkTo @route="pipeline.build" @model={{build.id}} @title={{build.id}}>
-          <BsTooltip @placement="top" @renderInPlace={{true}}>
+          <BsTooltip @placement="top" @renderInPlace={{true}} class="tooltip">
             <p>Build# {{build.id}}</p>
             <p>Start - {{moment-format build.startTime "DD/MM/YYYY HH:mm"}}</p>
             <p>End - {{moment-format build.endTime "DD/MM/YYYY HH:mm"}}</p>
           </BsTooltip>
           <FaIcon @icon="circle" @fixedWidth="true" class={{build.status}} />
         </LinkTo>
+      </span>
       {{else}}
         <FaIcon @icon="circle" @fixedWidth="true" class={{build.status}} />
       {{/if}}

--- a/tests/integration/components/pipeline-list-history-cell/component-test.js
+++ b/tests/integration/components/pipeline-list-history-cell/component-test.js
@@ -136,7 +136,7 @@ module(
           },
           {
             id: 2,
-            status: 'SUCCESS',
+            status: 'FAILURE',
             startTime: '2023-03-02T18:58:46.493Z',
             endTime: '2023-03-02T20:58:56.411Z'
           }
@@ -152,6 +152,9 @@ module(
 
       await triggerEvent('.build-status:first-child', 'mouseenter');
       assert.dom('.tooltip').exists({ count: 1 });
+      assert
+        .dom('.tooltip')
+        .hasText('Build# 1 Start - 02/03/2023 10:58 End - 02/03/2023 10:58');
     });
   }
 );

--- a/tests/integration/components/pipeline-list-history-cell/component-test.js
+++ b/tests/integration/components/pipeline-list-history-cell/component-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render, triggerEvent } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
 
@@ -123,6 +123,35 @@ module(
 
       assert.dom('.fa-circle').hasClass('RANDOM');
       assert.dom('.fa-circle').exists({ count: 2 });
+    });
+
+    test('it renders tooltip upon hover with build details', async function (assert) {
+      this.set('record', {
+        history: [
+          {
+            id: 1,
+            status: 'SUCCESS',
+            startTime: '2023-03-02T18:58:46.493Z',
+            endTime: '2023-03-02T18:58:56.411Z'
+          },
+          {
+            id: 2,
+            status: 'SUCCESS',
+            startTime: '2023-03-02T18:58:46.493Z',
+            endTime: '2023-03-02T20:58:56.411Z'
+          }
+        ]
+      });
+
+      await render(hbs`<PipelineListHistoryCell
+        @record={{this.record}}
+      />`);
+
+      assert.dom('.fa-circle').hasClass('SUCCESS');
+      assert.dom('.fa-circle').exists({ count: 2 });
+
+      await triggerEvent('.build-status:first-child', 'mouseenter');
+      assert.dom('.tooltip').exists({ count: 1 });
     });
   }
 );

--- a/tests/integration/components/pipeline-list-history-cell/component-test.js
+++ b/tests/integration/components/pipeline-list-history-cell/component-test.js
@@ -154,7 +154,9 @@ module(
       assert.dom('.tooltip').exists({ count: 1 });
       assert
         .dom('.tooltip')
-        .hasText('Build# 1 Start - 02/03/2023 10:58 End - 02/03/2023 10:58');
+        .hasText(
+          'Build# 1 Start - 03/02/2023 10:58AM End - 03/02/2023 10:58AM'
+        );
     });
   }
 );

--- a/tests/integration/components/pipeline-list-history-cell/component-test.js
+++ b/tests/integration/components/pipeline-list-history-cell/component-test.js
@@ -152,11 +152,7 @@ module(
 
       await triggerEvent('.build-status:first-child', 'mouseenter');
       assert.dom('.tooltip').exists({ count: 1 });
-      assert
-        .dom('.tooltip')
-        .hasText(
-          'Build# 1 Start - 03/02/2023 10:58AM End - 03/02/2023 10:58AM'
-        );
+      assert.dom('.tooltip').containsText('Build# 1 Start - 03/02/2023');
     });
   }
 );


### PR DESCRIPTION
## Context

To find a specific build for a specific job in a very large pipeline, click on "jobs" view to get a recent list of builds for each job and hover over the green/red circles, build number visible which is not meaningful to a user.
## Objective
To display build date/time.
<img width="1284" alt="Screenshot 2023-03-15 at 11 31 15 AM" src="https://user-images.githubusercontent.com/104225232/225360733-1461fdfe-7c4f-4986-9e84-98ee7235e399.png">



## References

https://github.com/screwdriver-cd/screwdriver/issues/2774
## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
