### PR TITLE
fix(2928): move the command/template delete button to right side

### DIFF
--- a/app/components/command-header/component.js
+++ b/app/components/command-header/component.js
@@ -6,6 +6,7 @@ export default Component.extend({
   commandToRemove: null,
   scmUrl: null,
   isRemoving: false,
+  showToggleTrustModal: false,
   store: service(),
   isTrusted: null,
   isLatestVersion: alias('command.latest'),
@@ -36,9 +37,16 @@ export default Component.extend({
         this.set('isRemoving', false);
       });
     },
+    showToggleTrustModal() {
+      this.set('showToggleTrustModal', true);
+    },
+    cancelToggleTrustModal() {
+      this.set('showToggleTrustModal', false);
+    },
     updateTrust(namespace, name, toTrust) {
-      this.set('isTrusted', toTrust);
       this.onUpdateTrust(namespace, name, toTrust);
+      this.set('isTrusted', toTrust);
+      this.set('showToggleTrustModal', false);
     }
   }
 });

--- a/app/components/command-header/styles.scss
+++ b/app/components/command-header/styles.scss
@@ -29,14 +29,12 @@
     vertical-align: middle;
   }
 
-  .trusted-toggle {
-    display: inline-block;
+  .clickable {
+    cursor: pointer;
   }
 
-  .trusted-toggle-label {
-    display: flex;
-    cursor: pointer;
-    font-size: 0.5em;
+  .trusted.distrusted {
+    fill: $sd-text-med;
   }
 
   .command-stats {
@@ -61,10 +59,5 @@
     background-color: #f5f5f5;
     border: 1px solid #ccc;
     border-radius: 4px;
-  }
-
-  .x-toggle-container {
-    font-size: 0.75rem;
-    margin-right: 7px;
   }
 }

--- a/app/components/command-header/styles.scss
+++ b/app/components/command-header/styles.scss
@@ -6,6 +6,18 @@
     list-style: none;
   }
 
+  .header {
+    justify-content: space-between;
+    display: flex;
+
+    .danger {
+      color: $sd-failure;
+    }
+    .danger:hover {
+      text-decoration: none;
+    }
+  }
+
   .back {
     float: right;
   }
@@ -18,10 +30,20 @@
   }
 
   .trusted-toggle {
-    display: inline-flex;
+    display: inline-block;
+  }
+
+  .trusted-toggle-label {
+    display: flex;
     cursor: pointer;
     font-size: 0.5em;
-    float: right;
+  }
+
+  .command-stats {
+    display: flex;
+    justify-content: space-between;
+    margin-top: 20px;
+    margin-bottom: 10px;
   }
 
   .link {

--- a/app/components/command-header/template.hbs
+++ b/app/components/command-header/template.hbs
@@ -1,10 +1,22 @@
 <div class="header">
   <div class="left-header">
     <h1>
-      {{#if this.isTrusted}}
-        <span title="Trusted">
-          {{svg-jar "trusted" class="trusted"}}
-        </span>
+      {{#if this.isAdmin}}
+        {{#if this.isTrusted}}
+          <span title="Trusted" class="clickable" onclick={{action "updateTrust" this.command.namespace this.command.name false}}>
+            {{svg-jar "trusted" class="trusted"}}
+          </span>
+        {{else}}
+          <span title="Trusted" class="clickable" onclick={{action "updateTrust" this.command.namespace this.command.name true}} >
+            {{svg-jar "trusted" class="trusted distrusted"}}
+          </span>
+        {{/if}}
+      {{else}}
+        {{#if this.isTrusted}}
+          <span title="Trusted">
+            {{svg-jar "trusted" class="trusted"}}
+          </span>
+        {{/if}}
       {{/if}}
       <LinkTo
         @route="pipeline"
@@ -33,17 +45,6 @@
         <a href="#" class="danger link" {{action "setCommandToRemove" this.command}}>
           <FaIcon @icon="trash" @title="Delete command" />
         </a>
-        <div class="trusted-toggle">
-          <label class="trusted-toggle-label">
-            <XToggle
-              @size="medium"
-              @theme="light"
-              @value={{this.isTrusted}}
-              @onToggle={{action "updateTrust" this.command.namespace this.command.name}}
-            />
-            <div>Trust?</div>
-          </label>
-        </div>
       {{else}}
         {{#if this.scmUrl}}
           <a href="#" class="danger link" {{action "setCommandToRemove" this.command}}>

--- a/app/components/command-header/template.hbs
+++ b/app/components/command-header/template.hbs
@@ -1,58 +1,71 @@
-<h1>
-  {{#if this.isTrusted}}
-    <span title="Trusted">
-      {{svg-jar "trusted" class="trusted"}}
-    </span>
-  {{/if}}
-  <LinkTo
-    @route="pipeline"
-    @model={{this.command.pipelineId}}
-    @title="Go to command pipeline"
-    class="link"
-  >
-    {{this.command.namespace}}/{{this.command.name}}
-  </LinkTo>
-  {{#if this.scmUrl}}
-    <a href={{this.scmUrl}} class="link">
-      <FaIcon @icon="code-branch" @title="Source code" />
-    </a>
-  {{else}}
-    <FaIcon
-      @icon="code-branch"
-      @title="The pipeline for this command does not exist."
-      class="link"
-    />
-  {{/if}}
-  {{#if this.isAdmin}}
-    <a href="#" class="link" {{action "setCommandToRemove" this.command}}>
-      <FaIcon @icon="trash" @title="Delete command" />
-    </a>
-    <label class="trusted-toggle">
-      <XToggle
-        @size="medium"
-        @theme="light"
-        @value={{this.isTrusted}}
-        @onToggle={{action "updateTrust" this.command.namespace this.command.name}}
-      />
-      Trust?
-    </label>
-  {{else}}
-    {{#if this.scmUrl}}
-      <a href="#" class="link" {{action "setCommandToRemove" this.command}}>
-        <FaIcon @icon="trash" @title="Delete command" />
-      </a>
-    {{else}}
-      <FaIcon
-        @icon="trash"
-        @title="Cannot delete command; pipeline could not be found."
+<div class="header">
+  <div class="left-header">
+    <h1>
+      {{#if this.isTrusted}}
+        <span title="Trusted">
+          {{svg-jar "trusted" class="trusted"}}
+        </span>
+      {{/if}}
+      <LinkTo
+        @route="pipeline"
+        @model={{this.command.pipelineId}}
+        @title="Go to command pipeline"
         class="link"
-      />
-    {{/if}}
-  {{/if}}
-</h1>
-<h2>
-  {{this.command.version}}{{if this.isLatestVersion " - latest"}}
-</h2>
+      >
+        {{this.command.namespace}}/{{this.command.name}}
+      </LinkTo>
+      {{#if this.scmUrl}}
+        <a href={{this.scmUrl}} class="link">
+          <FaIcon @icon="code-branch" @title="Source code" />
+        </a>
+      {{else}}
+        <FaIcon
+          @icon="code-branch"
+          @title="The pipeline for this command does not exist."
+          class="link"
+        />
+      {{/if}}
+    </h1>
+  </div>
+  <div class="right-header">
+    <h1>
+      {{#if this.isAdmin}}
+        <a href="#" class="danger link" {{action "setCommandToRemove" this.command}}>
+          <FaIcon @icon="trash" @title="Delete command" />
+        </a>
+        <div class="trusted-toggle">
+          <label class="trusted-toggle-label">
+            <XToggle
+              @size="medium"
+              @theme="light"
+              @value={{this.isTrusted}}
+              @onToggle={{action "updateTrust" this.command.namespace this.command.name}}
+            />
+            <div>Trust?</div>
+          </label>
+        </div>
+      {{else}}
+        {{#if this.scmUrl}}
+          <a href="#" class="danger link" {{action "setCommandToRemove" this.command}}>
+            <FaIcon @icon="trash" @title="Delete command" />
+          </a>
+        {{else}}
+          <span title="Cannot delete command; pipeline could not be found.">
+            <FaIcon
+              @icon="trash"
+              class="danger link disabled"
+            />
+          </span>
+        {{/if}}
+      {{/if}}
+    </h1>
+  </div>
+</div>
+<div class="command-stats">
+  <h2>
+    {{this.command.version}}{{if this.isLatestVersion " - latest"}}
+  </h2>
+</div>
 <p>
   {{this.command.description}}
 </p>

--- a/app/components/command-header/template.hbs
+++ b/app/components/command-header/template.hbs
@@ -2,15 +2,13 @@
   <div class="left-header">
     <h1>
       {{#if this.isAdmin}}
-        {{#if this.isTrusted}}
-          <span title="Trusted" class="clickable" onclick={{action "updateTrust" this.command.namespace this.command.name false}}>
+        <span title="Toggle command trusted" class="clickable" onclick={{action "showToggleTrustModal"}}>
+          {{#if this.isTrusted}}
             {{svg-jar "trusted" class="trusted"}}
-          </span>
-        {{else}}
-          <span title="Trusted" class="clickable" onclick={{action "updateTrust" this.command.namespace this.command.name true}} >
+          {{else}}
             {{svg-jar "trusted" class="trusted distrusted"}}
-          </span>
-        {{/if}}
+          {{/if}}
+        </span>
       {{else}}
         {{#if this.isTrusted}}
           <span title="Trusted">
@@ -130,4 +128,18 @@
       </modal.footer>
     </BsModal>
   {{/if}}
+{{/if}}
+{{#if this.showToggleTrustModal}}
+  <BsModalSimple
+    @title="Confirm command trusted"
+    @closeTitle="Cancel"
+    @submitTitle="Confirm"
+    @submitButtonType="primary"
+    @size={{null}}
+    @fade={{true}}
+    @onSubmit={{action "updateTrust" this.command.namespace this.command.name (not this.isTrusted)}}
+    @onHide={{action "cancelToggleTrustModal"}}
+  >
+    Set {{this.command.namespace}}/{{this.command.name}} command to {{if this.isTrusted "Distrusted" "Trusted"}}.
+  </BsModalSimple>
 {{/if}}

--- a/app/components/command-header/template.hbs
+++ b/app/components/command-header/template.hbs
@@ -41,23 +41,17 @@
   </div>
   <div class="right-header">
     <h1>
-      {{#if this.isAdmin}}
+      {{#if (or this.isAdmin this.scmUrl)}}
         <a href="#" class="danger link" {{action "setCommandToRemove" this.command}}>
           <FaIcon @icon="trash" @title="Delete command" />
         </a>
       {{else}}
-        {{#if this.scmUrl}}
-          <a href="#" class="danger link" {{action "setCommandToRemove" this.command}}>
-            <FaIcon @icon="trash" @title="Delete command" />
-          </a>
-        {{else}}
-          <span title="Cannot delete command; pipeline could not be found.">
-            <FaIcon
-              @icon="trash"
-              class="danger link disabled"
-            />
-          </span>
-        {{/if}}
+        <span title="Cannot delete command; pipeline could not be found.">
+          <FaIcon
+            @icon="trash"
+            class="danger link disabled"
+          />
+        </span>
       {{/if}}
     </h1>
   </div>

--- a/app/components/template-header/component.js
+++ b/app/components/template-header/component.js
@@ -5,6 +5,7 @@ export default Component.extend({
   templateToRemove: null,
   scmUrl: null,
   isRemoving: false,
+  showToggleTrustModal: false,
   store: service(),
   isTrusted: null,
   init() {
@@ -35,9 +36,16 @@ export default Component.extend({
         this.set('isRemoving', false);
       });
     },
+    showToggleTrustModal() {
+      this.set('showToggleTrustModal', true);
+    },
+    cancelToggleTrustModal() {
+      this.set('showToggleTrustModal', false);
+    },
     updateTrust(fullName, toTrust) {
-      this.set('isTrusted', toTrust);
       this.onUpdateTrust(fullName, toTrust);
+      this.set('isTrusted', toTrust);
+      this.set('showToggleTrustModal', false);
     }
   }
 });

--- a/app/components/template-header/styles.scss
+++ b/app/components/template-header/styles.scss
@@ -1,4 +1,16 @@
 & {
+  .header {
+    justify-content: space-between;
+    display: flex;
+
+    .danger {
+      color: $sd-failure;
+    }
+    .danger:hover {
+      text-decoration: none;
+    }
+  }
+
   .template-label {
     margin: 0 5px;
     padding: 3px 5px;
@@ -46,10 +58,13 @@
   }
 
   .trusted-toggle {
-    display: inline-flex;
+    display: inline-block;
+  }
+
+  .trusted-toggle-label {
+    display: flex;
     cursor: pointer;
     font-size: 0.5em;
-    float: right;
   }
 
   .link {

--- a/app/components/template-header/styles.scss
+++ b/app/components/template-header/styles.scss
@@ -57,14 +57,12 @@
     vertical-align: middle;
   }
 
-  .trusted-toggle {
-    display: inline-block;
+  .clickable {
+    cursor: pointer;
   }
 
-  .trusted-toggle-label {
-    display: flex;
-    cursor: pointer;
-    font-size: 0.5em;
+  .trusted.distrusted {
+    fill: $sd-text-med;
   }
 
   .link {
@@ -82,10 +80,5 @@
     background-color: #f5f5f5;
     border: 1px solid #ccc;
     border-radius: 4px;
-  }
-
-  .x-toggle-container {
-    font-size: 0.75rem;
-    margin-right: 7px;
   }
 }

--- a/app/components/template-header/template.hbs
+++ b/app/components/template-header/template.hbs
@@ -1,62 +1,72 @@
-<h1>
-  {{#if this.isTrusted}}
-    <span title="Trusted">
-      {{svg-jar "trusted" class="trusted"}}
-    </span>
-  {{/if}}
-  <LinkTo
-    @route="pipeline"
-    @model={{this.template.pipelineId}}
-    @title="Go to template pipeline"
-    class="link"
-  >
-    {{this.template.fullName}}
-  </LinkTo>
-  {{#if this.scmUrl}}
-    <a href={{this.scmUrl}} class="link">
-      <FaIcon @icon="code-branch" @title="Source code" />
-    </a>
-  {{else}}
-    <FaIcon
-      @icon="code-branch"
-      @title="The pipeline for this template does not exist."
-      class="link"
-    />
-  {{/if}}
-  {{#if this.isAdmin}}
-    <a href="#" class="link" {{action "setTemplateToRemove" this.template}}>
-      <FaIcon @icon="trash" @title="Delete template" />
-    </a>
-    <label class="trusted-toggle">
-      <XToggle
-        @size="medium"
-        @theme="light"
-        @value={{this.isTrusted}}
-        @onToggle={{action "updateTrust" this.template.fullName}}
-      />
-      Trust?
-    </label>
-  {{else}}
-    {{#if this.scmUrl}}
-      <a href="#" class="link" {{action "setTemplateToRemove" this.template}}>
-        <FaIcon @icon="trash" @title="Delete template" />
-      </a>
-    {{else}}
-      <FaIcon
-        @icon="trash"
-        @title="Cannot delete template; pipeline could not be found."
+<div class="header">
+  <div class="left-header">
+    <h1>
+      {{#if this.isTrusted}}
+        <span title="Trusted">
+          {{svg-jar "trusted" class="trusted"}}
+        </span>
+      {{/if}}
+      <LinkTo
+        @route="pipeline"
+        @model={{this.template.pipelineId}}
+        @title="Go to template pipeline"
         class="link"
-      />
-    {{/if}}
-  {{/if}}
-</h1>
+      >
+        {{this.template.fullName}}
+      </LinkTo>
+      {{#if this.scmUrl}}
+        <a href={{this.scmUrl}} class="link">
+          <FaIcon @icon="code-branch" @title="Source code" />
+        </a>
+      {{else}}
+        <FaIcon
+          @icon="code-branch"
+          @title="The pipeline for this template does not exist."
+          class="link"
+        />
+      {{/if}}
+    </h1>
+  </div>
+  <div class="right-header">
+    <h1>
+      {{#if this.isAdmin}}
+        <a href="#" class="danger link" {{action "setTemplateToRemove" this.template}}>
+          <FaIcon @icon="trash" @title="Delete template" />
+        </a>
+        <div class="trusted-toggle">
+          <label class="trusted-toggle-label">
+            <XToggle
+              @size="medium"
+              @theme="light"
+              @value={{this.isTrusted}}
+              @onToggle={{action "updateTrust" this.template.fullName}}
+            />
+            <div>Trust?</div>
+          </label>
+        </div>
+      {{else}}
+        {{#if this.scmUrl}}
+          <a href="#" class="danger link" disabled {{action "setTemplateToRemove" this.template}}>
+            <FaIcon @icon="trash" @title="Delete template" />
+          </a>
+        {{else}}
+          <span title="Cannot delete template; pipeline could not be found.">
+            <FaIcon
+              @icon="trash"
+              class="danger link disabled"
+            />
+          </span>
+        {{/if}}
+      {{/if}}
+    </h1>
+  </div>
+</div>
 <div class="template-stats">
   <h2 class="template-version">
     {{this.template.version}}
   </h2>
   <div class="template-metrics">
-    Usage - Jobs: {{this.template.metrics.jobs.count
-    }} | Builds: {{this.template.metrics.builds.count}}
+    Usage - Jobs: {{this.template.metrics.jobs.count}} | Builds: {{this.template.metrics.builds.count}}
   </div>
 </div>
 <p>

--- a/app/components/template-header/template.hbs
+++ b/app/components/template-header/template.hbs
@@ -1,10 +1,22 @@
 <div class="header">
   <div class="left-header">
     <h1>
-      {{#if this.isTrusted}}
-        <span title="Trusted">
-          {{svg-jar "trusted" class="trusted"}}
-        </span>
+      {{#if this.isAdmin}}
+        {{#if this.isTrusted}}
+          <span title="Trusted" class="clickable" onclick={{action "updateTrust" this.template.fullName false}} >
+            {{svg-jar "trusted" class="trusted"}}
+          </span>
+        {{else}}
+          <span title="Trusted" class="clickable" onclick={{action "updateTrust" this.template.fullName true}} >
+            {{svg-jar "trusted" class="trusted distrusted"}}
+          </span>
+        {{/if}}
+      {{else}}
+        {{#if this.isTrusted}}
+          <span title="Trusted">
+            {{svg-jar "trusted" class="trusted"}}
+          </span>
+        {{/if}}
       {{/if}}
       <LinkTo
         @route="pipeline"
@@ -29,34 +41,17 @@
   </div>
   <div class="right-header">
     <h1>
-      {{#if this.isAdmin}}
-        <a href="#" class="danger link" {{action "setTemplateToRemove" this.template}}>
+      {{#if (or this.isAdmin this.scmUrl)}}
+        <a href="#" class="danger link" disabled {{action "setTemplateToRemove" this.template}}>
           <FaIcon @icon="trash" @title="Delete template" />
         </a>
-        <div class="trusted-toggle">
-          <label class="trusted-toggle-label">
-            <XToggle
-              @size="medium"
-              @theme="light"
-              @value={{this.isTrusted}}
-              @onToggle={{action "updateTrust" this.template.fullName}}
-            />
-            <div>Trust?</div>
-          </label>
-        </div>
       {{else}}
-        {{#if this.scmUrl}}
-          <a href="#" class="danger link" disabled {{action "setTemplateToRemove" this.template}}>
-            <FaIcon @icon="trash" @title="Delete template" />
-          </a>
-        {{else}}
-          <span title="Cannot delete template; pipeline could not be found.">
-            <FaIcon
-              @icon="trash"
-              class="danger link disabled"
-            />
-          </span>
-        {{/if}}
+        <span title="Cannot delete template; pipeline could not be found.">
+          <FaIcon
+            @icon="trash"
+            class="danger link disabled"
+          />
+        </span>
       {{/if}}
     </h1>
   </div>

--- a/app/components/template-header/template.hbs
+++ b/app/components/template-header/template.hbs
@@ -2,15 +2,13 @@
   <div class="left-header">
     <h1>
       {{#if this.isAdmin}}
-        {{#if this.isTrusted}}
-          <span title="Trusted" class="clickable" onclick={{action "updateTrust" this.template.fullName false}} >
+        <span title="Toggle template trusted" class="clickable" onclick={{action "showToggleTrustModal"}}>
+          {{#if this.isTrusted}}
             {{svg-jar "trusted" class="trusted"}}
-          </span>
-        {{else}}
-          <span title="Trusted" class="clickable" onclick={{action "updateTrust" this.template.fullName true}} >
+          {{else}}
             {{svg-jar "trusted" class="trusted distrusted"}}
-          </span>
-        {{/if}}
+          {{/if}}
+        </span>
       {{else}}
         {{#if this.isTrusted}}
           <span title="Trusted">
@@ -157,4 +155,18 @@
       </modal.footer>
     </BsModal>
   {{/if}}
+{{/if}}
+{{#if this.showToggleTrustModal}}
+  <BsModalSimple
+    @title="Confirm template trusted"
+    @closeTitle="Cancel"
+    @submitTitle="Confirm"
+    @submitButtonType="primary"
+    @size={{null}}
+    @fade={{true}}
+    @onSubmit={{action "updateTrust" this.template.fullName (not this.isTrusted)}}
+    @onHide={{action "cancelToggleTrustModal"}}
+  >
+    Set {{this.template.fullName}} template to {{if this.isTrusted "Distrusted" "Trusted"}}.
+  </BsModalSimple>
 {{/if}}

--- a/app/components/template-version-list-actions-cell/template.hbs
+++ b/app/components/template-version-list-actions-cell/template.hbs
@@ -7,6 +7,7 @@
       title="Confirm deletion"
       closeTitle="Cancel"
       submitTitle="Confirm"
+      submitButtonType="danger"
       size=null
       fade=false
       onSubmit=(action "deleteVersion")

--- a/tests/integration/components/command-header/component-test.js
+++ b/tests/integration/components/command-header/component-test.js
@@ -61,6 +61,6 @@ module('Integration | Component | command header', function (hooks) {
     this.set('isAdmin', true);
 
     assert.dom('svg').exists({ count: 3 });
-    assert.dom('.x-toggle-component').exists({ count: 1 });
+    assert.dom('.clickable .trusted').exists({ count: 1 });
   });
 });

--- a/tests/integration/components/command-header/component-test.js
+++ b/tests/integration/components/command-header/component-test.js
@@ -47,7 +47,8 @@ module('Integration | Component | command header', function (hooks) {
       hbs`<CommandHeader @command={{this.mock}} @trusted={{this.trusted}} @isAdmin={{this.isAdmin}} />`
     );
 
-    assert.dom('h1').hasText('foo/bar Source code Delete command');
+    assert.dom('.header .left-header h1').hasText('foo/bar Source code');
+    assert.dom('.header .right-header h1').hasText('Delete command');
     assert.dom('h2').hasText('1.0.0');
     assert.dom('p').hasText('A test example');
     assert.dom('ul li:first-child').hasText('Released by: test@example.com');

--- a/tests/integration/components/template-header/component-test.js
+++ b/tests/integration/components/template-header/component-test.js
@@ -56,7 +56,8 @@ module('Integration | Component | template header', function (hooks) {
       hbs`<TemplateHeader @template={{this.mock}} @trusted={{this.trusted}} @isAdmin={{this.isAdmin}} />`
     );
 
-    assert.dom('h1').hasText('foo/bar Source code Delete template');
+    assert.dom('.header .left-header h1').hasText('foo/bar Source code');
+    assert.dom('.header .right-header h1').hasText('Delete template');
     assert.dom('h2').hasText('2.0.0');
     assert.dom('p').hasText('A test example');
     assert.dom('#template-namespace').hasText('Namespace: foo');

--- a/tests/integration/components/template-header/component-test.js
+++ b/tests/integration/components/template-header/component-test.js
@@ -73,6 +73,6 @@ module('Integration | Component | template header', function (hooks) {
     this.set('isAdmin', true);
 
     assert.dom('svg').exists({ count: 3 });
-    assert.dom('.x-toggle-component').exists({ count: 1 });
+    assert.dom('.clickable .trusted').exists({ count: 1 });
   });
 });

--- a/tests/integration/components/template-versions/component-test.js
+++ b/tests/integration/components/template-versions/component-test.js
@@ -189,10 +189,10 @@ module('Integration | Component | template versions', function (hooks) {
         'You\'re about to delete the version "1.0.0". This action cannot be undone. Are you sure?'
       );
     assert
-      .dom('.modal-dialog .modal-content .modal-footer button.btn-primary')
+      .dom('.modal-dialog .modal-content .modal-footer button.btn-danger')
       .hasText('Confirm');
     await click(
-      '.modal-dialog .modal-content .modal-footer button.btn-primary'
+      '.modal-dialog .modal-content .modal-footer button.btn-danger'
     );
   });
 });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Users might mistakenly click the command/template delete button when they actually intend to click the repository link.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

This PR will move the command/template delete button to the right side and merge the trusted toggle button with the trusted icon.

### SD admin's view

![admin-after](https://github.com/screwdriver-cd/ui/assets/43719835/21c247e5-b9f8-4e2d-9f26-fba41320da3a)

SD admin can toggle trusted as below:

https://github.com/screwdriver-cd/ui/assets/43719835/06f3b1cb-5d42-4c17-940f-27976bb4b45c

### User's view

Distrusted icon does not appear in user's view.

![user-after](https://github.com/screwdriver-cd/ui/assets/43719835/0780b570-b13e-4aa8-86ca-093d5fc53e5b)

If the repository does not exist, the delete button will be disabled.
![user-after-without-repo](https://github.com/screwdriver-cd/ui/assets/43719835/1858d5b7-527f-4a06-9b1f-678ba832edab)

The color of the confirm button on the specific version template deletion modal is set to red.
![confirm](https://github.com/screwdriver-cd/ui/assets/43719835/b1604214-388e-48f8-825a-576f6e5b8dbf)

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

Issue
https://github.com/screwdriver-cd/screwdriver/issues/2928

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
