### PR TITLE
fix(2967): keep the value of display job name length

### DIFF
--- a/app/user-settings/preferences/controller.js
+++ b/app/user-settings/preferences/controller.js
@@ -14,7 +14,7 @@ export default Controller.extend({
   store: service(),
   shuttle: service(),
   userSettings: service(),
-  displayJobNameLength: 20,
+  displayJobNameLength: MINIMUM_JOBNAME_LENGTH,
   minDisplayLength: MINIMUM_JOBNAME_LENGTH,
   maxDisplayLength: MAXIMUM_JOBNAME_LENGTH,
   isDisabled: bool('isSaving'),
@@ -26,7 +26,7 @@ export default Controller.extend({
   async init() {
     this._super(...arguments);
 
-    let desiredJobNameLength = MINIMUM_JOBNAME_LENGTH;
+    let displayJobNameLength = MINIMUM_JOBNAME_LENGTH;
 
     let selectedTimestampFormat = this.get(
       `timestampOptions.${TIMESTAMP_DEFAULT_OPTION}`
@@ -35,14 +35,14 @@ export default Controller.extend({
     const userPreferences = await this.userSettings.getUserPreference();
 
     if (userPreferences) {
-      desiredJobNameLength = userPreferences.displayJobNameLength;
+      displayJobNameLength = userPreferences.displayJobNameLength;
       selectedTimestampFormat = this.timestampOptions.find(
         timestamp => timestamp.value === userPreferences.timestampFormat
       );
     }
 
     this.setProperties({
-      desiredJobNameLength,
+      displayJobNameLength,
       userPreferences,
       selectedTimestampFormat
     });

--- a/app/user-settings/preferences/template.hbs
+++ b/app/user-settings/preferences/template.hbs
@@ -18,7 +18,7 @@
               min={{this.minDisplayLength}}
               max={{this.maxDisplayLength}}
               placeholder={{this.minDisplayLength}}
-              value={{this.desiredJobNameLength}}
+              value={{this.displayJobNameLength}}
               oninput={{action (mut this.displayJobNameLength) value="target.value"}}
             />
           </div>


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

The value of Job Name Length is reset when user click save button without inputting that value.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Fix the initial value of `Job Name Length`.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

https://github.com/screwdriver-cd/screwdriver/issues/2967

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
