### PR TITLE
fix: only mark warning on successful build

### DIFF
--- a/app/components/collection-view/styles.scss
+++ b/app/components/collection-view/styles.scss
@@ -418,6 +418,10 @@
     color: $sd-unstable;
   }
 
+  .build-warning {
+    color: $sd-unstable;
+  }
+
   .build-frozen {
     color: $sd-frozen;
   }

--- a/app/components/workflow-graph-d3/component.js
+++ b/app/components/workflow-graph-d3/component.js
@@ -62,12 +62,7 @@ export default Component.extend({
         // set warning status if has warning
         if (builds.length) {
           builds.forEach(build => {
-            if (
-              build.meta &&
-              build.meta.build &&
-              build.meta.build.warning &&
-              build.status === 'SUCCESS'
-            ) {
+            if (build?.meta?.build?.warning && build.status === 'SUCCESS') {
               build.status = 'WARNING';
             }
           });

--- a/app/components/workflow-graph-d3/component.js
+++ b/app/components/workflow-graph-d3/component.js
@@ -62,7 +62,12 @@ export default Component.extend({
         // set warning status if has warning
         if (builds.length) {
           builds.forEach(build => {
-            if (build.meta && build.meta.build && build.meta.build.warning) {
+            if (
+              build.meta &&
+              build.meta.build &&
+              build.meta.build.warning &&
+              build.status === 'SUCCESS'
+            ) {
               build.status = 'WARNING';
             }
           });

--- a/app/event/model.js
+++ b/app/event/model.js
@@ -138,12 +138,6 @@ export default Model.extend(ModelReloaderMixin, {
           return;
         }
 
-        list.forEach(build => {
-          if (build.meta && build.meta.build && build.meta.build.warning) {
-            build.status = 'WARNING';
-          }
-        });
-
         if (!this.isDestroying && !this.isDestroyed) {
           const validList = list.filter(
             b => b.status !== 'SUCCESS' && b.status !== 'CREATED'

--- a/app/pipeline/jobs/index/controller.js
+++ b/app/pipeline/jobs/index/controller.js
@@ -122,12 +122,7 @@ export default Controller.extend(ModelReloaderMixin, {
 
           if (nextJobDetail.builds) {
             nextJobDetail.builds.forEach(build => {
-              if (
-                build.meta &&
-                build.meta.build &&
-                build.meta.build.warning &&
-                build.status === 'SUCCESS'
-              ) {
+              if (build?.meta?.build?.warning && build.status === 'SUCCESS') {
                 build.status = 'WARNING';
               }
             });

--- a/app/pipeline/jobs/index/controller.js
+++ b/app/pipeline/jobs/index/controller.js
@@ -122,7 +122,12 @@ export default Controller.extend(ModelReloaderMixin, {
 
           if (nextJobDetail.builds) {
             nextJobDetail.builds.forEach(build => {
-              if (build.meta && build.meta.build && build.meta.build.warning) {
+              if (
+                build.meta &&
+                build.meta.build &&
+                build.meta.build.warning &&
+                build.status === 'SUCCESS'
+              ) {
                 build.status = 'WARNING';
               }
             });

--- a/app/utils/metric.js
+++ b/app/utils/metric.js
@@ -109,7 +109,7 @@ const formatMetrics = metrics => {
     // only overwrite success event with warning
     if (event && event.builds && eventStatus === 'success') {
       event.builds.forEach(build => {
-        if (build.meta && build.meta.build && build.meta.build.warning) {
+        if (build?.meta?.build?.warning) {
           eventStatus = 'warning';
         }
       });
@@ -126,7 +126,7 @@ const formatMetrics = metrics => {
   // only overwrite success event with warning
   if (lastEvent && lastEvent.builds && lastEventStatus === 'success') {
     lastEvent.builds.forEach(build => {
-      if (build.meta && build.meta.build && build.meta.build.warning) {
+      if (build?.meta?.build?.warning) {
         lastEventStatus = 'warning';
       }
     });

--- a/tests/integration/components/pipeline-list-history-cell/component-test.js
+++ b/tests/integration/components/pipeline-list-history-cell/component-test.js
@@ -154,5 +154,27 @@ module(
       assert.dom('.tooltip').exists({ count: 1 });
       assert.dom('.tooltip').containsText('Build# 1 Start - 03/02/2023');
     });
+
+    test('it renders warning build', async function (assert) {
+      this.set('record', {
+        history: [
+          {
+            id: 2,
+            status: 'WARNING'
+          },
+          {
+            id: 1,
+            status: 'SUCCESS'
+          }
+        ]
+      });
+
+      await render(hbs`<PipelineListHistoryCell
+        @record={{this.record}}
+      />`);
+
+      assert.dom('.fa-circle').hasClass('WARNING');
+      assert.dom('.fa-circle').exists({ count: 2 });
+    });
   }
 );


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
it could confusing to users when failed builds are marked with warning
## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
only mark successful builds
## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
