### PR TITLE
fix: syntax errors after ember 4 upgrade

### DIFF
--- a/app/commands/controller.js
+++ b/app/commands/controller.js
@@ -14,7 +14,9 @@ export default Controller.extend({
       return params;
     },
     set(_, value) {
-      return (this._routeParams = value);
+      this.set('_routeParams', value);
+
+      return value;
     }
   }),
   crumbs: computed('routeParams', {

--- a/app/components/build-banner/component.js
+++ b/app/components/build-banner/component.js
@@ -40,7 +40,9 @@ export default Component.extend({
       return url.split('/').pop();
     },
     set(_, value) {
-      return set(this, '_prNumber', value);
+      set(this, '_prNumber', value);
+
+      return value;
     }
   }),
 

--- a/app/components/build-step-collection/component.js
+++ b/app/components/build-step-collection/component.js
@@ -29,7 +29,9 @@ export default Component.extend({
       return '';
     },
     set(_, value) {
-      return set(this, '_iframeUrl', value);
+      set(this, '_iframeUrl', value);
+
+      return value;
     }
   }),
   selectedStep: computed(
@@ -85,7 +87,9 @@ export default Component.extend({
         return true;
       },
       set(_, value) {
-        return set(this, '_teardownCollapsed', value);
+        set(this, '_teardownCollapsed', value);
+
+        return value;
       }
     }
   ),

--- a/app/components/build-step-item/component.js
+++ b/app/components/build-step-item/component.js
@@ -53,7 +53,9 @@ export default Component.extend({
       return null;
     },
     set(_, value) {
-      return (this._duration = value);
+      this.set('_duration', value);
+
+      return value;
     }
   }),
   click() {

--- a/app/components/collection-view/component.js
+++ b/app/components/collection-view/component.js
@@ -73,7 +73,9 @@ export default Component.extend({
         return this.store.findAll('collection');
       },
       set(_, value) {
-        return (this._collections = value);
+        this.set('_collections', value);
+
+        return value;
       }
     }
   ),
@@ -149,7 +151,9 @@ export default Component.extend({
       return sorted.concat(unknownStatusPipelines);
     },
     set(_, value) {
-      return (this._sortedPipelines = value);
+      this.set('_sortedPipelines', value);
+
+      return value;
     }
   }),
   sortByText: computed('sortBy', {
@@ -174,7 +178,9 @@ export default Component.extend({
       return hasAliasName;
     },
     set(_, value) {
-      return (this._hasAliasName = value);
+      this.set('_hasAliasName', value);
+
+      return value;
     }
   }),
   collectionPipelines: computed('collection.id', 'collection.pipelines.[]', {

--- a/app/components/pipeline-child-list-state-cell/component.js
+++ b/app/components/pipeline-child-list-state-cell/component.js
@@ -8,7 +8,9 @@ export default Component.extend({
       return getStateIcon(this.get('state'));
     },
     set(_, value) {
-      return (this._stateIcon = value);
+      this.set('_stateIcon', value);
+
+      return value;
     }
   }),
   stateName: computed('state', {
@@ -16,7 +18,9 @@ export default Component.extend({
       return this.get('state').toLowerCase();
     },
     set(_, value) {
-      return (this._stateName = value);
+      this.set('_stateName', value);
+
+      return value;
     }
   })
 });

--- a/app/components/pipeline-events/component.js
+++ b/app/components/pipeline-events/component.js
@@ -539,7 +539,9 @@ export default Component.extend(ModelReloaderMixin, {
       return isInactivePipeline(this.get('pipeline'));
     },
     set(_, value) {
-      return (this._isInactivePipeline = value);
+      this.set('_isInactivePipeline', value);
+
+      return value;
     }
   }),
 

--- a/app/components/pipeline-pr-view/component.js
+++ b/app/components/pipeline-pr-view/component.js
@@ -18,7 +18,9 @@ export default Component.extend({
       return {};
     },
     set(_, value) {
-      return set(this, '_build', value);
+      set(this, '_build', value);
+
+      return value;
     }
   }),
   displayName: computed('job.name', 'workflowGraph.nodes', {

--- a/app/components/pipeline-start/template.hbs
+++ b/app/components/pipeline-start/template.hbs
@@ -18,7 +18,7 @@
         </button>
       </div>
     {{/if}}
-    {{#if isShowingModal}}
+    {{#if this.isShowingModal}}
       <ModalDialog
         @targetAttachment="center"
         @translucentOverlay={{true}}

--- a/app/job/model.js
+++ b/app/job/model.js
@@ -32,7 +32,9 @@ export default Model.extend({
       return this.isPR ? parseInt(this.name.slice('PR-'.length), 10) : null;
     },
     set(_, value) {
-      return (this._group = value);
+      this.set('_group', value);
+
+      return value;
     }
   }),
   prNumber: alias('group'),
@@ -82,7 +84,9 @@ export default Model.extend({
       return this.state === 'DISABLED';
     },
     set(_, value) {
-      return (this._isDisabled = value);
+      this.set('_isDisabled', value);
+
+      return value;
     }
   }),
   modelToReload: 'builds',

--- a/app/pipeline/jobs/index/controller.js
+++ b/app/pipeline/jobs/index/controller.js
@@ -192,7 +192,9 @@ export default Controller.extend(ModelReloaderMixin, {
       return isInactivePipeline(this.get('pipeline'));
     },
     set(_, value) {
-      return (this._isInactivePipeline = value);
+      this.set('_isInactivePipeline', value);
+
+      return value;
     }
   }),
 

--- a/app/templates/controller.js
+++ b/app/templates/controller.js
@@ -16,7 +16,9 @@ export default Controller.extend({
       return params;
     },
     set(_, value) {
-      return (this._routeParams = value);
+      this.set('_routeParams', value);
+
+      return value;
     }
   }),
   crumbs: computed('routeParams', {
@@ -54,7 +56,9 @@ export default Controller.extend({
       return breadcrumbs;
     },
     set(_, value) {
-      return (this._crumbs = value);
+      this.set('_crumbs', value);
+
+      return value;
     }
   })
 });


### PR DESCRIPTION
## Context
Sometimes we see broken pages for these 2 reasons: 

 

1) Strict mode in handlebars template files `template.hbs`. 

Error message sample:
```
Uncaught (in promise) Error: Attempted to resolve a value in a strict mode template, but that value was not in scope: isShowingModal
```

![image](https://user-images.githubusercontent.com/15989893/224402648-87f664de-05bb-4dab-9ff0-f3ed09868fa2.png)



Before: 
```hbs
{{#if isShowingModal}}

```


After
```
{{#if this.isShowingModal}}
```
See https://github.com/emberjs/rfcs/blob/master/text/0496-handlebars-strict-mode.md#2-no-implicit-this-fallback

2) Change the implicit `set` to explicit `this.set`, for Ember version [3.20.0+](https://github.com/emberjs/ember.js/pull/18961) for an implicit set.

![2023-03-10_11-49-59 (1)](https://user-images.githubusercontent.com/15989893/224414430-a03b2c11-a46c-40a8-9a1a-bde504851c21.gif)

Error Message: 
```
Uncaught (in promise) Error: Assertion Failed: You attempted to update <screwdriver-ui@model:job::ember545:4816773>._isDisabled to "false", but it is being tracked by a tracking context, such as a template, computed property, or observer. In order to make sure the context updates properly, you must invalidate the property when updating it. You can mark the property as `@tracked`, or use `@ember/object#set` to do this.
```

Before:


```js
routeParams: computed('model', {
    set(_, value) {
      return (this._routeParams = value);
    }
}
```

After: 
```js
routeParams: computed('model', {
    set(_, value) {
      this.set('_routeParams', value);

      return value;
    }
}
```




----

> You must return the new intended value of the computed property from the setter function.

I also updated to have return value explicitly as well, from

```js
return this.set('_isInactivePipeline', value);
```

To
 
```js
this.set('_isInactivePipeline', value);

return value;
```


<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
This PR is merely to solve the blank pages issue, and we need to consider a path to move forward and use the latest glimmer syntax. 

Such as: we need to move away from [computed properties](https://guides.emberjs.com/v3.5.0/object-model/computed-properties/#toc_setting-computed-properties) 
![image](https://user-images.githubusercontent.com/15989893/224402892-12083175-50c2-4ba4-84bd-1e540e91b12e.png)

To `tracked` [computed values](https://guides.emberjs.com/v4.4.0/components/component-state-and-actions/#toc_computed-values)
![image](https://user-images.githubusercontent.com/15989893/224406329-379bf552-450d-4efc-ae08-2cd488c6909a.png)



<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
1) [computed properties](https://guides.emberjs.com/v3.5.0/object-model/computed-properties/#toc_setting-computed-properties) 
2) [Why do I not need to mark the property as tracked?](https://discuss.emberjs.com/t/why-do-i-not-need-to-mark-the-property-as-tracked/18093/3)


<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

https://github.com/screwdriver-cd/screwdriver/issues/2838

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
