### PR TITLE
fix:(2215): fix issue of moving between pipelines in the same branch

### DIFF
--- a/app/components/pipeline-header/component.js
+++ b/app/components/pipeline-header/component.js
@@ -29,7 +29,7 @@ export default Component.extend({
   sameRepoPipeline: computed('pipeline', {
     get() {
       return this.pipelineService.getSiblingPipeline(this.pipeline.scmRepo.name).then(value =>
-        value.toArray().filter(pipe => pipe.id !== this.pipeline.id).map((pipe, i) => ({
+        value.toArray().filter(pipe => pipe.id !== this.pipeline.id && this.pipeline.scmUri.substring(0, this.pipeline.scmUri.lastIndexOf(':')) === pipe.scmUri.substring(0, pipe.scmUri.lastIndexOf(':'))).map((pipe, i) => ({
           index: i,
           url: `/pipelines/${pipe.id}`,
           branchAndRootDir: pipe.scmRepo.rootDir ? `${pipe.scmRepo.branch}:${pipe.scmRepo.rootDir}` : pipe.scmRepo.branch

--- a/tests/integration/components/pipeline-header/component-test.js
+++ b/tests/integration/components/pipeline-header/component-test.js
@@ -40,6 +40,7 @@ module('Integration | Component | pipeline header', function (hooks) {
       hubUrl: 'http://example.com/batman/batmobile',
       branch: 'master',
       scmContext: 'github:github.com',
+      scmUri: 'github.com:123456:master',
       scmRepo: {
         name: 'batman/batmobile',
         branch: 'master'
@@ -51,20 +52,30 @@ module('Integration | Component | pipeline header', function (hooks) {
         id: 1,
         scmRepo: {
           branch: 'master'
-        }
+        },
+        scmUri: 'github.com:123456:master',
       },
       {
         id: 2,
         scmRepo: {
           branch: 'develop'
-        }
+        },
+        scmUri: 'github.com:123456:develop',
       },
       {
         id: 3,
         scmRepo: {
           branch: 'develop',
           rootDir: 'src'
-        }
+        },
+        scmUri: 'github.com:123456:develop',
+      },
+      {
+        id: 4,
+        scmRepo: {
+          branch: 'develop'
+        },
+        scmUri: 'github.com:654321:develop',
       }
     ];
 


### PR DESCRIPTION
## Context
#962  allows us to switch to a pipeline of the same repository, but sometimes pipelines of other repositories also appear as options for switching to.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
We filter correctly so that pipelines from other repositories do not appear.
The format of `scmUri` is `<SCM>:<repository ID>:<branch>`. We can accurately determine if they are the same repository by comparing the string up to the last `:`.
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/screwdriver/issues/2215
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
