### PR TITLE
fix(#1795): crumbs header and add latest to latest version when copy command

### DIFF
--- a/app/commands/controller.js
+++ b/app/commands/controller.js
@@ -27,8 +27,6 @@ export default Controller.extend({
 
       const params = this.routeParams;
 
-      console.log('params', params);
-
       if (params.namespace || params.detail) {
         breadcrumbs.push({
           name: 'Commands',

--- a/app/commands/controller.js
+++ b/app/commands/controller.js
@@ -1,7 +1,9 @@
 import Controller from '@ember/controller';
 import { computed } from '@ember/object';
+import { inject as service } from '@ember/service';
 
 export default Controller.extend({
+  router: service(),
   routeParams: computed('model', {
     get() {
       const route = this.model;
@@ -24,6 +26,8 @@ export default Controller.extend({
       const breadcrumbs = [];
 
       const params = this.routeParams;
+
+      console.log('params', params);
 
       if (params.namespace || params.detail) {
         breadcrumbs.push({

--- a/app/commands/route.js
+++ b/app/commands/route.js
@@ -9,8 +9,10 @@ export default Route.extend(AuthenticatedRouteMixin, {
   actions: {
     willTransition(transition) {
       const newParams = transition.to.params;
+      const { routeParams } = this.controller;
+      const newRouteParams = { ...routeParams, ...newParams };
 
-      this.controller.set('routeParams', newParams);
+      this.controller.set('routeParams', newRouteParams);
     }
   }
 });

--- a/app/components/command-header/component.js
+++ b/app/components/command-header/component.js
@@ -1,5 +1,6 @@
 import Component from '@ember/component';
 import { inject as service } from '@ember/service';
+import { alias } from '@ember/object/computed';
 
 export default Component.extend({
   commandToRemove: null,
@@ -7,6 +8,7 @@ export default Component.extend({
   isRemoving: false,
   store: service(),
   isTrusted: null,
+  isLatestVersion: alias('command.latest'),
   init() {
     this._super(...arguments);
     this.store
@@ -17,7 +19,7 @@ export default Component.extend({
       .catch(() => {
         this.set('scmUrl', null);
       });
-    this.set('isTrusted', this.command.trusted)
+    this.set('isTrusted', this.command.trusted);
   },
   actions: {
     setCommandToRemove(command) {

--- a/app/components/command-header/template.hbs
+++ b/app/components/command-header/template.hbs
@@ -51,7 +51,7 @@
   {{/if}}
 </h1>
 <h2>
-  {{this.command.version}}
+  {{this.command.version}}{{if this.isLatestVersion " - latest"}}
 </h2>
 <p>
   {{this.command.description}}
@@ -73,9 +73,13 @@
   Usage:
 </h4>
 {{#if this.command.usage}}
-  <pre>{{this.command.usage}}  </pre>
+  <pre>{{this.command.usage}} </pre>
 {{else}}
-  <pre>sd-cmd exec {{this.command.namespace}}/{{this.command.name}}@{{this.command.version}}  </pre>
+  {{#if this.isLatestVersion}}
+    <pre>sd-cmd exec {{this.command.namespace}}/{{this.command.name}}@latest </pre>
+  {{else}}
+    <pre>sd-cmd exec {{this.command.namespace}}/{{this.command.name}}@{{this.command.version}} </pre>
+  {{/if}}
 {{/if}}
 {{#if this.commandToRemove}}
   {{#if this.isRemoving}}


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
1) When visit latest version of command, will show latest instead pinned version as issue https://github.com/screwdriver-cd/screwdriver/issues/1795 suggests

2) fix crumbs when change command urls

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Before:
<img width="907" alt="image" src="https://github.com/screwdriver-cd/ui/assets/15989893/1f81b7d5-bc79-4c0c-9837-91396ea46354">

<img width="882" alt="image" src="https://github.com/screwdriver-cd/ui/assets/15989893/2b9f86f7-c81c-47cc-815a-53cba4b520f8">

After:
<img width="909" alt="image" src="https://github.com/screwdriver-cd/ui/assets/15989893/f81d04f9-3a50-4bf6-950e-a751f2d15392">

## References
https://github.com/screwdriver-cd/screwdriver/issues/1795
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
