### PR TITLE
fix: remove duplicate event

### DIFF
--- a/app/components/pipeline-events/component.js
+++ b/app/components/pipeline-events/component.js
@@ -123,7 +123,10 @@ export async function createEvent(eventPayload, toActiveTab) {
     this.forceReload();
 
     if (toActiveTab === true && this.activeTab === 'pulls') {
-      return this.router.transitionTo('pipeline.pulls', newEvent.get('pipelineId'));
+      return this.router.transitionTo(
+        'pipeline.pulls',
+        newEvent.get('pipelineId')
+      );
     }
 
     return this.router.transitionTo('pipeline', newEvent.get('pipelineId'));
@@ -376,10 +379,13 @@ export default Component.extend(ModelReloaderMixin, {
         const filteredPaginateEvents = this.paginateEvents.filter(
           e => e.pipelineId === pipelineId
         );
-        const pipelineEvents = [].concat(
-          this.modelEvents,
-          filteredPaginateEvents
-        );
+
+        // remove duplicate event
+        const pipelineEvents = [
+          ...this.modelEvents,
+          ...filteredPaginateEvents
+        ].uniqBy('id');
+
         const selectedEventId = this.selected;
 
         let filteredEvents = pipelineEvents;


### PR DESCRIPTION
## Context
Show duplicate events

Before:
![image](https://github.com/screwdriver-cd/ui/assets/15989893/7931f27a-dceb-48ba-b2f6-e7973cbae2df)

After:
![image](https://github.com/screwdriver-cd/ui/assets/15989893/4ac7c3d8-a383-4c01-b5de-a3d5d686226a)

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
Caused by PR https://github.com/screwdriver-cd/ui/pull/928 
https://github.com/screwdriver-cd/ui/pull/928/files#diff-29f222214b5312afa539ba16b8a5f802ad973a6dda503372ad6ea712e9d20637R55

It is addressed by only filter and only keep the uniq events: 
https://github.com/screwdriver-cd/ui/compare/adong/fix-duplicate-event?expand=1#diff-4471e0b00b5f0d4e8264e36000b4629e3002b8971be9addd16b5461b45c65d7eR387

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
