### PR TITLE
fix: isFilteredEventsForNoBuilds is not a computed property

### DIFF
--- a/app/components/pipeline-events/component.js
+++ b/app/components/pipeline-events/component.js
@@ -185,6 +185,9 @@ export default Component.extend(ModelReloaderMixin, {
   // Update the job status
   jobService: service('job'),
   lastRefreshed: moment(),
+  isFilteredEventsForNoBuilds: alias(
+    'pipeline.settings.isFilteredEventsForNoBuilds'
+  ),
   filterSchedulerEvents: alias('pipeline.settings.filterSchedulerEvents'),
   shouldReload(model) {
     let res = SHOULD_RELOAD_SKIP;
@@ -396,7 +399,9 @@ export default Component.extend(ModelReloaderMixin, {
 
         // filter events created by screwdriver scheduler
         if (this.filterSchedulerEvents) {
-          filteredEvents = filteredEvents.filter(event => event.creator.name !== SD_SCHEDULER);
+          filteredEvents = filteredEvents.filter(
+            event => event.creator.name !== SD_SCHEDULER
+          );
         }
 
         return filteredEvents;


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
`isFilteredEventsForNoBuilds` does not exist and is not a computed property

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
