### PR TITLE
fix(2862): Call API twice for header and metrics

### DIFF
--- a/app/templates/detail/route.js
+++ b/app/templates/detail/route.js
@@ -33,33 +33,28 @@ export default Route.extend({
 
     const { startTime, endTime, fetchAll, fetchFiltered } = this;
 
-    let query = {};
-
-    if (startTime) {
-      query = {
-        startTime,
-        endTime
-      };
-    }
-
     return RSVP.all([
+      fetchAll
+        ? this.template.getOneTemplateWithMetrics(
+            `${params.namespace}/${params.name}`
+          )
+        : RSVP.resolve(this.templateData),
       fetchAll || fetchFiltered
         ? this.template.getOneTemplateWithMetrics(
             `${params.namespace}/${params.name}`,
-            query
+            {
+              startTime,
+              endTime
+            }
           )
         : RSVP.resolve(this.templateDataFiltered),
       fetchAll
         ? this.template.getTemplateTags(params.namespace, params.name)
         : this.templateTagData
     ]).then(arr => {
-      let [templateDataFiltered, templateTagData] = arr;
+      let [templateData, templateDataFiltered, templateTagData] = arr;
 
-      // templateData is a property for displaying aggregate values for 1 year in template-header.
-      // It should not be updated when the time range is changed.
-      const templateData = this.controller?.templates
-        ? this.controller.templates
-        : templateDataFiltered.filter(t => t.namespace === params.namespace);
+      templateData = templateData.filter(t => t.namespace === params.namespace);
 
       if (templateData.length === 0) {
         this.router.transitionTo('/404');


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
In the template detail page, we'd like to show 1 year metrics for each template version and all time count for jobs/builds in the template header.
https://github.com/screwdriver-cd/screwdriver/issues/2862#issuecomment-1841355144
So that we show above information, we have to call API twice.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Separate API call for metrics for each template versions and the count for jobs/builds in the template header.
Revert a part of the past PR.
https://github.com/screwdriver-cd/ui/pull/961

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/2862

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
