### PR TITLE
fix(2857): fix pipeline navigator tab for PR event

### DIFF
--- a/app/pipeline/pulls/route.js
+++ b/app/pipeline/pulls/route.js
@@ -13,6 +13,7 @@ export default EventsRoute.extend({
       activeTab: 'pulls',
       selected: null
     });
+    this.pipelineService.setBuildsLink('pipeline.pulls');
   },
   model() {
     const pipelineEventsController = this.controllerFor('pipeline.events');


### PR DESCRIPTION
## Context
`Builds` tab is not highlighted when selecting the Pull Requests tab.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
Builds tab is highlighted when displaying builds, even for PR events.
If the last event opened is a PR event, the PR event is displayed when returning to the `Builds` tab from a tab other than `Builds`. 
This is similar to the display of jobs listview.
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/screwdriver/issues/2857
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
