### PR TITLE
fix(2952): Make full-width space available in branch name [4]

### DIFF
--- a/app/utils/git.js
+++ b/app/utils/git.js
@@ -5,9 +5,9 @@
  * @return {Object}         Data about the url
  */
 function parse(scmUrl) {
-  // eslint-disable-next-line max-len
   const match = scmUrl.match(
-    /^(?:(?:https:\/\/(?:[^@/:\s]+@)?)|git@|org-\d+@)+([^/:\s]+)(?:\/|:)([^/:\s]+)\/([^\s]+?)(?:\.git)(#[^:\s]+)?(:[^\s]+)?$/
+    // eslint-disable-next-line no-irregular-whitespace
+    /^(?:(?:https:\/\/(?:[^@/:\s]+@)?)|git@|org-\d+@)+([^/:\s]+)(?:\/|:)([^/:\s]+)\/([^\s]+?)(?:\.git)(#([^:\s]|(　))+)?(:[^\s]+)?$/
   );
 
   if (!match) {

--- a/app/utils/git.js
+++ b/app/utils/git.js
@@ -7,7 +7,7 @@
 function parse(scmUrl) {
   const match = scmUrl.match(
     // eslint-disable-next-line no-irregular-whitespace
-    /^(?:(?:https:\/\/(?:[^@/:\s]+@)?)|git@|org-\d+@)+([^/:\s]+)(?:\/|:)([^/:\s]+)\/([^\s]+?)(?:\.git)(#([^:\s]|(　))+)?(:[^\s]+)?$/
+    /^(?:(?:https:\/\/(?:[^@/:\s]+@)?)|git@|org-\d+@)+([^/:\s]+)(?:\/|:)([^/:\s]+)\/([^\s]+?)(?:\.git)(#[^:　\s]*　[^:　\s]*|#[^:　\s]+)?(:[^:　\s]*　[^:　\s]*|:[^:　\s]+)?$/
   );
 
   if (!match) {

--- a/tests/integration/components/pipeline-create-form/component-test.js
+++ b/tests/integration/components/pipeline-create-form/component-test.js
@@ -57,4 +57,86 @@ module('Integration | Component | pipeline create form', function (hooks) {
 
     await click('button.blue-button');
   });
+
+  test('it handles the entire ui flow with branch', async function (assert) {
+    assert.expect(3);
+
+    injectScmServiceStub(this);
+
+    const sessionStub = Service.extend({
+      get() {
+        return 'github:github.com';
+      }
+    });
+
+    this.owner.register('service:session', sessionStub);
+
+    const scm = 'git@github.com:foo/bar.git#baz';
+    const root = 'lib';
+
+    this.set('createPipeline', ({ scmUrl, rootDir }) => {
+      assert.equal(scmUrl, scm);
+      assert.equal(rootDir, root);
+    });
+
+    await render(
+      hbs`<PipelineCreateForm
+        @errorMessage=""
+        @isSaving={{false}}
+        @onCreatePipeline={{action this.createPipeline}}
+        />`
+    );
+
+    await fillIn('.scm-url', scm);
+    await click('label.toggle-use-root-dir');
+    await fillIn('input.root-dir', root);
+    await click('label.toggle-auto-deploy-key-generation');
+    await triggerKeyEvent('.scm-url', 'keyup', 32);
+    await triggerKeyEvent('.root-dir', 'keyup', 32);
+
+    assert.dom('svg').hasClass('fa-check');
+
+    await click('button.blue-button');
+  });
+
+  test('it handles the entire ui flow with special characters branch', async function (assert) {
+    assert.expect(3);
+
+    injectScmServiceStub(this);
+
+    const sessionStub = Service.extend({
+      get() {
+        return 'github:github.com';
+      }
+    });
+
+    this.owner.register('service:session', sessionStub);
+
+    const scm = 'git@github.com:foo/bar.git#!"#$%&\'()-=|@`{;+]},<.>/　🚗';
+    const root = 'lib';
+
+    this.set('createPipeline', ({ scmUrl, rootDir }) => {
+      assert.equal(scmUrl, scm);
+      assert.equal(rootDir, root);
+    });
+
+    await render(
+      hbs`<PipelineCreateForm
+        @errorMessage=""
+        @isSaving={{false}}
+        @onCreatePipeline={{action this.createPipeline}}
+        />`
+    );
+
+    await fillIn('.scm-url', scm);
+    await click('label.toggle-use-root-dir');
+    await fillIn('input.root-dir', root);
+    await click('label.toggle-auto-deploy-key-generation');
+    await triggerKeyEvent('.scm-url', 'keyup', 32);
+    await triggerKeyEvent('.root-dir', 'keyup', 32);
+
+    assert.dom('svg').hasClass('fa-check');
+
+    await click('button.blue-button');
+  });
 });

--- a/tests/integration/components/pipeline-create-form/component-test.js
+++ b/tests/integration/components/pipeline-create-form/component-test.js
@@ -112,8 +112,8 @@ module('Integration | Component | pipeline create form', function (hooks) {
 
     this.owner.register('service:session', sessionStub);
 
-    const scm = 'git@github.com:foo/bar.git#!"#$%&\'()-=|@`{;+]},<.>/　🚗';
-    const root = 'lib';
+    const scm = 'git@github.com:foo/bar.git#baz!"#$%&\'()-=|@`{;+]},<.>/　🚗';
+    const root = 'path/to/!"#$%&\'()-=|@`{;+]},<.>/　🚗';
 
     this.set('createPipeline', ({ scmUrl, rootDir }) => {
       assert.equal(scmUrl, scm);

--- a/tests/unit/utils/git-test.js
+++ b/tests/unit/utils/git-test.js
@@ -26,6 +26,18 @@ module('Unit | Utility | git', function () {
       branch: 'tree',
       valid: true
     });
+
+    result = git.parse(
+      'git@github.com:bananas/peel.git#!"#$%&\'() -= | @`{;+]},<.>/　a'
+    );
+
+    assert.deepEqual(result, {
+      server: 'github.com',
+      owner: 'bananas',
+      repo: 'peel',
+      branch: '#!"#$%&\'() -= | @`{;+]},<.>/　a',
+      valid: true
+    });
   });
 
   test('it generates the checkout URL correctly', assert => {
@@ -37,8 +49,29 @@ module('Unit | Utility | git', function () {
     assert.strictEqual(result, 'git@github.com:bananas/peel.git#master');
   });
 
+  test('it generates the checkout URL correctly with special characters', assert => {
+    const result = git.getCheckoutUrl({
+      appId: 'bananas/peel',
+      scmUri: 'github.com:12345:!"#$%&\'() -= | @`{;+]},<.>/　a'
+    });
+
+    assert.strictEqual(
+      result,
+      'git@github.com:bananas/peel.git#!"#$%&\'() -= | @`{;+]},<.>/　a'
+    );
+  });
+
   test('it parses the org checkout URL correctly', assert => {
     const orgGitUrl = 'org-1000@github.com:bananas/peel.git#tree';
+
+    const result = git.parse(orgGitUrl);
+
+    assert.ok(result.valid, `${orgGitUrl} is valid`);
+  });
+
+  test('it parses the org checkout URL correctly with special characters', assert => {
+    const orgGitUrl =
+      'org-1000@github.com:bananas/peel.git#!"#$%&\'() -= | @`{;+]},<.>/　a';
 
     const result = git.parse(orgGitUrl);
 

--- a/tests/unit/utils/git-test.js
+++ b/tests/unit/utils/git-test.js
@@ -26,16 +26,22 @@ module('Unit | Utility | git', function () {
       branch: 'tree',
       valid: true
     });
+  });
+
+  test('it parses the checkout URL correctly with special characters', assert => {
+    let result = git.parse('!"#$%&\'()-=|@`{;+]},<.>/　🚗');
+
+    assert.notOk(result.valid);
 
     result = git.parse(
-      'git@github.com:bananas/peel.git#!"#$%&\'() -= | @`{;+]},<.>/　a'
+      'git@github.com:bananas/peel.git#!"#$%&\'()-=|@`{;+]},<.>/　🚗'
     );
 
     assert.deepEqual(result, {
       server: 'github.com',
       owner: 'bananas',
       repo: 'peel',
-      branch: '#!"#$%&\'() -= | @`{;+]},<.>/　a',
+      branch: '!"#$%&\'()-=|@`{;+]},<.>/　🚗',
       valid: true
     });
   });
@@ -52,12 +58,12 @@ module('Unit | Utility | git', function () {
   test('it generates the checkout URL correctly with special characters', assert => {
     const result = git.getCheckoutUrl({
       appId: 'bananas/peel',
-      scmUri: 'github.com:12345:!"#$%&\'() -= | @`{;+]},<.>/　a'
+      scmUri: 'github.com:12345:!"#$%&\'()-=|@`{;+]},<.>/　🚗'
     });
 
     assert.strictEqual(
       result,
-      'git@github.com:bananas/peel.git#!"#$%&\'() -= | @`{;+]},<.>/　a'
+      'git@github.com:bananas/peel.git#!"#$%&\'()-=|@`{;+]},<.>/　🚗'
     );
   });
 
@@ -71,7 +77,7 @@ module('Unit | Utility | git', function () {
 
   test('it parses the org checkout URL correctly with special characters', assert => {
     const orgGitUrl =
-      'org-1000@github.com:bananas/peel.git#!"#$%&\'() -= | @`{;+]},<.>/　a';
+      'org-1000@github.com:bananas/peel.git#!"#$%&\'()-=|@`{;+]},<.>/　🚗';
 
     const result = git.parse(orgGitUrl);
 


### PR DESCRIPTION
## Context
<!-- Why do we need this PR? What was the reason that led you to make this change? -->
On GitHub, it was possible to use full-width space of Japanese in branch names, but these characters were not available in SD.

## Objective
<!-- What does this PR fix? What intentional changes will this PR make? -->
Change to allow the input of Japanese full-width spaces.
This will allow the use of character pipelines such as "🚗　🚗".

## References
- https://github.com/screwdriver-cd/screwdriver/issues/2952
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
