### PR TITLE
fix(2838): Trusted tag and parameter build bugs

### DIFF
--- a/app/components/command-header/component.js
+++ b/app/components/command-header/component.js
@@ -6,6 +6,7 @@ export default Component.extend({
   scmUrl: null,
   isRemoving: false,
   store: service(),
+  isTrusted: null,
   init() {
     this._super(...arguments);
     this.store
@@ -16,6 +17,7 @@ export default Component.extend({
       .catch(() => {
         this.set('scmUrl', null);
       });
+    this.set('isTrusted', this.command.trusted)
   },
   actions: {
     setCommandToRemove(command) {
@@ -33,7 +35,7 @@ export default Component.extend({
       });
     },
     updateTrust(namespace, name, toTrust) {
-      this.set('trusted', toTrust);
+      this.set('isTrusted', toTrust);
       this.onUpdateTrust(namespace, name, toTrust);
     }
   }

--- a/app/components/command-header/template.hbs
+++ b/app/components/command-header/template.hbs
@@ -1,5 +1,5 @@
 <h1>
-  {{#if this.trusted}}
+  {{#if this.isTrusted}}
     <span title="Trusted">
       {{svg-jar "trusted" class="trusted"}}
     </span>
@@ -31,7 +31,7 @@
       <XToggle
         @size="medium"
         @theme="light"
-        @value={{this.trusted}}
+        @value={{this.isTrusted}}
         @onToggle={{action "updateTrust" this.command.namespace this.command.name}}
       />
       Trust?

--- a/app/components/pipeline-parameterized-build/template.hbs
+++ b/app/components/pipeline-parameterized-build/template.hbs
@@ -64,12 +64,12 @@
                             parameterGroup.jobName
                             parameter.name
                         )}}
-                        @onkeydown={{fn (action
+                        @onkeydown={{ action
                             "searchOrAddtoList"
                             this.parameterizedModel
                             parameterGroup.jobName
                             parameter.name
-                        )}}
+                        }}
                         @searchPlaceholder="Type to filter"
                         @noMatchesMessage="Hit enter to override" as |selectedValue|
                       >

--- a/app/components/template-header/component.js
+++ b/app/components/template-header/component.js
@@ -6,6 +6,7 @@ export default Component.extend({
   scmUrl: null,
   isRemoving: false,
   store: service(),
+  isTrusted: null, 
   init() {
     this._super(...arguments);
     this.store
@@ -16,6 +17,8 @@ export default Component.extend({
       .catch(() => {
         this.set('scmUrl', null);
       });
+
+    this.set('isTrusted', this.template.trusted);
   },
   actions: {
     setTemplateToRemove(template) {
@@ -33,7 +36,7 @@ export default Component.extend({
       });
     },
     updateTrust(fullName, toTrust) {
-      this.set('trusted', toTrust);
+      this.set('isTrusted', toTrust)
       this.onUpdateTrust(fullName, toTrust);
     }
   }

--- a/app/components/template-header/component.js
+++ b/app/components/template-header/component.js
@@ -36,7 +36,7 @@ export default Component.extend({
       });
     },
     updateTrust(fullName, toTrust) {
-      this.set('isTrusted', toTrust)
+      this.set('isTrusted', toTrust);
       this.onUpdateTrust(fullName, toTrust);
     }
   }

--- a/app/components/template-header/template.hbs
+++ b/app/components/template-header/template.hbs
@@ -1,5 +1,5 @@
 <h1>
-  {{#if this.trusted}}
+  {{#if this.isTrusted}}
     <span title="Trusted">
       {{svg-jar "trusted" class="trusted"}}
     </span>
@@ -31,7 +31,7 @@
       <XToggle
         @size="medium"
         @theme="light"
-        @value={{this.trusted}}
+        @value={{this.isTrusted}}
         @onToggle={{action "updateTrust" this.template.fullName}}
       />
       Trust?

--- a/tests/integration/components/command-header/component-test.js
+++ b/tests/integration/components/command-header/component-test.js
@@ -14,7 +14,8 @@ const COMMAND = {
   maintainer: 'test@example.com',
   format: 'docker',
   docker: '{"image":"test","command":"example"}',
-  pipelineId: 100
+  pipelineId: 100,
+  trusted: true
 };
 
 const mockPipeline = {
@@ -40,7 +41,6 @@ module('Integration | Component | command header', function (hooks) {
     this.owner.register('service:store', storeStub);
 
     this.set('mock', COMMAND);
-    this.set('trusted', false);
     this.set('isAdmin', false);
 
     await render(
@@ -57,7 +57,6 @@ module('Integration | Component | command header', function (hooks) {
     assert.dom('h4').hasText('Usage:');
     assert.dom('pre').hasText('sd-cmd exec foo/bar@1.0.0');
 
-    this.set('trusted', true);
     this.set('isAdmin', true);
 
     assert.dom('svg').exists({ count: 3 });

--- a/tests/integration/components/template-header/component-test.js
+++ b/tests/integration/components/template-header/component-test.js
@@ -22,7 +22,8 @@ const TEMPLATE = {
   images: {
     stable: 'node:6',
     development: 'node:7'
-  }
+  },
+  trusted: true
 };
 
 const mockPipeline = {
@@ -46,7 +47,6 @@ module('Integration | Component | template header', function (hooks) {
     });
 
     this.set('mock', TEMPLATE);
-    this.set('trusted', false);
     this.set('isAdmin', false);
 
     this.owner.unregister('service:store');
@@ -69,7 +69,6 @@ module('Integration | Component | template header', function (hooks) {
     assert.dom('h4').hasText('Usage:');
     assert.dom('pre').hasText('jobs: main: template: foo/bar@2.0.0');
 
-    this.set('trusted', true);
     this.set('isAdmin', true);
 
     assert.dom('svg').exists({ count: 3 });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Display corruption due to update Ember.js are fixed.


## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
1. Screwdriver admins cannot trust the template/command.
The following error message appears
<img width="782" alt="スクリーンショット 2023-04-17 11 26 09" src="https://user-images.githubusercontent.com/17828065/232363388-13cd932f-35ef-47a8-9f02-762a6735b0e4.png">
The cause is an unsuccessful attempt to override the readonly property

2. Build parameter function does not allow users to set any value
<img width="452" alt="スクリーンショット 2023-04-17 11 32 26" src="https://user-images.githubusercontent.com/17828065/232364116-1c089009-9d87-4626-bdf1-a1e41336eb3a.png">
The cause was a failed action helper call.


## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
related to: https://github.com/screwdriver-cd/screwdriver/issues/2838

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
