### PR TITLE
fix(2842): Fix artifact deeplink expansion

### DIFF
--- a/app/components/artifact-tree-children/component.js
+++ b/app/components/artifact-tree-children/component.js
@@ -10,7 +10,7 @@ export default Component.extend({
         return '';
       }
 
-      return dividePath[0];
+      return decodeURIComponent(dividePath[0]);
     }
   }),
   selectedArtifactRelativeChild: computed('selectedArtifactRelative', {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Artifact deeplink path is encoded for URI path.
Therefore, it have to be decoded to compare original text.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Decode artifact deeplink path.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
screwdriver-cd/screwdriver#2842

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
