### PR TITLE
fix: Stay job list view after Build start

### DIFF
--- a/app/components/pipeline-events/component.js
+++ b/app/components/pipeline-events/component.js
@@ -129,7 +129,9 @@ export async function createEvent(eventPayload, toActiveTab) {
       );
     }
 
-    return this.router.transitionTo('pipeline', newEvent.get('pipelineId'));
+    if (this.showListView !== true) {
+      return this.router.transitionTo('pipeline', newEvent.get('pipelineId'));
+    }
   } catch (e) {
     // eslint-disable-next-line no-console
     console.log('***** error', e);


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Currently, users force move to workflow page after start build when show job list view.
It should stay show job list view if the build start from job list view.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
If users use job list view, not to transit event tab after create event.


## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
