### PR TITLE
feat: show compatibilities for clouds and arches on templates and commands pages

### DIFF
--- a/app/components/command-header/template.hbs
+++ b/app/components/command-header/template.hbs
@@ -69,6 +69,24 @@
       {{this.command.maintainer}}
     </a>
   </li>
+  {{#if this.command.compatibilities}}
+    {{#if this.command.compatibilities.clouds.length}}
+    <li>
+      Supported Clouds: 
+      {{#each this.command.compatibilities.clouds as |cloud|}}
+        <span>{{cloud}}</span>
+      {{/each}}
+    </li>
+    {{/if}}
+    {{#if this.command.compatibilities.architectures.length}}
+    <li>
+      Supported Arches:
+      {{#each this.command.compatibilities.architectures as |arch|}}
+        <span>{{arch}}</span>
+      {{/each}}
+    </li>
+    {{/if}}
+  {{/if}}
   {{#if this.command.lastUpdated}}
     <li>
       Last published: {{this.command.lastUpdated}}

--- a/app/components/template-header/template.hbs
+++ b/app/components/template-header/template.hbs
@@ -93,6 +93,38 @@
     </a>
   </div>
 </div>
+{{#if this.template.compatibilities}}
+  {{#if this.template.compatibilities.clouds.length}}
+  <div class="template-details--item" id="template-compatibilities">
+    <div class="template-details--label">
+      Supported Clouds:
+    </div>
+    <div class="template-details--value">
+      {{#each this.template.compatibilities.clouds as |cloud|}}
+        <span class="template-label">
+          {{cloud}}
+        </span>
+      {{/each}}
+    </div>
+  </div>
+  {{/if}}
+
+  {{#if this.template.compatibilities.architectures.length}}
+  <div class="template-details--item" id="template-compatibilities">
+    <div class="template-details--label">
+      Supported Arches:
+    </div>
+    <div class="template-details--value">
+      {{#each this.template.compatibilities.architectures as |arch|}}
+        <span class="template-label">
+          {{arch}}
+        </span>
+      {{/each}}
+    </div>
+  </div>
+  {{/if}}
+{{/if}}
+
 {{#if this.template.labels.length}}
   <div class="template-details--item" id="template-tags">
     <div class="template-details--label">

--- a/app/components/template-header/template.hbs
+++ b/app/components/template-header/template.hbs
@@ -101,14 +101,11 @@
     </div>
     <div class="template-details--value">
       {{#each this.template.compatibilities.clouds as |cloud|}}
-        <span class="template-label">
-          {{cloud}}
-        </span>
+        <span>{{cloud}}</span>
       {{/each}}
     </div>
   </div>
   {{/if}}
-
   {{#if this.template.compatibilities.architectures.length}}
   <div class="template-details--item" id="template-compatibilities">
     <div class="template-details--label">
@@ -116,9 +113,7 @@
     </div>
     <div class="template-details--value">
       {{#each this.template.compatibilities.architectures as |arch|}}
-        <span class="template-label">
-          {{arch}}
-        </span>
+        <span>{{arch}}</span>
       {{/each}}
     </div>
   </div>


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Add UI to show compatibilities for Template:
![image](https://github.com/screwdriver-cd/ui/assets/15989893/06fe2cbb-739d-4d41-a86b-7424e5721408)


and for commands:
![image](https://github.com/screwdriver-cd/ui/assets/15989893/14ac7304-888c-4d00-a3b6-2eb97a6b599a)



## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
