### PR TITLE
fix(2924): Adjust font size in workflow to prevent text overflow

### DIFF
--- a/app/components/workflow-graph-d3/component.js
+++ b/app/components/workflow-graph-d3/component.js
@@ -348,6 +348,15 @@ export default Component.extend({
           return 'graph-label';
         })
         .attr('font-size', `${TITLE_SIZE}px`)
+        .each(function () {
+          const text = d3.select(this);
+          const textWidth = text.node().getBBox().width;
+          const maxWidth = X_WIDTH - EDGE_GAP / 2;
+          if (textWidth > maxWidth) {
+            const fontSize = TITLE_SIZE * maxWidth / textWidth; // calculate the new font-size based on the maximum width
+            text.style("font-size", fontSize + "px");
+          }
+        })
         .style('text-anchor', 'middle')
         .attr('x', d => calcXCenter(d.pos.x))
         .attr(


### PR DESCRIPTION
## Context
With jobs that include a large number of wide-width characters, the text overflows in the workflow graph.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->
<img width="298" alt="Q7" src="https://github.com/screwdriver-cd/ui/assets/22903716/d728e789-524a-44d2-b1eb-9af80e56840c">

## Objective
We reduce the font size when overflowing.
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/screwdriver/issues/2924
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
