### PR TITLE
fix(2770): reload build status

### DIFF
--- a/app/components/pipeline-workflow/component.js
+++ b/app/components/pipeline-workflow/component.js
@@ -217,6 +217,13 @@ export default Component.extend({
         const pipelineParameters = {};
         const jobParameters = {};
         const isPR = this.get('selectedEventObj.prNum');
+        const builds = this.get('selectedEventObj.builds') || [];
+        const build = builds.find(b => `${b.jobId}` === `${job.id}`);
+
+        if (build) {
+          job.buildId = build.id;
+          job.status = build.status;
+        }
 
         // Segregate pipeline level and job level parameters
         Object.entries(eventParameters).forEach(

--- a/app/components/workflow-tooltip/template.hbs
+++ b/app/components/workflow-tooltip/template.hbs
@@ -10,13 +10,15 @@
       </LinkTo>
     {{/each}}
   {{else}}
-    {{#if this.tooltipData.job.buildId}}
-      {{#if (not-eq this.tooltipData.job.status "CREATED")}}
-        <LinkTo @route="pipeline.build" @model={{this.tooltipData.job.buildId}}>
-          Go to build details
-        </LinkTo>
-      {{/if}}
-    {{/if}}
+
+    <LinkTo
+      @route="pipeline.build"
+      @model={{this.tooltipData.job.buildId}}
+      @disabled={{not (and this.tooltipData.job.buildId (not-eq this.tooltipData.job.status "CREATED"))}}
+    >
+      Go to build details
+    </LinkTo>
+
     <LinkTo @route="pipeline.metrics" @query={{hash jobId=this.tooltipData.job.id}}>
       Go to build metrics
     </LinkTo>

--- a/tests/integration/components/workflow-tooltip/component-test.js
+++ b/tests/integration/components/workflow-tooltip/component-test.js
@@ -10,7 +10,8 @@ module('Integration | Component | workflow tooltip', function (hooks) {
   test('it renders', async function (assert) {
     await render(hbs`<WorkflowTooltip/>`);
 
-    assert.dom('a:nth-of-type(1)').hasText('Go to build metrics');
+    assert.dom('a:nth-of-type(1)').hasText('Go to build details');
+    assert.dom('a:nth-of-type(2)').hasText('Go to build metrics');
 
     // Template block usage:
     await render(hbs`
@@ -39,6 +40,43 @@ module('Integration | Component | workflow tooltip', function (hooks) {
     assert.dom('a:nth-of-type(1)').hasText('Go to build details');
     assert.dom('a:nth-of-type(2)').hasText('Go to build metrics');
     assert.dom('a:nth-of-type(3)').hasText('Disable this job');
+  });
+
+  test('it renders disabled build detail link', async function (assert) {
+    await render(hbs`<WorkflowTooltip />`);
+
+    assert.dom('a:nth-of-type(1)').hasText('Go to build details');
+    assert.dom('a:nth-of-type(1)').hasClass('disabled');
+
+    let data = {
+      job: {
+        id: 1,
+        buildId: 1234,
+        name: 'batmobile',
+        status: 'CREATED',
+        isDisabled: false
+      }
+    };
+
+    this.set('data', data);
+
+    await render(hbs`<WorkflowTooltip @tooltipData={{this.data}} />`);
+
+    assert.dom('a:nth-of-type(1)').hasText('Go to build details');
+    assert.dom('a:nth-of-type(1)').hasClass('disabled');
+
+    data = {
+      job: {
+        id: 1,
+        name: 'batmobile',
+        isDisabled: false
+      }
+    };
+
+    await render(hbs`<WorkflowTooltip @tooltipData={{this.data}} />`);
+
+    assert.dom('a:nth-of-type(1)').hasText('Go to build details');
+    assert.dom('a:nth-of-type(1)').hasClass('disabled');
   });
 
   test('it renders remote trigger link', async function (assert) {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

I sometimes click the `Go to build metrics` link by mistake on running event.
This is due to the `Go to build details` link disappearing and not loading automatically.

![first](https://github.com/screwdriver-cd/ui/assets/43719835/79c3bb7c-5717-469a-afa4-72428e736c21)

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Alway displays the `Go to build details` disabled link and automatically updates its status.

![disabled-link](https://github.com/screwdriver-cd/ui/assets/43719835/a1f996ad-0729-4586-94df-413796cfccc1)
![enabled-link](https://github.com/screwdriver-cd/ui/assets/43719835/26c999e4-de4f-4162-a037-4fa26068fd20)

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

https://github.com/screwdriver-cd/screwdriver/issues/2770

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
