### PR TITLE
feat:(2215) move to same repository pipeline

### DIFF
--- a/app/components/pipeline-header/component.js
+++ b/app/components/pipeline-header/component.js
@@ -5,6 +5,7 @@ import Component from '@ember/component';
 export default Component.extend({
   showCollectionModal: false,
   scmService: service('scm'),
+  pipelineService: service('pipeline'),
   classNameBindings: ['isBuildPage'],
   router: service(),
   addCollectionError: null,
@@ -23,6 +24,17 @@ export default Component.extend({
         scm: scm.displayName,
         scmIcon: scm.iconType
       };
+    }
+  }),
+  sameRepoPipeline: computed('pipeline', {
+    get() {
+      return this.pipelineService.getSiblingPipeline(this.pipeline.scmRepo.name).then(value =>
+        value.toArray().filter(pipe => pipe.id !== this.pipeline.id).map((pipe, i) => ({
+          index: i,
+          url: `/pipelines/${pipe.id}`,
+          branchAndRootDir: pipe.scmRepo.rootDir ? `${pipe.scmRepo.branch}:${pipe.scmRepo.rootDir}` : pipe.scmRepo.branch
+        }))
+      );
     }
   }),
   actions: {

--- a/app/components/pipeline-header/styles.scss
+++ b/app/components/pipeline-header/styles.scss
@@ -55,6 +55,11 @@ a.active {
   background-color: #d1edff;
 }
 
+.branch-dropdown {
+  padding-left: 10px;
+  padding-right: 10px;
+}
+
 .dropdown {
   display:inline-block;
 }

--- a/app/components/pipeline-header/styles.scss
+++ b/app/components/pipeline-header/styles.scss
@@ -42,3 +42,19 @@ a.active {
   right: 25px;
   display: inline;
 }
+
+.branch-move {
+  padding-right: 6px;
+}
+
+.branch-item {
+  padding: 1px 0px;
+}
+
+.branch-item a:hover {
+  background-color: #d1edff;
+}
+
+.dropdown {
+  display:inline-block;
+}

--- a/app/components/pipeline-header/styles.scss
+++ b/app/components/pipeline-header/styles.scss
@@ -49,6 +49,10 @@ a.active {
 
 .branch-item {
   padding: 1px 0px;
+  .img {
+    width: 10px;
+    height: 10px;
+  }
 }
 
 .branch-item a:hover {

--- a/app/components/pipeline-header/template.hbs
+++ b/app/components/pipeline-header/template.hbs
@@ -40,7 +40,7 @@
         </ddm.item>
       {{else}}
         <li class="branch-item">
-          No same repository Pipeline
+          No other Pipelines with the same repository
         </li>
       {{/each}}
     </dd.menu>

--- a/app/components/pipeline-header/template.hbs
+++ b/app/components/pipeline-header/template.hbs
@@ -18,14 +18,14 @@
   </h1>
 </LinkTo>
 <span class="branch-move">
-  <a href={{branch-url-encode this.pipeline.hubUrl}} class="branch">
-    <FaIcon @icon="code-branch" @title="Source code" />
-    {{this.pipeline.branch}}
-  </a>
   <BsDropdown as |dd|>
     <dd.toggle>
+      <span class="branch">
+        <FaIcon @icon="code-branch" @title="Source code" />
+        {{this.pipeline.branch}}
+      </span>
       <span class="caret caret-display"></span>
-      <BsTooltip @placement="bottom" @renderInPlace={{true}} @triggerEvents="hover" class="tooltip">
+      <BsTooltip @placement="bottom" @renderInPlace={{false}} @triggerEvents="hover" class="tooltip">
         Move to a same repository Pipeline
       </BsTooltip>
     </dd.toggle>
@@ -46,10 +46,10 @@
     </dd.menu>
   </BsDropdown>
 </span>
-<span class="scm">
+<a href={{branch-url-encode this.pipeline.hubUrl}}  class="scm">
   <FaIcon @icon={{this.scmContext.scmIcon}} @prefix="fab" />
   {{this.scmContext.scm}}
-</span>
+</a>
 {{#if this.pipeline.configPipelineId}}
   <FaIcon @icon="cog" />
   <LinkTo @route="pipeline" @model={{this.pipeline.configPipelineId}}>

--- a/app/components/pipeline-header/template.hbs
+++ b/app/components/pipeline-header/template.hbs
@@ -17,10 +17,28 @@
     {{this.pipeline.appId}}
   </h1>
 </LinkTo>
-<a href={{branch-url-encode this.pipeline.hubUrl}} class="branch">
-  <FaIcon @icon="code-branch" @title="Source code" />
-  {{this.pipeline.branch}}
-</a>
+<span class="branch-move">
+  <a href={{branch-url-encode this.pipeline.hubUrl}} class="branch">
+    <FaIcon @icon="code-branch" @title="Source code" />
+    {{this.pipeline.branch}}
+  </a>
+  <BsDropdown as |dd|>
+    <dd.toggle>
+      <span class="caret caret-display"></span>
+    </dd.toggle>
+    <dd.menu class="commit-dropdown" as |ddm|>
+      {{#each (await this.sameRepoPipeline) as |pipe|}}
+        <ddm.item>
+          <li class="branch-item">
+            <a href={{pipe.url}}>
+              {{pipe.branchAndRootDir}}
+            </a>
+          </li>
+        </ddm.item>
+      {{/each}}
+    </dd.menu>
+  </BsDropdown>
+</span>
 <span class="scm">
   <FaIcon @icon={{this.scmContext.scmIcon}} @prefix="fab" />
   {{this.scmContext.scm}}

--- a/app/components/pipeline-header/template.hbs
+++ b/app/components/pipeline-header/template.hbs
@@ -25,16 +25,23 @@
   <BsDropdown as |dd|>
     <dd.toggle>
       <span class="caret caret-display"></span>
+      <BsTooltip @placement="bottom" @renderInPlace={{true}} @triggerEvents="hover" class="tooltip">
+        Move to a same repository Pipeline
+      </BsTooltip>
     </dd.toggle>
     <dd.menu class="branch-dropdown" as |ddm|>
       {{#each (await this.sameRepoPipeline) as |pipe|}}
         <ddm.item>
           <li class="branch-item">
             <a href={{pipe.url}}>
-              {{pipe.branchAndRootDir}}
+              {{svg-jar "link" class="img"}} {{pipe.branchAndRootDir}}
             </a>
           </li>
         </ddm.item>
+      {{else}}
+        <li class="branch-item">
+          No same repository Pipeline
+        </li>
       {{/each}}
     </dd.menu>
   </BsDropdown>

--- a/app/components/pipeline-header/template.hbs
+++ b/app/components/pipeline-header/template.hbs
@@ -26,7 +26,7 @@
       </span>
       <span class="caret caret-display"></span>
       <BsTooltip @placement="bottom" @renderInPlace={{false}} @triggerEvents="hover" class="tooltip">
-        Move to a same repository Pipeline
+        Switch to another Pipeline with the same repository
       </BsTooltip>
     </dd.toggle>
     <dd.menu class="branch-dropdown" as |ddm|>

--- a/app/components/pipeline-header/template.hbs
+++ b/app/components/pipeline-header/template.hbs
@@ -26,7 +26,7 @@
     <dd.toggle>
       <span class="caret caret-display"></span>
     </dd.toggle>
-    <dd.menu class="commit-dropdown" as |ddm|>
+    <dd.menu class="branch-dropdown" as |ddm|>
       {{#each (await this.sameRepoPipeline) as |pipe|}}
         <ddm.item>
           <li class="branch-item">

--- a/app/pipeline/service.js
+++ b/app/pipeline/service.js
@@ -1,9 +1,23 @@
-import Service from '@ember/service';
+import Service, { inject as service } from '@ember/service';
+import ENV from 'screwdriver-ui/config/environment';
 
 export default Service.extend({
+  store: service(),
   buildsLink: `pipeline.events`,
 
   setBuildsLink(buildsLink) {
     this.set('buildsLink', buildsLink);
+  },
+
+  getSiblingPipeline(scmRepo) {
+    const pipelineListConfig = {
+      page: 1,
+      count: ENV.APP.NUM_PIPELINES_LISTED,
+      search: scmRepo,
+      sortBy: 'name',
+      sort: 'ascending'
+    };
+
+    return this.store.query('pipeline', pipelineListConfig);
   }
 });

--- a/tests/integration/components/pipeline-header/component-test.js
+++ b/tests/integration/components/pipeline-header/component-test.js
@@ -26,6 +26,7 @@ module('Integration | Component | pipeline header', function (hooks) {
     assert
       .dom('a.branch')
       .hasAttribute('href', 'http://example.com/batman/batmobile');
+    assert.dom('caret-display').exists();
 
     assert.dom('span.scm').hasText('github.com');
     assert.dom('.scm > .fa-github').exists({ count: 1 });

--- a/tests/integration/components/pipeline-header/component-test.js
+++ b/tests/integration/components/pipeline-header/component-test.js
@@ -1,8 +1,9 @@
 import EmberObject from '@ember/object';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { click, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import Service from '@ember/service';
 import injectScmServiceStub from '../../../helpers/inject-scm';
 
 module('Integration | Component | pipeline header', function (hooks) {
@@ -30,6 +31,60 @@ module('Integration | Component | pipeline header', function (hooks) {
 
     assert.dom('a.scm').hasText('github.com');
     assert.dom('.scm > .fa-github').exists({ count: 1 });
+  });
+
+  test('it renders branch-move', async function (assert) {
+    const pipelineMock = EmberObject.create({
+      id: 1,
+      appId: 'batman/batmobile',
+      hubUrl: 'http://example.com/batman/batmobile',
+      branch: 'master',
+      scmContext: 'github:github.com',
+      scmRepo: {
+        name: 'batman/batmobile',
+        branch: 'master'
+      }
+    });
+
+    const siblingPipelineMock = [
+      {
+        id: 1,
+        scmRepo: {
+          branch: 'master'
+        }
+      },
+      {
+        id: 2,
+        scmRepo: {
+          branch: 'develop'
+        }
+      },
+      {
+        id: 3,
+        scmRepo: {
+          branch: 'develop',
+          rootDir: 'src'
+        }
+      }
+    ];
+
+    const pipelineStub = Service.extend({
+      getSiblingPipeline() {
+        return Promise.resolve(siblingPipelineMock);
+      }
+    });
+
+    this.owner.unregister('service:pipeline');
+    this.owner.register('service:pipeline', pipelineStub);
+
+    injectScmServiceStub(this);
+
+    this.set('pipelineMock', pipelineMock);
+    await render(hbs`<PipelineHeader @pipeline={{this.pipelineMock}} />`);
+
+    await click('span.branch');
+
+    assert.dom('li.branch-item').exists({ count: 2 });
   });
 
   test('it renders link to parent pipeline for child pipeline', async function (assert) {

--- a/tests/integration/components/pipeline-header/component-test.js
+++ b/tests/integration/components/pipeline-header/component-test.js
@@ -26,7 +26,7 @@ module('Integration | Component | pipeline header', function (hooks) {
     assert
       .dom('a.branch')
       .hasAttribute('href', 'http://example.com/batman/batmobile');
-    assert.dom('caret-display').exists();
+    assert.dom('a.dropdown-toggle').exists();
 
     assert.dom('span.scm').hasText('github.com');
     assert.dom('.scm > .fa-github').exists({ count: 1 });

--- a/tests/integration/components/pipeline-header/component-test.js
+++ b/tests/integration/components/pipeline-header/component-test.js
@@ -22,13 +22,13 @@ module('Integration | Component | pipeline header', function (hooks) {
     await render(hbs`<PipelineHeader @pipeline={{this.pipelineMock}} />`);
 
     assert.dom('h1').hasText('batman/batmobile');
-    assert.dom('a.branch').hasText('Source code master');
-    assert
-      .dom('a.branch')
-      .hasAttribute('href', 'http://example.com/batman/batmobile');
+    assert.dom('span.branch').hasText('Source code master');
     assert.dom('a.dropdown-toggle').exists();
+    assert
+      .dom('a.scm')
+      .hasAttribute('href', 'http://example.com/batman/batmobile');
 
-    assert.dom('span.scm').hasText('github.com');
+    assert.dom('a.scm').hasText('github.com');
     assert.dom('.scm > .fa-github').exists({ count: 1 });
   });
 

--- a/tests/unit/pipeline/service-test.js
+++ b/tests/unit/pipeline/service-test.js
@@ -1,0 +1,39 @@
+import EmberObject from '@ember/object';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import Service from '@ember/service';
+
+let pipelines;
+
+const storeServiceStub = Service.extend({
+  query() {
+    return pipelines
+  }
+});
+
+module('Unit | Service | pipeline', function (hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.owner.unregister('service:store');
+    this.owner.register('service:store', storeServiceStub);
+  });
+
+  test('it exists', function (assert) {
+    const service = this.owner.lookup('service:pipeline');
+
+    assert.ok(service);
+  });
+
+  test('it handles updating job state', function (assert) {
+    pipelines = EmberObject.create([{
+      id: 123456,
+      name: 'screwdriver-cd/screwdriver'
+    }]);
+
+    const service = this.owner.lookup('service:pipeline');
+    const value = service.getSiblingPipeline('screwdriver-cd/screwdriver');
+
+    assert.equal(value, pipelines);
+  });
+});


### PR DESCRIPTION
## Context
We want to easily transition to the pipeline in the same repository.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
We implemented the function to transition to the pipeline of the same repository. The link to the scm repository has been moved to the icon on the right.
<!-- What does thi
s PR fix? What intentional changes will this PR make? -->
<img width="658" alt="branch-move" src="https://github.com/screwdriver-cd/ui/assets/22903716/bba84892-2dd9-4387-aa7a-7b6d4d7e994d">


## References
https://github.com/screwdriver-cd/screwdriver/issues/2215#issuecomment-949189578
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
