### PR TITLE
fix: add disable/enable auto scroll when viewing loading logs

### DIFF
--- a/app/components/build-log/component.js
+++ b/app/components/build-log/component.js
@@ -327,6 +327,11 @@ export default Component.extend({
     }
   },
 
+  scrollToBottom() {
+    set(this, 'autoscroll', true);
+    this.scrollDown();
+  },
+
   /**
    * Scroll back to the last anchor point
    * @method scrollStill
@@ -413,8 +418,7 @@ export default Component.extend({
       this.scrollTop();
     },
     scrollToBottom() {
-      set(this, 'autoscroll', true);
-      this.scrollDown();
+      this.scrollToBottom();
     },
     download() {
       const { buildId, stepName } = this;
@@ -467,8 +471,7 @@ export default Component.extend({
       this.toggleProperty('hasEnabledAutoscroll');
 
       if (this.hasEnabledAutoscroll) {
-        set(this, 'autoscroll', true);
-        this.scrollDown();
+        this.scrollToBottom();
       } else {
         set(this, 'autoscroll', false);
       }

--- a/app/components/build-log/component.js
+++ b/app/components/build-log/component.js
@@ -254,19 +254,14 @@ export default Component.extend({
     if (this.stepName) {
       this.getLogs();
     }
-
-    // this.element.addEventListener('scrollDirectionDetector', this.scrollDirectionDetector);
   },
 
-  scrollDirectionDetector(e) {
+  scrollDirectionDetector(/* e */) {
     let direction = '';
     const oldScrollY = this.scrollY;
-    // const newScrollY = window.scrollY; // global scroll
     const newScrollY = this.element.querySelectorAll('.wrap')[0].scrollTop;
 
-    console.log(`oldScrollY ${oldScrollY}, newScrollY ${newScrollY}`);
-
-    if(oldScrollY < newScrollY){
+    if (oldScrollY < newScrollY) {
       direction = 'DOWN';
     } else {
       direction = 'UP';
@@ -277,7 +272,6 @@ export default Component.extend({
       this.autoscroll = false;
     }
 
-    console.log(`direction, ${direction}`);
     this.set('scrollY', newScrollY);
   },
 
@@ -310,8 +304,6 @@ export default Component.extend({
   willDestroyElement() {
     this._super(...arguments);
     this.logService.resetCache();
-
-    // this.element.removeEventListener('scrollDirectionDetector');
   },
 
   /**
@@ -430,16 +422,11 @@ export default Component.extend({
 
       window.open(downloadLink, '_blank');
     },
-    logScroll(e) {
+    logScroll() {
       const container = this.element.querySelectorAll('.wrap')[0];
 
+      // plugin stop autoscroll feature
       this.scrollDirectionDetector();
-
-      // console.log(`this.hasEnabledAutoscroll ${this.hasEnabledAutoscroll}, and this.autoscroll ${this.autoscroll},
-      //    logScroll got called, 
-      //    this.lastScrollTop: ${this.lastScrollTop}
-      //    this.lastScrollHeight: ${this.lastScrollHeight}
-      //    event ${e}`);
 
       if (
         !this.inProgress &&
@@ -479,17 +466,12 @@ export default Component.extend({
     toggleHasAutoScroll() {
       this.toggleProperty('hasEnabledAutoscroll');
 
-      console.log(`autoScroll is now: ${this.hasEnabledAutoscroll}`);
-
       if (this.hasEnabledAutoscroll) {
-        console.log(`autoScroll is now on, scroll to bottom`);
-
-        this.sendAction('scrollToBottom');
+        set(this, 'autoscroll', true);
+        this.scrollDown();
       } else {
-        console.log(`autoScroll is now off`);
-        this.set('autscroll', false);
+        set(this, 'autoscroll', false);
       }
-      
     }
   }
 });

--- a/app/components/build-log/template.hbs
+++ b/app/components/build-log/template.hbs
@@ -17,6 +17,13 @@
       </div>
       <div>
         <a
+          onClick={{action "toggleHasAutoScroll"}}
+          alt="Toggle auto scroll screen logs"
+          title="Toggle auto scroll logs"
+        >
+          <FaIcon @icon="scroll" />
+        </a>
+        <a
           onClick={{action "toggleZoom"}}
           alt="Toggle full screen logs"
           title="Toggle fullscreen"


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
When users scroll up a loading/generating log on the build detail page, UI should not auto scroll to the bottom to show the latest log

Screenshot:
![image](https://github.com/screwdriver-cd/ui/assets/15989893/cec52a15-f9b7-4eff-9e16-fdcf3e84832c)

We might need a better icon for `scroll`
## Objective
```
If the user opt-in to new behavior: 
	if the user scrolled up:
		disable auto-scroll to the bottom.

If the user opt-in back to old behavior: 
	if the user scrolled to the bottom:
		re-enable auto-scroll to the bottom as loading more logs.

if the user does not opt-in to new behavior:
	do nothing
```

Testing Repo: https://github.com/adong/sd-random-log-loop/
Testing Pipeline: https://cd.screwdriver.cd/pipelines/11109

Test pending

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/screwdriver/issues/1720
https://github.com/screwdriver-cd/ui/pull/912
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License


<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
