### PR TITLE
fix: reload event data just after user stop events

### DIFF
--- a/app/components/pipeline-event-row/template.hbs
+++ b/app/components/pipeline-event-row/template.hbs
@@ -30,7 +30,7 @@
       {{/if}}
       {{#if (and this.event.isRunning (not-eq this.event.status "UNKNOWN"))}}
         <BsButton
-          @onClick={{action this.stopEvent this.event.id}}
+          @onClick={{action this.stopEvent this.event}}
           class="stopButton"
           @title="Stop all builds for this event"
         >

--- a/app/components/pipeline-events-list/component.js
+++ b/app/components/pipeline-events-list/component.js
@@ -84,8 +84,9 @@ export default Component.extend({
     startPRBuild(parameters) {
       this.startPRBuild.apply(null, [parameters, this.events]);
     },
-    stopEvent(eventId) {
-      this.stopEvent(eventId);
+    async stopEvent(event) {
+      await this.stopEvent(event.id);
+      event.hasMany('builds').reload();
     },
     async eventClick(id, eventType) {
       set(this, 'selected', id);

--- a/app/components/pipeline-events/component.js
+++ b/app/components/pipeline-events/component.js
@@ -623,7 +623,7 @@ export default Component.extend(ModelReloaderMixin, {
       }
 
       try {
-        return await this.stop.stopBuilds(stopEventId);
+        await this.stop.stopBuilds(stopEventId);
       } catch (e) {
         this.set(
           'errorMessage',


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Events status do not update immediately when user stops events.
So user should reload window to get correct event status.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Reload event data just after user stops events.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
