### PR TITLE
fix: open app-header links in a new tab

### DIFF
--- a/app/components/app-header/template.hbs
+++ b/app/components/app-header/template.hbs
@@ -3,7 +3,7 @@
     <LinkTo @route="home" class="logo navbar-brand" title="Screwdriver Home">
       {{svg-jar "Screwdriver_Logo_FullWhite" class="img"}}
     </LinkTo>
-   <navbar.toggle/>
+    <navbar.toggle/>
   </div>
   <navbar.content>
     <navbar.nav class="mr-auto" as |nav|>
@@ -100,6 +100,7 @@
                 href={{this.docUrl}}
                 class="dropdown-item icon docs"
                 title="Documentation and Contact"
+                target="_blank"
               >
                 {{svg-jar "file-text" class="img"}}
                 <span>
@@ -117,19 +118,19 @@
             </ddm.item>
             {{ddm.divider}}
             <ddm.item>
-              <a href="http://blog.screwdriver.cd" class="icon blog dropdown-item">
+              <a href="http://blog.screwdriver.cd" target="_blank" class="icon blog dropdown-item">
                 {{svg-jar "tumblr" class="img"}}
                   Blog
               </a>
             </ddm.item>
             <ddm.item>
-              <a href={{this.slackUrl}} class="icon community dropdown-item">
+              <a href={{this.slackUrl}} target="_blank" class="icon community dropdown-item">
                 {{svg-jar "slack" class="img"}}
                   Slack Workspace
               </a>
             </ddm.item>
             <ddm.item>
-              <a href="https://github.com/screwdriver-cd" class="icon github dropdown-item">
+              <a href="https://github.com/screwdriver-cd" target="_blank" class="icon github dropdown-item">
                 {{svg-jar "github" class="img"}}
                   GitHub
               </a>


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Currently, app-header links open in the same tab, which might be inconvenient.

![header](https://github.com/screwdriver-cd/ui/assets/43719835/7efc34bf-33c3-49a6-98fd-47e10744a837)

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Open app-header links in a new tab.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
