### PR TITLE
fix(2215): sort same repository pipeline links

### DIFF
--- a/app/components/pipeline-header/component.js
+++ b/app/components/pipeline-header/component.js
@@ -37,7 +37,7 @@ export default Component.extend({
           index: i,
           url: `/pipelines/${pipe.id}`,
           branchAndRootDir: pipe.scmRepo.rootDir ? `${pipe.scmRepo.branch}:${pipe.scmRepo.rootDir}` : pipe.scmRepo.branch
-        }))
+        })).sort((l, r) => l.branchAndRootDir.localeCompare(r.branchAndRootDir))
       );
     }
   }),

--- a/tests/integration/components/pipeline-header/component-test.js
+++ b/tests/integration/components/pipeline-header/component-test.js
@@ -58,25 +58,41 @@ module('Integration | Component | pipeline header', function (hooks) {
       {
         id: 2,
         scmRepo: {
-          branch: 'develop'
+          branch: 'efg'
         },
-        scmUri: 'github.com:123456:develop',
+        scmUri: 'github.com:123456:efg',
       },
       {
         id: 3,
         scmRepo: {
-          branch: 'develop',
+          branch: 'efg',
           rootDir: 'src'
         },
-        scmUri: 'github.com:123456:develop:src',
+        scmUri: 'github.com:123456:efg:src',
       },
       {
         id: 4,
         scmRepo: {
-          branch: 'develop'
+          branch: 'abc',
+          rootDir: 'zzz'
         },
-        scmUri: 'github.com:654321:develop',
-      }
+        scmUri: 'github.com:123456:abc:zzz',
+      },
+      {
+        id: 5,
+        scmRepo: {
+          branch: 'abc',
+          rootDir: 'aaa'
+        },
+        scmUri: 'github.com:123456:abc:aaa',
+      },
+      {
+        id: 6,
+        scmRepo: {
+          branch: 'abc'
+        },
+        scmUri: 'github.com:654321:abc',
+      },
     ];
 
     const pipelineStub = Service.extend({
@@ -95,7 +111,11 @@ module('Integration | Component | pipeline header', function (hooks) {
 
     await click('span.branch');
 
-    assert.dom('li.branch-item').exists({ count: 2 });
+    assert.dom('li.branch-item').exists({ count: 4 });
+    assert.dom('li.branch-item:nth-child(1)').hasText('link abc:aaa');
+    assert.dom('li.branch-item:nth-child(2)').hasText('link abc:zzz');
+    assert.dom('li.branch-item:nth-child(3)').hasText('link efg');
+    assert.dom('li.branch-item:nth-child(4)').hasText('link efg:src');
   });
 
   test('it renders link to parent pipeline for child pipeline', async function (assert) {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

https://github.com/screwdriver-cd/ui/pull/962 adds links for pipelines from the same repository, but they are not sorted.
This makes it difficult to easily find the branch names in this list.

![links](https://github.com/screwdriver-cd/ui/assets/43719835/f2d351af-ad39-49c3-ad7b-7b12a4f9ee68)

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Sort same repository pipeline links by their names.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

- https://github.com/screwdriver-cd/screwdriver/issues/2215

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
