### PR TITLE
fix(2838): migrate .fa icons to svg in CSS

### DIFF
--- a/app/components/app-header/styles.scss
+++ b/app/components/app-header/styles.scss
@@ -99,7 +99,7 @@
       ); // Standard syntax
       border-style: none;
 
-      .fa {
+      svg {
         font-size: 15px;
         padding-left: 5px;
       }

--- a/app/components/collection-view/styles.scss
+++ b/app/components/collection-view/styles.scss
@@ -172,7 +172,7 @@
     width: 15%;
     max-width: 250px;
     .icon-wrapper {
-      .fa {
+      svg {
         line-height: 0;
       }
     }
@@ -210,7 +210,7 @@
     cursor: pointer;
 
     .icon-wrapper {
-      .fa {
+      svg {
         line-height: 0;
       }
     }
@@ -223,7 +223,7 @@
     cursor: pointer;
 
     .icon-wrapper {
-      .fa {
+      svg {
         line-height: 0;
       }
     }

--- a/app/components/info-message/styles.scss
+++ b/app/components/info-message/styles.scss
@@ -1,25 +1,3 @@
 & {
   margin-top: 10px;
-
-  &.disabled {
-    display: none;
-  }
-
-  &.error {
-    i.fa {
-      color: $sd-failure;
-    }
-  }
-
-  &.warning {
-    i.fa {
-      color: $sd-warning;
-    }
-  }
-
-  &.info {
-    i.fa {
-      color: $sd-running;
-    }
-  }
 }

--- a/app/components/metrics/chart/template.hbs
+++ b/app/components/metrics/chart/template.hbs
@@ -42,6 +42,6 @@
     onClick={{action "resetZoom" this.chartName this.dependentChartNames}}
     title="Reset Zoom Level"
   >
-    <FaIcon @icon="refresh" />
+    <FaIcon @icon="sync" />
   </p>
 </div>

--- a/app/components/nav-banner/style.scss
+++ b/app/components/nav-banner/style.scss
@@ -15,7 +15,7 @@
     color: $sd-info-fg;
   }
 
-  .banner .fa {
+  .banner svg {
     padding-right: 7px;
     font-size: 20px;
   }

--- a/app/components/pipeline-child-list-actions-cell/styles.scss
+++ b/app/components/pipeline-child-list-actions-cell/styles.scss
@@ -1,6 +1,6 @@
 & {
   .actions-cell {
-    .fa {
+    svg {
       width: 0.8em;
       font-size: 1.2em;
       cursor: pointer;

--- a/app/components/pipeline-list-actions-cell/styles.scss
+++ b/app/components/pipeline-list-actions-cell/styles.scss
@@ -1,5 +1,5 @@
 & {
-  .fa {
+  svg {
     width: 0.8em;
     font-size: 1.2em;
     cursor: pointer;

--- a/app/components/pipeline-list-job-cell/styles.scss
+++ b/app/components/pipeline-list-job-cell/styles.scss
@@ -9,7 +9,7 @@
     word-break: break-word;
   }
 
-  .fa {
+  svg {
     width: 0.8em;
     font-size: 1.5em;
   }

--- a/app/components/quickstart-guide/styles.scss
+++ b/app/components/quickstart-guide/styles.scss
@@ -95,7 +95,7 @@
           margin-left: 14px;
           margin-right: 14px;
 
-          & .svg {
+          & svg {
             padding-top: 8px;
           }
         }

--- a/app/components/quickstart-guide/styles.scss
+++ b/app/components/quickstart-guide/styles.scss
@@ -95,7 +95,7 @@
           margin-left: 14px;
           margin-right: 14px;
 
-          & .fa {
+          & .svg {
             padding-top: 8px;
           }
         }

--- a/app/pipeline/metrics/template.hbs
+++ b/app/pipeline/metrics/template.hbs
@@ -213,7 +213,7 @@
       onClick={{action "resetZoom" this.eventsChartName this.buildsChartName}}
       title="Reset Zoom Level"
     >
-      <FaIcon @icon="refresh" />
+      <FaIcon @icon="sync" />
     </p>
   </div>
 
@@ -265,7 +265,7 @@
       onClick={{action "resetZoom" this.buildsChartName this.eventsChartName}}
       title="Reset Zoom Level"
     >
-      <FaIcon @icon="refresh" />
+      <FaIcon @icon="sync" />
     </p>
   </div>
 
@@ -335,7 +335,7 @@
         onClick={{action "resetZoom" this.stepsChartName}}
         title="Reset Zoom Level"
       >
-        <FaIcon @icon="refresh" />
+        <FaIcon @icon="sync" />
       </p>
     </div>
   {{else}}

--- a/app/styles/chart.scss
+++ b/app/styles/chart.scss
@@ -193,7 +193,7 @@
     &:hover {
       color: #0a0a0a;
 
-      .fa {
+      svg {
         @include scale(1.5);
       }
     }

--- a/app/user-settings/preferences/template.hbs
+++ b/app/user-settings/preferences/template.hbs
@@ -54,7 +54,7 @@
               class="reset-button"
               {{action "resetUserSettings"}}
             >
-              <FaIcon @icon="refresh" />
+              <FaIcon @icon="sync" />
               Reset
             </button>
             <button

--- a/tests/acceptance/metrics-test.js
+++ b/tests/acceptance/metrics-test.js
@@ -56,7 +56,7 @@ module('Acceptance | metrics', function (hooks) {
     assert.dom('.custom-date-selection input').exists({ count: 1 });
     assert.dom('.filters-selection input').exists({ count: 1 });
     assert.dom('.chart-pipeline-info .measure').exists({ count: 5 });
-    assert.dom('.chart-c3 svg').exists({ count: 3 });
+    assert.dom('.chart-c3 svg').exists({ count: 6 });
     assert.dom('.chart-c3 .c3-event-rects').exists({ count: 3 });
     assert.dom('.chart-cta').exists({ count: 1 });
     assert.dom('.chart-cta select').exists({ count: 1 });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

After upgrading to Ember@4, `<FaIcon>` renders `<svg>` instead of `<i class='fa'>`.
Thus we need to fix CSS accordingly.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Fix CSS and icon names.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

https://github.com/screwdriver-cd/screwdriver/issues/2838

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
