### PR TITLE
fix(2862): Improve default display performance of template metrics

### DIFF
--- a/app/components/time-range-picker/component.js
+++ b/app/components/time-range-picker/component.js
@@ -20,6 +20,8 @@ export default Component.extend({
   // flatpickr addon seems to prefer dates in string
   customRange: computed('startTime', 'endTime', {
     get() {
+      if (!this.get('startTime')) return null;
+
       return ['startTime', 'endTime'].map(t =>
         toCustomLocaleString(new Date(this.get(t)), {
           options: {

--- a/app/components/time-range-picker/component.js
+++ b/app/components/time-range-picker/component.js
@@ -15,7 +15,8 @@ export default Component.extend({
     { alias: '1mo', value: '1mo' },
     { alias: '3mo', value: '3mo' },
     { alias: '6mo', value: '180d' },
-    { alias: '1yr', value: '1yr' }
+    { alias: '1yr', value: '1yr' },
+    { alias: 'all', value: null }
   ],
   // flatpickr addon seems to prefer dates in string
   customRange: computed('startTime', 'endTime', {
@@ -42,16 +43,24 @@ export default Component.extend({
 
       this.set('selectedRange', range);
 
-      const { startTime, endTime } = timeRange(new Date(), range);
+      if (range) {
+        const { startTime, endTime } = timeRange(new Date(), range);
 
-      this.onTimeRangeChange(startTime, endTime);
+        this.onTimeRangeChange(startTime, endTime);
+      } else {
+        this.onTimeRangeChange();
+      }
     },
     setCustomRange([start, end]) {
       this.set('selectedRange');
 
-      // always set end to a minute before EOD, and of local time
-      end.setHours(23, 59, 59);
-      this.onTimeRangeChange(start.toISOString(), end.toISOString());
+      if (start) {
+        end.setHours(23, 59, 59);
+        this.onTimeRangeChange(start.toISOString(), end.toISOString());
+      } else {
+        // always set end to a minute before EOD, and of local time
+        this.onTimeRangeChange();
+      }
     }
   }
 });

--- a/app/templates/detail/route.js
+++ b/app/templates/detail/route.js
@@ -1,7 +1,6 @@
 import { inject as service } from '@ember/service';
 import RSVP from 'rsvp';
 import Route from '@ember/routing/route';
-import timeRange from 'screwdriver-ui/utils/time-range';
 
 export default Route.extend({
   router: service(),
@@ -15,11 +14,6 @@ export default Route.extend({
   fetchFiltered: false,
   init() {
     this._super(...arguments);
-    const { startTime, endTime } = timeRange(new Date(), '1yr');
-
-    // these are used for querying, so they are in ISO8601 format
-    this.set('startTime', startTime);
-    this.set('endTime', endTime);
 
     this.set('fetchAll', true);
     this.set('fetchFiltered', false);
@@ -33,6 +27,15 @@ export default Route.extend({
 
     const { startTime, endTime, fetchAll, fetchFiltered } = this;
 
+    let query = {};
+
+    if (startTime) {
+      query = {
+        startTime,
+        endTime
+      };
+    }
+
     return RSVP.all([
       fetchAll
         ? this.template.getOneTemplateWithMetrics(
@@ -42,10 +45,7 @@ export default Route.extend({
       fetchAll || fetchFiltered
         ? this.template.getOneTemplateWithMetrics(
             `${params.namespace}/${params.name}`,
-            {
-              startTime,
-              endTime
-            }
+            query
           )
         : RSVP.resolve(this.templateDataFiltered),
       fetchAll


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Fix the problem in the following comment.
https://github.com/screwdriver-cd/screwdriver/issues/2862#issuecomment-1786509652

When tallying the number of builds using a template, it may take longer if createTime is specified.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
When the template detail page is opened, the default is to display it without specifying a time period, thereby reducing the time required to display it.

Also add `all` button to aggregate all periods.
<img width="1413" alt="image" src="https://github.com/screwdriver-cd/ui/assets/59165943/665f8a9e-93dc-43f1-bef8-5a5d8f105e78">

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
