### PR TITLE
fix: load pr builds automatically when click start button

### DIFF
--- a/app/components/pipeline-events/component.js
+++ b/app/components/pipeline-events/component.js
@@ -696,7 +696,10 @@ export default Component.extend(ModelReloaderMixin, {
             Array.isArray(e.errors) ? e.errors[0].detail : ''
           );
         })
-        .finally(() => jobs.forEach(j => j.hasMany('builds').reload()));
+        .finally(() => jobs.forEach(async j => {
+          await j.hasMany('builds').reload();
+          j.notifyPropertyChange('builds');
+        }));
     },
 
     async syncAdmins() {

--- a/app/components/pipeline-pr-list/component.js
+++ b/app/components/pipeline-pr-list/component.js
@@ -53,8 +53,8 @@ export default Component.extend({
   allJobBuilds: computed('jobs.@each.builds', function () {
     const builds = [];
 
-    this.jobs.forEach(j => {
-      builds.pushObjects(j.builds.toArray());
+    this.jobs.forEach(async j => {
+      builds.pushObjects((await j.builds).toArray());
     });
 
     return builds;

--- a/tests/integration/components/pipeline-events/component-test.js
+++ b/tests/integration/components/pipeline-events/component-test.js
@@ -427,7 +427,7 @@ module('Integration | Component | pipeline events', function (hooks) {
   test('it starts PR build(s)', async function (assert) {
     const prNum = 999;
 
-    assert.expect(5);
+    assert.expect(6);
     server.post('http://localhost:8080/v4/events', () => [
       201,
       { 'Content-Type': 'application/json' },
@@ -444,7 +444,10 @@ module('Integration | Component | pipeline events', function (hooks) {
 
     const component = this.owner.lookup('component:pipeline-events');
 
-    const jobs = [{ hasMany: () => ({ reload: () => assert.ok(true) }) }];
+    const jobs = [{
+      hasMany: () => ({ reload: () => assert.ok(true) }),
+      notifyPropertyChange: key => assert.equal(key, 'builds')
+    }];
 
     run(() => {
       component.set(
@@ -479,9 +482,12 @@ module('Integration | Component | pipeline events', function (hooks) {
 
   test('New event comes top of PR list when it starts a PR build with prChain', async function (assert) {
     const prNum = 3;
-    const jobs = [{ hasMany: () => ({ reload: () => assert.ok(true) }) }];
+    const jobs = [{
+      hasMany: () => ({ reload: () => assert.ok(true) }),
+      notifyPropertyChange: key => assert.equal(key, 'builds')
+    }];
 
-    assert.expect(5);
+    assert.expect(6);
 
     server.post('http://localhost:8080/v4/events', () => [
       201,


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

- PR builds don't appear automatically after users click the start button on PR list
- Start button is showing during the PR builds are running

![before](https://github.com/screwdriver-cd/ui/assets/43719835/f3907e8d-3172-4d36-8b23-808838570e25)

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

- Load PR builds automatically when user click PR start button
- Show Stop button when the PR builds are running

![after](https://github.com/screwdriver-cd/ui/assets/43719835/2b071f7f-b956-49f9-8c4b-2ab6c4a85146)

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
