### PR TITLE
fix: warning not set on direct build page load

### DIFF
--- a/app/pipeline/build/route.js
+++ b/app/pipeline/build/route.js
@@ -16,12 +16,18 @@ export default Route.extend({
       all([
         this.store.findRecord('job', build.get('jobId')),
         this.store.findRecord('event', build.get('eventId'))
-      ]).then(([job, event]) => ({
-        build,
-        job,
-        event,
-        pipeline: this.pipeline
-      }))
+      ]).then(([job, event]) => {
+        if (build?.meta?.build?.warning && build.status === 'SUCCESS') {
+          build.status = 'WARNING';
+        }
+
+        return {
+          build,
+          job,
+          event,
+          pipeline: this.pipeline
+        };
+      })
     );
   },
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
When using build.warning and directly transitioning to a build where the UI display is Warning, it seems that the build details screen does not turn into Warning.
## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
build warning should be set on direct load to build page
## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/2949
## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
