### PR TITLE
fix(2982): Reload page after sync pipeline

### DIFF
--- a/app/components/pipeline-options/component.js
+++ b/app/components/pipeline-options/component.js
@@ -307,12 +307,16 @@ export default Component.extend({
 
       return this.sync
         .syncRequests(this.get('pipeline.id'), syncPath)
-        .then(() =>
-          this.setProperties({
-            successMessage: 'Pipeline sync successful',
-            errorMessage: ''
-          })
-        )
+        .then(() => {
+          if (syncPath) {
+            this.setProperties({
+              successMessage: 'Pipeline sync successful',
+              errorMessage: ''
+            });
+          } else {
+            window.location.reload(true);
+          }
+        })
         .catch(error => this.set('errorMessage', error))
         .finally(() => this.set('isShowingModal', false));
     },


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
If there is an update to the pipeline information when the sync button is clicked, users have to reload page manually to show updated info on UI.
Therefore, the page is automatically reloaded after the sync button is clicked.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Reload page after sync pipeline.
Sync webhooks and PRs do not update pipeline info. So we have to reload page only after sync pipeline.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/2982

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
