### PR TITLE
fix(2846): Filter other pipeline events

### DIFF
--- a/app/components/pipeline-events/component.js
+++ b/app/components/pipeline-events/component.js
@@ -217,7 +217,6 @@ export default Component.extend(ModelReloaderMixin, {
     this._super(...arguments);
     this.startReloading();
     this.set('eventsPage', 1);
-    this.set('paginateEvents', []);
   },
 
   reload() {
@@ -275,6 +274,7 @@ export default Component.extend(ModelReloaderMixin, {
     }
   }),
   jobsDetails: [],
+  paginateEvents: [],
   prChainEnabled: alias('pipeline.prChain'),
   completeWorkflowGraph: computed(
     'model.triggers.@each.triggers',
@@ -368,12 +368,18 @@ export default Component.extend(ModelReloaderMixin, {
     'pipeline.id',
     {
       get() {
-        this.shuttle
-          .getLatestCommitEvent(this.get('pipeline.id'))
-          .then(event => {
-            this.set('latestCommit', event);
-          });
-        const pipelineEvents = [].concat(this.modelEvents, this.paginateEvents);
+        const pipelineId = this.get('pipeline.id');
+        const filteredPaginateEvents = this.paginateEvents.filter(
+          e => e.pipelineId === pipelineId
+        );
+        const pipelineEvents = [].concat(
+          this.modelEvents,
+          filteredPaginateEvents
+        );
+
+        this.shuttle.getLatestCommitEvent(pipelineId).then(event => {
+          this.set('latestCommit', event);
+        });
 
         // filter events for no builds
         if (this.isFilteredEventsForNoBuilds) {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
In [PR911](https://github.com/screwdriver-cd/ui/pull/911), we try to reset paginateEvents.
However, it cannot be reset correctly.
Therefore, we filter the events instead of reset.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Filter events.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/2846

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
