### PR TITLE
fix: unable to see build display name

### DIFF
--- a/app/components/pipeline-list-job-cell/component.js
+++ b/app/components/pipeline-list-job-cell/component.js
@@ -20,7 +20,7 @@ export default Component.extend({
   }),
   jobName: computed('record.job.jobName', 'record.job.displayName', {
     get() {
-      if(this.record.job.displayName){
+      if(this.record.job.displayName) {
 
         return this.record.job.displayName;
       }

--- a/app/components/pipeline-list-job-cell/component.js
+++ b/app/components/pipeline-list-job-cell/component.js
@@ -20,7 +20,7 @@ export default Component.extend({
   }),
   jobName: computed('record.job.jobName', 'record.job.displayName', {
     get() {
-      if(this.record.job.displayName) {
+      if (this.record.job.displayName) {
 
         return this.record.job.displayName;
       }

--- a/app/components/pipeline-list-job-cell/component.js
+++ b/app/components/pipeline-list-job-cell/component.js
@@ -18,8 +18,13 @@ export default Component.extend({
       };
     }
   }),
-  jobName: computed('record.job.jobName', {
+  jobName: computed('record.job.jobName', 'record.job.displayName', {
     get() {
+      if(this.record.job.displayName){
+
+        return this.record.job.displayName;
+      }
+
       return this.record.job.jobName;
     }
   })

--- a/app/components/pipeline-list-job-cell/template.hbs
+++ b/app/components/pipeline-list-job-cell/template.hbs
@@ -15,7 +15,7 @@
   {{/if}}
   <div class="job-name">
     <BsTooltip @placement="bottom">
-      {{this.record.job.jobName}} {{this.build.status}}
+      {{this.record.job.jobName}}
     </BsTooltip>
     {{this.jobName}}
   </div>

--- a/app/components/pipeline-list-job-cell/template.hbs
+++ b/app/components/pipeline-list-job-cell/template.hbs
@@ -14,6 +14,9 @@
     <span class="fa"></span>
   {{/if}}
   <div class="job-name">
+    <BsTooltip @placement="bottom">
+      {{this.record.job.jobName}} {{this.build.status}}
+    </BsTooltip>
     {{this.jobName}}
   </div>
 </div>

--- a/app/components/pipeline-list-view/component.js
+++ b/app/components/pipeline-list-view/component.js
@@ -171,6 +171,7 @@ export default Component.extend({
 
       const jobData = {
         jobName,
+        displayName: annotations['screwdriver.cd/displayName'],
         build: latestBuild
       };
 

--- a/tests/integration/components/pipeline-list-job-cell/component-test.js
+++ b/tests/integration/components/pipeline-list-job-cell/component-test.js
@@ -92,4 +92,24 @@ module('Integration | Component | pipeline list job cell', function (hooks) {
     assert.dom('.fa-times-circle').exists({ count: 1 });
     assert.dom('.job-name').hasText('b');
   });
+
+  test('it renders displayName if present', async function (assert) {
+    this.set('record', {
+      job: {
+        jobName: 'a',
+        build: {
+          id: 2,
+          status: 'RUNNING'
+        },
+        displayName: 'dummyjob'
+      }
+    });
+
+    await render(hbs`<PipelineListJobCell
+      @record={{this.record}}
+    />`);
+
+    assert.dom('.fa-spinner').exists({ count: 1 });
+    assert.dom('.job-name').hasText('dummyjob');
+  });
 });

--- a/tests/integration/components/pipeline-list-view/component-test.js
+++ b/tests/integration/components/pipeline-list-view/component-test.js
@@ -31,7 +31,10 @@ module('Integration | Component | pipeline list view', function (hooks) {
             startTime: '',
             endTime: ''
           }
-        ]
+        ],
+        annotations: {
+          'screwdriver.cd/displayName': 'a'
+        }
       },
       {
         jobId: 2,
@@ -51,7 +54,10 @@ module('Integration | Component | pipeline list view', function (hooks) {
             startTime: '',
             endTime: ''
           }
-        ]
+        ],
+        annotations: {
+          'screwdriver.cd/displayName': null
+        }
       }
     ];
 
@@ -116,7 +122,10 @@ module('Integration | Component | pipeline list view', function (hooks) {
             startTime: '',
             endTime: ''
           }
-        ]
+        ],
+        annotations: {
+          'screwdriver.cd/displayName': 'a'
+        }
       },
       {
         jobId: 2,
@@ -136,7 +145,10 @@ module('Integration | Component | pipeline list view', function (hooks) {
             startTime: '',
             endTime: ''
           }
-        ]
+        ],
+        annotations: {
+          'screwdriver.cd/displayName': 'a'
+        }
       }
     ]);
     set(this, 'updateListViewJobs', () => Promise.resolve([]));
@@ -191,7 +203,10 @@ module('Integration | Component | pipeline list view', function (hooks) {
             startTime: '2020-04-16T01:30:01.447',
             endTime: '2020-04-16T07:43:09.447'
           }
-        ]
+        ],
+        annotations: {
+          'screwdriver.cd/displayName': 'a'
+        }
       }
     ];
 
@@ -253,7 +268,10 @@ module('Integration | Component | pipeline list view', function (hooks) {
             startTime: '2020-04-16T01:30:01.447',
             endTime: null
           }
-        ]
+        ],
+        annotations: {
+          'screwdriver.cd/displayName': 'a'
+        }
       }
     ];
 
@@ -313,7 +331,10 @@ module('Integration | Component | pipeline list view', function (hooks) {
             startTime: '2020-04-16T01:30:01.447',
             endTime: null
           }
-        ]
+        ],
+        annotations: {
+          'screwdriver.cd/displayName': 'a'
+        }
       }
     ];
 
@@ -373,7 +394,10 @@ module('Integration | Component | pipeline list view', function (hooks) {
             startTime: '2020-04-16T01:30:01.447',
             endTime: null
           }
-        ]
+        ],
+        annotations: {
+          'screwdriver.cd/displayName': 'a'
+        }
       }
     ];
 
@@ -433,7 +457,10 @@ module('Integration | Component | pipeline list view', function (hooks) {
             startTime: '2020-04-16T01:30:01.447',
             endTime: null
           }
-        ]
+        ],
+        annotations: {
+          'screwdriver.cd/displayName': 'a'
+        }
       }
     ];
 
@@ -493,7 +520,10 @@ module('Integration | Component | pipeline list view', function (hooks) {
             startTime: '2020-04-16T01:30:01.447',
             endTime: null
           }
-        ]
+        ],
+        annotations: {
+          'screwdriver.cd/displayName': 'a'
+        }
       }
     ];
 
@@ -553,7 +583,10 @@ module('Integration | Component | pipeline list view', function (hooks) {
             startTime: null,
             endTime: null
           }
-        ]
+        ],
+        annotations: {
+          'screwdriver.cd/displayName': 'a'
+        }
       }
     ];
 
@@ -613,7 +646,10 @@ module('Integration | Component | pipeline list view', function (hooks) {
             startTime: '2020-04-16T01:30:01.447',
             endTime: null
           }
-        ]
+        ],
+        annotations: {
+          'screwdriver.cd/displayName': undefined
+        }
       }
     ]);
     set(this, 'updateListViewJobs', () => Promise.resolve([]));


### PR DESCRIPTION
## Context

Unable to see display name on Build Details or Options, and unable to see "real" name on Overview.

## Objective
All UI views should be consistent about which name is used for a job.
![image](https://user-images.githubusercontent.com/104225232/226980445-38d6ec60-d55e-4d4a-bc4c-8d4f4ea1ef20.png)




## References
https://github.com/screwdriver-cd/screwdriver/issues/2773

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
