### PR TITLE
fix(2838): Fix artifacts tree

### DIFF
--- a/app/components/artifact-tree-content/component.js
+++ b/app/components/artifact-tree-content/component.js
@@ -44,9 +44,6 @@ export default Component.extend({
         this.router.currentURL.split('artifacts/')[0].length
       );
 
-      console.log(baseURL);
-      console.log(this.artifactPath);
-
       return `${baseURL}artifacts/${this.artifactPath}`;
     }
   }),

--- a/app/components/artifact-tree-content/component.js
+++ b/app/components/artifact-tree-content/component.js
@@ -7,24 +7,33 @@ export default Component.extend({
 
   artifactPath: computed('node.directory', 'node.file.a_attr.href', {
     get() {
+      // Recursively search the child for files and identify paths
+      const getParentPath = node => {
+        let childPath;
+
+        if (node.children === undefined) {
+          childPath = node.a_attr.href.substring(
+            node.a_attr.href.split('artifacts/')[0].length + 10
+          );
+        } else {
+          childPath = getParentPath(node.children[0]);
+        }
+
+        return childPath.substring(
+          0,
+          childPath.length -
+            childPath.split('/')[childPath.split('/').length - 1].length -
+            1
+        );
+      };
+
       if (this.node.directory === undefined) {
         return this.node.file.a_attr.href.substring(
           this.node.file.a_attr.href.split('artifacts/')[0].length + 10
         );
       }
 
-      console.log('WSWSWS');
-      console.log(this.node.directory);
-      const childPath = this.node.directory[0].a_attr.href.substring(
-        this.node.directory[0].a_attr.href.split('artifacts/')[0].length + 10
-      );
-
-      return `${childPath.substring(
-        0,
-        childPath.length -
-          childPath.split('/')[childPath.split('/').length - 1].length -
-          1
-      )}/`;
+      return `${getParentPath(this.node.directory[0])}/`;
     }
   }),
 

--- a/app/components/artifact-tree-content/component.js
+++ b/app/components/artifact-tree-content/component.js
@@ -1,0 +1,54 @@
+import { inject as service } from '@ember/service';
+import { computed } from '@ember/object';
+import Component from '@ember/component';
+
+export default Component.extend({
+  router: service(),
+
+  artifactPath: computed('node.directory', 'node.file.a_attr.href', {
+    get() {
+      if (this.node.directory === undefined) {
+        return this.node.file.a_attr.href.substring(
+          this.node.file.a_attr.href.split('artifacts/')[0].length + 10
+        );
+      }
+
+      console.log('WSWSWS');
+      console.log(this.node.directory);
+      const childPath = this.node.directory[0].a_attr.href.substring(
+        this.node.directory[0].a_attr.href.split('artifacts/')[0].length + 10
+      );
+
+      return `${childPath.substring(
+        0,
+        childPath.length -
+          childPath.split('/')[childPath.split('/').length - 1].length -
+          1
+      )}/`;
+    }
+  }),
+
+  nodeURL: computed('artifactPath', 'router.currentURL', {
+    get() {
+      const baseURL = this.router.currentURL.substring(
+        0,
+        this.router.currentURL.split('artifacts/')[0].length
+      );
+
+      console.log(baseURL);
+      console.log(this.artifactPath);
+
+      return `${baseURL}artifacts/${this.artifactPath}`;
+    }
+  }),
+
+  actions: {
+    toggle() {
+      this.node.actions.toggle();
+      this.router.transitionTo(
+        'pipeline.build.artifacts.detail',
+        this.artifactPath
+      );
+    }
+  }
+});

--- a/app/components/artifact-tree-content/component.js
+++ b/app/components/artifact-tree-content/component.js
@@ -37,17 +37,6 @@ export default Component.extend({
     }
   }),
 
-  nodeURL: computed('artifactPath', 'router.currentURL', {
-    get() {
-      const baseURL = this.router.currentURL.substring(
-        0,
-        this.router.currentURL.split('artifacts/')[0].length
-      );
-
-      return `${baseURL}artifacts/${this.artifactPath}`;
-    }
-  }),
-
   actions: {
     toggle() {
       this.node.actions.toggle();

--- a/app/components/artifact-tree-content/style.scss
+++ b/app/components/artifact-tree-content/style.scss
@@ -1,0 +1,6 @@
+a,
+a:hover,
+a:visited {
+  color: inherit;
+  text-decoration: none;
+}

--- a/app/components/artifact-tree-content/template.hbs
+++ b/app/components/artifact-tree-content/template.hbs
@@ -1,9 +1,11 @@
 {{#if (eq 'file' @node.file.type)}}
-  <a {{on "click" (fn @tree.clicked @node.file)}}>
+  <a href={{this.nodeURL}} {{on "click" (fn @tree.clicked @node.file)}}>
     <FaIcon @icon="file" @fixedWidth={{true}}/>
     {{@node.file.text}}
   </a>
 {{else}}
-  <FaIcon @icon="folder{{if @node.isExpanded "-open"}}" @fixedWidth={{true}}/>
-  {{@node.fileName}}
+  <span onclick={{action "toggle"}}>
+    <FaIcon @icon="folder{{if @node.isExpanded "-open"}}" @fixedWidth={{true}}/>
+    {{@node.fileName}}
+  </span>
 {{/if}}

--- a/app/components/artifact-tree-content/template.hbs
+++ b/app/components/artifact-tree-content/template.hbs
@@ -1,8 +1,10 @@
 {{#if (eq 'file' @node.file.type)}}
-  <a href={{this.nodeURL}}>
+  <LinkTo
+    @route="pipeline.build.artifacts.detail"
+    @model={{this.artifactPath}}>
     <FaIcon @icon="file" @fixedWidth={{true}}/>
     {{@node.file.text}}
-  </a>
+  </LinkTo>
 {{else}}
   <span onclick={{action "toggle"}}>
     <FaIcon @icon="folder{{if @node.isExpanded "-open"}}" @fixedWidth={{true}}/>

--- a/app/components/artifact-tree-content/template.hbs
+++ b/app/components/artifact-tree-content/template.hbs
@@ -1,5 +1,5 @@
 {{#if (eq 'file' @node.file.type)}}
-  <a href={{this.nodeURL}} {{on "click" (fn @tree.clicked @node.file)}}>
+  <a href={{this.nodeURL}}>
     <FaIcon @icon="file" @fixedWidth={{true}}/>
     {{@node.file.text}}
   </a>

--- a/app/components/artifact-tree/component.js
+++ b/app/components/artifact-tree/component.js
@@ -77,20 +77,6 @@ export default Component.extend({
       }
     },
 
-    showArtifactPreview(treeData) {
-      const { href } = treeData.a_attr;
-      const artifactPath = href.substring(
-        href.split('artifacts/')[0].length + 10
-      );
-
-      this.setProperties({
-        href,
-        iframeUrl: `${href}?type=preview`
-      });
-
-      this.router.transitionTo('pipeline.build.artifacts.detail', artifactPath);
-    },
-
     handleJstreeEventDidChange(data = {}) {
       const { node, instance } = data;
 

--- a/app/components/artifact-tree/template.hbs
+++ b/app/components/artifact-tree/template.hbs
@@ -5,7 +5,6 @@
 {{#if this.treedata.content.length}}
   <BasicTree
     @contentComponent={{component "artifact-tree-content"}}
-    @clicked={{action "showArtifactPreview"}}
     @childrenComponent={{component "artifact-tree-children"}} as |tree|
   >
     <tree.Node

--- a/app/components/pipeline-events/component.js
+++ b/app/components/pipeline-events/component.js
@@ -123,7 +123,10 @@ export async function createEvent(eventPayload, toActiveTab) {
     this.forceReload();
 
     if (toActiveTab === true && this.activeTab === 'pulls') {
-      return this.router.transitionTo('pipeline.pulls', newEvent.get('pipelineId'));
+      return this.router.transitionTo(
+        'pipeline.pulls',
+        newEvent.get('pipelineId')
+      );
     }
 
     return this.router.transitionTo('pipeline', newEvent.get('pipelineId'));
@@ -376,10 +379,13 @@ export default Component.extend(ModelReloaderMixin, {
         const filteredPaginateEvents = this.paginateEvents.filter(
           e => e.pipelineId === pipelineId
         );
-        const pipelineEvents = [].concat(
-          this.modelEvents,
-          filteredPaginateEvents
-        );
+
+        // remove duplicate event
+        const pipelineEvents = [
+          ...this.modelEvents,
+          ...filteredPaginateEvents
+        ].uniqBy('id');
+
         const selectedEventId = this.selected;
 
         let filteredEvents = pipelineEvents;

--- a/tests/integration/components/artifact-tree/component-test.js
+++ b/tests/integration/components/artifact-tree/component-test.js
@@ -2,7 +2,7 @@ import { resolve } from 'rsvp';
 import Service from '@ember/service';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, click, waitFor } from '@ember/test-helpers';
+import { render, waitFor } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 const parsedManifest = [
@@ -13,14 +13,14 @@ const parsedManifest = [
       {
         text: 'coverage.json',
         type: 'file',
-        a_attr: { href: 'http://foo.com/coverage.json' }
+        a_attr: { href: 'http://foo.com/artifacts/coverage.json' }
       }
     ]
   },
   {
     text: 'test.txt',
     type: 'file',
-    a_attr: { href: 'http://foo.com/test.txt' }
+    a_attr: { href: 'http://foo.com/artifacts/test.txt' }
   }
 ];
 
@@ -54,24 +54,33 @@ module('Integration | Component | artifact tree', function (hooks) {
   });
 
   test('it renders with artifacts if build finished', async function (assert) {
-    await render(hbs`<ArtifactTree @buildStatus="SUCCESS" />`);
+    const component = this.owner.lookup('component:artifact-tree-content');
 
-    await waitFor('.ember-basic-tree');
+    component.router.currentURL = 'http://foo.com/artifacts';
+
+    await render(hbs`<ArtifactTree @buildStatus="SUCCESS" />`);
 
     assert.dom('.ember-basic-tree-node').exists({ count: 3 });
 
     // Check if the href is correctly set and then click the link
     assert
       .dom(
-        '.ember-basic-tree > li > .ember-basic-tree-children > .ember-basic-tree-children > li > a'
+        '.ember-basic-tree > li > .ember-basic-tree-children > .ember-basic-tree-children > li > div > a'
       )
       .hasText('test.txt');
-    await click(
-      '.ember-basic-tree > li > .ember-basic-tree-children > .ember-basic-tree-children > li > a'
-    );
+
+    assert
+      .dom(
+        '.ember-basic-tree > li > .ember-basic-tree-children > .ember-basic-tree-children > li > div > a'
+      )
+      .hasAttribute('href', 'http://foo.com/artifactsartifacts/test.txt');
   });
 
   test('it renders with artifacts with artifact preselected', async function (assert) {
+    const component = this.owner.lookup('component:artifact-tree-content');
+
+    component.router.currentURL = 'http://foo.com/artifacts';
+
     await render(
       hbs`<ArtifactTree @buildStatus="SUCCESS" @selectedArtifact="coverage/coverage.json" />`
     );
@@ -81,7 +90,7 @@ module('Integration | Component | artifact tree', function (hooks) {
     assert.dom('.ember-basic-tree-node').exists({ count: 4 });
     assert
       .dom(
-        '.ember-basic-tree > li > .ember-basic-tree-children > .ember-basic-tree-children > li > .ember-basic-tree-children > .ember-basic-tree-children > li > a'
+        '.ember-basic-tree > li > .ember-basic-tree-children > .ember-basic-tree-children > li > .ember-basic-tree-children > .ember-basic-tree-children > li > div > a'
       )
       .hasText('coverage.json');
   });

--- a/tests/integration/components/artifact-tree/component-test.js
+++ b/tests/integration/components/artifact-tree/component-test.js
@@ -2,7 +2,7 @@ import { resolve } from 'rsvp';
 import Service from '@ember/service';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, waitFor } from '@ember/test-helpers';
+import { render, click, waitFor } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 const parsedManifest = [
@@ -54,10 +54,6 @@ module('Integration | Component | artifact tree', function (hooks) {
   });
 
   test('it renders with artifacts if build finished', async function (assert) {
-    const component = this.owner.lookup('component:artifact-tree-content');
-
-    component.router.currentURL = 'http://foo.com/artifacts';
-
     await render(hbs`<ArtifactTree @buildStatus="SUCCESS" />`);
 
     assert.dom('.ember-basic-tree-node').exists({ count: 3 });
@@ -69,18 +65,12 @@ module('Integration | Component | artifact tree', function (hooks) {
       )
       .hasText('test.txt');
 
-    assert
-      .dom(
-        '.ember-basic-tree > li > .ember-basic-tree-children > .ember-basic-tree-children > li > div > a'
-      )
-      .hasAttribute('href', 'http://foo.com/artifactsartifacts/test.txt');
+    await click(
+      '.ember-basic-tree > li > .ember-basic-tree-children > .ember-basic-tree-children > li > div > span'
+    );
   });
 
   test('it renders with artifacts with artifact preselected', async function (assert) {
-    const component = this.owner.lookup('component:artifact-tree-content');
-
-    component.router.currentURL = 'http://foo.com/artifacts';
-
     await render(
       hbs`<ArtifactTree @buildStatus="SUCCESS" @selectedArtifact="coverage/coverage.json" />`
     );


### PR DESCRIPTION
## Context
- Artifacts can not be right clicked and opened in a new tab. 
- We have to click on the arrow to open the Artifacts dictory, and clicking on the folder icon does not open it.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
The Artifacts folder was changed to a link. And, clicking on a folder icon or text now opens the directory.
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/screwdriver/issues/2838
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
