### PR TITLE
fix: selected event from url is not filtered

### DIFF
--- a/app/components/pipeline-events/component.js
+++ b/app/components/pipeline-events/component.js
@@ -385,7 +385,6 @@ export default Component.extend(ModelReloaderMixin, {
           filteredPaginateEvents
         );
         const selectedEventId = this.selected;
-        const selectedEvent = this.modelEvents.findBy('id', selectedEventId);
 
         let filteredEvents = pipelineEvents;
 
@@ -395,21 +394,24 @@ export default Component.extend(ModelReloaderMixin, {
 
         // filter events for no builds
         if (this.isFilteredEventsForNoBuilds) {
-          filteredEvents = filteredEvents.filter(
-            (event, idx) => event.status !== 'SKIPPED' || idx === 0
-          );
+          filteredEvents = filteredEvents.filter((event, idx) => {
+            if (event.id === selectedEventId) {
+              return true;
+            }
+
+            return event.status !== 'SKIPPED' || idx === 0;
+          });
         }
 
         // filter events created by screwdriver scheduler
         if (this.filterSchedulerEvents) {
-          filteredEvents = filteredEvents.filter(
-            event => event.creator.name !== SD_SCHEDULER
-          );
-        }
+          filteredEvents = filteredEvents.filter(event => {
+            if (event.id === selectedEventId) {
+              return true;
+            }
 
-        // ensure selected event from url is not filtered
-        if (!filteredEvents.findBy('id', selectedEventId)) {
-          filteredEvents.pushObject(selectedEvent);
+            return event.creator.name !== SD_SCHEDULER;
+          });
         }
 
         return filteredEvents;

--- a/app/components/pipeline-events/component.js
+++ b/app/components/pipeline-events/component.js
@@ -368,11 +368,12 @@ export default Component.extend(ModelReloaderMixin, {
     }
   }),
   pipelineEvents: computed(
-    'isFilteredEventsForNoBuilds',
     'filterSchedulerEvents',
+    'isFilteredEventsForNoBuilds',
     'modelEvents',
     'paginateEvents.[]',
     'pipeline.id',
+    'selected',
     {
       get() {
         const pipelineId = this.get('pipeline.id');
@@ -383,6 +384,8 @@ export default Component.extend(ModelReloaderMixin, {
           this.modelEvents,
           filteredPaginateEvents
         );
+        const selectedEventId = this.selected;
+        const selectedEvent = this.modelEvents.findBy('id', selectedEventId);
 
         let filteredEvents = pipelineEvents;
 
@@ -402,6 +405,11 @@ export default Component.extend(ModelReloaderMixin, {
           filteredEvents = filteredEvents.filter(
             event => event.creator.name !== SD_SCHEDULER
           );
+        }
+
+        // ensure selected event from url is not filtered
+        if (!filteredEvents.findBy('id', selectedEventId)) {
+          filteredEvents.pushObject(selectedEvent);
         }
 
         return filteredEvents;

--- a/app/components/pipeline-events/component.js
+++ b/app/components/pipeline-events/component.js
@@ -368,8 +368,8 @@ export default Component.extend(ModelReloaderMixin, {
     }
   }),
   pipelineEvents: computed(
-    'filterSchedulerEvents',
     'isFilteredEventsForNoBuilds',
+    'filterSchedulerEvents',
     'modelEvents',
     'paginateEvents.[]',
     'pipeline.id',

--- a/tests/integration/components/pipeline-events/component-test.js
+++ b/tests/integration/components/pipeline-events/component-test.js
@@ -1,9 +1,10 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import EmberObject from '@ember/object';
+import { render, waitUntil } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
 import { A as newArray } from '@ember/array';
 import { run } from '@ember/runloop';
-import { waitUntil } from '@ember/test-helpers';
 import Pretender from 'pretender';
 import Service from '@ember/service';
 import { Promise as EmberPromise } from 'rsvp';
@@ -37,6 +38,9 @@ module('Integration | Component | pipeline events', function (hooks) {
     const shuttleStub = Service.extend({
       getLatestCommitEvent() {
         return new EmberPromise(resolve => resolve(latestCommitEvent));
+      },
+      getUserSetting() {
+        return [];
       }
     });
 
@@ -734,5 +738,1594 @@ module('Integration | Component | pipeline events', function (hooks) {
     assert.equal(payload.state, 'ENABLED');
     assert.equal(payload.stateChangeMessage, 'testing');
     assert.equal(component.errorMessage, 'Test Error');
+  });
+
+  test('it filters scheduled build', async function (assert) {
+    const filterSchedulerEvents = true;
+    const pipelineData = {
+      id: 11326,
+      name: 'adong/sd-periodic',
+      scmUri: 'github.com:630153541:main',
+      scmContext: 'github:github.com',
+      scmRepo: {
+        branch: 'main',
+        name: 'adong/sd-periodic',
+        url: 'https://github.com/adong/sd-periodic/tree/main',
+        rootDir: '',
+        private: false
+      },
+      createTime: '2023-04-19T19:29:03.576Z',
+      admins: { adong: true },
+      workflowGraph: {
+        nodes: [
+          { name: '~pr' },
+          { name: '~commit' },
+          { name: 'main', id: 98321 }
+        ],
+        edges: [
+          { src: '~commit', dest: 'main' },
+          { src: '~pr', dest: 'main' }
+        ]
+      },
+      annotations: { 'screwdriver.cd/buildCluster': 'bf1' },
+      lastEventId: 735442,
+      prChain: false,
+      parameters: {},
+      settings: { filterSchedulerEvents },
+      state: 'ACTIVE',
+      subscribedScmUrlsWithActions: []
+    };
+    const events1 = [
+      {
+        id: 735442,
+        groupEventId: 735442,
+        causeMessage: 'Merged by adong',
+        commit: {
+          author: {
+            avatar: 'https://avatars.githubusercontent.com/u/15989893?v=4',
+            name: 'Alan',
+            username: 'adong',
+            url: 'https://github.com/adong'
+          },
+          committer: {
+            avatar: 'https://avatars.githubusercontent.com/u/19864447?v=4',
+            name: 'GitHub Web Flow',
+            username: 'web-flow',
+            url: 'https://github.com/web-flow'
+          },
+          message: 'Update screwdriver.yaml',
+          url: 'https://github.com/adong/sd-periodic/commit/b549aa9502292ddb0894cfb88ced6cc144ed2a76'
+        },
+        createTime: '2023-04-20T16:57:21.936Z',
+        creator: {
+          avatar: 'https://avatars.githubusercontent.com/u/15989893?v=4',
+          name: 'Alan',
+          username: 'adong',
+          url: 'https://github.com/adong'
+        },
+        meta: {
+          build: {
+            buildId: '858092',
+            coverageKey: 'job:98321',
+            eventId: '735442',
+            jobId: '98321',
+            jobName: 'main',
+            pipelineId: '11326',
+            sha: 'b549aa9502292ddb0894cfb88ced6cc144ed2a76'
+          },
+          commit: {
+            author: {
+              avatar: 'https://avatars.githubusercontent.com/u/15989893?v=4',
+              name: 'Alan',
+              url: 'https://github.com/adong',
+              username: 'adong'
+            },
+            changedFiles: 'screwdriver.yaml',
+            committer: {
+              avatar: 'https://avatars.githubusercontent.com/u/19864447?v=4',
+              name: 'GitHub Web Flow',
+              url: 'https://github.com/web-flow',
+              username: 'web-flow'
+            },
+            message: 'Update screwdriver.yaml',
+            url: 'https://github.com/adong/sd-periodic/commit/b549aa9502292ddb0894cfb88ced6cc144ed2a76'
+          },
+          event: { creator: 'adong' }
+        },
+        pipelineId: 11326,
+        sha: 'b549aa9502292ddb0894cfb88ced6cc144ed2a76',
+        configPipelineSha: 'b549aa9502292ddb0894cfb88ced6cc144ed2a76',
+        startFrom: '~commit',
+        type: 'pipeline',
+        workflowGraph: {
+          nodes: [
+            { name: '~pr' },
+            { name: '~commit' },
+            { name: 'main', id: 98321 }
+          ],
+          edges: [
+            { src: '~commit', dest: 'main' },
+            { src: '~pr', dest: 'main' }
+          ]
+        },
+        pr: {},
+        baseBranch: 'main'
+      },
+      {
+        id: 735440,
+        groupEventId: 735440,
+        causeMessage: 'Started by periodic build scheduler',
+        commit: {
+          author: {
+            avatar: 'https://avatars.githubusercontent.com/u/15989893?v=4',
+            name: 'Alan',
+            username: 'adong',
+            url: 'https://github.com/adong'
+          },
+          committer: {
+            avatar: 'https://avatars.githubusercontent.com/u/19864447?v=4',
+            name: 'GitHub Web Flow',
+            username: 'web-flow',
+            url: 'https://github.com/web-flow'
+          },
+          message: 'Update screwdriver.yaml',
+          url: 'https://github.com/adong/sd-periodic/commit/439c9f91ff65aee5a698c710206f1ff64f1e5a54'
+        },
+        createTime: '2023-04-20T16:40:09.509Z',
+        creator: { name: 'Screwdriver scheduler', username: 'sd:scheduler' },
+        meta: {
+          build: {
+            buildId: '858089',
+            coverageKey: 'job:98321',
+            eventId: '735440',
+            jobId: '98321',
+            jobName: 'main',
+            pipelineId: '11326',
+            sha: '439c9f91ff65aee5a698c710206f1ff64f1e5a54'
+          },
+          commit: {
+            author: {
+              avatar: 'https://avatars.githubusercontent.com/u/15989893?v=4',
+              name: 'Alan',
+              url: 'https://github.com/adong',
+              username: 'adong'
+            },
+            changedFiles: '',
+            committer: {
+              avatar: 'https://avatars.githubusercontent.com/u/19864447?v=4',
+              name: 'GitHub Web Flow',
+              url: 'https://github.com/web-flow',
+              username: 'web-flow'
+            },
+            message: 'Update screwdriver.yaml',
+            url: 'https://github.com/adong/sd-periodic/commit/439c9f91ff65aee5a698c710206f1ff64f1e5a54'
+          },
+          event: { creator: 'sd:scheduler' }
+        },
+        pipelineId: 11326,
+        sha: '439c9f91ff65aee5a698c710206f1ff64f1e5a54',
+        startFrom: 'main',
+        type: 'pipeline',
+        workflowGraph: {
+          nodes: [
+            { name: '~pr' },
+            { name: '~commit' },
+            { name: 'main', id: 98321 }
+          ],
+          edges: [
+            { src: '~commit', dest: 'main' },
+            { src: '~pr', dest: 'main' }
+          ]
+        },
+        pr: {}
+      },
+      {
+        id: 735433,
+        groupEventId: 735433,
+        causeMessage: 'Started by periodic build scheduler',
+        commit: {
+          author: {
+            avatar: 'https://avatars.githubusercontent.com/u/15989893?v=4',
+            name: 'Alan',
+            username: 'adong',
+            url: 'https://github.com/adong'
+          },
+          committer: {
+            avatar: 'https://avatars.githubusercontent.com/u/19864447?v=4',
+            name: 'GitHub Web Flow',
+            username: 'web-flow',
+            url: 'https://github.com/web-flow'
+          },
+          message: 'Update screwdriver.yaml',
+          url: 'https://github.com/adong/sd-periodic/commit/439c9f91ff65aee5a698c710206f1ff64f1e5a54'
+        },
+        createTime: '2023-04-20T15:40:07.455Z',
+        creator: { name: 'Screwdriver scheduler', username: 'sd:scheduler' },
+        meta: {
+          build: {
+            buildId: '858082',
+            coverageKey: 'job:98321',
+            eventId: '735433',
+            jobId: '98321',
+            jobName: 'main',
+            pipelineId: '11326',
+            sha: '439c9f91ff65aee5a698c710206f1ff64f1e5a54'
+          },
+          commit: {
+            author: {
+              avatar: 'https://avatars.githubusercontent.com/u/15989893?v=4',
+              name: 'Alan',
+              url: 'https://github.com/adong',
+              username: 'adong'
+            },
+            changedFiles: '',
+            committer: {
+              avatar: 'https://avatars.githubusercontent.com/u/19864447?v=4',
+              name: 'GitHub Web Flow',
+              url: 'https://github.com/web-flow',
+              username: 'web-flow'
+            },
+            message: 'Update screwdriver.yaml',
+            url: 'https://github.com/adong/sd-periodic/commit/439c9f91ff65aee5a698c710206f1ff64f1e5a54'
+          },
+          event: { creator: 'sd:scheduler' }
+        },
+        pipelineId: 11326,
+        sha: '439c9f91ff65aee5a698c710206f1ff64f1e5a54',
+        startFrom: 'main',
+        type: 'pipeline',
+        workflowGraph: {
+          nodes: [
+            { name: '~pr' },
+            { name: '~commit' },
+            { name: 'main', id: 98321 }
+          ],
+          edges: [
+            { src: '~commit', dest: 'main' },
+            { src: '~pr', dest: 'main' }
+          ]
+        },
+        pr: {}
+      },
+      {
+        id: 735425,
+        groupEventId: 735425,
+        causeMessage: 'Started by periodic build scheduler',
+        commit: {
+          author: {
+            avatar: 'https://avatars.githubusercontent.com/u/15989893?v=4',
+            name: 'Alan',
+            username: 'adong',
+            url: 'https://github.com/adong'
+          },
+          committer: {
+            avatar: 'https://avatars.githubusercontent.com/u/19864447?v=4',
+            name: 'GitHub Web Flow',
+            username: 'web-flow',
+            url: 'https://github.com/web-flow'
+          },
+          message: 'Update screwdriver.yaml',
+          url: 'https://github.com/adong/sd-periodic/commit/439c9f91ff65aee5a698c710206f1ff64f1e5a54'
+        },
+        createTime: '2023-04-20T14:40:08.520Z',
+        creator: { name: 'Screwdriver scheduler', username: 'sd:scheduler' },
+        meta: {
+          build: {
+            buildId: '858077',
+            coverageKey: 'job:98321',
+            eventId: '735425',
+            jobId: '98321',
+            jobName: 'main',
+            pipelineId: '11326',
+            sha: '439c9f91ff65aee5a698c710206f1ff64f1e5a54'
+          },
+          commit: {
+            author: {
+              avatar: 'https://avatars.githubusercontent.com/u/15989893?v=4',
+              name: 'Alan',
+              url: 'https://github.com/adong',
+              username: 'adong'
+            },
+            changedFiles: '',
+            committer: {
+              avatar: 'https://avatars.githubusercontent.com/u/19864447?v=4',
+              name: 'GitHub Web Flow',
+              url: 'https://github.com/web-flow',
+              username: 'web-flow'
+            },
+            message: 'Update screwdriver.yaml',
+            url: 'https://github.com/adong/sd-periodic/commit/439c9f91ff65aee5a698c710206f1ff64f1e5a54'
+          },
+          event: { creator: 'sd:scheduler' }
+        },
+        pipelineId: 11326,
+        sha: '439c9f91ff65aee5a698c710206f1ff64f1e5a54',
+        startFrom: 'main',
+        type: 'pipeline',
+        workflowGraph: {
+          nodes: [
+            { name: '~pr' },
+            { name: '~commit' },
+            { name: 'main', id: 98321 }
+          ],
+          edges: [
+            { src: '~commit', dest: 'main' },
+            { src: '~pr', dest: 'main' }
+          ]
+        },
+        pr: {}
+      },
+      {
+        id: 735415,
+        groupEventId: 735415,
+        causeMessage: 'Started by periodic build scheduler',
+        commit: {
+          author: {
+            avatar: 'https://avatars.githubusercontent.com/u/15989893?v=4',
+            name: 'Alan',
+            username: 'adong',
+            url: 'https://github.com/adong'
+          },
+          committer: {
+            avatar: 'https://avatars.githubusercontent.com/u/19864447?v=4',
+            name: 'GitHub Web Flow',
+            username: 'web-flow',
+            url: 'https://github.com/web-flow'
+          },
+          message: 'Update screwdriver.yaml',
+          url: 'https://github.com/adong/sd-periodic/commit/439c9f91ff65aee5a698c710206f1ff64f1e5a54'
+        },
+        createTime: '2023-04-20T13:40:05.477Z',
+        creator: { name: 'Screwdriver scheduler', username: 'sd:scheduler' },
+        meta: {
+          build: {
+            buildId: '858069',
+            coverageKey: 'job:98321',
+            eventId: '735415',
+            jobId: '98321',
+            jobName: 'main',
+            pipelineId: '11326',
+            sha: '439c9f91ff65aee5a698c710206f1ff64f1e5a54'
+          },
+          commit: {
+            author: {
+              avatar: 'https://avatars.githubusercontent.com/u/15989893?v=4',
+              name: 'Alan',
+              url: 'https://github.com/adong',
+              username: 'adong'
+            },
+            changedFiles: '',
+            committer: {
+              avatar: 'https://avatars.githubusercontent.com/u/19864447?v=4',
+              name: 'GitHub Web Flow',
+              url: 'https://github.com/web-flow',
+              username: 'web-flow'
+            },
+            message: 'Update screwdriver.yaml',
+            url: 'https://github.com/adong/sd-periodic/commit/439c9f91ff65aee5a698c710206f1ff64f1e5a54'
+          },
+          event: { creator: 'sd:scheduler' }
+        },
+        pipelineId: 11326,
+        sha: '439c9f91ff65aee5a698c710206f1ff64f1e5a54',
+        startFrom: 'main',
+        type: 'pipeline',
+        workflowGraph: {
+          nodes: [
+            { name: '~pr' },
+            { name: '~commit' },
+            { name: 'main', id: 98321 }
+          ],
+          edges: [
+            { src: '~commit', dest: 'main' },
+            { src: '~pr', dest: 'main' }
+          ]
+        },
+        pr: {}
+      }
+    ];
+    const events2 = [
+      {
+        id: 735398,
+        groupEventId: 735398,
+        causeMessage: 'Started by periodic build scheduler',
+        commit: {
+          author: {
+            avatar: 'https://avatars.githubusercontent.com/u/15989893?v=4',
+            name: 'Alan',
+            username: 'adong',
+            url: 'https://github.com/adong'
+          },
+          committer: {
+            avatar: 'https://avatars.githubusercontent.com/u/19864447?v=4',
+            name: 'GitHub Web Flow',
+            username: 'web-flow',
+            url: 'https://github.com/web-flow'
+          },
+          message: 'Update screwdriver.yaml',
+          url: 'https://github.com/adong/sd-periodic/commit/439c9f91ff65aee5a698c710206f1ff64f1e5a54'
+        },
+        createTime: '2023-04-20T12:40:09.382Z',
+        creator: { name: 'Screwdriver scheduler', username: 'sd:scheduler' },
+        meta: {
+          build: {
+            buildId: '858052',
+            coverageKey: 'job:98321',
+            eventId: '735398',
+            jobId: '98321',
+            jobName: 'main',
+            pipelineId: '11326',
+            sha: '439c9f91ff65aee5a698c710206f1ff64f1e5a54'
+          },
+          commit: {
+            author: {
+              avatar: 'https://avatars.githubusercontent.com/u/15989893?v=4',
+              name: 'Alan',
+              url: 'https://github.com/adong',
+              username: 'adong'
+            },
+            changedFiles: '',
+            committer: {
+              avatar: 'https://avatars.githubusercontent.com/u/19864447?v=4',
+              name: 'GitHub Web Flow',
+              url: 'https://github.com/web-flow',
+              username: 'web-flow'
+            },
+            message: 'Update screwdriver.yaml',
+            url: 'https://github.com/adong/sd-periodic/commit/439c9f91ff65aee5a698c710206f1ff64f1e5a54'
+          },
+          event: { creator: 'sd:scheduler' }
+        },
+        pipelineId: 11326,
+        sha: '439c9f91ff65aee5a698c710206f1ff64f1e5a54',
+        startFrom: 'main',
+        type: 'pipeline',
+        workflowGraph: {
+          nodes: [
+            { name: '~pr' },
+            { name: '~commit' },
+            { name: 'main', id: 98321 }
+          ],
+          edges: [
+            { src: '~commit', dest: 'main' },
+            { src: '~pr', dest: 'main' }
+          ]
+        },
+        pr: {}
+      },
+      {
+        id: 735385,
+        groupEventId: 735385,
+        causeMessage: 'Started by periodic build scheduler',
+        commit: {
+          author: {
+            avatar: 'https://avatars.githubusercontent.com/u/15989893?v=4',
+            name: 'Alan',
+            username: 'adong',
+            url: 'https://github.com/adong'
+          },
+          committer: {
+            avatar: 'https://avatars.githubusercontent.com/u/19864447?v=4',
+            name: 'GitHub Web Flow',
+            username: 'web-flow',
+            url: 'https://github.com/web-flow'
+          },
+          message: 'Update screwdriver.yaml',
+          url: 'https://github.com/adong/sd-periodic/commit/439c9f91ff65aee5a698c710206f1ff64f1e5a54'
+        },
+        createTime: '2023-04-20T11:40:03.775Z',
+        creator: { name: 'Screwdriver scheduler', username: 'sd:scheduler' },
+        meta: {
+          build: {
+            buildId: '858039',
+            coverageKey: 'job:98321',
+            eventId: '735385',
+            jobId: '98321',
+            jobName: 'main',
+            pipelineId: '11326',
+            sha: '439c9f91ff65aee5a698c710206f1ff64f1e5a54'
+          },
+          commit: {
+            author: {
+              avatar: 'https://avatars.githubusercontent.com/u/15989893?v=4',
+              name: 'Alan',
+              url: 'https://github.com/adong',
+              username: 'adong'
+            },
+            changedFiles: '',
+            committer: {
+              avatar: 'https://avatars.githubusercontent.com/u/19864447?v=4',
+              name: 'GitHub Web Flow',
+              url: 'https://github.com/web-flow',
+              username: 'web-flow'
+            },
+            message: 'Update screwdriver.yaml',
+            url: 'https://github.com/adong/sd-periodic/commit/439c9f91ff65aee5a698c710206f1ff64f1e5a54'
+          },
+          event: { creator: 'sd:scheduler' }
+        },
+        pipelineId: 11326,
+        sha: '439c9f91ff65aee5a698c710206f1ff64f1e5a54',
+        startFrom: 'main',
+        type: 'pipeline',
+        workflowGraph: {
+          nodes: [
+            { name: '~pr' },
+            { name: '~commit' },
+            { name: 'main', id: 98321 }
+          ],
+          edges: [
+            { src: '~commit', dest: 'main' },
+            { src: '~pr', dest: 'main' }
+          ]
+        },
+        pr: {}
+      },
+      {
+        id: 735374,
+        groupEventId: 735374,
+        causeMessage: 'Started by periodic build scheduler',
+        commit: {
+          author: {
+            avatar: 'https://avatars.githubusercontent.com/u/15989893?v=4',
+            name: 'Alan',
+            username: 'adong',
+            url: 'https://github.com/adong'
+          },
+          committer: {
+            avatar: 'https://avatars.githubusercontent.com/u/19864447?v=4',
+            name: 'GitHub Web Flow',
+            username: 'web-flow',
+            url: 'https://github.com/web-flow'
+          },
+          message: 'Update screwdriver.yaml',
+          url: 'https://github.com/adong/sd-periodic/commit/439c9f91ff65aee5a698c710206f1ff64f1e5a54'
+        },
+        createTime: '2023-04-20T10:40:08.115Z',
+        creator: { name: 'Screwdriver scheduler', username: 'sd:scheduler' },
+        meta: {
+          build: {
+            buildId: '858027',
+            coverageKey: 'job:98321',
+            eventId: '735374',
+            jobId: '98321',
+            jobName: 'main',
+            pipelineId: '11326',
+            sha: '439c9f91ff65aee5a698c710206f1ff64f1e5a54'
+          },
+          commit: {
+            author: {
+              avatar: 'https://avatars.githubusercontent.com/u/15989893?v=4',
+              name: 'Alan',
+              url: 'https://github.com/adong',
+              username: 'adong'
+            },
+            changedFiles: '',
+            committer: {
+              avatar: 'https://avatars.githubusercontent.com/u/19864447?v=4',
+              name: 'GitHub Web Flow',
+              url: 'https://github.com/web-flow',
+              username: 'web-flow'
+            },
+            message: 'Update screwdriver.yaml',
+            url: 'https://github.com/adong/sd-periodic/commit/439c9f91ff65aee5a698c710206f1ff64f1e5a54'
+          },
+          event: { creator: 'sd:scheduler' }
+        },
+        pipelineId: 11326,
+        sha: '439c9f91ff65aee5a698c710206f1ff64f1e5a54',
+        startFrom: 'main',
+        type: 'pipeline',
+        workflowGraph: {
+          nodes: [
+            { name: '~pr' },
+            { name: '~commit' },
+            { name: 'main', id: 98321 }
+          ],
+          edges: [
+            { src: '~commit', dest: 'main' },
+            { src: '~pr', dest: 'main' }
+          ]
+        },
+        pr: {}
+      },
+      {
+        id: 735361,
+        groupEventId: 735361,
+        causeMessage: 'Started by periodic build scheduler',
+        commit: {
+          author: {
+            avatar: 'https://avatars.githubusercontent.com/u/15989893?v=4',
+            name: 'Alan',
+            username: 'adong',
+            url: 'https://github.com/adong'
+          },
+          committer: {
+            avatar: 'https://avatars.githubusercontent.com/u/19864447?v=4',
+            name: 'GitHub Web Flow',
+            username: 'web-flow',
+            url: 'https://github.com/web-flow'
+          },
+          message: 'Update screwdriver.yaml',
+          url: 'https://github.com/adong/sd-periodic/commit/439c9f91ff65aee5a698c710206f1ff64f1e5a54'
+        },
+        createTime: '2023-04-20T09:40:05.733Z',
+        creator: { name: 'Screwdriver scheduler', username: 'sd:scheduler' },
+        meta: {
+          build: {
+            buildId: '858015',
+            coverageKey: 'job:98321',
+            eventId: '735361',
+            jobId: '98321',
+            jobName: 'main',
+            pipelineId: '11326',
+            sha: '439c9f91ff65aee5a698c710206f1ff64f1e5a54'
+          },
+          commit: {
+            author: {
+              avatar: 'https://avatars.githubusercontent.com/u/15989893?v=4',
+              name: 'Alan',
+              url: 'https://github.com/adong',
+              username: 'adong'
+            },
+            changedFiles: '',
+            committer: {
+              avatar: 'https://avatars.githubusercontent.com/u/19864447?v=4',
+              name: 'GitHub Web Flow',
+              url: 'https://github.com/web-flow',
+              username: 'web-flow'
+            },
+            message: 'Update screwdriver.yaml',
+            url: 'https://github.com/adong/sd-periodic/commit/439c9f91ff65aee5a698c710206f1ff64f1e5a54'
+          },
+          event: { creator: 'sd:scheduler' }
+        },
+        pipelineId: 11326,
+        sha: '439c9f91ff65aee5a698c710206f1ff64f1e5a54',
+        startFrom: 'main',
+        type: 'pipeline',
+        workflowGraph: {
+          nodes: [
+            { name: '~pr' },
+            { name: '~commit' },
+            { name: 'main', id: 98321 }
+          ],
+          edges: [
+            { src: '~commit', dest: 'main' },
+            { src: '~pr', dest: 'main' }
+          ]
+        },
+        pr: {}
+      },
+      {
+        id: 735344,
+        groupEventId: 735344,
+        causeMessage: 'Started by periodic build scheduler',
+        commit: {
+          author: {
+            avatar: 'https://avatars.githubusercontent.com/u/15989893?v=4',
+            name: 'Alan',
+            username: 'adong',
+            url: 'https://github.com/adong'
+          },
+          committer: {
+            avatar: 'https://avatars.githubusercontent.com/u/19864447?v=4',
+            name: 'GitHub Web Flow',
+            username: 'web-flow',
+            url: 'https://github.com/web-flow'
+          },
+          message: 'Update screwdriver.yaml',
+          url: 'https://github.com/adong/sd-periodic/commit/439c9f91ff65aee5a698c710206f1ff64f1e5a54'
+        },
+        createTime: '2023-04-20T08:40:08.636Z',
+        creator: { name: 'Screwdriver scheduler', username: 'sd:scheduler' },
+        meta: {
+          build: {
+            buildId: '858000',
+            coverageKey: 'job:98321',
+            eventId: '735344',
+            jobId: '98321',
+            jobName: 'main',
+            pipelineId: '11326',
+            sha: '439c9f91ff65aee5a698c710206f1ff64f1e5a54'
+          },
+          commit: {
+            author: {
+              avatar: 'https://avatars.githubusercontent.com/u/15989893?v=4',
+              name: 'Alan',
+              url: 'https://github.com/adong',
+              username: 'adong'
+            },
+            changedFiles: '',
+            committer: {
+              avatar: 'https://avatars.githubusercontent.com/u/19864447?v=4',
+              name: 'GitHub Web Flow',
+              url: 'https://github.com/web-flow',
+              username: 'web-flow'
+            },
+            message: 'Update screwdriver.yaml',
+            url: 'https://github.com/adong/sd-periodic/commit/439c9f91ff65aee5a698c710206f1ff64f1e5a54'
+          },
+          event: { creator: 'sd:scheduler' }
+        },
+        pipelineId: 11326,
+        sha: '439c9f91ff65aee5a698c710206f1ff64f1e5a54',
+        startFrom: 'main',
+        type: 'pipeline',
+        workflowGraph: {
+          nodes: [
+            { name: '~pr' },
+            { name: '~commit' },
+            { name: 'main', id: 98321 }
+          ],
+          edges: [
+            { src: '~commit', dest: 'main' },
+            { src: '~pr', dest: 'main' }
+          ]
+        },
+        pr: {}
+      }
+    ];
+
+    server.get('http://localhost:8080/v4/pipelines/11326', () => [
+      200,
+      { 'Content-Type': 'application/json' },
+      JSON.stringify(pipelineData)
+    ]);
+
+    server.get('http://localhost:8080/v4/events/735254', () => [
+      200,
+      {},
+      JSON.stringify({
+        id: 735254,
+        groupEventId: 735254,
+        causeMessage: 'Manually started by adong',
+        commit: {
+          author: {
+            avatar: 'https://avatars.githubusercontent.com/u/15989893?v=4',
+            name: 'Alan',
+            username: 'adong',
+            url: 'https://github.com/adong'
+          },
+          committer: {
+            avatar: 'https://avatars.githubusercontent.com/u/19864447?v=4',
+            name: 'GitHub Web Flow',
+            username: 'web-flow',
+            url: 'https://github.com/web-flow'
+          },
+          message: 'Update screwdriver.yaml',
+          url: 'https://github.com/adong/sd-periodic/commit/439c9f91ff65aee5a698c710206f1ff64f1e5a54'
+        },
+        createTime: '2023-04-19T19:29:11.770Z',
+        creator: {
+          avatar: 'https://avatars.githubusercontent.com/u/15989893?v=4',
+          name: 'Alan',
+          username: 'adong',
+          url: 'https://github.com/adong'
+        },
+        meta: {
+          build: {
+            buildId: '857909',
+            coverageKey: 'job:98321',
+            eventId: '735254',
+            jobId: '98321',
+            jobName: 'main',
+            pipelineId: '11326',
+            sha: '439c9f91ff65aee5a698c710206f1ff64f1e5a54'
+          },
+          commit: {
+            author: {
+              avatar: 'https://avatars.githubusercontent.com/u/15989893?v=4',
+              name: 'Alan',
+              url: 'https://github.com/adong',
+              username: 'adong'
+            },
+            changedFiles: '',
+            committer: {
+              avatar: 'https://avatars.githubusercontent.com/u/19864447?v=4',
+              name: 'GitHub Web Flow',
+              url: 'https://github.com/web-flow',
+              username: 'web-flow'
+            },
+            message: 'Update screwdriver.yaml',
+            url: 'https://github.com/adong/sd-periodic/commit/439c9f91ff65aee5a698c710206f1ff64f1e5a54'
+          },
+          event: { creator: 'adong' }
+        },
+        pipelineId: 11326,
+        sha: '439c9f91ff65aee5a698c710206f1ff64f1e5a54',
+        startFrom: '~commit',
+        type: 'pipeline',
+        workflowGraph: {
+          nodes: [
+            { name: '~pr' },
+            { name: '~commit' },
+            { name: 'main', id: 98321 }
+          ],
+          edges: [
+            { src: '~commit', dest: 'main' },
+            { src: '~pr', dest: 'main' }
+          ]
+        },
+        pr: {}
+      })
+    ]);
+
+    server.get('http://localhost:8080/v4/pipelines/11326/events', request => {
+      // const count = parseInt(request.queryParams.count, 10);
+      const page = parseInt(request.queryParams.page, 10);
+
+      return [
+        200,
+        { 'Content-Type': 'application/json' },
+        JSON.stringify(page === '1' ? events1 : events2)
+      ];
+    });
+
+    server.get('http://localhost:8080/v4/pipelines/11326/jobs', () => [
+      200,
+      {},
+      JSON.stringify([
+        {
+          id: 98321,
+          name: 'main',
+          permutations: [
+            {
+              annotations: {},
+              commands: [{ name: 'step-1', command: 'ls' }],
+              environment: {},
+              image: 'node:18',
+              secrets: [],
+              settings: {},
+              requires: ['~commit', '~pr']
+            }
+          ],
+          pipelineId: 11326,
+          state: 'ENABLED',
+          archived: false
+        }
+      ])
+    ]);
+
+    const component = this.owner.lookup('component:pipeline-events');
+    const pipeline = await component.store.findRecord('pipeline', 11326);
+
+    this.setProperties({
+      pipeline,
+      showPRJobs: true,
+      model: {
+        pipelinePreference: [],
+        desiredJobNameLengthjobs: 20,
+        triggers: [{ jobName: 'main', triggers: [] }],
+        events: events1
+      },
+      selected: '735254',
+      activeTab: 'events',
+      paginateEvents: events1,
+      eventsPage: 2,
+      expandedEventsGroup: {},
+      latestCommit: {
+        id: 735442,
+        groupEventId: 735442,
+        causeMessage: 'Merged by adong',
+        commit: {
+          author: {
+            avatar: 'https://avatars.githubusercontent.com/u/15989893?v=4',
+            name: 'Alan',
+            username: 'adong',
+            url: 'https://github.com/adong'
+          },
+          committer: {
+            avatar: 'https://avatars.githubusercontent.com/u/19864447?v=4',
+            name: 'GitHub Web Flow',
+            username: 'web-flow',
+            url: 'https://github.com/web-flow'
+          },
+          message: 'Update screwdriver.yaml',
+          url: 'https://github.com/adong/sd-periodic/commit/b549aa9502292ddb0894cfb88ced6cc144ed2a76'
+        },
+        createTime: '2023-04-20T16:57:21.936Z',
+        creator: {
+          avatar: 'https://avatars.githubusercontent.com/u/15989893?v=4',
+          name: 'Alan',
+          username: 'adong',
+          url: 'https://github.com/adong'
+        },
+        meta: {
+          build: {
+            buildId: '858092',
+            coverageKey: 'job:98321',
+            eventId: '735442',
+            jobId: '98321',
+            jobName: 'main',
+            pipelineId: '11326',
+            sha: 'b549aa9502292ddb0894cfb88ced6cc144ed2a76'
+          },
+          commit: {
+            author: {
+              avatar: 'https://avatars.githubusercontent.com/u/15989893?v=4',
+              name: 'Alan',
+              url: 'https://github.com/adong',
+              username: 'adong'
+            },
+            changedFiles: 'screwdriver.yaml',
+            committer: {
+              avatar: 'https://avatars.githubusercontent.com/u/19864447?v=4',
+              name: 'GitHub Web Flow',
+              url: 'https://github.com/web-flow',
+              username: 'web-flow'
+            },
+            message: 'Update screwdriver.yaml',
+            url: 'https://github.com/adong/sd-periodic/commit/b549aa9502292ddb0894cfb88ced6cc144ed2a76'
+          },
+          event: { creator: 'adong' }
+        },
+        pipelineId: 11326,
+        sha: 'b549aa9502292ddb0894cfb88ced6cc144ed2a76',
+        configPipelineSha: 'b549aa9502292ddb0894cfb88ced6cc144ed2a76',
+        startFrom: '~commit',
+        type: 'pipeline',
+        workflowGraph: {
+          nodes: [
+            { name: '~pr' },
+            { name: '~commit' },
+            { name: 'main', id: 98321 }
+          ],
+          edges: [
+            { src: '~commit', dest: 'main' },
+            { src: '~pr', dest: 'main' }
+          ]
+        },
+        pr: {},
+        baseBranch: 'main'
+      }
+    });
+
+    await render(hbs`<PipelineEvents
+      @session={{this.session}}
+      @model={{this.model}}
+      @pipeline={{this.pipeline}}
+      @showPRJobs={{this.showPRJobs}}
+      @selected={{mut this.selected}}
+      @showListView={{false}}
+      @showDownstreamTriggers={{this.showDownstreamTriggers}}
+      @jobId={{this.jobId}}
+      @showPRJobs={{this.showPRJobs}}
+      @activeTab={{this.activeTab}}
+      @expandedEventsGroup={{mut this.expandedEventsGroup}}
+      @paginateEvents={{mut this.paginateEvents}}
+      @eventsPage={{this.eventsPage}}
+      @isShowingModal={{false}}
+    />`);
+
+    assert.equal(
+      this.element.querySelectorAll('div.status').length,
+      1,
+      'only has one event which is not triggered by sd scheduler'
+    );
+  });
+
+  test('it will not filter scheduled build', async function (assert) {
+    const filterSchedulerEvents = false;
+    const pipelineData = {
+      id: 11326,
+      name: 'adong/sd-periodic',
+      scmUri: 'github.com:630153541:main',
+      scmContext: 'github:github.com',
+      scmRepo: {
+        branch: 'main',
+        name: 'adong/sd-periodic',
+        url: 'https://github.com/adong/sd-periodic/tree/main',
+        rootDir: '',
+        private: false
+      },
+      createTime: '2023-04-19T19:29:03.576Z',
+      admins: { adong: true },
+      workflowGraph: {
+        nodes: [
+          { name: '~pr' },
+          { name: '~commit' },
+          { name: 'main', id: 98321 }
+        ],
+        edges: [
+          { src: '~commit', dest: 'main' },
+          { src: '~pr', dest: 'main' }
+        ]
+      },
+      annotations: { 'screwdriver.cd/buildCluster': 'bf1' },
+      lastEventId: 735442,
+      prChain: false,
+      parameters: {},
+      settings: { filterSchedulerEvents },
+      state: 'ACTIVE',
+      subscribedScmUrlsWithActions: []
+    };
+    const events1 = [
+      {
+        id: 735442,
+        groupEventId: 735442,
+        causeMessage: 'Merged by adong',
+        commit: {
+          author: {
+            avatar: 'https://avatars.githubusercontent.com/u/15989893?v=4',
+            name: 'Alan',
+            username: 'adong',
+            url: 'https://github.com/adong'
+          },
+          committer: {
+            avatar: 'https://avatars.githubusercontent.com/u/19864447?v=4',
+            name: 'GitHub Web Flow',
+            username: 'web-flow',
+            url: 'https://github.com/web-flow'
+          },
+          message: 'Update screwdriver.yaml',
+          url: 'https://github.com/adong/sd-periodic/commit/b549aa9502292ddb0894cfb88ced6cc144ed2a76'
+        },
+        createTime: '2023-04-20T16:57:21.936Z',
+        creator: {
+          avatar: 'https://avatars.githubusercontent.com/u/15989893?v=4',
+          name: 'Alan',
+          username: 'adong',
+          url: 'https://github.com/adong'
+        },
+        meta: {
+          build: {
+            buildId: '858092',
+            coverageKey: 'job:98321',
+            eventId: '735442',
+            jobId: '98321',
+            jobName: 'main',
+            pipelineId: '11326',
+            sha: 'b549aa9502292ddb0894cfb88ced6cc144ed2a76'
+          },
+          commit: {
+            author: {
+              avatar: 'https://avatars.githubusercontent.com/u/15989893?v=4',
+              name: 'Alan',
+              url: 'https://github.com/adong',
+              username: 'adong'
+            },
+            changedFiles: 'screwdriver.yaml',
+            committer: {
+              avatar: 'https://avatars.githubusercontent.com/u/19864447?v=4',
+              name: 'GitHub Web Flow',
+              url: 'https://github.com/web-flow',
+              username: 'web-flow'
+            },
+            message: 'Update screwdriver.yaml',
+            url: 'https://github.com/adong/sd-periodic/commit/b549aa9502292ddb0894cfb88ced6cc144ed2a76'
+          },
+          event: { creator: 'adong' }
+        },
+        pipelineId: 11326,
+        sha: 'b549aa9502292ddb0894cfb88ced6cc144ed2a76',
+        configPipelineSha: 'b549aa9502292ddb0894cfb88ced6cc144ed2a76',
+        startFrom: '~commit',
+        type: 'pipeline',
+        workflowGraph: {
+          nodes: [
+            { name: '~pr' },
+            { name: '~commit' },
+            { name: 'main', id: 98321 }
+          ],
+          edges: [
+            { src: '~commit', dest: 'main' },
+            { src: '~pr', dest: 'main' }
+          ]
+        },
+        pr: {},
+        baseBranch: 'main'
+      },
+      {
+        id: 735440,
+        groupEventId: 735440,
+        causeMessage: 'Started by periodic build scheduler',
+        commit: {
+          author: {
+            avatar: 'https://avatars.githubusercontent.com/u/15989893?v=4',
+            name: 'Alan',
+            username: 'adong',
+            url: 'https://github.com/adong'
+          },
+          committer: {
+            avatar: 'https://avatars.githubusercontent.com/u/19864447?v=4',
+            name: 'GitHub Web Flow',
+            username: 'web-flow',
+            url: 'https://github.com/web-flow'
+          },
+          message: 'Update screwdriver.yaml',
+          url: 'https://github.com/adong/sd-periodic/commit/439c9f91ff65aee5a698c710206f1ff64f1e5a54'
+        },
+        createTime: '2023-04-20T16:40:09.509Z',
+        creator: { name: 'Screwdriver scheduler', username: 'sd:scheduler' },
+        meta: {
+          build: {
+            buildId: '858089',
+            coverageKey: 'job:98321',
+            eventId: '735440',
+            jobId: '98321',
+            jobName: 'main',
+            pipelineId: '11326',
+            sha: '439c9f91ff65aee5a698c710206f1ff64f1e5a54'
+          },
+          commit: {
+            author: {
+              avatar: 'https://avatars.githubusercontent.com/u/15989893?v=4',
+              name: 'Alan',
+              url: 'https://github.com/adong',
+              username: 'adong'
+            },
+            changedFiles: '',
+            committer: {
+              avatar: 'https://avatars.githubusercontent.com/u/19864447?v=4',
+              name: 'GitHub Web Flow',
+              url: 'https://github.com/web-flow',
+              username: 'web-flow'
+            },
+            message: 'Update screwdriver.yaml',
+            url: 'https://github.com/adong/sd-periodic/commit/439c9f91ff65aee5a698c710206f1ff64f1e5a54'
+          },
+          event: { creator: 'sd:scheduler' }
+        },
+        pipelineId: 11326,
+        sha: '439c9f91ff65aee5a698c710206f1ff64f1e5a54',
+        startFrom: 'main',
+        type: 'pipeline',
+        workflowGraph: {
+          nodes: [
+            { name: '~pr' },
+            { name: '~commit' },
+            { name: 'main', id: 98321 }
+          ],
+          edges: [
+            { src: '~commit', dest: 'main' },
+            { src: '~pr', dest: 'main' }
+          ]
+        },
+        pr: {}
+      },
+      {
+        id: 735433,
+        groupEventId: 735433,
+        causeMessage: 'Started by periodic build scheduler',
+        commit: {
+          author: {
+            avatar: 'https://avatars.githubusercontent.com/u/15989893?v=4',
+            name: 'Alan',
+            username: 'adong',
+            url: 'https://github.com/adong'
+          },
+          committer: {
+            avatar: 'https://avatars.githubusercontent.com/u/19864447?v=4',
+            name: 'GitHub Web Flow',
+            username: 'web-flow',
+            url: 'https://github.com/web-flow'
+          },
+          message: 'Update screwdriver.yaml',
+          url: 'https://github.com/adong/sd-periodic/commit/439c9f91ff65aee5a698c710206f1ff64f1e5a54'
+        },
+        createTime: '2023-04-20T15:40:07.455Z',
+        creator: { name: 'Screwdriver scheduler', username: 'sd:scheduler' },
+        meta: {
+          build: {
+            buildId: '858082',
+            coverageKey: 'job:98321',
+            eventId: '735433',
+            jobId: '98321',
+            jobName: 'main',
+            pipelineId: '11326',
+            sha: '439c9f91ff65aee5a698c710206f1ff64f1e5a54'
+          },
+          commit: {
+            author: {
+              avatar: 'https://avatars.githubusercontent.com/u/15989893?v=4',
+              name: 'Alan',
+              url: 'https://github.com/adong',
+              username: 'adong'
+            },
+            changedFiles: '',
+            committer: {
+              avatar: 'https://avatars.githubusercontent.com/u/19864447?v=4',
+              name: 'GitHub Web Flow',
+              url: 'https://github.com/web-flow',
+              username: 'web-flow'
+            },
+            message: 'Update screwdriver.yaml',
+            url: 'https://github.com/adong/sd-periodic/commit/439c9f91ff65aee5a698c710206f1ff64f1e5a54'
+          },
+          event: { creator: 'sd:scheduler' }
+        },
+        pipelineId: 11326,
+        sha: '439c9f91ff65aee5a698c710206f1ff64f1e5a54',
+        startFrom: 'main',
+        type: 'pipeline',
+        workflowGraph: {
+          nodes: [
+            { name: '~pr' },
+            { name: '~commit' },
+            { name: 'main', id: 98321 }
+          ],
+          edges: [
+            { src: '~commit', dest: 'main' },
+            { src: '~pr', dest: 'main' }
+          ]
+        },
+        pr: {}
+      },
+      {
+        id: 735425,
+        groupEventId: 735425,
+        causeMessage: 'Started by periodic build scheduler',
+        commit: {
+          author: {
+            avatar: 'https://avatars.githubusercontent.com/u/15989893?v=4',
+            name: 'Alan',
+            username: 'adong',
+            url: 'https://github.com/adong'
+          },
+          committer: {
+            avatar: 'https://avatars.githubusercontent.com/u/19864447?v=4',
+            name: 'GitHub Web Flow',
+            username: 'web-flow',
+            url: 'https://github.com/web-flow'
+          },
+          message: 'Update screwdriver.yaml',
+          url: 'https://github.com/adong/sd-periodic/commit/439c9f91ff65aee5a698c710206f1ff64f1e5a54'
+        },
+        createTime: '2023-04-20T14:40:08.520Z',
+        creator: { name: 'Screwdriver scheduler', username: 'sd:scheduler' },
+        meta: {
+          build: {
+            buildId: '858077',
+            coverageKey: 'job:98321',
+            eventId: '735425',
+            jobId: '98321',
+            jobName: 'main',
+            pipelineId: '11326',
+            sha: '439c9f91ff65aee5a698c710206f1ff64f1e5a54'
+          },
+          commit: {
+            author: {
+              avatar: 'https://avatars.githubusercontent.com/u/15989893?v=4',
+              name: 'Alan',
+              url: 'https://github.com/adong',
+              username: 'adong'
+            },
+            changedFiles: '',
+            committer: {
+              avatar: 'https://avatars.githubusercontent.com/u/19864447?v=4',
+              name: 'GitHub Web Flow',
+              url: 'https://github.com/web-flow',
+              username: 'web-flow'
+            },
+            message: 'Update screwdriver.yaml',
+            url: 'https://github.com/adong/sd-periodic/commit/439c9f91ff65aee5a698c710206f1ff64f1e5a54'
+          },
+          event: { creator: 'sd:scheduler' }
+        },
+        pipelineId: 11326,
+        sha: '439c9f91ff65aee5a698c710206f1ff64f1e5a54',
+        startFrom: 'main',
+        type: 'pipeline',
+        workflowGraph: {
+          nodes: [
+            { name: '~pr' },
+            { name: '~commit' },
+            { name: 'main', id: 98321 }
+          ],
+          edges: [
+            { src: '~commit', dest: 'main' },
+            { src: '~pr', dest: 'main' }
+          ]
+        },
+        pr: {}
+      },
+      {
+        id: 735415,
+        groupEventId: 735415,
+        causeMessage: 'Started by periodic build scheduler',
+        commit: {
+          author: {
+            avatar: 'https://avatars.githubusercontent.com/u/15989893?v=4',
+            name: 'Alan',
+            username: 'adong',
+            url: 'https://github.com/adong'
+          },
+          committer: {
+            avatar: 'https://avatars.githubusercontent.com/u/19864447?v=4',
+            name: 'GitHub Web Flow',
+            username: 'web-flow',
+            url: 'https://github.com/web-flow'
+          },
+          message: 'Update screwdriver.yaml',
+          url: 'https://github.com/adong/sd-periodic/commit/439c9f91ff65aee5a698c710206f1ff64f1e5a54'
+        },
+        createTime: '2023-04-20T13:40:05.477Z',
+        creator: { name: 'Screwdriver scheduler', username: 'sd:scheduler' },
+        meta: {
+          build: {
+            buildId: '858069',
+            coverageKey: 'job:98321',
+            eventId: '735415',
+            jobId: '98321',
+            jobName: 'main',
+            pipelineId: '11326',
+            sha: '439c9f91ff65aee5a698c710206f1ff64f1e5a54'
+          },
+          commit: {
+            author: {
+              avatar: 'https://avatars.githubusercontent.com/u/15989893?v=4',
+              name: 'Alan',
+              url: 'https://github.com/adong',
+              username: 'adong'
+            },
+            changedFiles: '',
+            committer: {
+              avatar: 'https://avatars.githubusercontent.com/u/19864447?v=4',
+              name: 'GitHub Web Flow',
+              url: 'https://github.com/web-flow',
+              username: 'web-flow'
+            },
+            message: 'Update screwdriver.yaml',
+            url: 'https://github.com/adong/sd-periodic/commit/439c9f91ff65aee5a698c710206f1ff64f1e5a54'
+          },
+          event: { creator: 'sd:scheduler' }
+        },
+        pipelineId: 11326,
+        sha: '439c9f91ff65aee5a698c710206f1ff64f1e5a54',
+        startFrom: 'main',
+        type: 'pipeline',
+        workflowGraph: {
+          nodes: [
+            { name: '~pr' },
+            { name: '~commit' },
+            { name: 'main', id: 98321 }
+          ],
+          edges: [
+            { src: '~commit', dest: 'main' },
+            { src: '~pr', dest: 'main' }
+          ]
+        },
+        pr: {}
+      }
+    ];
+    const events2 = [];
+
+    server.get('http://localhost:8080/v4/pipelines/11326', () => [
+      200,
+      { 'Content-Type': 'application/json' },
+      JSON.stringify(pipelineData)
+    ]);
+
+    server.get('http://localhost:8080/v4/events/735254', () => [
+      200,
+      {},
+      JSON.stringify({
+        id: 735254,
+        groupEventId: 735254,
+        causeMessage: 'Manually started by adong',
+        commit: {
+          author: {
+            avatar: 'https://avatars.githubusercontent.com/u/15989893?v=4',
+            name: 'Alan',
+            username: 'adong',
+            url: 'https://github.com/adong'
+          },
+          committer: {
+            avatar: 'https://avatars.githubusercontent.com/u/19864447?v=4',
+            name: 'GitHub Web Flow',
+            username: 'web-flow',
+            url: 'https://github.com/web-flow'
+          },
+          message: 'Update screwdriver.yaml',
+          url: 'https://github.com/adong/sd-periodic/commit/439c9f91ff65aee5a698c710206f1ff64f1e5a54'
+        },
+        createTime: '2023-04-19T19:29:11.770Z',
+        creator: {
+          avatar: 'https://avatars.githubusercontent.com/u/15989893?v=4',
+          name: 'Alan',
+          username: 'adong',
+          url: 'https://github.com/adong'
+        },
+        meta: {
+          build: {
+            buildId: '857909',
+            coverageKey: 'job:98321',
+            eventId: '735254',
+            jobId: '98321',
+            jobName: 'main',
+            pipelineId: '11326',
+            sha: '439c9f91ff65aee5a698c710206f1ff64f1e5a54'
+          },
+          commit: {
+            author: {
+              avatar: 'https://avatars.githubusercontent.com/u/15989893?v=4',
+              name: 'Alan',
+              url: 'https://github.com/adong',
+              username: 'adong'
+            },
+            changedFiles: '',
+            committer: {
+              avatar: 'https://avatars.githubusercontent.com/u/19864447?v=4',
+              name: 'GitHub Web Flow',
+              url: 'https://github.com/web-flow',
+              username: 'web-flow'
+            },
+            message: 'Update screwdriver.yaml',
+            url: 'https://github.com/adong/sd-periodic/commit/439c9f91ff65aee5a698c710206f1ff64f1e5a54'
+          },
+          event: { creator: 'adong' }
+        },
+        pipelineId: 11326,
+        sha: '439c9f91ff65aee5a698c710206f1ff64f1e5a54',
+        startFrom: '~commit',
+        type: 'pipeline',
+        workflowGraph: {
+          nodes: [
+            { name: '~pr' },
+            { name: '~commit' },
+            { name: 'main', id: 98321 }
+          ],
+          edges: [
+            { src: '~commit', dest: 'main' },
+            { src: '~pr', dest: 'main' }
+          ]
+        },
+        pr: {}
+      })
+    ]);
+
+    server.get('http://localhost:8080/v4/pipelines/11326/events', request => {
+      // const count = parseInt(request.queryParams.count, 10);
+      const page = parseInt(request.queryParams.page, 10);
+
+      return [
+        200,
+        { 'Content-Type': 'application/json' },
+        JSON.stringify(page === '1' ? events1 : events2)
+      ];
+    });
+
+    server.get('http://localhost:8080/v4/pipelines/11326/jobs', () => [
+      200,
+      {},
+      JSON.stringify([
+        {
+          id: 98321,
+          name: 'main',
+          permutations: [
+            {
+              annotations: {},
+              commands: [{ name: 'step-1', command: 'ls' }],
+              environment: {},
+              image: 'node:18',
+              secrets: [],
+              settings: {},
+              requires: ['~commit', '~pr']
+            }
+          ],
+          pipelineId: 11326,
+          state: 'ENABLED',
+          archived: false
+        }
+      ])
+    ]);
+
+    const component = this.owner.lookup('component:pipeline-events');
+    const pipeline = await component.store.findRecord('pipeline', 11326);
+
+    this.setProperties({
+      pipeline,
+      showPRJobs: true,
+      model: {
+        pipelinePreference: [],
+        desiredJobNameLengthjobs: 20,
+        triggers: [{ jobName: 'main', triggers: [] }],
+        events: events1
+      },
+      selected: '735254',
+      activeTab: 'events',
+      paginateEvents: events1,
+      eventsPage: 2,
+      expandedEventsGroup: {},
+      latestCommit: {
+        id: 735442,
+        groupEventId: 735442,
+        causeMessage: 'Merged by adong',
+        commit: {
+          author: {
+            avatar: 'https://avatars.githubusercontent.com/u/15989893?v=4',
+            name: 'Alan',
+            username: 'adong',
+            url: 'https://github.com/adong'
+          },
+          committer: {
+            avatar: 'https://avatars.githubusercontent.com/u/19864447?v=4',
+            name: 'GitHub Web Flow',
+            username: 'web-flow',
+            url: 'https://github.com/web-flow'
+          },
+          message: 'Update screwdriver.yaml',
+          url: 'https://github.com/adong/sd-periodic/commit/b549aa9502292ddb0894cfb88ced6cc144ed2a76'
+        },
+        createTime: '2023-04-20T16:57:21.936Z',
+        creator: {
+          avatar: 'https://avatars.githubusercontent.com/u/15989893?v=4',
+          name: 'Alan',
+          username: 'adong',
+          url: 'https://github.com/adong'
+        },
+        meta: {
+          build: {
+            buildId: '858092',
+            coverageKey: 'job:98321',
+            eventId: '735442',
+            jobId: '98321',
+            jobName: 'main',
+            pipelineId: '11326',
+            sha: 'b549aa9502292ddb0894cfb88ced6cc144ed2a76'
+          },
+          commit: {
+            author: {
+              avatar: 'https://avatars.githubusercontent.com/u/15989893?v=4',
+              name: 'Alan',
+              url: 'https://github.com/adong',
+              username: 'adong'
+            },
+            changedFiles: 'screwdriver.yaml',
+            committer: {
+              avatar: 'https://avatars.githubusercontent.com/u/19864447?v=4',
+              name: 'GitHub Web Flow',
+              url: 'https://github.com/web-flow',
+              username: 'web-flow'
+            },
+            message: 'Update screwdriver.yaml',
+            url: 'https://github.com/adong/sd-periodic/commit/b549aa9502292ddb0894cfb88ced6cc144ed2a76'
+          },
+          event: { creator: 'adong' }
+        },
+        pipelineId: 11326,
+        sha: 'b549aa9502292ddb0894cfb88ced6cc144ed2a76',
+        configPipelineSha: 'b549aa9502292ddb0894cfb88ced6cc144ed2a76',
+        startFrom: '~commit',
+        type: 'pipeline',
+        workflowGraph: {
+          nodes: [
+            { name: '~pr' },
+            { name: '~commit' },
+            { name: 'main', id: 98321 }
+          ],
+          edges: [
+            { src: '~commit', dest: 'main' },
+            { src: '~pr', dest: 'main' }
+          ]
+        },
+        pr: {},
+        baseBranch: 'main'
+      }
+    });
+
+    await render(hbs`<PipelineEvents
+      @session={{this.session}}
+      @model={{this.model}}
+      @pipeline={{this.pipeline}}
+      @showPRJobs={{this.showPRJobs}}
+      @selected={{mut this.selected}}
+      @showListView={{false}}
+      @showDownstreamTriggers={{this.showDownstreamTriggers}}
+      @jobId={{this.jobId}}
+      @showPRJobs={{this.showPRJobs}}
+      @activeTab={{this.activeTab}}
+      @expandedEventsGroup={{mut this.expandedEventsGroup}}
+      @paginateEvents={{mut this.paginateEvents}}
+      @eventsPage={{this.eventsPage}}
+      @isShowingModal={{false}}
+    />`);
+
+    assert.equal(
+      this.element.querySelectorAll('div.status').length,
+      5,
+      'will have 5 events including triggered by sd scheduler'
+    );
   });
 });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
With the event filter ON, and users visit the the url with given event, which belongs to the part of the filters, we should show the event.


## Objective

For example, event 735440 is a scheduled event, which ought not to be displayed, yet if users share the URL to other users and visit the URL directly, 
https://cd.screwdriver.cd/pipelines/11326/events/735440

Users should see the event on the right side regardless
![image](https://user-images.githubusercontent.com/15989893/234062617-68cd2526-4487-4aff-814e-c63f39c2b4d8.png)

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
