### PR TITLE
feat(#2970): use DOM parser instead of Regex to sanitize user html input

### DIFF
--- a/tests/integration/components/info-message/component-test.js
+++ b/tests/integration/components/info-message/component-test.js
@@ -37,4 +37,29 @@ module('Integration | Component | info message', function (hooks) {
 
     assert.dom('.alert > span').hasText('batman');
   });
+
+  test('it renders image tag with empty string', async function (assert) {
+    const userInput = `Image tag: <img src="#notanimage" onerror="alert('unsafe script injection from warning!')" />`;
+
+    this.userInput = userInput;
+
+    await render(hbs`<InfoMessage @message={{this.userInput}} />`);
+
+    assert.dom('.alert > span').hasText('Image tag:');
+  });
+
+  test('it renders link with href attribute only', async function (assert) {
+    const userInput = `message - blocked by some builds, <a href="/builds/913516" rel="noopener" onclick="alert('xss test');">913516</a>`;
+
+    this.userInput = userInput;
+
+    await render(hbs`<InfoMessage @message={{this.userInput}} />`);
+
+    assert
+      .dom('.alert > span')
+      .hasText('message - blocked by some builds, 913516');
+    assert.dom('.alert > span > a').hasAttribute('href', '/builds/913516');
+    assert.dom('.alert > span > a').hasNoAttribute('rel');
+    assert.dom('.alert > span > a').hasNoAttribute('onclck');
+  });
 });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Previous PR https://github.com/screwdriver-cd/ui/pull/974 will filter almost every tags, and will not allow `anchor` tag to work

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Instead of using regex, use DOM Parser to filter out allow/deny elements and attributes

Screenshots:

![image](https://github.com/screwdriver-cd/ui/assets/15989893/7b21a22c-2957-44af-a5ef-2c9cdb6c0bea)

![image](https://github.com/screwdriver-cd/ui/assets/15989893/a0e27c71-9e2d-4ca6-918c-96af950d93e5)


## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
Issue: https://github.com/screwdriver-cd/screwdriver/issues/2970

Test Links: 
1) https://cd.screwdriver.cd/pipelines/10293/builds/913516
2) https://cd.screwdriver.cd/pipelines/12888/builds/915788

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
