### PR TITLE
feat(2911): Handle overflow in Job Template Pipeline Report table

### DIFF
--- a/app/components/template-version-pipeline-usage/component.js
+++ b/app/components/template-version-pipeline-usage/component.js
@@ -24,8 +24,10 @@ export default Component.extend({
       propertyName: 'lastRunDate'
     },
     {
-      title: 'ADMIN',
-      resizable: true,
+      title: 'ADMINS',
+      resizable: false,
+      width: '10%',
+      component: 'truncated-table-cell-with-hover-tooltip',
       propertyName: 'admins'
     }
   ],
@@ -47,7 +49,13 @@ export default Component.extend({
           branch: branchWithDir,
           url: m.scmRepo.url,
           lastRunDate: lastRun,
-          admins: Object.keys(m.admins)
+          truncatedCellConfig: {
+            ADMINS: {
+              maxColumnWidth: 40,
+              delimiter: ', ',
+              data: Object.keys(m.admins)
+            }
+          }
         };
       });
     }

--- a/app/components/truncated-table-cell-with-hover-tooltip/component.js
+++ b/app/components/truncated-table-cell-with-hover-tooltip/component.js
@@ -8,22 +8,22 @@ export default Component.extend({
       return this.record.truncatedCellConfig[this.column.title] || {};
     }
   }),
-  data: computed('config.data', {
+  data: computed('config', {
     get() {
       return this.config.data || [];
     }
   }),
-  delimiter: computed('config.delimiter', {
+  delimiter: computed('config', {
     get() {
       return this.config.delimiter || ', ';
     }
   }),
-  maxColumnWidth: computed('config.maxColumnWidth', {
+  maxColumnWidth: computed('config', {
     get() {
       return this.config.maxColumnWidth || 40;
     }
   }),
-  ellipsis: computed('config.ellipsis', 'delimiter', {
+  ellipsis: computed('config', 'delimiter', {
     get() {
       return this.config.ellipsis || `${this.delimiter}...`;
     }

--- a/app/components/truncated-table-cell-with-hover-tooltip/component.js
+++ b/app/components/truncated-table-cell-with-hover-tooltip/component.js
@@ -1,0 +1,59 @@
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+
+export default Component.extend({
+  isTruncated: false,
+  config: computed('column.title', 'record.truncatedCellConfig', {
+    get() {
+      return this.record.truncatedCellConfig[this.column.title] || {};
+    }
+  }),
+  data: computed('config.data', {
+    get() {
+      return this.config.data || [];
+    }
+  }),
+  delimiter: computed('config.delimiter', {
+    get() {
+      return this.config.delimiter || ', ';
+    }
+  }),
+  maxColumnWidth: computed('config.maxColumnWidth', {
+    get() {
+      return this.config.maxColumnWidth || 40;
+    }
+  }),
+  ellipsis: computed('config.ellipsis', 'delimiter', {
+    get() {
+      return this.config.ellipsis || `${this.delimiter}...`;
+    }
+  }),
+
+  truncatedString: computed('data', 'delimiter', 'maxColumnWidth', 'ellipsis', {
+    get() {
+      const { ellipsis, data, delimiter, maxColumnWidth } = this;
+
+      const truncatedArray = data.filter(
+        (_, i, arr) =>
+          arr.slice(0, i + 1).join(delimiter).length <=
+          maxColumnWidth - ellipsis.length
+      );
+
+      const truncatedStr = truncatedArray.join(delimiter);
+
+      if (truncatedArray.length !== data.length) {
+        this.isTruncated = true;
+
+        return truncatedStr + ellipsis;
+      }
+
+      return truncatedStr;
+    }
+  }),
+
+  fullString: computed('data', 'delimiter', {
+    get() {
+      return this.data.join(this.delimiter);
+    }
+  })
+});

--- a/app/components/truncated-table-cell-with-hover-tooltip/template.hbs
+++ b/app/components/truncated-table-cell-with-hover-tooltip/template.hbs
@@ -1,0 +1,7 @@
+{{this.truncatedString}}
+{{#if this.isTruncated}}
+<EmberTooltip>
+{{this.fullString}}
+</EmberTooltip>
+{{/if}}
+{{yield}}

--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
     "ember-svg-jar": "^2.4.2",
     "ember-template-lint": "^4.8.0",
     "ember-toggle": "^9.0.0",
+    "ember-tooltips": "^3.6.0",
     "ember-truth-helpers": "~3.1.1",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.5.0",

--- a/tests/integration/components/template-version-pipeline-usage/component-test.js
+++ b/tests/integration/components/template-version-pipeline-usage/component-test.js
@@ -31,7 +31,9 @@ const metrics = [
     },
     lastRun: null,
     admins: {
-      test: true
+      test1: true,
+      test2: true,
+      test3: true
     }
   },
   {
@@ -46,7 +48,17 @@ const metrics = [
     },
     lastRun: '2023-07-31T17:15:37.510Z',
     admins: {
-      test: true
+      test1: true,
+      test2: true,
+      test3: true,
+      test4: true,
+      test5: true,
+      test6: true,
+      test7: true,
+      test8: true,
+      test9: true,
+      test10: true,
+      test11: true
     }
   }
 ];
@@ -74,7 +86,7 @@ module(
       assert.dom('thead tr th:nth-child(1)').hasText('NAME');
       assert.dom('thead tr th:nth-child(2)').hasText('BRANCH');
       assert.dom('thead tr th:nth-child(3)').hasText('LAST RUN');
-      assert.dom('thead tr th:nth-child(4)').hasText('ADMIN');
+      assert.dom('thead tr th:nth-child(4)').hasText('ADMINS');
       assert.dom('tbody').exists({ count: 1 });
       assert.dom('tbody tr').exists({ count: 3 });
 
@@ -112,7 +124,9 @@ module(
         .dom('tbody tr:nth-child(2) td:nth-child(2) a')
         .hasAttribute('href', metrics[1].scmRepo.url);
       assert.dom('tbody tr:nth-child(2) td:nth-child(3)').hasText('--/--/----');
-      assert.dom('tbody tr:nth-child(2) td:nth-child(4)').hasText('test');
+      assert
+        .dom('tbody tr:nth-child(2) td:nth-child(4)')
+        .hasText('test1, test2, test3');
 
       // Third row
       assert.dom('tbody tr:nth-child(3) td').exists({ count: 4 });
@@ -130,7 +144,9 @@ module(
         .dom('tbody tr:nth-child(3) td:nth-child(2) a')
         .hasAttribute('href', metrics[2].scmRepo.url);
       assert.dom('tbody tr:nth-child(3) td:nth-child(3)').hasText('07/31/2023');
-      assert.dom('tbody tr:nth-child(3) td:nth-child(4)').hasText('test');
+      assert
+        .dom('tbody tr:nth-child(3) td:nth-child(4)')
+        .hasText('test1, test2, test3, test4, test5, ...');
     });
   }
 );

--- a/tests/integration/components/truncated-table-cell-with-hover-tooltip/component-test.js
+++ b/tests/integration/components/truncated-table-cell-with-hover-tooltip/component-test.js
@@ -1,0 +1,72 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module(
+  'Integration | Component | truncated-table-cell-with-hover-tooltip',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test('it renders', async function (assert) {
+      const admins = [
+        {
+          admin: true,
+          admin2: false,
+          admin3: false,
+          admin4: false,
+          admin5: false,
+          admin6: false,
+          admin7: false,
+          admin8: false,
+          admin9: false,
+          admin10: false,
+          admin11: false,
+          admin12: false,
+          admin13: false
+        },
+        {
+          admin: true,
+          admin2: false,
+          admin3: false
+        }
+      ];
+
+      const column = { title: 'ADMINS' };
+      const record = {
+        truncatedCellConfig: {
+          ADMINS: {
+            maxColumnWidth: 40,
+            delimiter: ', ',
+            ellipsis: ', ...',
+            data: Object.keys(admins[0])
+          }
+        }
+      };
+
+      this.set('record', record);
+      this.set('column', column);
+
+      await render(
+        hbs`<TruncatedTableCellWithHoverTooltip @record={{this.record}} @column={{this.column}}/>`
+      );
+
+      assert.ok(
+        this.element.textContent.includes('admin, admin2, admin3, admin4, ...'),
+        'Expected text to be truncated'
+      );
+
+      record.truncatedCellConfig.ADMINS.data = Object.keys(admins[1]);
+
+      await render(
+        hbs`<TruncatedTableCellWithHoverTooltip @record={{this.record}} @column={{this.column}}/>`
+      );
+
+      assert.equal(
+        this.element.textContent.trim(),
+        'admin, admin2, admin3',
+        'Expected text to not be truncated'
+      );
+    });
+  }
+);

--- a/tests/integration/components/truncated-table-cell-with-hover-tooltip/component.js
+++ b/tests/integration/components/truncated-table-cell-with-hover-tooltip/component.js
@@ -1,0 +1,59 @@
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+
+export default Component.extend({
+  isTruncated: false,
+  config: computed('column.title', 'record.truncatedCellConfig', {
+    get() {
+      return this.record.truncatedCellConfig[this.column.title] || {};
+    }
+  }),
+  data: computed('config.data', {
+    get() {
+      return this.config.data || [];
+    }
+  }),
+  delimiter: computed('config.delimiter', {
+    get() {
+      return this.config.delimiter || ', ';
+    }
+  }),
+  maxColumnWidth: computed('config.maxColumnWidth', {
+    get() {
+      return this.config.maxColumnWidth || 40;
+    }
+  }),
+  ellipsis: computed('config.ellipsis', 'delimiter', {
+    get() {
+      return this.config.ellipsis || `${this.delimiter}...`;
+    }
+  }),
+
+  truncatedString: computed('data', 'delimiter', 'maxColumnWidth', 'ellipsis', {
+    get() {
+      const { ellipsis, data, delimiter, maxColumnWidth } = this;
+
+      const truncatedArray = data.filter(
+        (_, i, arr) =>
+          arr.slice(0, i + 1).join(delimiter).length <=
+          maxColumnWidth - ellipsis.length
+      );
+
+      const truncatedStr = truncatedArray.join(delimiter);
+
+      if (truncatedArray.length !== data.length) {
+        this.isTruncated = true;
+
+        return truncatedStr + ellipsis;
+      }
+
+      return truncatedStr;
+    }
+  }),
+
+  fullString: computed('data', 'delimiter', {
+    get() {
+      return this.data.join(this.delimiter);
+    }
+  })
+});


### PR DESCRIPTION
## Context

Previously, if there were many admins in the pipeline report table, it would get rendered like this

<img width="923" alt="image" src="https://github.com/screwdriver-cd/ui/assets/74019033/05003089-ea07-4e67-ac07-efa34bf072e9">


## Objective

This implements a column width limit of 40 characters and adds a tooltip that is activated on hover if
the admin list needed to be truncated.

## Screenshots

If user hovers over row with non truncated admin list:

<img width="987" alt="image" src="https://github.com/screwdriver-cd/ui/assets/74019033/840bb77a-488c-494c-bf0c-a54fdd315048">

If user hovers over row with truncated admin list:

<img width="1162" alt="image" src="https://github.com/screwdriver-cd/ui/assets/74019033/ea362cf8-d41d-40c5-96f5-9e2e922a9b18">

## References

Part of #943 

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
