### PR TITLE
fix: build warning should fetch from meta.build instead

### DIFF
--- a/app/pipeline/build/template.hbs
+++ b/app/pipeline/build/template.hbs
@@ -53,8 +53,8 @@
     @icon="exclamation-triangle"
   />
 {{/if}}
-{{#if this.build.meta.meta.warning}}
-  {{#each-in this.build.meta.meta.warning as |name value|}}
+{{#if this.build.meta.build.warning}}
+  {{#each-in this.build.meta.build.warning as |name value|}}
     <InfoMessage
       @message="{{name}} - {{value}}"
       @type="warning"


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
it's an oversight that warning still fetching from build.meta.meta.warning, it should be build.meta.build.warning instead
## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
build warning should fetch from meta.build instead
## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
