### PR TITLE
fix:input required for delete pipeline

### DIFF
--- a/app/components/pipeline-options/component.js
+++ b/app/components/pipeline-options/component.js
@@ -238,9 +238,9 @@ export default Component.extend({
     },
     checkPipelineName(val) {
       this.set('pipelineName', val.trim());
-      const originalPipeline = this.get('pipeline.scmRepo.name');
+      const originalPipelineName = this.get('pipeline.scmRepo.name');
 
-      if (originalPipeline === this.pipelineName) {
+      if (originalPipelineName === this.pipelineName) {
         this.set('deleteBtnDisabled', false);
       } else {
         this.set('deleteBtnDisabled', true);

--- a/app/components/pipeline-options/component.js
+++ b/app/components/pipeline-options/component.js
@@ -50,7 +50,6 @@ export default Component.extend({
   filterEventsForNoBuilds: false,
   aliasName: '',
   pipelineName: '',
-  deleteBtnDisabled: true,
   sortedJobs: computed('jobs', function filterThenSortJobs() {
     const prRegex = /PR-\d+:.*/;
 
@@ -65,6 +64,13 @@ export default Component.extend({
       const val = this.scmUrl;
 
       return val.length !== 0 && parse(val).valid;
+    }
+  }),
+  isPipelineDeletionDisabled: computed('pipelineName', 'pipeline.scmRepo.name', {
+    get() {
+      const isDisabled = this.get('pipeline.scmRepo.name') !== this.pipelineName;
+
+      return isDisabled;
     }
   }),
   // Updating a pipeline
@@ -235,16 +241,6 @@ export default Component.extend({
     showRemoveButtons() {
       this.set('showRemoveDangerButton', false);
       this.set('showRemoveButtons', true);
-    },
-    checkPipelineName(val) {
-      this.set('pipelineName', val.trim());
-      const originalPipelineName = this.get('pipeline.scmRepo.name');
-
-      if (originalPipelineName === this.pipelineName) {
-        this.set('deleteBtnDisabled', false);
-      } else {
-        this.set('deleteBtnDisabled', true);
-      }
     },
     cancelRemove() {
       this.set('showRemoveDangerButton', true);

--- a/app/components/pipeline-options/component.js
+++ b/app/components/pipeline-options/component.js
@@ -49,6 +49,8 @@ export default Component.extend({
   showEventTriggers: false,
   filterEventsForNoBuilds: false,
   aliasName: '',
+  pipelineName: '',
+  deleteBtnDisabled: true,
   sortedJobs: computed('jobs', function filterThenSortJobs() {
     const prRegex = /PR-\d+:.*/;
 
@@ -233,6 +235,16 @@ export default Component.extend({
     showRemoveButtons() {
       this.set('showRemoveDangerButton', false);
       this.set('showRemoveButtons', true);
+    },
+    checkPipelineName(val) {
+      this.set('pipelineName', val.trim());
+      const originalPipeline = this.get('pipeline.scmRepo.name');
+
+      if (originalPipeline === this.pipelineName) {
+        this.set('deleteBtnDisabled', false);
+      } else {
+        this.set('deleteBtnDisabled', true);
+      }
     },
     cancelRemove() {
       this.set('showRemoveDangerButton', true);

--- a/app/components/pipeline-options/template.hbs
+++ b/app/components/pipeline-options/template.hbs
@@ -524,17 +524,42 @@
               </div>
             {{/if}}
             {{#if this.showRemoveButtons}}
-              <h4>
-                Are you absolutely sure?
-              </h4>
-              <a href="#" class="cancel" {{action "cancelRemove"}}>
-                <FaIcon @icon="ban" />
-                Cancel
-              </a>
-              <a href="#" class="remove" {{action "removePipeline"}}>
-                <FaIcon @icon="trash" />
-                Delete
-              </a>
+              <BsModal
+                @onSubmit={{action "removePipeline"}}
+                @onHide={{action "cancelRemove"}} as |modal|
+              >
+                <div class="delete-pipeline__modal">
+                    <modal.header>
+                      <h4>
+                        Are you absolutely sure?
+                      </h4>
+                    </modal.header>
+                    <modal.body>
+                      <FaIcon @icon="exclamation-triangle" @pull="left" @size="4" />
+                      <span>This action cannot be undone. Are you sure you want to delete the pipeline?</span>
+                      <p>Please type <b>{{this.pipeline.scmRepo.name}}</b>  to confirm.</p> 
+                        <input
+                          type="text"
+                          class="delete-pipeline__input col-12"
+                          value={{this.pipelineName}}
+                          oninput={{action "checkPipelineName" value="target.value"}}
+                        />
+                    </modal.body>
+                    <modal.footer>
+                      <BsButton
+                        class="delete-pipeline-cancel"
+                        @onClick={{action modal.close}}
+                        @outline={{true}}
+                        @type="secondary"
+                      >
+                        Cancel
+                      </BsButton>
+                      <BsButton disabled={{this.deleteBtnDisabled}} @outline={{true}} @onClick={{action "removePipeline"}} @type="danger" class="delete-pipeline-btn">
+                        Delete the pipeline
+                      </BsButton>
+                    </modal.footer>
+                  </div>
+                </BsModal>
             {{/if}}
             {{#if this.isRemoving}}
               <p>

--- a/app/components/pipeline-options/template.hbs
+++ b/app/components/pipeline-options/template.hbs
@@ -538,12 +538,11 @@
                       <FaIcon @icon="exclamation-triangle" @pull="left" @size="4" />
                       <span>This action cannot be undone. Are you sure you want to delete the pipeline?</span>
                       <p>Please type <b>{{this.pipeline.scmRepo.name}}</b>  to confirm.</p> 
-                        <input
-                          type="text"
-                          class="delete-pipeline__input col-12"
-                          value={{this.pipelineName}}
-                          oninput={{action "checkPipelineName" value="target.value"}}
-                        />
+                      <Input
+                        @type="text"
+                        class="delete-pipeline__input col-12"
+                        @value={{this.pipelineName}}
+                      />
                     </modal.body>
                     <modal.footer>
                       <BsButton
@@ -554,8 +553,8 @@
                       >
                         Cancel
                       </BsButton>
-                      <BsButton disabled={{this.deleteBtnDisabled}} @outline={{true}} @onClick={{action "removePipeline"}} @type="danger" class="delete-pipeline-btn">
-                        Delete the pipeline
+                      <BsButton disabled={{this.isPipelineDeletionDisabled}} @outline={{true}} @onClick={{action "removePipeline"}} @type="danger" class="delete-pipeline-btn">
+                        Delete
                       </BsButton>
                     </modal.footer>
                   </div>

--- a/tests/integration/components/pipeline-options/component-test.js
+++ b/tests/integration/components/pipeline-options/component-test.js
@@ -621,7 +621,10 @@ module('Integration | Component | pipeline options', function (hooks) {
       EmberObject.create({
         appId: 'foo/bar',
         scmUri: 'github.com:84604643:master',
-        id: 'abc1234'
+        id: 'abc1234',
+        scmRepo: {
+          name: 'test/test-pipeline'
+        }
       })
     );
 
@@ -636,19 +639,36 @@ module('Integration | Component | pipeline options', function (hooks) {
     assert.dom('section.danger h4').hasText('Delete this pipeline');
 
     await click('section.danger a');
+    
+    assert.dom('.modal-dialog').exists();
+    assert.dom('.modal-dialog h4').hasText('Are you absolutely sure?');
+    //starts with button disabled
+    assert.dom('.modal-footer .delete-pipeline-btn').isDisabled();
 
-    assert.dom('section.danger h4').hasText('Are you absolutely sure?');
-    assert.dom('section.danger a').exists({ count: 2 });
+    //cancel button closes the modal
+    await click('.modal-footer .delete-pipeline-cancel');
+    assert.dom('.modal-dialog').doesNotExist();
 
     await click('section.danger a');
+    assert.dom('.modal-dialog').exists();
+    assert.dom('.modal-dialog h4').hasText('Are you absolutely sure?');
 
-    assert.dom('section.danger h4').hasText('Delete this pipeline');
+    await fillIn('.modal-body input', 'screwdriver');
+    //wrong pipeline name button is still disabled
+    assert.dom('.modal-footer .delete-pipeline-btn').isDisabled();
+
+    await click('.modal-footer .delete-pipeline-cancel');
 
     await click('section.danger a');
+    assert.dom('.modal-dialog').exists();
+    assert.dom('.modal-dialog h4').hasText('Are you absolutely sure?');
 
-    assert.dom('section.danger h4').hasText('Are you absolutely sure?');
+    await fillIn('.modal-body input', 'test/test-pipeline');
+    // correct pipeline so button is enable
+    assert.dom('.modal-footer .delete-pipeline-btn').isEnabled();
 
-    await click('section.danger a:last-child');
+    await click('.modal-footer .delete-pipeline-btn');
+    assert.dom('.modal-dialog').doesNotExist();
 
     assert.dom('section.danger p').hasText('Please wait...');
   });


### PR DESCRIPTION
## Context

When operating the danger zone, we may be worried that I'm operating the wrong pipeline. There is also the possibility of mistakenly pressing cancel and delete.


## Objective
Before:
<img width="543" alt="Screenshot 2023-03-27 at 1 04 33 PM" src=https://user-images.githubusercontent.com/24538326/130915772-37a39f85-6234-4719-9c78-bd50428722a3.png>

After
while no input:
<img width="560" alt="Screenshot 2023-03-27 at 1 03 03 PM" src="https://user-images.githubusercontent.com/104225232/228272822-717c7a7d-5120-4d4c-b041-e20943c5658e.png">
while wrong input:

<img width="543" alt="Screenshot 2023-03-27 at 1 04 33 PM" src="https://user-images.githubusercontent.com/104225232/228272848-b351fa7f-a6a6-473b-a082-9a9f24cb92c2.png">

while correct input:
<img width="579" alt="Screenshot 2023-03-27 at 1 05 26 PM" src="https://user-images.githubusercontent.com/104225232/228272868-31abd981-63e2-4852-ae36-4e1401f01ac1.png">



## References

https://github.com/screwdriver-cd/screwdriver/issues/2542
## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
