### PR TITLE
fix: sanitize user input before displaying info message

### DIFF
--- a/app/components/info-message/component.js
+++ b/app/components/info-message/component.js
@@ -1,7 +1,14 @@
 import Component from '@ember/component';
+import { computed } from '@ember/object';
+import { sanitizeString } from 'screwdriver-ui/helpers/sanitize-string';
 
 export default Component.extend({
   type: 'info',
+  sanitizedMessgae: computed('message', {
+    get() {
+      return sanitizeString(this.message);
+    }
+  }),
   actions: {
     clearMessage: function clearMessage() {
       this.set('message', null);

--- a/app/components/info-message/template.hbs
+++ b/app/components/info-message/template.hbs
@@ -9,7 +9,7 @@
         {{! template-lint-disable no-triple-curlies }}
         <FaIcon @icon={{@icon}} />
         <span>
-          {{{@message}}} Please login to
+          {{{this.sanitizedMessgae}}} Please login to
         </span>
 
         <a href="#authenticate" {{action "authenticate" @scmContext}}>
@@ -18,14 +18,14 @@
       {{else}}
         <FaIcon @icon={{@icon}} />
         <span>
-          {{{@message}}}
+          {{{this.sanitizedMessgae}}}
         </span>
       {{/if}}
     {{else}}
       {{! template-lint-disable no-triple-curlies }}
       <FaIcon @icon={{@icon}} />
       <span>
-        {{{@message}}}
+        {{{this.sanitizedMessgae}}}
       </span>
     {{/if}}
   </BsAlert>

--- a/app/helpers/sanitize-string.js
+++ b/app/helpers/sanitize-string.js
@@ -1,0 +1,25 @@
+import { helper } from '@ember/component/helper';
+import { htmlSafe } from '@ember/template';
+
+/**
+ * Sanitizes given string
+ * @method sanitizeString
+ * @param  {String}  string  String to be sanitized
+ * @return {String}          Sanitized string
+ */
+export function sanitizeString(string) {
+  const escape = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;',
+    '/': '&#x2F;',
+    '`': '&#x60;',
+    '=': '&#x3D;'
+  };
+
+  return htmlSafe(string.replace(/[&<>"'`=/]/g, match => escape[match]));
+}
+
+export default helper(sanitizeString);


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
sanitize user input before displaying info message
## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
before
<img width="250" alt="Screenshot 2023-12-07 at 3 44 49 PM" src="https://github.com/screwdriver-cd/ui/assets/55161078/bb0a7103-1d04-4060-b5ff-fa61c6d83eba">
after
<img width="611" alt="Screenshot 2023-12-07 at 3 44 22 PM" src="https://github.com/screwdriver-cd/ui/assets/55161078/99ead4e3-2540-4265-a54f-9c6c43990bd3">

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
