### PR TITLE
fix(2954): Modify Artifact preview

### DIFF
--- a/app/components/artifact-preview/style.scss
+++ b/app/components/artifact-preview/style.scss
@@ -1,0 +1,6 @@
+& {
+  iframe {
+    width: 100%;
+    height: calc(90vh - 2rem);
+  }
+}

--- a/app/components/artifact-preview/template.hbs
+++ b/app/components/artifact-preview/template.hbs
@@ -7,13 +7,13 @@
     Download
   </BsButton>
   {{#if this.iframeUrl}}
-    <iframe id={{this.iframeId}} src={{this.iframeUrl}} width="100%" height="625px">
+    <iframe id={{this.iframeId}} src={{this.iframeUrl}}>
       <h4>
         Alternative content for browsers which do not support iframe.
       </h4>
     </iframe>
   {{else}}
-    <iframe id={{this.iframeId}} src="about:blank" width="100%" height="625px">
+    <iframe id={{this.iframeId}} src="about:blank">
       <h4>
         Alternative content for browsers which do not support iframe.
       </h4>

--- a/app/components/artifact-tree-content/style.scss
+++ b/app/components/artifact-tree-content/style.scss
@@ -1,3 +1,7 @@
+& {
+  min-width: max-content;
+}
+
 a,
 a:hover,
 a:visited {

--- a/app/components/build-step-collection/styles.scss
+++ b/app/components/build-step-collection/styles.scss
@@ -17,6 +17,10 @@
     padding: 10px;
   }
 
+  .tab-content {
+    overflow: scroll;
+  }
+
   ul {
     list-style: none;
     padding: 0;


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Modify the Artifact preview page layout.

Before:
- There is a blank space under the artifact preview window.
- Artifact tree cannot scroll horizontally. Because of this, deep directory paths or long file names are cutoff.
<img width="1501" alt="before_artifact_preview" src="https://github.com/screwdriver-cd/ui/assets/8113204/ea47557e-78e7-42c9-8539-c1d18caf6866">


After:
<img width="1512" alt="after_artifact_preview_2" src="https://github.com/screwdriver-cd/ui/assets/8113204/ca41eaca-8f3f-46f7-a8fa-891865066e0b">



## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Set proper properties on artifact preview iframe and artifact-tree-content.


## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/2954

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
