### PR TITLE
fix: redirect step from given url

### DIFF
--- a/app/pipeline/build/route.js
+++ b/app/pipeline/build/route.js
@@ -39,18 +39,18 @@ export default Route.extend({
     if (name) {
       this.router.transitionTo(
         'pipeline.build.step',
-        model.pipeline.get('id'),
-        model.build.get('id'),
+        get(model, 'pipeline.id'),
+        get(model, 'build.id'),
         name
       );
     }
   },
 
   redirect(model, transition) {
-    const pipelineId = model.pipeline.get('id');
+    const pipelineId = get(model, 'pipeline.id');
 
     // Build not found for this pipeline, redirecting to the pipeline page
-    if (pipelineId !== model.job.get('pipelineId')) {
+    if (pipelineId !== get(model, 'job.pipelineId')) {
       this.router.transitionTo('pipeline', pipelineId);
     } else {
       set(model.event, 'isPaused', true);
@@ -59,7 +59,7 @@ export default Route.extend({
           transition.targetName
         )
       ) {
-        const currentBuildStatus = model.build.get('status');
+        const currentBuildStatus = get(model, 'build.status');
 
         if (isActiveBuild(currentBuildStatus)) {
           const name = getActiveStep(get(model, 'build.steps'));
@@ -67,8 +67,8 @@ export default Route.extend({
           if (name) {
             this.router.transitionTo(
               'pipeline.build.step',
-              model.pipeline.get('id'),
-              model.build.get('id'),
+              get(model, 'pipeline.id'),
+              get(model, 'build.id'),
               name
             );
           }

--- a/app/pipeline/build/route.js
+++ b/app/pipeline/build/route.js
@@ -1,7 +1,7 @@
 import { all } from 'rsvp';
 import Route from '@ember/routing/route';
 import { set, get } from '@ember/object';
-import { getActiveStep } from 'screwdriver-ui/utils/build';
+import { getActiveStep, isActiveBuild } from 'screwdriver-ui/utils/build';
 import { inject as service } from '@ember/service';
 
 export default Route.extend({
@@ -59,15 +59,19 @@ export default Route.extend({
           transition.targetName
         )
       ) {
-        const name = getActiveStep(get(model, 'build.steps'));
+        const currentBuildStatus = model.build.get('status');
 
-        if (name) {
-          this.router.transitionTo(
-            'pipeline.build.step',
-            model.pipeline.get('id'),
-            model.build.get('id'),
-            name
-          );
+        if (isActiveBuild(currentBuildStatus)) {
+          const name = getActiveStep(get(model, 'build.steps'));
+
+          if (name) {
+            this.router.transitionTo(
+              'pipeline.build.step',
+              model.pipeline.get('id'),
+              model.build.get('id'),
+              name
+            );
+          }
         }
       }
     }

--- a/tests/acceptance/pipeline-builds-test.js
+++ b/tests/acceptance/pipeline-builds-test.js
@@ -154,10 +154,7 @@ module('Acceptance | pipeline build', function (hooks) {
 
     await visit(`/pipelines/${pipelineId}/builds/${buildId}`);
 
-    assert.equal(
-      currentURL(),
-      `/pipelines/${pipelineId}/builds/${buildId}/steps/install`
-    );
+    assert.equal(currentURL(), `/pipelines/${pipelineId}/builds/${buildId}`);
 
     assert.equal(
       getPageTitle(),

--- a/tests/unit/pipeline/build/route-test.js
+++ b/tests/unit/pipeline/build/route-test.js
@@ -39,24 +39,26 @@ module('Unit | Route | pipeline/build', function (hooks) {
     route.redirect(model);
   });
 
-  test('it redirects if not step route', function (assert) {
+  test('it redirects step route if is running build', function (assert) {
     const route = this.owner.lookup('route:pipeline/build');
 
     const buildId = 345;
     const pipelineId = 123;
+    const jobId = 567;
 
     const transition = { targetName: 'pipeline.build.index' };
 
     const model = {
       pipeline: {
-        get: type => (type === 'id' ? pipelineId : null)
+        id: pipelineId
       },
       build: {
-        get: type => (type === 'id' ? buildId : null),
+        id: buildId,
         steps: []
       },
       job: {
-        get: type => (type === 'pipelineId' ? pipelineId : null)
+        id: jobId,
+        pipelineId
       },
       event: {
         isPaused: true
@@ -75,8 +77,7 @@ module('Unit | Route | pipeline/build', function (hooks) {
     this.owner.unregister('service:router');
     this.owner.register('service:router', routerServiceMock);
 
-    route.redirect(model, transition);
-
+    model.build.status = 'RUNNING';
     model.build.steps = [
       { startTime: 's', endTime: 'e', name: 'error', code: 1 }
     ];

--- a/tests/unit/pipeline/build/route-test.js
+++ b/tests/unit/pipeline/build/route-test.js
@@ -13,30 +13,27 @@ module('Unit | Route | pipeline/build', function (hooks) {
     assert.ok(route);
   });
 
-  test('it redirects if build not found', function (assert) {
+  test('it will NOT redirect if transition is null', function (assert) {
     const route = this.owner.lookup('route:pipeline/build');
     const jobId = 345;
     const pipelineId = 123;
+    const transition = { targetName: null };
     const model = {
       pipeline: {
-        get: type => (type === 'id' ? pipelineId : null)
+        id: pipelineId
       },
       job: {
-        get: type => (type === 'id' ? jobId : null)
-      }
+        id: jobId,
+        pipelineId
+      },
+      event: {}
     };
 
-    const routerServiceMock = Service.extend({
-      transitionTo: (path, id) => {
-        assert.equal(path, 'pipeline');
-        assert.equal(id, pipelineId);
-      }
-    });
+    const spy = sinon.spy(getActiveStep);
 
-    this.owner.unregister('service:router');
-    this.owner.register('service:router', routerServiceMock);
+    route.redirect(model, transition);
 
-    route.redirect(model);
+    assert.ok(spy.notCalled, 'redirect was not called');
   });
 
   test('it redirects step route if is running build', function (assert) {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Currently, the given step in the URL is not honored if the build is finished i.e.

Visit

`https://cd.screwdriver.cd/pipelines/3066/builds/142678/steps/install_binaries`
![image](https://github.com/screwdriver-cd/ui/assets/15989893/5579716d-070d-4e4e-b27b-e2c91b678634)

Will end up

`https://cd.screwdriver.cd/pipelines/3066/builds/142678/steps/publish`
![image](https://github.com/screwdriver-cd/ui/assets/15989893/7b060b2b-bb9e-4118-9e6e-29e0360688c2)

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

If build is running, then visiting `https://cd.screwdriver.cd/pipelines/3066/builds/142678/steps/install_binaries` should redirect users to their latest step

If build is in finishing state (FAILED, ABORTED, UNKNOWN, etc,.), then visiting `https://cd.screwdriver.cd/pipelines/3066/builds/142678/steps/install_binaries` should NOT redirect users to other steps, instead, it should stay in the specified step from the given url. 

## References
https://github.com/screwdriver-cd/screwdriver/issues/2905
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
