### PR TITLE
fix: Stop exact clicked event

### DIFF
--- a/app/components/pipeline-event-row/template.hbs
+++ b/app/components/pipeline-event-row/template.hbs
@@ -30,7 +30,7 @@
       {{/if}}
       {{#if (and this.event.isRunning (not-eq this.event.status "UNKNOWN"))}}
         <BsButton
-          @onClick={{action this.stopEvent}}
+          @onClick={{action this.stopEvent this.event.id}}
           class="stopButton"
           @title="Stop all builds for this event"
         >

--- a/app/components/pipeline-events-list/component.js
+++ b/app/components/pipeline-events-list/component.js
@@ -84,8 +84,8 @@ export default Component.extend({
     startPRBuild(parameters) {
       this.startPRBuild.apply(null, [parameters, this.events]);
     },
-    stopEvent() {
-      this.stopEvent();
+    stopEvent(eventId) {
+      this.stopEvent(eventId);
     },
     async eventClick(id, eventType) {
       set(this, 'selected', id);

--- a/app/components/pipeline-events/component.js
+++ b/app/components/pipeline-events/component.js
@@ -611,12 +611,19 @@ export default Component.extend(ModelReloaderMixin, {
     },
     startDetachedBuild,
     stopBuild,
-    async stopEvent() {
-      const event = this.selectedEventObj;
-      const eventId = event.id;
+    async stopEvent(eventId) {
+      let stopEventId;
+
+      if (!eventId) {
+        const event = this.selectedEventObj;
+
+        stopEventId = event.id;
+      } else {
+        stopEventId = eventId;
+      }
 
       try {
-        return await this.stop.stopBuilds(eventId);
+        return await this.stop.stopBuilds(stopEventId);
       } catch (e) {
         this.set(
           'errorMessage',


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
When some events are running in a pipeline and users try to stop a event which is not selected, the selected event will be stopped.
So we will fix this behavior.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
When the stop event button is clicked, the eventid associated with the clicked event is passed to the stopEvent action.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
