### PR TITLE
fix(2901): Show blank window when dir is selected

### DIFF
--- a/app/components/artifact-preview/template.hbs
+++ b/app/components/artifact-preview/template.hbs
@@ -6,9 +6,17 @@
   >
     Download
   </BsButton>
-  <iframe id={{this.iframeId}} src={{this.iframeUrl}} width="100%" height="625px">
-    <h4>
-      Alternative content for browsers which do not support iframe.
-    </h4>
-  </iframe>
+  {{#if this.iframeUrl}}
+    <iframe id={{this.iframeId}} src={{this.iframeUrl}} width="100%" height="625px">
+      <h4>
+        Alternative content for browsers which do not support iframe.
+      </h4>
+    </iframe>
+  {{else}}
+    <iframe id={{this.iframeId}} src="about:blank" width="100%" height="625px">
+      <h4>
+        Alternative content for browsers which do not support iframe.
+      </h4>
+    </iframe>
+  {{/if}}
 </div>

--- a/app/components/build-step-collection/template.hbs
+++ b/app/components/build-step-collection/template.hbs
@@ -104,7 +104,7 @@
     </BsTab>
   </div>
   <div class="col-9 partial-view">
-    {{#if (and this.isArtifacts this.iframeUrl)}}
+    {{#if this.isArtifacts}}
       <ArtifactPreview @iframeUrl={{this.iframeUrl}} />
     {{else}}
       <BuildLog


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
After viewing the build steps, open the Artifact preview and click on the directory to see the last build step displayed.
Build step should not be displayed in artifact preview page, we fix this behavior.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
When artifact directory is selected, iframeUrl set blank.
So blank iframe is displayed in preview window if iframeUrl is blank.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
screwdriver-cd/screwdriver#2901

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
