### PR TITLE
fix: update redirect logics

### DIFF
--- a/app/pipeline/build/route.js
+++ b/app/pipeline/build/route.js
@@ -1,7 +1,7 @@
 import { all } from 'rsvp';
 import Route from '@ember/routing/route';
 import { set, get } from '@ember/object';
-import { getActiveStep, isActiveBuild } from 'screwdriver-ui/utils/build';
+import { getActiveStep } from 'screwdriver-ui/utils/build';
 import { inject as service } from '@ember/service';
 
 export default Route.extend({
@@ -32,20 +32,6 @@ export default Route.extend({
     set(model, 'userSelectedStepName', null);
   },
 
-  goToActiveStep() {
-    const model = this.controller.get('model');
-    const name = getActiveStep(get(model, 'build.steps'));
-
-    if (name) {
-      this.router.transitionTo(
-        'pipeline.build.step',
-        get(model, 'pipeline.id'),
-        get(model, 'build.id'),
-        name
-      );
-    }
-  },
-
   redirect(model, transition) {
     const pipelineId = get(model, 'pipeline.id');
 
@@ -59,20 +45,20 @@ export default Route.extend({
           transition.targetName
         )
       ) {
-        const currentBuildStatus = get(model, 'build.status');
+        const preselectedStepName = transition?.to?.params?.step_id;
 
-        if (isActiveBuild(currentBuildStatus)) {
-          const name = getActiveStep(get(model, 'build.steps'));
+        let stepName = preselectedStepName;
 
-          if (name) {
-            this.router.transitionTo(
-              'pipeline.build.step',
-              get(model, 'pipeline.id'),
-              get(model, 'build.id'),
-              name
-            );
-          }
+        if (!preselectedStepName) {
+          stepName = getActiveStep(get(model, 'build.steps'));
         }
+
+        this.router.transitionTo(
+          'pipeline.build.step',
+          get(model, 'pipeline.id'),
+          get(model, 'build.id'),
+          stepName
+        );
       }
     }
   }

--- a/app/pipeline/build/route.js
+++ b/app/pipeline/build/route.js
@@ -53,12 +53,14 @@ export default Route.extend({
           stepName = getActiveStep(get(model, 'build.steps'));
         }
 
-        this.router.transitionTo(
-          'pipeline.build.step',
-          get(model, 'pipeline.id'),
-          get(model, 'build.id'),
-          stepName
-        );
+        if (stepName) {
+          this.router.transitionTo(
+            'pipeline.build.step',
+            get(model, 'pipeline.id'),
+            get(model, 'build.id'),
+            stepName
+          );
+        }
       }
     }
   }

--- a/tests/acceptance/pipeline-builds-test.js
+++ b/tests/acceptance/pipeline-builds-test.js
@@ -154,7 +154,10 @@ module('Acceptance | pipeline build', function (hooks) {
 
     await visit(`/pipelines/${pipelineId}/builds/${buildId}`);
 
-    assert.equal(currentURL(), `/pipelines/${pipelineId}/builds/${buildId}`);
+    assert.equal(
+      currentURL(),
+      `/pipelines/${pipelineId}/builds/${buildId}/steps/install`
+    );
 
     assert.equal(
       getPageTitle(),


### PR DESCRIPTION
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
Continue work of https://github.com/screwdriver-cd/ui/pull/946

Add more logics that:
1. if step is given in the url, go to specified step route
2. if non step is given in the url, go to the default active step route
	- if it's a success build, then don't redirect to any step and let users to pick
	- if it's a failed build, show the first failed step

## Context

<!-- What does this PR fix? What intentional changes will this PR make? -->
Currently, if the url is given as

`https://cd.screwdriver.cd/pipelines/1056914/builds/68077307`

We will show build page without any step preselected. 

This PR changes that behavior for failed build, will auto redirect `failed build` to `failed build with the first failed step`

i.e. 
Visiting `https://cd.screwdriver.cd/pipelines/1056914/builds/68077307`

If build `68077307` is success build, 
then go to url `https://cd.screwdriver.cd/pipelines/1056914/builds/68077307`

If build `68077307` is failed build, 
then go to url `https://cd.screwdriver.cd/pipelines/1056914/builds/68077307/steps/first_failed_step`


## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
