### PR TITLE
fix(2894): Workflow graph not displayed for triggers [~pr, ~pr:foo]

### DIFF
--- a/app/components/pipeline-events/component.js
+++ b/app/components/pipeline-events/component.js
@@ -436,25 +436,18 @@ export default Component.extend(ModelReloaderMixin, {
           const prNodes = prWorkflowGraph.nodes.filter(n =>
             n.name.startsWith('~pr')
           );
-          const edgesToAdd = [];
-          const nodesToAdd = [...prNodes];
+          const uniqueNodes = [...new Set(prNodes)];
+          const edgesToAdd = prWorkflowGraph.edges.filter(e =>
+            uniqueNodes.some(n => n.name === e.src)
+          );
+          const nodesToAdd = uniqueNodes.concat(
+            prWorkflowGraph.nodes.filter(n =>
+              edgesToAdd.some(e => e.dest === n.name)
+            )
+          );
 
-          // 1 level deep
-          prWorkflowGraph.edges.forEach(e => {
-            prNodes.forEach(prNode => {
-              if (prNode.name === e.src) {
-                const endNode = prWorkflowGraph.nodes.findBy('name', e.dest);
-
-                nodesToAdd.pushObject(endNode);
-                edgesToAdd.pushObject(e);
-              }
-            });
-          });
-
-          prWorkflowGraph.edges.clear();
-          prWorkflowGraph.edges.pushObjects(edgesToAdd);
-          prWorkflowGraph.nodes.clear();
-          prWorkflowGraph.nodes.pushObjects(nodesToAdd);
+          prWorkflowGraph.edges.setObjects(edgesToAdd);
+          prWorkflowGraph.nodes.setObjects(nodesToAdd);
 
           return prEvent;
         });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Fixed the following Issue.
https://github.com/screwdriver-cd/screwdriver/issues/2894

The problem occurs when the nodes in the workflowGraph have values with the same name.
When the same name occurs, an object is created where pos is not given, and it is undefined at the point where pos is referenced.

Below is an example of the workflowGraph in question
```
edges: [ { src: ~pr, dest: artifact }  { src: ~pr:foo, dest: artifact }]
nodes:[  {name: '~pr'} {name: '~pr:foo'}  {name: 'artifact'} {name: 'artifact'}]
```
This PR changes the processing of the graphs displayed in the PR to avoid unnecessary duplication.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
I am modifying the workflowGraph for each PR event to extract the nodes starting with `~pr` and create that unique set of nodes.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/2894

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
