### PR TITLE
fix: add saucelabs coverage support

### DIFF
--- a/app/components/build-banner/component.js
+++ b/app/components/build-banner/component.js
@@ -6,7 +6,6 @@ import { isActiveBuild, isPRJob } from 'screwdriver-ui/utils/build';
 import PromiseProxyMixin from '@ember/object/promise-proxy-mixin';
 import ObjectProxy from '@ember/object/proxy';
 import { getTimestamp } from '../../utils/timestamp-format';
-
 const ObjectPromiseProxy = ObjectProxy.extend(PromiseProxyMixin);
 
 export default Component.extend({
@@ -150,14 +149,22 @@ export default Component.extend({
 
     // override coverage info if set in build meta
     if (buildMeta && buildMeta.tests) {
+      let testOutput = buildMeta.tests;
+      const { sonarqube, saucelabs } = buildMeta.tests;
+
+      if (saucelabs) {
+        testOutput = saucelabs;
+      } else if (sonarqube) {
+        testOutput = sonarqube;
+      }
+
       const {
         coverage,
         coverageUrl,
         results: tests,
         resultsUrl: testsUrl
-      } = buildMeta.tests;
-      const BUILD_URL_REGEX = /^.+\/pipelines\/\d+\/builds\/\d+/;
-      const buildUrl = window.location.href.match(BUILD_URL_REGEX);
+      } = testOutput;
+
       const coverageFloat = parseFloat(coverage)
         ? Number(parseFloat(coverage).toFixed(2))
         : null;
@@ -169,17 +176,17 @@ export default Component.extend({
         coverageInfo.coverageUrl = '#';
       }
 
-      if (String(coverageUrl).match(/^(\/[^/]+)+$/) && buildUrl) {
-        coverageInfo.coverageUrl = `${buildUrl[0]}/artifacts${coverageUrl}`;
+      if (coverageUrl) {
+        coverageInfo.coverageUrl = coverageUrl;
       }
 
-      if (String(tests).match(/^\d+\/\d+$/)) {
+      if (tests) {
         coverageInfo.tests = tests;
         coverageInfo.testsUrl = '#';
       }
 
-      if (String(testsUrl).match(/^(\/[^/]+)+$/) && buildUrl) {
-        coverageInfo.testsUrl = `${buildUrl[0]}/artifacts${testsUrl}`;
+      if (testsUrl) {
+        coverageInfo.testsUrl = testsUrl;
       }
 
       this.set('coverageInfo', coverageInfo);

--- a/app/components/build-banner/component.js
+++ b/app/components/build-banner/component.js
@@ -6,7 +6,7 @@ import { isActiveBuild, isPRJob } from 'screwdriver-ui/utils/build';
 import PromiseProxyMixin from '@ember/object/promise-proxy-mixin';
 import ObjectProxy from '@ember/object/proxy';
 import { getTimestamp } from '../../utils/timestamp-format';
-import { isValidHttpOrHttpsUrl } from '../../utils/url-regex';
+import { isValidHttpOrHttpsUrl } from '../../utils/url';
 
 const ObjectPromiseProxy = ObjectProxy.extend(PromiseProxyMixin);
 

--- a/app/components/build-banner/component.js
+++ b/app/components/build-banner/component.js
@@ -6,6 +6,8 @@ import { isActiveBuild, isPRJob } from 'screwdriver-ui/utils/build';
 import PromiseProxyMixin from '@ember/object/promise-proxy-mixin';
 import ObjectProxy from '@ember/object/proxy';
 import { getTimestamp } from '../../utils/timestamp-format';
+import { isValidHttpOrHttpsUrl } from '../../utils/url-regex';
+
 const ObjectPromiseProxy = ObjectProxy.extend(PromiseProxyMixin);
 
 export default Component.extend({
@@ -176,16 +178,16 @@ export default Component.extend({
         coverageInfo.coverageUrl = '#';
       }
 
-      if (coverageUrl) {
+      if (coverageUrl && isValidHttpOrHttpsUrl(coverageUrl)) {
         coverageInfo.coverageUrl = coverageUrl;
       }
 
-      if (tests) {
+      if (String(tests).match(/^\d+\/\d+$/)) {
         coverageInfo.tests = tests;
         coverageInfo.testsUrl = '#';
       }
 
-      if (testsUrl) {
+      if (testsUrl && isValidHttpOrHttpsUrl(testsUrl)) {
         coverageInfo.testsUrl = testsUrl;
       }
 

--- a/app/components/build-banner/template.hbs
+++ b/app/components/build-banner/template.hbs
@@ -119,6 +119,7 @@
       <span class="banner-value">
         <a
           href={{this.coverageInfo.coverageUrl}}
+          target="_blank" rel="noopener noreferrer"
           title={{if
             (eq this.coverageInfo.coverage "N/A")
             "Coverage report not generated"
@@ -135,6 +136,7 @@
       <span class="banner-value">
         <a
           href={{this.coverageInfo.testsUrl}}
+          target="_blank" rel="noopener noreferrer"
           title={{if
             (eq this.coverageInfo.tests "N/A")
             "Tests report not generated"

--- a/app/helpers/linkify.js
+++ b/app/helpers/linkify.js
@@ -3,7 +3,7 @@ import { typeOf } from '@ember/utils';
 import { helper } from '@ember/component/helper';
 import { htmlSafe } from '@ember/template';
 import Ember from 'ember';
-import { urlRegex, shortenUrl } from '../utils/url-regex';
+import { urlRegex, shortenUrl } from '../utils/url';
 
 const ALLOWED_ATTRIBUTE_NAMES = ['rel', 'class', 'target', 'urlLength'];
 

--- a/app/utils/url-regex.js
+++ b/app/utils/url-regex.js
@@ -15,4 +15,13 @@ function shortenUrl(url, length) {
   return url;
 }
 
-export { urlRegex, shortenUrl };
+function isValidHttpOrHttpsUrl(url) {
+  try {
+    const newUrl = new URL(url);
+    return newUrl.protocol === 'http:' || newUrl.protocol === 'https:';
+  } catch (err) {
+    return false;
+  }
+}
+
+export { urlRegex, shortenUrl, isValidHttpOrHttpsUrl };

--- a/app/utils/url.js
+++ b/app/utils/url.js
@@ -18,7 +18,7 @@ function shortenUrl(url, length) {
 function isValidHttpOrHttpsUrl(url) {
   try {
     const newUrl = new URL(url);
-    return newUrl.protocol === 'http:' || newUrl.protocol === 'https:';
+    return ['http:', 'https:'].includes(newUrl.protocol);
   } catch (err) {
     return false;
   }

--- a/tests/integration/components/build-banner/component-test.js
+++ b/tests/integration/components/build-banner/component-test.js
@@ -687,16 +687,14 @@ module('Integration | Component | build banner', function (hooks) {
       @prEvents={{this.prEvents}}
     />`);
 
-    return settled().then(() => {
-      assert.dom('.coverage .banner-value').hasText('98%');
-      assert.dom('.tests .banner-value').hasText('7/10');
-      assert
-        .dom('.coverage a')
-        .hasAttribute('href', 'http://example.com/coverage/123');
-      assert
-        .dom('.tests a')
-        .hasAttribute('href', 'http://example.com/coverage/123');
-    });
+    assert.dom('.coverage .banner-value').hasText('98%');
+    assert.dom('.tests .banner-value').hasText('7/10');
+    assert
+      .dom('.coverage a')
+      .hasAttribute('href', 'http://example.com/coverage/123');
+    assert
+      .dom('.tests a')
+      .hasAttribute('href', 'http://example.com/coverage/123');
   });
 
   test('it does not render coverage info if there is no coverage step', async function (assert) {
@@ -898,18 +896,16 @@ module('Integration | Component | build banner', function (hooks) {
       @prEvents={{this.prEvents}}
     />`);
 
-    return settled().then(() => {
-      assert.dom('.coverage .banner-value').hasText('98%');
-      assert
-        .dom('.coverage a')
-        .hasAttribute('href', 'http://example.com/coverage/123');
-      assert.dom('.tests .banner-value').hasText('2/2');
-      assert
-        .dom('.tests a')
-        .hasAttribute(
-          'href',
-          'https://app.saucelabs.com/builds/vdc/aabbccddeeffggIsNotAReadBuildID'
-        );
-    });
+    assert.dom('.coverage .banner-value').hasText('98%');
+    assert
+      .dom('.coverage a')
+      .hasAttribute('href', 'http://example.com/coverage/123');
+    assert.dom('.tests .banner-value').hasText('2/2');
+    assert
+      .dom('.tests a')
+      .hasAttribute(
+        'href',
+        'https://app.saucelabs.com/builds/vdc/aabbccddeeffggIsNotAReadBuildID'
+      );
   });
 });

--- a/tests/integration/components/build-banner/component-test.js
+++ b/tests/integration/components/build-banner/component-test.js
@@ -687,7 +687,7 @@ module('Integration | Component | build banner', function (hooks) {
       @prEvents={{this.prEvents}}
     />`);
 
-    await settled().then(() => {
+    return settled().then(() => {
       assert.dom('.coverage .banner-value').hasText('98%');
       assert.dom('.tests .banner-value').hasText('7/10');
       assert


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Add support for UI to display Saucelabs test information. 

![image](https://user-images.githubusercontent.com/15989893/228014886-6c41490a-77fc-410f-950c-cf9afcb7af29.png)

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
For backward compatibility purposes,  see the screenshot attached.

UI will keep the old behavior and only override the coverage info when `buildMeta.tests.saucelabs` or `buildMeta.tests.sonarqube` present. 

https://docs.screwdriver.cd/user-guide/metadata.html#coverage-and-test-results

![image](https://user-images.githubusercontent.com/15989893/228014494-0b824bfb-4f2a-42fa-98b1-6df82b0642f8.png)


The precedence is `buildMeta.tests.saucelabs` > `buildMeta.tests.sonarqube` > `buildMeta.tests`


## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
