### PR TITLE
feat(2862): Allow template owners (repo admins) to delete a template version

### DIFF
--- a/app/components/template-version-list-actions-cell/component.js
+++ b/app/components/template-version-list-actions-cell/component.js
@@ -1,20 +1,7 @@
 import Component from '@ember/component';
-import { computed } from '@ember/object';
 
 export default Component.extend({
   showDeleteConfirmation: false,
-
-  deleteAllowed: computed('record.actions.isAdmin', {
-    get() {
-      return this.get('record.actions.isAdmin');
-    }
-  }),
-
-  deleteButtonClass: computed('record.actions.isAdmin', {
-    get() {
-      return this.get('record.actions.isAdmin') ? '' : 'clicks-disabled';
-    }
-  }),
 
   actions: {
     showDeleteConfirmation() {

--- a/app/components/template-version-list-actions-cell/styles.scss
+++ b/app/components/template-version-list-actions-cell/styles.scss
@@ -4,9 +4,4 @@
     font-size: 1.2em;
     cursor: pointer;
   }
-
-  .clicks-disabled {
-    color: $grey-600 !important;
-    pointer-events: none;
-  }
 }

--- a/app/components/template-version-list-actions-cell/template.hbs
+++ b/app/components/template-version-list-actions-cell/template.hbs
@@ -1,21 +1,23 @@
 <div class="actions-cell">
-  {{#if this.deleteAllowed}}
-    <span class={{this.deleteButtonClass}} {{action "showDeleteConfirmation"}}>
-      <FaIcon @icon="trash" @fixedWidth={{true}} title="Delete version" />
-    </span>
-    {{#if this.showDeleteConfirmation}}
-      {{#bs-modal-simple
-        title="Confirm deletion"
-        closeTitle="Cancel"
-        submitTitle="Confirm"
-        size=null
-        fade=false
-        onSubmit=(action "deleteVersion")
-        onHide=(action "cancelDelete")
-      }}
+  <span {{action "showDeleteConfirmation"}}>
+    <FaIcon @icon="trash" @fixedWidth={{true}} title="Delete version" />
+  </span>
+  {{#if this.showDeleteConfirmation}}
+    {{#bs-modal-simple
+      title="Confirm deletion"
+      closeTitle="Cancel"
+      submitTitle="Confirm"
+      size=null
+      fade=false
+      onSubmit=(action "deleteVersion")
+      onHide=(action "cancelDelete")
+    }}
+      {{#if (gt this.record.metrics.jobCount 0)}}
+        You're about to delete the version "{{this.record.version}}" which is being used by {{this.record.metrics.jobCount}} jobs. This action cannot be undone. Are you sure?
+      {{else}}
         You're about to delete the version "{{this.record.version}}". This action cannot be undone. Are you sure?
-      {{/bs-modal-simple}}
-    {{/if}}
+      {{/if}}
+    {{/bs-modal-simple}}
   {{/if}}
 
 </div>

--- a/app/components/template-versions/component.js
+++ b/app/components/template-versions/component.js
@@ -92,62 +92,55 @@ export default Component.extend({
     this.set('jobsDetails', []);
   },
 
-  data: computed(
-    'isAdmin',
-    'removeVersion',
-    'templates.[]',
-    'timestampPreference',
-    {
-      get() {
-        const { templates, isAdmin, timestampPreference } = this;
+  data: computed('removeVersion', 'templates.[]', 'timestampPreference', {
+    get() {
+      const { templates, timestampPreference } = this;
 
-        return templates.map(template => {
-          const {
-            name,
-            namespace,
-            fullName,
-            version,
-            createTime,
-            trusted,
-            metrics,
-            tag
-          } = template;
+      return templates.map(template => {
+        const {
+          name,
+          namespace,
+          fullName,
+          version,
+          createTime,
+          trusted,
+          metrics,
+          tag
+        } = template;
 
-          let publishedTime;
+        let publishedTime;
 
-          if (timestampPreference === 'UTC') {
-            publishedTime = `${toCustomLocaleString(new Date(createTime), {
-              timeZone: 'UTC'
-            })}`;
-          } else {
-            publishedTime = `${toCustomLocaleString(new Date(createTime))}`;
-          }
+        if (timestampPreference === 'UTC') {
+          publishedTime = `${toCustomLocaleString(new Date(createTime), {
+            timeZone: 'UTC'
+          })}`;
+        } else {
+          publishedTime = `${toCustomLocaleString(new Date(createTime))}`;
+        }
 
-          const actionsData = {
-            removeVersion: this.removeVersion.bind(this),
-            fullName,
-            version,
-            isAdmin
-          };
+        const actionsData = {
+          removeVersion: this.removeVersion.bind(this),
+          fullName,
+          version
+        };
 
-          return {
-            name,
-            namespace,
-            version,
-            trusted,
-            tag,
-            publishedTime,
-            metrics: {
-              jobCount: metrics.jobs.count,
-              buildCount: metrics.builds.count,
-              pipelineCount: metrics.pipelines.count
-            },
-            actions: actionsData
-          };
-        });
-      }
+        return {
+          name,
+          namespace,
+          version,
+          trusted,
+          tag,
+          publishedTime,
+          metrics: {
+            jobCount: metrics.jobs.count,
+            buildCount: metrics.builds.count,
+            pipelineCount: metrics.pipelines.count
+          },
+          actions: actionsData
+        };
+      });
     }
-  ),
+  }),
 
   removeVersion(fullName, version) {
     this.onRemoveVersion(fullName, version);

--- a/app/templates/detail/template.hbs
+++ b/app/templates/detail/template.hbs
@@ -35,7 +35,6 @@
   @templates={{this.filteredTemplates}}
   @startTime={{this.startTime}}
   @endTime={{this.endTime}}
-  @isAdmin={{this.isAdmin}}
   @onRemoveVersion={{action "removeVersion"}}
   @onTimeRangeChange={{action "timeRangeChange"}}
 />

--- a/tests/integration/components/template-versions/component-test.js
+++ b/tests/integration/components/template-versions/component-test.js
@@ -73,11 +73,8 @@ module('Integration | Component | template versions', function (hooks) {
 
   test('it renders template versions in a table', async function (assert) {
     this.set('mock', TEMPLATES);
-    this.set('isAdmin', true);
 
-    await render(
-      hbs`<TemplateVersions @templates={{this.mock}} @isAdmin={{this.isAdmin}}/>;`
-    );
+    await render(hbs`<TemplateVersions @templates={{this.mock}}/>;`);
 
     assert.dom('h4').hasText('All Versions');
 
@@ -167,25 +164,6 @@ module('Integration | Component | template versions', function (hooks) {
     assert.dom('tfoot tr td:nth-child(6)').hasText('');
   });
 
-  test('it does not show remove button for non admins', async function (assert) {
-    this.set('mock', TEMPLATES);
-    this.set('isAdmin', false);
-
-    await render(
-      hbs`<TemplateVersions @templates={{this.mock}} @isAdmin={{this.isAdmin}}/>;`
-    );
-
-    assert.dom('table').exists({ count: 1 });
-    assert.dom('thead').exists({ count: 1 });
-    assert.dom('thead tr th').exists({ count: 6 });
-    assert.dom('tbody').exists({ count: 1 });
-    assert.dom('tbody tr').exists({ count: 3 });
-    assert.dom('tbody tr:nth-child(1) td').exists({ count: 6 });
-    assert.dom('tbody tr:nth-child(2) td').exists({ count: 6 });
-    assert.dom('tbody tr:nth-child(3) td').exists({ count: 6 });
-    assert.dom('tbody tr td svg.fa-trash').doesNotExist();
-  });
-
   test('it removes a version', async function (assert) {
     assert.expect(4);
 
@@ -198,10 +176,9 @@ module('Integration | Component | template versions', function (hooks) {
 
     this.set('onRemoveVersion', onRemoveVersionMock);
     this.set('mock', TEMPLATES);
-    this.set('isAdmin', true);
 
     await render(
-      hbs`<TemplateVersions @templates={{this.mock}} @isAdmin={{this.isAdmin}} @onRemoveVersion={{this.onRemoveVersion}}/>;`
+      hbs`<TemplateVersions @templates={{this.mock}} @onRemoveVersion={{this.onRemoveVersion}}/>;`
     );
 
     await click('tbody tr:nth-child(3) td:nth-child(6) svg.fa-trash');


### PR DESCRIPTION
## Context
PR https://github.com/screwdriver-cd/ui/pull/937 add in template detail view to delete a specific version on the template.
But, the delete action was only available to Screwdriver admins.

API to delete a template version also allow template owners (repo admins) to delete a specific version

## Objective
Make delete action available to all users.

If a user who do not have admin permission on the template repo attempts to delete a template version, API would fail with 403 and below error will be displayed in the UI
![image](https://github.com/screwdriver-cd/ui/assets/2124590/33dccd69-eadb-4e96-959f-9f32efa525e0)

## References

https://github.com/screwdriver-cd/screwdriver/issues/2862

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
