### PR TITLE
fix(2862): Improve the load on the DB for template metrics

### DIFF
--- a/app/components/time-range-picker/component.js
+++ b/app/components/time-range-picker/component.js
@@ -6,7 +6,7 @@ import timeRange, {
 
 export default Component.extend({
   classNames: ['chart-controls'],
-  selectedRange: null,
+  selectedRange: '1yr',
   timeRanges: [
     { alias: '6hr', value: '6hr' },
     { alias: '12hr', value: '12hr' },

--- a/app/components/time-range-picker/component.js
+++ b/app/components/time-range-picker/component.js
@@ -20,6 +20,8 @@ export default Component.extend({
   // flatpickr addon seems to prefer dates in string
   customRange: computed('startTime', 'endTime', {
     get() {
+      if (!this.get('startTime')) return null;
+
       return ['startTime', 'endTime'].map(t =>
         toCustomLocaleString(new Date(this.get(t)), {
           options: {

--- a/app/components/time-range-picker/component.js
+++ b/app/components/time-range-picker/component.js
@@ -15,7 +15,8 @@ export default Component.extend({
     { alias: '1mo', value: '1mo' },
     { alias: '3mo', value: '3mo' },
     { alias: '6mo', value: '180d' },
-    { alias: '1yr', value: '1yr' }
+    { alias: '1yr', value: '1yr' },
+    { alias: 'all', value: null }
   ],
   // flatpickr addon seems to prefer dates in string
   customRange: computed('startTime', 'endTime', {
@@ -42,16 +43,24 @@ export default Component.extend({
 
       this.set('selectedRange', range);
 
-      const { startTime, endTime } = timeRange(new Date(), range);
+      if (range) {
+        const { startTime, endTime } = timeRange(new Date(), range);
 
-      this.onTimeRangeChange(startTime, endTime);
+        this.onTimeRangeChange(startTime, endTime);
+      } else {
+        this.onTimeRangeChange();
+      }
     },
     setCustomRange([start, end]) {
       this.set('selectedRange');
 
-      // always set end to a minute before EOD, and of local time
-      end.setHours(23, 59, 59);
-      this.onTimeRangeChange(start.toISOString(), end.toISOString());
+      if (start) {
+        end.setHours(23, 59, 59);
+        this.onTimeRangeChange(start.toISOString(), end.toISOString());
+      } else {
+        // always set end to a minute before EOD, and of local time
+        this.onTimeRangeChange();
+      }
     }
   }
 });

--- a/app/templates/detail/route.js
+++ b/app/templates/detail/route.js
@@ -20,6 +20,7 @@ export default Route.extend({
     // these are used for querying, so they are in ISO8601 format
     this.set('startTime', startTime);
     this.set('endTime', endTime);
+
     this.set('fetchAll', true);
     this.set('fetchFiltered', false);
   },

--- a/app/templates/detail/route.js
+++ b/app/templates/detail/route.js
@@ -1,6 +1,7 @@
 import { inject as service } from '@ember/service';
 import RSVP from 'rsvp';
 import Route from '@ember/routing/route';
+import timeRange from 'screwdriver-ui/utils/time-range';
 
 export default Route.extend({
   router: service(),
@@ -14,7 +15,11 @@ export default Route.extend({
   fetchFiltered: false,
   init() {
     this._super(...arguments);
+    const { startTime, endTime } = timeRange(new Date(), '1yr');
 
+    // these are used for querying, so they are in ISO8601 format
+    this.set('startTime', startTime);
+    this.set('endTime', endTime);
     this.set('fetchAll', true);
     this.set('fetchFiltered', false);
   },
@@ -37,11 +42,6 @@ export default Route.extend({
     }
 
     return RSVP.all([
-      fetchAll
-        ? this.template.getOneTemplateWithMetrics(
-            `${params.namespace}/${params.name}`
-          )
-        : RSVP.resolve(this.templateData),
       fetchAll || fetchFiltered
         ? this.template.getOneTemplateWithMetrics(
             `${params.namespace}/${params.name}`,
@@ -52,9 +52,13 @@ export default Route.extend({
         ? this.template.getTemplateTags(params.namespace, params.name)
         : this.templateTagData
     ]).then(arr => {
-      let [templateData, templateDataFiltered, templateTagData] = arr;
+      let [templateDataFiltered, templateTagData] = arr;
 
-      templateData = templateData.filter(t => t.namespace === params.namespace);
+      // templateData is a property for displaying aggregate values for 1 year in template-header.
+      // It should not be updated when the time range is changed.
+      const templateData = this.controller?.templates
+        ? this.controller.templates
+        : templateDataFiltered.filter(t => t.namespace === params.namespace);
 
       if (templateData.length === 0) {
         this.router.transitionTo('/404');

--- a/app/templates/detail/route.js
+++ b/app/templates/detail/route.js
@@ -1,7 +1,6 @@
 import { inject as service } from '@ember/service';
 import RSVP from 'rsvp';
 import Route from '@ember/routing/route';
-import timeRange from 'screwdriver-ui/utils/time-range';
 
 export default Route.extend({
   router: service(),
@@ -15,11 +14,6 @@ export default Route.extend({
   fetchFiltered: false,
   init() {
     this._super(...arguments);
-    const { startTime, endTime } = timeRange(new Date(), '1yr');
-
-    // these are used for querying, so they are in ISO8601 format
-    this.set('startTime', startTime);
-    this.set('endTime', endTime);
 
     this.set('fetchAll', true);
     this.set('fetchFiltered', false);
@@ -33,6 +27,15 @@ export default Route.extend({
 
     const { startTime, endTime, fetchAll, fetchFiltered } = this;
 
+    let query = {};
+
+    if (startTime) {
+      query = {
+        startTime,
+        endTime
+      };
+    }
+
     return RSVP.all([
       fetchAll
         ? this.template.getOneTemplateWithMetrics(
@@ -42,10 +45,7 @@ export default Route.extend({
       fetchAll || fetchFiltered
         ? this.template.getOneTemplateWithMetrics(
             `${params.namespace}/${params.name}`,
-            {
-              startTime,
-              endTime
-            }
+            query
           )
         : RSVP.resolve(this.templateDataFiltered),
       fetchAll


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Fix the problem in the following comment.
https://github.com/screwdriver-cd/ui/pull/960#issuecomment-1803212548

Currently, the total for the entire period is being aggregated to show the number of builds in the template-header, and the total for one year to show the number of builds per version.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Because double aggregation is a burden on the DB, modify the values displayed in template-header to refer to one year's aggregation.
Also, add an `all` button to display version metrics for the entire period

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
