### PR TITLE
fix: event from url is not showing up on workflowGraph and testsUrl

### DIFF
--- a/app/components/build-banner/component.js
+++ b/app/components/build-banner/component.js
@@ -188,7 +188,7 @@ export default Component.extend({
           coverageInfo.coverageUrl = coverageUrl;
         }
 
-        if (isValidRelativePath(coverageUrl)) {
+        if (isValidRelativePath(coverageUrl) && pipelineBuildUrlMatch) {
           coverageInfo.coverageUrl = `${pipelineBuildUrlMatch[0]}/artifacts${coverageUrl}`;
         }
       }
@@ -203,7 +203,7 @@ export default Component.extend({
           coverageInfo.testsUrl = testsUrl;
         }
 
-        if (isValidRelativePath(testsUrl)) {
+        if (isValidRelativePath(testsUrl) && pipelineBuildUrlMatch) {
           coverageInfo.testsUrl = `${pipelineBuildUrlMatch[0]}/artifacts${testsUrl}`;
         }
       }

--- a/app/components/build-banner/component.js
+++ b/app/components/build-banner/component.js
@@ -6,7 +6,11 @@ import { isActiveBuild, isPRJob } from 'screwdriver-ui/utils/build';
 import PromiseProxyMixin from '@ember/object/promise-proxy-mixin';
 import ObjectProxy from '@ember/object/proxy';
 import { getTimestamp } from '../../utils/timestamp-format';
-import { isValidHttpOrHttpsUrl } from '../../utils/url';
+import {
+  isValidHttpOrHttpsUrl,
+  isValidRelativePath,
+  getPipelineBuildUrl
+} from '../../utils/url';
 
 const ObjectPromiseProxy = ObjectProxy.extend(PromiseProxyMixin);
 
@@ -172,14 +176,21 @@ export default Component.extend({
         : null;
 
       const coverageInfo = { ...this.coverageInfo };
+      const pipelineBuildUrlMatch = getPipelineBuildUrl();
 
       if (coverageFloat) {
         coverageInfo.coverage = `${coverageFloat}%`;
         coverageInfo.coverageUrl = '#';
       }
 
-      if (coverageUrl && isValidHttpOrHttpsUrl(coverageUrl)) {
-        coverageInfo.coverageUrl = coverageUrl;
+      if (coverageUrl) {
+        if (isValidHttpOrHttpsUrl(coverageUrl)) {
+          coverageInfo.coverageUrl = coverageUrl;
+        }
+
+        if (isValidRelativePath(coverageUrl)) {
+          coverageInfo.coverageUrl = `${pipelineBuildUrlMatch[0]}/artifacts${coverageUrl}`;
+        }
       }
 
       if (String(tests).match(/^\d+\/\d+$/)) {
@@ -187,8 +198,14 @@ export default Component.extend({
         coverageInfo.testsUrl = '#';
       }
 
-      if (testsUrl && isValidHttpOrHttpsUrl(testsUrl)) {
-        coverageInfo.testsUrl = testsUrl;
+      if (testsUrl) {
+        if (isValidHttpOrHttpsUrl(testsUrl)) {
+          coverageInfo.testsUrl = testsUrl;
+        }
+
+        if (isValidRelativePath(testsUrl)) {
+          coverageInfo.testsUrl = `${pipelineBuildUrlMatch[0]}/artifacts${testsUrl}`;
+        }
       }
 
       this.set('coverageInfo', coverageInfo);

--- a/app/pipeline/events/show/route.js
+++ b/app/pipeline/events/show/route.js
@@ -44,8 +44,10 @@ export default class PipelineEventsShowRoute extends Route {
 
     const { event_id: eventId } = this.paramsFor(this.routeName);
     const pipelineEventsController = this.controllerFor('pipeline.events');
-
-    const desiredEvent = pipelineEventsController.events.findBy('id', eventId);
+    const desiredEvent = pipelineEventsController.paginateEvents.findBy(
+      'id',
+      eventId
+    );
 
     if (!desiredEvent) {
       const event = await this.store.findRecord('event', eventId);

--- a/app/pipeline/events/show/route.js
+++ b/app/pipeline/events/show/route.js
@@ -1,4 +1,4 @@
-import { action } from '@ember/object';
+import { action, get } from '@ember/object';
 import Route from '@ember/routing/route';
 import { debounce, later } from '@ember/runloop';
 import { inject as service } from '@ember/service';
@@ -44,6 +44,33 @@ export default class PipelineEventsShowRoute extends Route {
 
     const { event_id: eventId } = this.paramsFor(this.routeName);
     const pipelineEventsController = this.controllerFor('pipeline.events');
+
+    const desiredEvent = pipelineEventsController.events.findBy('id', eventId);
+
+    if (!desiredEvent) {
+      const event = await this.store.findRecord('event', eventId);
+
+      pipelineEventsController.paginateEvents.pushObject(event);
+    } else {
+      const isGroupedEvents =
+        get(pipelineEventsController, 'pipeline.settings.groupedEvents') ??
+        true;
+
+      if (isGroupedEvents === true) {
+        const { groupEventId } = desiredEvent;
+
+        const expandedEventsGroup =
+          pipelineEventsController.expandedEventsGroup || {};
+
+        if (expandedEventsGroup[groupEventId] === undefined) {
+          expandedEventsGroup[groupEventId] = true;
+        }
+        pipelineEventsController.set(
+          'expandedEventsGroup',
+          expandedEventsGroup
+        );
+      }
+    }
 
     pipelineEventsController.set('selected', eventId);
 

--- a/app/utils/url.js
+++ b/app/utils/url.js
@@ -24,4 +24,16 @@ function isValidHttpOrHttpsUrl(url) {
   }
 }
 
-export { urlRegex, shortenUrl, isValidHttpOrHttpsUrl };
+
+function isValidRelativePath(path) {
+  return String(path).match(/^(\/[^/]+)+$/);
+}
+
+function getPipelineBuildUrl() {
+  const BUILD_URL_REGEX = /^.+\/pipelines\/\d+\/builds\/\d+/;
+  const buildUrlMatch = window.location.href.match(BUILD_URL_REGEX);
+
+  return buildUrlMatch;
+}
+
+export { urlRegex, shortenUrl, isValidHttpOrHttpsUrl, isValidRelativePath, getPipelineBuildUrl };

--- a/tests/integration/components/build-banner/component-test.js
+++ b/tests/integration/components/build-banner/component-test.js
@@ -617,11 +617,13 @@ module('Integration | Component | build banner', function (hooks) {
     };
 
     assert.expect(2);
-    this.set('eventMock', prEventMock);
-    this.set('buildStepsMock', coverageStepsMock);
-    this.set('buildMetaMock', buildMetaMock);
-    this.set('prEvents', new EmberPromise(resolves => resolves([])));
-    this.set('jobDisabled', new EmberPromise(resolves => resolves(false)));
+    this.setProperties({
+      eventMock: prEventMock,
+      buildStepsMock: coverageStepsMock,
+      buildMetaMock,
+      prEvents: new EmberPromise(resolves => resolves([])),
+      jobDisabled: new EmberPromise(resolves => resolves(false))
+    });
 
     await render(hbs`<BuildBanner
       @buildContainer="node:6"


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
1) event from url is not showing up on workflowGraph
This is regression caused by https://github.com/screwdriver-cd/ui/pull/844/files#diff-7447ce8254a7360f874589e7e4f3f6d2a5bf45b146a010b71b889fd2bb2895a0R59-R61, which abstracted and pagination logics from controller to component. 

![image](https://github.com/screwdriver-cd/ui/assets/15989893/d49a09f8-134d-49f0-8bbb-9e4e1d7c0ce8)

![image](https://github.com/screwdriver-cd/ui/assets/15989893/c677df9c-1138-4f9a-8155-2ed922c9e202)

2) add relative path support for meta testUrl and coverageUrl
This is caused by PR https://github.com/screwdriver-cd/ui/pull/909, which added full url support while removed relative path as url. 

i.e. 
When set `meta.testsUrl` as a relative path, i.e. `'/sd/workspace/artifacts/summary.html'`, UI will redirect to artifacts 

```
https://screwdriver.cd/pipelines/eventId/builds/builId/artifacts/sd/workspace/artifacts/summary.html

i.e.

https://screwdriver.cd/pipelines/1026570/builds/62088097/artifacts/sd/workspace/artifacts/summary.html
```

![image](https://github.com/screwdriver-cd/ui/assets/15989893/c57a693a-ed89-427f-8529-b9a41f3fefaa)


## Objective
This PR fixes these two issues
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
