### PR TITLE
fix(2838): Page Title

### DIFF
--- a/app/application/route.js
+++ b/app/application/route.js
@@ -38,12 +38,5 @@ export default Route.extend(ApplicationRouteMixin, {
         this.reloadPage();
       }
     }
-  ),
-  title(tokens) {
-    const arr = Array.isArray(tokens) ? tokens : [];
-
-    arr.push('screwdriver.cd');
-
-    return arr.join(' > ');
-  }
+  )
 });

--- a/app/commands/detail/route.js
+++ b/app/commands/detail/route.js
@@ -67,15 +67,5 @@ export default Route.extend({
 
       return true;
     }
-  },
-  titleToken(model) {
-    let title = `${model.namespace || ''}/${model.name || ''}`;
-    const version = model.versionOrTagFromUrl;
-
-    if (version !== undefined) {
-      title = `${title}@${version}`;
-    }
-
-    return title;
   }
 });

--- a/app/commands/detail/template.hbs
+++ b/app/commands/detail/template.hbs
@@ -1,3 +1,9 @@
+{{#if @model.versionOrTagFromUrl}}
+  {{page-title @model.namespace '/' @model.name '@' @model.versionOrTagFromUrl}}
+{{else}}
+  {{page-title @model.namespace '/' @model.name}}
+{{/if}}
+
 <InfoMessage
   @message={{this.errorMessage}}
   @type="warning"

--- a/app/commands/route.js
+++ b/app/commands/route.js
@@ -12,6 +12,5 @@ export default Route.extend(AuthenticatedRouteMixin, {
 
       this.controller.set('routeParams', newParams);
     }
-  },
-  titleToken: 'Commands'
+  }
 });

--- a/app/commands/template.hbs
+++ b/app/commands/template.hbs
@@ -1,3 +1,5 @@
+{{page-title "Commands"}}
+
 <BreadCrumbs @crumbs={{this.crumbs}} />
 
 {{outlet}}

--- a/app/create/route.js
+++ b/app/create/route.js
@@ -4,7 +4,6 @@ import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-rout
 import { hash } from 'rsvp';
 
 export default Route.extend(AuthenticatedRouteMixin, {
-  titleToken: 'Create Pipeline',
   routeAfterAuthentication: 'create',
   shuttle: service(),
 

--- a/app/create/template.hbs
+++ b/app/create/template.hbs
@@ -1,3 +1,5 @@
+{{page-title "Create Pipeline"}}
+
 <div class="create-pipeline">
   <div class="left">
     <div class="back" onclick={{action "goBack"}}>

--- a/app/dashboard/index/route.js
+++ b/app/dashboard/index/route.js
@@ -2,7 +2,6 @@ import Route from '@ember/routing/route';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
 export default Route.extend(AuthenticatedRouteMixin, {
-  titleToken: 'Dashboard',
   routeAfterAuthentication: 'home',
 
   model() {

--- a/app/dashboard/index/template.hbs
+++ b/app/dashboard/index/template.hbs
@@ -1,1 +1,2 @@
+{{page-title "Dashboard"}}
 {{outlet}}

--- a/app/dashboard/route.js
+++ b/app/dashboard/route.js
@@ -5,7 +5,6 @@ import { inject as service } from '@ember/service';
 
 export default Route.extend(AuthenticatedRouteMixin, {
   router: service(),
-  titleToken: 'Dashboard',
   routeAfterAuthentication: 'home',
 
   beforeModel(/* transition */) {

--- a/app/dashboard/template.hbs
+++ b/app/dashboard/template.hbs
@@ -1,1 +1,2 @@
+{{page-title "Dashboard"}}
 {{outlet}}

--- a/app/login/route.js
+++ b/app/login/route.js
@@ -4,7 +4,6 @@ import UnauthenticatedRouteMixin from 'ember-simple-auth/mixins/unauthenticated-
 
 export default Route.extend(UnauthenticatedRouteMixin, {
   scmService: service('scm'),
-  titleToken: 'Login',
   routeIfAlreadyAuthenticated: 'home',
   model() {
     return this.modelFor('application');

--- a/app/login/template.hbs
+++ b/app/login/template.hbs
@@ -1,3 +1,5 @@
+{{page-title "Login"}}
+
 <LoginButton
   @authenticate={{action "authenticate"}}
   @scmContexts={{this.scmContexts}}

--- a/app/pipeline-visualizer/route.js
+++ b/app/pipeline-visualizer/route.js
@@ -13,7 +13,6 @@ export default Route.extend(AuthenticatedRouteMixin, {
     }
   },
   routeAfterAuthentication: 'pipeline-visualizer',
-  titleToken: 'Pipeline Visualizer',
 
   async model(params) {
     this._super(...arguments);

--- a/app/pipeline-visualizer/template.hbs
+++ b/app/pipeline-visualizer/template.hbs
@@ -1,3 +1,5 @@
+{{page-title "Pipeline Visualizer"}}
+
 <div class="row">
   <div
     class="col-md-2"

--- a/app/pipeline/build/route.js
+++ b/app/pipeline/build/route.js
@@ -25,10 +25,6 @@ export default Route.extend({
     );
   },
 
-  titleToken(model) {
-    return `${model.job.get('name')} > #${model.build.get('truncatedSha')}`;
-  },
-
   deactivate() {
     const model = this.modelFor(this.routeName);
 

--- a/app/pipeline/build/template.hbs
+++ b/app/pipeline/build/template.hbs
@@ -1,3 +1,5 @@
+{{page-title @model.job.name ' > #' @model.build.truncatedSha}}
+
 <BuildBanner
   @buildContainer={{this.build.buildContainer}}
   @duration={{this.build.totalDuration}}

--- a/app/pipeline/child-pipelines/route.js
+++ b/app/pipeline/child-pipelines/route.js
@@ -7,7 +7,6 @@ export default Route.extend({
   router: service(),
   store: service(),
   routeAfterAuthentication: 'pipeline.child-pipelines',
-  titleToken: 'Child Pipelines',
   model() {
     // Guests should not access this page
     if (get(this, 'session.data.authenticated.isGuest')) {

--- a/app/pipeline/child-pipelines/template.hbs
+++ b/app/pipeline/child-pipelines/template.hbs
@@ -1,3 +1,5 @@
+{{page-title "Child Pipelines"}}
+
 {{#if this.session.isAuthenticated}}
   <PipelineNav @pipeline={{this.pipeline}} />
 {{/if}}

--- a/app/pipeline/route.js
+++ b/app/pipeline/route.js
@@ -43,9 +43,5 @@ export default Route.extend(AuthenticatedRouteMixin, {
 
       return true;
     }
-  },
-
-  titleToken(model) {
-    return get(model, 'pipeline.name');
   }
 });

--- a/app/pipeline/secrets/route.js
+++ b/app/pipeline/secrets/route.js
@@ -7,7 +7,6 @@ export default Route.extend({
   store: service(),
   router: service(),
   routeAfterAuthentication: 'pipeline.secrets',
-  titleToken: 'Secrets',
   model() {
     //Refresh error message
     this.controllerFor('pipeline.secrets').set('errorMessage', '');

--- a/app/pipeline/secrets/template.hbs
+++ b/app/pipeline/secrets/template.hbs
@@ -1,3 +1,5 @@
+{{page-title "Secrets"}}
+
 {{#if this.session.isAuthenticated}}
   <PipelineNav @pipeline={{this.pipeline}} />
 {{/if}}

--- a/app/pipeline/template.hbs
+++ b/app/pipeline/template.hbs
@@ -1,3 +1,5 @@
+{{page-title @model.pipeline.name}}
+
 <PipelineHeader
   @pipeline={{this.pipeline}}
   @collections={{this.collections}}

--- a/app/search/route.js
+++ b/app/search/route.js
@@ -13,7 +13,6 @@ export default Route.extend(AuthenticatedRouteMixin, {
     }
   },
   routeAfterAuthentication: 'search',
-  titleToken: 'Search',
   model(params) {
     const pipelineListConfig = {
       page: 1,

--- a/app/search/template.hbs
+++ b/app/search/template.hbs
@@ -1,3 +1,5 @@
+{{page-title "Search"}}
+
 <div class="row">
   {{#if this.session.isAuthenticated}}
     <CollectionsFlyout

--- a/app/templates/detail/route.js
+++ b/app/templates/detail/route.js
@@ -98,15 +98,5 @@ export default Route.extend({
 
       return true;
     }
-  },
-  titleToken(model) {
-    let title = `${model.namespace || ''}/${model.name || ''}`;
-    const version = model.versionOrTagFromUrl;
-
-    if (version !== undefined) {
-      title = `${title}@${version}`;
-    }
-
-    return title;
   }
 });

--- a/app/templates/detail/template.hbs
+++ b/app/templates/detail/template.hbs
@@ -1,3 +1,9 @@
+{{#if @model.versionOrTagFromUrl}}
+  {{page-title @model.namespace '/' @model.name '@' @model.versionOrTagFromUrl}}
+{{else}}
+  {{page-title @model.namespace '/' @model.name}}
+{{/if}}
+
 <InfoMessage
   @message={{this.errorMessage}}
   @type="warning"

--- a/app/templates/route.js
+++ b/app/templates/route.js
@@ -12,6 +12,5 @@ export default Route.extend(AuthenticatedRouteMixin, {
 
       this.controller.set('routeParams', newParams);
     }
-  },
-  titleToken: 'Templates'
+  }
 });

--- a/app/templates/template.hbs
+++ b/app/templates/template.hbs
@@ -1,3 +1,5 @@
+{{page-title "Templates"}}
+
 <BreadCrumbs @crumbs={{this.crumbs}} />
 
 {{outlet}}

--- a/app/user-settings/access-tokens/route.js
+++ b/app/user-settings/access-tokens/route.js
@@ -2,6 +2,5 @@ import Route from '@ember/routing/route';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
 export default Route.extend(AuthenticatedRouteMixin, {
-  titleToken: 'Access Tokens',
   routeAfterAuthentication: 'user-settings'
 });

--- a/app/user-settings/access-tokens/template.hbs
+++ b/app/user-settings/access-tokens/template.hbs
@@ -1,3 +1,5 @@
+{{page-title "Access Tokens"}}
+
 <TokenList
   @tokens={{this.tokens}}
   @newToken={{this.newToken}}

--- a/app/user-settings/preferences/route.js
+++ b/app/user-settings/preferences/route.js
@@ -7,7 +7,6 @@ export default Route.extend(AuthenticatedRouteMixin, {
   router: service(),
   routeAfterAuthentication: 'user-settings',
   userSettings: service(),
-  titleToken: 'Preferences',
 
   model() {
     return RSVP.hash({

--- a/app/user-settings/preferences/template.hbs
+++ b/app/user-settings/preferences/template.hbs
@@ -1,3 +1,5 @@
+{{page-title "Preferences"}}
+
 <InfoMessage @message={{this.errorMessage}} @type="warning" @icon="exclamation-triangle" />
 <InfoMessage @message={{this.successMessage}} @type="success" @icon="check" />
 <div>

--- a/app/user-settings/route.js
+++ b/app/user-settings/route.js
@@ -7,7 +7,6 @@ export default Route.extend(AuthenticatedRouteMixin, {
   router: service(),
   store: service(),
   session: service(),
-  titleToken: 'User Settings',
   routeAfterAuthentication: 'user-settings',
   model() {
     // Guests should not access this page

--- a/app/user-settings/template.hbs
+++ b/app/user-settings/template.hbs
@@ -1,3 +1,5 @@
+{{page-title "User Settings"}}
+
 <div class="user-preference">
   <h2>Settings</h2>
   <div class="column-tabs-view">

--- a/config/environment.js
+++ b/config/environment.js
@@ -80,7 +80,11 @@ module.exports = environment => {
     'ember-local-storage': {
       namespace: true,
       keyDelimiter: ':'
-    }
+    },
+    pageTitle: {
+      separator: ' > ',
+      prepend: false
+    },
   };
 
   if (environment === 'development') {

--- a/tests/acceptance/commands-test.js
+++ b/tests/acceptance/commands-test.js
@@ -1,0 +1,101 @@
+import { visit, currentURL } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { authenticateSession } from 'ember-simple-auth/test-support';
+import Pretender from 'pretender';
+import { getPageTitle } from 'ember-page-title/test-support';
+import { hasCollections } from 'screwdriver-ui/tests/mock/collections';
+import { adminJWT } from '../mock/jwt';
+
+const dummyCommands = [
+  {
+      id: 2,
+      namespace: "foo",
+      version: "2.0.0",
+      description: "test command\n",
+      maintainer: "screwdriver@example.com",
+      format: "binary",
+      binary: {
+          "file": "tmpfile"
+      },
+      name: "bar",
+      pipelineId: 3,
+      createTime: "2016-09-23T16:53:00.274Z",
+      trusted: false,
+      latest: true,
+      lastUpdated: "4 days ago"
+  },
+  {
+      id: 1,
+      namespace: "foo",
+      version: "1.0.0",
+      description: "test command\n",
+      maintainer: "screwdriver@example.com",
+      format: "binary",
+      binary: {
+          "file": "tmpfile"
+      },
+      name: "bar",
+      pipelineId: 3,
+      createTime: "2016-09-23T16:53:00.274Z",
+      trusted: false,
+      latest: true,
+      lastUpdated: "4 days ago"
+  }
+];
+
+let server;
+
+module('Acceptance | commands', function (hooks) {
+  setupApplicationTest(hooks);
+
+  hooks.beforeEach(function () {
+    server = new Pretender();
+
+    server.get('http://localhost:8080/v4/collections', hasCollections);
+    server.get('http://localhost:8080/v4/commands', () => [
+      200,
+      { 'Content-Type': 'application/json' },
+      JSON.stringify(dummyCommands)
+    ]);
+    server.get('http://localhost:8080/v4/commands/foo/bar', () => [
+      200,
+      { 'Content-Type': 'application/json' },
+      JSON.stringify(dummyCommands)
+    ]);
+    server.get('http://localhost:8080/v4/commands/foo/bar/tags', () => [
+      200,
+      { 'Content-Type': 'application/json' },
+      JSON.stringify(dummyCommands)
+    ]);
+  });
+
+  hooks.afterEach(function () {
+    server.shutdown();
+  });
+
+  test('visiting /commands', async (assert) => {
+    await authenticateSession({ token: 'faketoken' });
+    await visit('/commands');
+
+    assert.dom('.models-table-wrapper').exists({ count: 1 });
+    assert.equal(currentURL(), '/commands');
+    assert.equal(getPageTitle(), 'Commands');
+  });
+
+  test('visiting /commands/foo/bar', async (assert) => {
+    await authenticateSession({ token: adminJWT });
+    await visit('/commands/foo/bar');
+
+    assert.equal(currentURL(), '/commands/foo/bar');
+    assert.equal(getPageTitle(), 'Commands > foo/bar');
+  });
+
+  test('visiting /commands/foo/bar/1.0.0', async (assert) => {
+    await authenticateSession({ token: adminJWT });
+    await visit('/commands/foo/bar/1.0.0');
+
+    assert.equal(currentURL(), '/commands/foo/bar/1.0.0');
+    assert.equal(getPageTitle(), 'Commands > foo/bar@1.0.0');
+  });
+});

--- a/tests/acceptance/commands-test.js
+++ b/tests/acceptance/commands-test.js
@@ -9,38 +9,38 @@ import { adminJWT } from '../mock/jwt';
 
 const dummyCommands = [
   {
-      id: 2,
-      namespace: "foo",
-      version: "2.0.0",
-      description: "test command\n",
-      maintainer: "screwdriver@example.com",
-      format: "binary",
-      binary: {
-          "file": "tmpfile"
-      },
-      name: "bar",
-      pipelineId: 3,
-      createTime: "2016-09-23T16:53:00.274Z",
-      trusted: false,
-      latest: true,
-      lastUpdated: "4 days ago"
+    id: 2,
+    namespace: 'foo',
+    version: '2.0.0',
+    description: 'test command\n',
+    maintainer: 'screwdriver@example.com',
+    format: 'binary',
+    binary: {
+      file: 'tmpfile'
+    },
+    name: 'bar',
+    pipelineId: 3,
+    createTime: '2016-09-23T16:53:00.274Z',
+    trusted: false,
+    latest: true,
+    lastUpdated: '4 days ago'
   },
   {
-      id: 1,
-      namespace: "foo",
-      version: "1.0.0",
-      description: "test command\n",
-      maintainer: "screwdriver@example.com",
-      format: "binary",
-      binary: {
-          "file": "tmpfile"
-      },
-      name: "bar",
-      pipelineId: 3,
-      createTime: "2016-09-23T16:53:00.274Z",
-      trusted: false,
-      latest: true,
-      lastUpdated: "4 days ago"
+    id: 1,
+    namespace: 'foo',
+    version: '1.0.0',
+    description: 'test command\n',
+    maintainer: 'screwdriver@example.com',
+    format: 'binary',
+    binary: {
+      file: 'tmpfile'
+    },
+    name: 'bar',
+    pipelineId: 3,
+    createTime: '2016-09-23T16:53:00.274Z',
+    trusted: false,
+    latest: true,
+    lastUpdated: '4 days ago'
   }
 ];
 
@@ -74,28 +74,32 @@ module('Acceptance | commands', function (hooks) {
     server.shutdown();
   });
 
-  test('visiting /commands', async (assert) => {
+  test('visiting /commands', async assert => {
     await authenticateSession({ token: 'faketoken' });
     await visit('/commands');
 
     assert.dom('.models-table-wrapper').exists({ count: 1 });
     assert.equal(currentURL(), '/commands');
-    assert.equal(getPageTitle(), 'Commands');
+    assert.equal(getPageTitle(), 'Commands', 'Page title is correct');
   });
 
-  test('visiting /commands/foo/bar', async (assert) => {
+  test('visiting /commands/foo/bar', async assert => {
     await authenticateSession({ token: adminJWT });
     await visit('/commands/foo/bar');
 
     assert.equal(currentURL(), '/commands/foo/bar');
-    assert.equal(getPageTitle(), 'Commands > foo/bar');
+    assert.equal(getPageTitle(), 'Commands > foo/bar', 'Page title is correct');
   });
 
-  test('visiting /commands/foo/bar/1.0.0', async (assert) => {
+  test('visiting /commands/foo/bar/1.0.0', async assert => {
     await authenticateSession({ token: adminJWT });
     await visit('/commands/foo/bar/1.0.0');
 
     assert.equal(currentURL(), '/commands/foo/bar/1.0.0');
-    assert.equal(getPageTitle(), 'Commands > foo/bar@1.0.0');
+    assert.equal(
+      getPageTitle(),
+      'Commands > foo/bar@1.0.0',
+      'Page title is correct'
+    );
   });
 });

--- a/tests/acceptance/create-page-test.js
+++ b/tests/acceptance/create-page-test.js
@@ -102,7 +102,7 @@ module('Acceptance | create', function (hooks) {
     await visit('/create');
 
     assert.equal(currentURL(), '/create');
-    assert.equal(getPageTitle(), 'Create Pipeline');
+    assert.equal(getPageTitle(), 'Create Pipeline', 'Page title is correct');
     await fillIn('.text-input', 'git@github.com:foo/bar.git');
     await triggerEvent('.text-input', 'keyup');
     await click('button.blue-button');

--- a/tests/acceptance/create-page-test.js
+++ b/tests/acceptance/create-page-test.js
@@ -10,6 +10,8 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import Pretender from 'pretender';
+import { getPageTitle } from 'ember-page-title/test-support';
+
 let server;
 
 module('Acceptance | create', function (hooks) {
@@ -100,6 +102,7 @@ module('Acceptance | create', function (hooks) {
     await visit('/create');
 
     assert.equal(currentURL(), '/create');
+    assert.equal(getPageTitle(), 'Create Pipeline');
     await fillIn('.text-input', 'git@github.com:foo/bar.git');
     await triggerEvent('.text-input', 'keyup');
     await click('button.blue-button');

--- a/tests/acceptance/dashboards-test.js
+++ b/tests/acceptance/dashboards-test.js
@@ -75,7 +75,7 @@ module('Acceptance | dashboards', function (hooks) {
     await visit('/');
     await waitFor('h2.header__name');
     assert.equal(currentURL(), '/dashboards/1');
-    assert.equal(getPageTitle(), 'Dashboard');
+    assert.equal(getPageTitle(), 'Dashboard', 'Page title is correct');
     assert.dom('.header__name').hasText('My Pipelines');
     assert
       .dom('.header__description')

--- a/tests/acceptance/dashboards-test.js
+++ b/tests/acceptance/dashboards-test.js
@@ -12,6 +12,7 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import Pretender from 'pretender';
+import { getPageTitle } from 'ember-page-title/test-support';
 
 import {
   hasCollections,
@@ -74,6 +75,7 @@ module('Acceptance | dashboards', function (hooks) {
     await visit('/');
     await waitFor('h2.header__name');
     assert.equal(currentURL(), '/dashboards/1');
+    assert.equal(getPageTitle(), 'Dashboard');
     assert.dom('.header__name').hasText('My Pipelines');
     assert
       .dom('.header__description')

--- a/tests/acceptance/login-test.js
+++ b/tests/acceptance/login-test.js
@@ -6,10 +6,10 @@ import { getPageTitle } from 'ember-page-title/test-support';
 module('Acceptance | commands', function (hooks) {
   setupApplicationTest(hooks);
 
-  test('visiting /login', async (assert) => {
+  test('visiting /login', async assert => {
     await visit('/login');
 
     assert.equal(currentURL(), '/login');
-    assert.equal(getPageTitle(), 'Login');
+    assert.equal(getPageTitle(), 'Login', 'Page title is correct');
   });
 });

--- a/tests/acceptance/login-test.js
+++ b/tests/acceptance/login-test.js
@@ -1,0 +1,15 @@
+import { visit, currentURL } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { getPageTitle } from 'ember-page-title/test-support';
+
+module('Acceptance | commands', function (hooks) {
+  setupApplicationTest(hooks);
+
+  test('visiting /login', async (assert) => {
+    await visit('/login');
+
+    assert.equal(currentURL(), '/login');
+    assert.equal(getPageTitle(), 'Login');
+  });
+});

--- a/tests/acceptance/login-test.js
+++ b/tests/acceptance/login-test.js
@@ -3,7 +3,7 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { getPageTitle } from 'ember-page-title/test-support';
 
-module('Acceptance | commands', function (hooks) {
+module('Acceptance | logins', function (hooks) {
   setupApplicationTest(hooks);
 
   test('visiting /login', async assert => {

--- a/tests/acceptance/pipeline-builds-test.js
+++ b/tests/acceptance/pipeline-builds-test.js
@@ -170,8 +170,8 @@ module('Acceptance | pipeline build', function (hooks) {
     await visit('/pipelines/4');
 
     assert.equal(currentURL(), `/pipelines/4/events/${desiredEventId}`);
-    assert.equal(getPageTitle(), 'foo/bar', 'Page title is foo/bar');
-    assert.dom('a h1').hasText('foo/bar', 'Pipeline name is foo/bar');
+    assert.equal(getPageTitle(), 'foo/bar', 'Page title is correct');
+    assert.dom('a h1').hasText('foo/bar', 'Pipeline name is correct');
     assert
       .dom('.pipelineWorkflow svg')
       .exists({ count: 1 }, 'not enough workflow');

--- a/tests/acceptance/pipeline-builds-test.js
+++ b/tests/acceptance/pipeline-builds-test.js
@@ -144,12 +144,6 @@ module('Acceptance | pipeline build', function (hooks) {
     const pipelineId = 4;
     const buildId = 1000000;
 
-    const controller = this.owner.lookup('controller:pipeline/build');
-
-    controller.actions.reload = () => {
-      assert.ok();
-    };
-
     const service = this.owner.lookup('service:build-logs');
 
     service.getCache = () => {

--- a/tests/acceptance/pipeline-builds-test.js
+++ b/tests/acceptance/pipeline-builds-test.js
@@ -3,6 +3,7 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import Pretender from 'pretender';
+import { getPageTitle } from 'ember-page-title/test-support';
 
 import makePipeline from '../mock/pipeline';
 import makeEvents from '../mock/events';
@@ -169,7 +170,8 @@ module('Acceptance | pipeline build', function (hooks) {
     await visit('/pipelines/4');
 
     assert.equal(currentURL(), `/pipelines/4/events/${desiredEventId}`);
-    assert.dom('a h1').hasText('foo/bar', 'incorrect pipeline name');
+    assert.equal(getPageTitle(), 'foo/bar', 'Page title is foo/bar');
+    assert.dom('a h1').hasText('foo/bar', 'Pipeline name is foo/bar');
     assert
       .dom('.pipelineWorkflow svg')
       .exists({ count: 1 }, 'not enough workflow');

--- a/tests/acceptance/pipeline-childPipelines-test.js
+++ b/tests/acceptance/pipeline-childPipelines-test.js
@@ -3,6 +3,7 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import Pretender from 'pretender';
+import { getPageTitle } from 'ember-page-title/test-support';
 let server;
 
 module('Acceptance | child pipeline', function (hooks) {
@@ -78,6 +79,7 @@ module('Acceptance | child pipeline', function (hooks) {
     await visit('/pipelines/1/child-pipelines');
 
     assert.equal(currentURL(), '/pipelines/1/child-pipelines');
+    assert.equal(getPageTitle(), 'Child Pipelines', 'Page title is correct');
     assert.dom('.appId:nth-child(1)').hasText('Name');
     assert.dom('tbody tr:first-child td.appId').hasText('child/one');
     assert.dom('tbody tr:first-child td.branch').hasText('master');

--- a/tests/acceptance/pipeline-visualizer-test.js
+++ b/tests/acceptance/pipeline-visualizer-test.js
@@ -1,0 +1,49 @@
+import { visit, currentURL } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { authenticateSession } from 'ember-simple-auth/test-support';
+import { getPageTitle } from 'ember-page-title/test-support';
+import Pretender from 'pretender';
+
+let server;
+
+module('Acceptance | pipeline-visualizer', function (hooks) {
+  setupApplicationTest(hooks);
+
+  hooks.beforeEach(function () {
+    server = new Pretender();
+    server.get('http://localhost:8080/v4/auth/contexts', () => [
+      200,
+      { 'Content-Type': 'application/json' },
+      JSON.stringify({})
+    ]);
+    server.get('http://localhost:8080/v4/collections', () => [
+      200,
+      { 'Content-Type': 'application/json' },
+      JSON.stringify({
+        id: '1'
+      })
+    ]);
+    server.get('http://localhost:8080/v4/banners', () => [
+      200,
+      { 'Content-Type': 'application/json' },
+      JSON.stringify({})
+    ]);
+  });
+
+  hooks.afterEach(function () {
+    server.shutdown();
+  });
+
+  test('visiting /pipeline-visualizer', async assert => {
+    await authenticateSession({ token: 'fakeToken' });
+    await visit('/pipeline-visualizer');
+
+    assert.equal(currentURL(), '/pipeline-visualizer');
+    assert.equal(
+      getPageTitle(),
+      'Pipeline Visualizer',
+      'Page title is correct'
+    );
+  });
+});

--- a/tests/acceptance/search-test.js
+++ b/tests/acceptance/search-test.js
@@ -3,6 +3,7 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import Pretender from 'pretender';
+import { getPageTitle } from 'ember-page-title/test-support';
 let server;
 
 module('Acceptance | search', function (hooks) {
@@ -125,6 +126,7 @@ module('Acceptance | search', function (hooks) {
     await visit('/search');
 
     assert.equal(currentURL(), '/search');
+    assert.equal(getPageTitle(), 'Search', 'Page title is correct');
     assert.dom('tr').exists({ count: 4 });
     assert.dom('.showMore').hasText('Show more results...');
     assert.dom('.num-results').hasText('Showing 3 result(s)');

--- a/tests/acceptance/secrets-test.js
+++ b/tests/acceptance/secrets-test.js
@@ -3,6 +3,7 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import Pretender from 'pretender';
+import { getPageTitle } from 'ember-page-title/test-support';
 let server;
 
 module('Acceptance | secrets', function (hooks) {
@@ -57,6 +58,7 @@ module('Acceptance | secrets', function (hooks) {
     await visit('/pipelines/1/secrets');
 
     assert.equal(currentURL(), '/pipelines/1/secrets');
+    assert.equal(getPageTitle(), 'Secrets', 'Page title is correct');
     assert.dom('.secrets tbody tr').exists({ count: 2 });
     assert.dom('.token-list tbody tr').exists({ count: 2 });
   });

--- a/tests/acceptance/templates-test.js
+++ b/tests/acceptance/templates-test.js
@@ -1,0 +1,106 @@
+import { visit, currentURL } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { authenticateSession } from 'ember-simple-auth/test-support';
+import Pretender from 'pretender';
+import { getPageTitle } from 'ember-page-title/test-support';
+import { hasCollections } from 'screwdriver-ui/tests/mock/collections';
+import { adminJWT } from '../mock/jwt';
+
+const dummyTemplates = [
+  {
+    id: 2,
+    namespace: 'foo',
+    name: 'bar',
+    version: '2.0.0',
+    description: 'test template\n',
+    maintainer: 'screwdriver@example.com',
+    pipelineId: 3,
+    createTime: '2016-09-23T16:53:00.274Z',
+    trusted: false,
+    latest: true,
+    lastUpdated: '4 days ago'
+  },
+  {
+    id: 1,
+    namespace: 'foo',
+    name: 'bar',
+    version: '1.0.0',
+    description: 'test template\n',
+    maintainer: 'screwdriver@example.com',
+    pipelineId: 3,
+    createTime: '2016-09-23T16:53:00.274Z',
+    trusted: false,
+    latest: true,
+    lastUpdated: '4 days ago'
+  }
+];
+
+let server;
+
+module('Acceptance | templates', function (hooks) {
+  setupApplicationTest(hooks);
+
+  hooks.beforeEach(function () {
+    server = new Pretender();
+
+    server.get('http://localhost:8080/v4/collections', hasCollections);
+    server.get('http://localhost:8080/v4/templates', () => [
+      200,
+      { 'Content-Type': 'application/json' },
+      JSON.stringify(dummyTemplates)
+    ]);
+    server.get('http://localhost:8080/v4/templates/foo/bar', () => [
+      200,
+      { 'Content-Type': 'application/json' },
+      JSON.stringify(dummyTemplates)
+    ]);
+    server.get('http://localhost:8080/v4/templates/foo%2Fbar/metrics', () => [
+      200,
+      { 'Content-Type': 'application/json' },
+      JSON.stringify(dummyTemplates)
+    ]);
+    server.get('http://localhost:8080/v4/templates/foo%2Fbar/tags', () => [
+      200,
+      { 'Content-Type': 'application/json' },
+      JSON.stringify(dummyTemplates)
+    ]);
+  });
+
+  hooks.afterEach(function () {
+    server.shutdown();
+  });
+
+  test('visiting /templates', async assert => {
+    await authenticateSession({ token: 'faketoken' });
+    await visit('/templates');
+
+    assert.dom('.models-table-wrapper').exists({ count: 1 });
+    assert.equal(currentURL(), '/templates');
+    assert.equal(getPageTitle(), 'Templates', 'Page title is correct');
+  });
+
+  test('visiting /templates/foo/bar', async assert => {
+    await authenticateSession({ token: adminJWT });
+    await visit('/templates/foo/bar');
+
+    assert.equal(currentURL(), '/templates/foo/bar');
+    assert.equal(
+      getPageTitle(),
+      'Templates > foo/bar',
+      'Page title is correct'
+    );
+  });
+
+  test('visiting /templates/foo/bar/1.0.0', async assert => {
+    await authenticateSession({ token: adminJWT });
+    await visit('/templates/foo/bar/1.0.0');
+
+    assert.equal(currentURL(), '/templates/foo/bar/1.0.0');
+    assert.equal(
+      getPageTitle(),
+      'Templates > foo/bar@1.0.0',
+      'Page title is correct'
+    );
+  });
+});

--- a/tests/acceptance/tokens-test.js
+++ b/tests/acceptance/tokens-test.js
@@ -43,6 +43,10 @@ module('Acceptance | tokens', function (hooks) {
     await visit('/user-settings/access-tokens');
 
     assert.dom('.token-list tbody tr').exists({ count: 2 });
-    assert.equal(getPageTitle(), 'User Settings > Access Tokens');
+    assert.equal(
+      getPageTitle(),
+      'User Settings > Access Tokens',
+      'Page title is correct'
+    );
   });
 });

--- a/tests/acceptance/tokens-test.js
+++ b/tests/acceptance/tokens-test.js
@@ -4,6 +4,7 @@ import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import Pretender from 'pretender';
 import { hasCollections } from 'screwdriver-ui/tests/mock/collections';
+import { getPageTitle } from 'ember-page-title/test-support';
 
 let server;
 
@@ -42,5 +43,6 @@ module('Acceptance | tokens', function (hooks) {
     await visit('/user-settings/access-tokens');
 
     assert.dom('.token-list tbody tr').exists({ count: 2 });
+    assert.equal(getPageTitle(), 'User Settings > Access Tokens');
   });
 });

--- a/tests/acceptance/user-settings-test.js
+++ b/tests/acceptance/user-settings-test.js
@@ -27,6 +27,22 @@ module('Acceptance | user-settings', function (hooks) {
         timestamFormat: 'LOCAL_TIMEZONE'
       })
     ]);
+
+    server.get('http://localhost:8080/v4/tokens', () => [
+      200,
+      { 'Content-Type': 'application/json' },
+      JSON.stringify({
+        id: '1'
+      })
+    ]);
+
+    server.get('http://localhost:8080/v4/collections', () => [
+      200,
+      { 'Content-Type': 'application/json' },
+      JSON.stringify({
+        id: '1'
+      })
+    ]);
   });
 
   hooks.afterEach(function () {
@@ -38,7 +54,7 @@ module('Acceptance | user-settings', function (hooks) {
     await visit('/user-settings/preferences');
 
     assert.equal(currentURL(), '/user-settings/preferences');
-    assert.dom('section.preference li').exists({ count: 2 });
+    assert.dom('section.preference li').exists({ count: 3 });
   });
 
   test('update user preferences', async function (assert) {
@@ -55,23 +71,28 @@ module('Acceptance | user-settings', function (hooks) {
       { 'Content-Type': 'application/json' },
       JSON.stringify({})
     ]);
-    const controller = this.owner.lookup('controller:user-settings/preference');
 
     await authenticateSession({ token: 'faketoken' });
     await visit('/user-settings/preferences');
 
     assert.equal(currentURL(), '/user-settings/preferences');
-    assert.equal(getPageTitle(), 'Preferences', 'Page title is correct');
-    assert.dom('.ember-power-select-selected-item').hasText('LOCAL_TIMEZONE');
-    await fillIn('.display-job-name', 50);
-    await fillIn('.ember-power-select-selected-item', 'UTC');
-
-    await click('button.blue-button');
-    assert.dom('.display-job-name').hasValue(50);
-    assert.dom('.ember-power-select-selected-item').hasValue('UTC');
-    assert.deepEqual(
-      controller.successMessage,
-      'User settings updated successfully!'
+    assert.equal(
+      getPageTitle(),
+      'User Settings > Preferences',
+      'Page title is correct'
     );
+    assert.dom('.ember-power-select-selected-item').hasText('Local Timezone');
+    assert.dom('.display-job-name').hasProperty('placeholder', '20');
+
+    await click('.ember-basic-dropdown-trigger');
+    await click('.ember-power-select-options li:last-child');
+    await fillIn('.display-job-name', 50);
+    await click('button.blue-button');
+
+    assert.dom('.ember-power-select-selected-item').hasText('UTC');
+    assert.dom('.display-job-name').hasValue('50');
+    assert
+      .dom('.alert-success span:not(button span)')
+      .hasText('User settings updated successfully!');
   });
 });

--- a/tests/acceptance/user-settings-tests.js
+++ b/tests/acceptance/user-settings-tests.js
@@ -3,6 +3,8 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import Pretender from 'pretender';
+import { getPageTitle } from 'ember-page-title/test-support';
+
 let server;
 
 module('Acceptance | user-settings', function (hooks) {
@@ -59,6 +61,7 @@ module('Acceptance | user-settings', function (hooks) {
     await visit('/user-settings/preferences');
 
     assert.equal(currentURL(), '/user-settings/preferences');
+    assert.equal(getPageTitle(), 'Preferences', 'Page title is correct');
     assert.dom('.ember-power-select-selected-item').hasText('LOCAL_TIMEZONE');
     await fillIn('.display-job-name', 50);
     await fillIn('.ember-power-select-selected-item', 'UTC');

--- a/tests/acceptance/user-settings-tests.js
+++ b/tests/acceptance/user-settings-tests.js
@@ -5,7 +5,7 @@ import { authenticateSession } from 'ember-simple-auth/test-support';
 import Pretender from 'pretender';
 let server;
 
-module('Acceptance |user-settings', function (hooks) {
+module('Acceptance | user-settings', function (hooks) {
   setupApplicationTest(hooks);
 
   hooks.beforeEach(function () {

--- a/tests/mock/events.js
+++ b/tests/mock/events.js
@@ -11,17 +11,17 @@ const events = [
       author: {
         username: 'batman',
         name: 'Bruce W',
-        avatar: 'http://example.com/u/batman/avatar',
-        url: 'http://example.com/u/batman'
+        avatar: 'https://avatars.githubusercontent.com/u/15989893?v=4',
+        url: 'https://github.com/adong'
       },
-      url: 'http://example.com/batcave/batmobile/commit/abcdef1029384'
+      url: 'https://github.com/adong/commit/abcdef1029384'
     },
     createTime: '2016-11-04T20:09:41.238Z',
     creator: {
       username: 'batman',
       name: 'Bruce W',
-      avatar: 'http://example.com/u/batman/avatar',
-      url: 'http://example.com/u/batman'
+      avatar: 'https://avatars.githubusercontent.com/u/15989893?v=4',
+      url: 'https://github.com/adong'
     },
     startFrom: '~commit',
     pipelineId: '4',
@@ -42,21 +42,21 @@ const events = [
       author: {
         username: 'robin',
         name: 'Tim D',
-        avatar: 'http://example.com/u/robin/avatar',
-        url: 'http://example.com/u/robin'
+        avatar: 'https://avatars.githubusercontent.com/u/15989893?v=4',
+        url: 'https://github.com/adong'
       },
-      url: 'http://example.com/batcave/batmobile/commit/1029384bbb'
+      url: 'https://github.com/adong/commit/abcdef1029384'
     },
     createTime: '2016-11-05T20:09:41.238Z',
     creator: {
       username: 'robin',
       name: 'Tim D',
-      avatar: 'http://example.com/u/robin/avatar',
-      url: 'http://example.com/u/robin'
+      avatar: 'https://avatars.githubusercontent.com/u/15989893?v=4',
+      url: 'https://github.com/adong'
     },
     startFrom: '~pr',
     pr: {
-      url: 'http://example.com/batcave/batmobile/pulls/42'
+      url: 'https://github.com/adong/batmobile/pulls/42'
     },
     pipelineId: '4',
     groupEventId: '23453',
@@ -77,21 +77,21 @@ const events = [
       author: {
         username: 'robin',
         name: 'Tim D',
-        avatar: 'http://example.com/u/robin/avatar',
-        url: 'http://example.com/u/robin'
+        avatar: 'https://avatars.githubusercontent.com/u/15989893?v=4',
+        url: 'https://github.com/adong'
       },
-      url: 'http://example.com/batcave/batmobile/commit/1030384bbb'
+      url: 'https://github.com/adong/batmobile/commit/1030384bbb'
     },
     createTime: '2016-11-04T20:09:41.238Z',
     creator: {
       username: 'robin',
       name: 'Tim D',
-      avatar: 'http://example.com/u/robin/avatar',
-      url: 'http://example.com/u/robin'
+      avatar: 'https://avatars.githubusercontent.com/u/15989893?v=4',
+      url: 'https://github.com/adong'
     },
     startFrom: '~pr',
     pr: {
-      url: 'http://example.com/batcave/batmobile/pulls/43'
+      url: 'https://github.com/adong/batmobile/pulls/43'
     },
     pipelineId: '4',
     groupEventId: '23454',

--- a/tests/mock/jwt.js
+++ b/tests/mock/jwt.js
@@ -1,0 +1,20 @@
+// {
+//     username: "test",
+//     scmContext: "test:github.com",
+//     scope: [
+//         "user",
+//         "admin"
+//     ]
+// }
+const adminJWT = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6ImIxMDE0ZjI5ZjMzOWExMzU3YmU1MjFmMTA5MDliM2E1In0.eyJ1c2VybmFtZSI6InRlc3QiLCJzY21Db250ZXh0IjoidGVzdDpnaXRodWIuY29tIiwic2NvcGUiOlsidXNlciIsImFkbWluIl19.TSZSWhXmexYe7DYXdu-dp7bgKiklgOSxw-drU8aE077iOQ9QBl3zZqbrbSkl-1MPo6mIUyo3RqygN0dnoYJUx0sXmg730v7vN6q4ATLXJlvycxXXyU0zbUtouQEADXUrjGG0kgT9PRWcyrSbJhg3xAJ8pXiM4xqYcJn0vSEgE4Kd9qP4GBlNqbZNFmmBGFsRwktWfGcOzG3q8BR3RUYmNM7jgNTTgzycnkpRrkhxpF4tu4wNByTidoxDCuzuSjeVaYaOZaWLqPaZsUiLcWbNXkRf-U9ohMMdTijvsramG2qPnchODx6Jmlal3CdB1tIRmvrdhwM7sg4YfDwEf9DHTZQbCNerlS4Mlcdga_wI_K9eyO2-3rNMMpFflkh1EVMg0MZKp9KSfTQ4Gdaw1HvbzYGn59IcgOfeV1xfqZoVF_vfiX8YnzqWM7J0JQD65px70nA_mVD2hT5UP0qJ2nnKAlTnErT4u9U3AwO8dZpKbxBCOdyUTwmQy4y9Hb2kbP7h';
+
+// {
+//     username: "test",
+//     scmContext: "test:github.com",
+//     scope: [
+//         "user"
+//     ]
+// }
+const userJWT = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6ImIxMDE0ZjI5ZjMzOWExMzU3YmU1MjFmMTA5MDliM2E1In0.eyJ1c2VybmFtZSI6InRlc3QiLCJzY21Db250ZXh0IjoidGVzdDpnaXRodWIuY29tIiwic2NvcGUiOlsidXNlciJdfQ.DRkoNwaXR4YvF4uv7oNgnVCK7UOpBT6WouSwhTRdgU0b4luF3abZzuePM2Tz2YKlSAwrkJAWE5Fcu3hyEHVD5ND3RVluOHZv92sCTUpj9jVbjx6z-cNBlMHn4Yw4IcqrPft3wk0c2ziJaNS70oXpWYyo0QP5AqJYcbOEk_98TCA-RSQTLi5uarPJpt2_nwQu9bhganeoW5Lo-ZY4YHT0Z1TnpZkv9-5iqxqtsmn_TRHTK36Tu7MQiSHXdyzxw_WS6QRREECkiuTXw1zXR8g3czHMaQJWZRM7yirGSXCvr7-CtE0BfTesUj2s3qX6jupnpGE5sd1AsUjjwns3nhQsQiiSXGxtiAPNUhv2eszb4sb-LZPLPsRsilFXWxe_73Jci6n58FCZaPIWkKrye5s4Cpo0kvB4SeiG-D3zdCGfzCNTPaPxJaIbj-k1njBPv3qWaIeixZYX27Io5T0XXqsWMLAD9pa7GBDarZb5RpA9Uvee4Jt2PcP0xzP-iDF6laJO';
+
+export { adminJWT, userJWT };

--- a/tests/mock/pipeline.js
+++ b/tests/mock/pipeline.js
@@ -6,6 +6,7 @@ export const pipeline = {
   id: '4',
   scmUrl: 'git@github.com:foo/bar.git#master',
   scmContext: 'github:github.com',
+  name: 'foo/bar',
   scmRepo: {
     name: 'foo/bar',
     branch: 'master',

--- a/tests/unit/application/route-test.js
+++ b/tests/unit/application/route-test.js
@@ -13,14 +13,6 @@ module('Unit | Route | application', function (hooks) {
     assert.ok(route);
   });
 
-  test('it calculates title', function (assert) {
-    const route = this.owner.lookup('route:application');
-
-    assert.equal(route.title(), 'screwdriver.cd');
-    assert.equal(route.title([]), 'screwdriver.cd');
-    assert.equal(route.title(['a', 'b', 'c']), 'a > b > c > screwdriver.cd');
-  });
-
   test('it should reload on sessionInvalidated', function (assert) {
     const route = this.owner.lookup('route:application');
     const reloadStub = sinon.stub(route, 'reloadPage');

--- a/tests/unit/commands/detail/router-test.js
+++ b/tests/unit/commands/detail/router-test.js
@@ -36,13 +36,6 @@ module('Unit | Route | commands/detail', function (hooks) {
     const route = this.owner.lookup('route:commands/detail');
 
     assert.ok(route);
-    assert.equal(
-      route.titleToken({
-        namespace: 'foo',
-        name: 'bar'
-      }),
-      'foo/bar'
-    );
 
     return route.model({ namespace: 'foo', name: 'bar' }).then(commands => {
       assert.equal(commands.commandData[0].name, 'bar');
@@ -56,14 +49,6 @@ module('Unit | Route | commands/detail', function (hooks) {
     const route = this.owner.lookup('route:commands/detail');
 
     assert.ok(route);
-    assert.equal(
-      route.titleToken({
-        namespace: 'foo',
-        name: 'baz',
-        versionOrTagFromUrl: '1.0.0'
-      }),
-      'foo/baz@1.0.0'
-    );
 
     return route
       .model({ namespace: 'foo', name: 'baz', version: '1.0.0' })
@@ -94,14 +79,6 @@ module('Unit | Route | commands/detail', function (hooks) {
     const route = this.owner.lookup('route:commands/detail');
 
     assert.ok(route);
-    assert.equal(
-      route.titleToken({
-        namespace: 'foo',
-        name: 'baz',
-        versionOrTagFromUrl: 'stable'
-      }),
-      'foo/baz@stable'
-    );
 
     return route
       .model({ namespace: 'foo', name: 'baz', version: 'stable' })

--- a/tests/unit/commands/router-test.js
+++ b/tests/unit/commands/router-test.js
@@ -8,6 +8,5 @@ module('Unit | Route | commands', function (hooks) {
     const route = this.owner.lookup('route:commands');
 
     assert.ok(route);
-    assert.equal(route.titleToken, 'Commands');
   });
 });

--- a/tests/unit/create/route-test.js
+++ b/tests/unit/create/route-test.js
@@ -8,6 +8,5 @@ module('Unit | Route | create', function (hooks) {
     const route = this.owner.lookup('route:create');
 
     assert.ok(route);
-    assert.equal(route.titleToken, 'Create Pipeline');
   });
 });

--- a/tests/unit/login/route-test.js
+++ b/tests/unit/login/route-test.js
@@ -8,6 +8,5 @@ module('Unit | Route | login', function (hooks) {
     const route = this.owner.lookup('route:login');
 
     assert.ok(route);
-    assert.equal(route.titleToken, 'Login');
   });
 });

--- a/tests/unit/pipeline/build/route-test.js
+++ b/tests/unit/pipeline/build/route-test.js
@@ -1,4 +1,3 @@
-import EmberObject from '@ember/object';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
@@ -12,16 +11,6 @@ module('Unit | Route | pipeline/build', function (hooks) {
     const route = this.owner.lookup('route:pipeline/build');
 
     assert.ok(route);
-    assert.equal(
-      route.titleToken({
-        job: EmberObject.create({ name: 'main' }),
-        build: EmberObject.create({
-          sha: 'abcd1234567890',
-          truncatedSha: 'abcd123'
-        })
-      }),
-      'main > #abcd123'
-    );
   });
 
   test('it redirects if build not found', function (assert) {

--- a/tests/unit/pipeline/route-test.js
+++ b/tests/unit/pipeline/route-test.js
@@ -1,5 +1,4 @@
 import Service from '@ember/service';
-import EmberObject from '@ember/object';
 import { Promise as EmberPromise } from 'rsvp';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
@@ -20,16 +19,6 @@ module('Unit | Route | pipeline', function (hooks) {
     const route = this.owner.lookup('route:pipeline');
 
     assert.ok(route);
-    assert.equal(
-      route.titleToken(
-        EmberObject.create({
-          pipeline: EmberObject.create({
-            name: 'foo:bar'
-          })
-        })
-      ),
-      'foo:bar'
-    );
   });
 
   test('it returns model', function (assert) {

--- a/tests/unit/pipeline/secrets/route-test.js
+++ b/tests/unit/pipeline/secrets/route-test.js
@@ -8,6 +8,5 @@ module('Unit | Route | pipeline/secrets', function (hooks) {
     const route = this.owner.lookup('route:pipeline/secrets');
 
     assert.ok(route);
-    assert.equal(route.titleToken, 'Secrets');
   });
 });

--- a/tests/unit/search/route-test.js
+++ b/tests/unit/search/route-test.js
@@ -19,7 +19,6 @@ module('Unit | Route | search', function (hooks) {
     const route = this.owner.lookup('route:search');
 
     assert.ok(route);
-    assert.equal(route.titleToken, 'Search');
   });
 
   test('it returns model even on collections fetch error', function (assert) {

--- a/tests/unit/templates/detail/route-test.js
+++ b/tests/unit/templates/detail/route-test.js
@@ -91,13 +91,6 @@ module('Unit | Route | templates/detail', function (hooks) {
     const route = this.owner.lookup('route:templates/detail');
 
     assert.ok(route);
-    assert.equal(
-      route.titleToken({
-        namespace: 'foo',
-        name: 'baz'
-      }),
-      'foo/baz'
-    );
 
     return route.model({ namespace: 'foo', name: 'baz' }).then(templates => {
       assert.equal(templates.templateData.length, 4);
@@ -113,14 +106,6 @@ module('Unit | Route | templates/detail', function (hooks) {
     const route = this.owner.lookup('route:templates/detail');
 
     assert.ok(route);
-    assert.equal(
-      route.titleToken({
-        namespace: 'foo',
-        name: 'baz',
-        versionOrTagFromUrl: '1.0.0'
-      }),
-      'foo/baz@1.0.0'
-    );
 
     return route
       .model({ namespace: 'foo', name: 'baz', version: '1.0.0' })
@@ -155,14 +140,6 @@ module('Unit | Route | templates/detail', function (hooks) {
     const route = this.owner.lookup('route:templates/detail');
 
     assert.ok(route);
-    assert.equal(
-      route.titleToken({
-        namespace: 'foo',
-        name: 'baz',
-        versionOrTagFromUrl: 'stable'
-      }),
-      'foo/baz@stable'
-    );
 
     return route
       .model({ namespace: 'foo', name: 'baz', version: 'stable' })

--- a/tests/unit/templates/route-test.js
+++ b/tests/unit/templates/route-test.js
@@ -8,6 +8,5 @@ module('Unit | Route | templates', function (hooks) {
     const route = this.owner.lookup('route:templates');
 
     assert.ok(route);
-    assert.equal(route.titleToken, 'Templates');
   });
 });

--- a/tests/unit/user-settings/access-tokens/route-test.js
+++ b/tests/unit/user-settings/access-tokens/route-test.js
@@ -8,6 +8,5 @@ module('Unit | Route | user-settings/access-tokens', function (hooks) {
     const route = this.owner.lookup('route:user-settings/access-tokens');
 
     assert.ok(route);
-    assert.equal(route.titleToken, 'Access Tokens');
   });
 });


### PR DESCRIPTION
## Context
The title of the page is always `Screwdriver.cd` after Ember@4 update.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
The title of the page is changed to the content of the page as it was before the update.

The page title was originally set in `route.js`, but is now set in `template.hbs`, and the test location is changed from `route-test.js` to AcceptanceTest accordingly.
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/screwdriver/issues/2838
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
