### PR TITLE
fix:(2215): fix issue of moving between pipelines in the same branch (rootDir)

### DIFF
--- a/app/components/pipeline-header/component.js
+++ b/app/components/pipeline-header/component.js
@@ -28,8 +28,9 @@ export default Component.extend({
   }),
   sameRepoPipeline: computed('pipeline', {
     get() {
+      const repositoryUri = this.pipeline.scmUri.substring(0,this.pipeline.scmUri.indexOf(':', this.pipeline.scmUri.indexOf(':') + 1))
       return this.pipelineService.getSiblingPipeline(this.pipeline.scmRepo.name).then(value =>
-        value.toArray().filter(pipe => pipe.id !== this.pipeline.id && this.pipeline.scmUri.substring(0, this.pipeline.scmUri.lastIndexOf(':')) === pipe.scmUri.substring(0, pipe.scmUri.lastIndexOf(':'))).map((pipe, i) => ({
+        value.toArray().filter(pipe => pipe.id !== this.pipeline.id && repositoryUri === pipe.scmUri.substring(0,pipe.scmUri.indexOf(':', pipe.scmUri.indexOf(':') + 1))).map((pipe, i) => ({
           index: i,
           url: `/pipelines/${pipe.id}`,
           branchAndRootDir: pipe.scmRepo.rootDir ? `${pipe.scmRepo.branch}:${pipe.scmRepo.rootDir}` : pipe.scmRepo.branch

--- a/app/components/pipeline-header/component.js
+++ b/app/components/pipeline-header/component.js
@@ -28,9 +28,12 @@ export default Component.extend({
   }),
   sameRepoPipeline: computed('pipeline', {
     get() {
-      const repositoryUri = this.pipeline.scmUri.substring(0,this.pipeline.scmUri.indexOf(':', this.pipeline.scmUri.indexOf(':') + 1))
+      const [scm, repositoryId] = this.pipeline.scmUri.split(':');
       return this.pipelineService.getSiblingPipeline(this.pipeline.scmRepo.name).then(value =>
-        value.toArray().filter(pipe => pipe.id !== this.pipeline.id && repositoryUri === pipe.scmUri.substring(0,pipe.scmUri.indexOf(':', pipe.scmUri.indexOf(':') + 1))).map((pipe, i) => ({
+        value.toArray().filter(pipe => {
+          const [s, r] = pipe.scmUri.split(':');
+          return pipe.id !== this.pipeline.id && scm === s && repositoryId === r;
+        }).map((pipe, i) => ({
           index: i,
           url: `/pipelines/${pipe.id}`,
           branchAndRootDir: pipe.scmRepo.rootDir ? `${pipe.scmRepo.branch}:${pipe.scmRepo.rootDir}` : pipe.scmRepo.branch

--- a/tests/integration/components/pipeline-header/component-test.js
+++ b/tests/integration/components/pipeline-header/component-test.js
@@ -68,7 +68,7 @@ module('Integration | Component | pipeline header', function (hooks) {
           branch: 'develop',
           rootDir: 'src'
         },
-        scmUri: 'github.com:123456:develop',
+        scmUri: 'github.com:123456:develop:src',
       },
       {
         id: 4,


### PR DESCRIPTION
## Context
In #964, we made sure to verify if each of the pipeline options for a switch was of the same repository. However, this has caused improper functioning when root directory is set.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
We have ensured correct operation even when root directory is set. In cases where the root directory is set, the format of `scmUri` is `<SCM>:<repository ID>:<branch>:<rootDir>`, so we decided to compare up to the second `:`.
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/screwdriver/issues/2215
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
