### PR TITLE
fix: expand job parameter on pipeline list view

### DIFF
--- a/app/components/pipeline-list-actions-cell/component.js
+++ b/app/components/pipeline-list-actions-cell/component.js
@@ -29,7 +29,7 @@ export default Component.extend({
     startSingleBuild(buildState = undefined) {
       const { actions } = this.record;
 
-      if (buildState === 'START' && actions.hasParameters) {
+      if (['START', 'RESTART'].includes(buildState) && actions.hasParameters) {
         actions.openParametersModal(actions.jobId, buildState);
       } else {
         actions.startSingleBuild(actions.jobId, actions.jobName, buildState);

--- a/app/components/pipeline-list-view/template.hbs
+++ b/app/components/pipeline-list-view/template.hbs
@@ -52,6 +52,7 @@
       @buildJobParameters={{this.jobParameters}}
       @onSave={{action "startBuild"}}
       @onClose={{action "closeModal"}}
+      @startFrom={{this.job.name}}
     />
   </ModalDialog>
 {{/if}}


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Job's build parameter form is expanded by default when user start/restart from the job on workflow tool tip.

![tooltip](https://github.com/screwdriver-cd/ui/assets/43719835/5dd9f6e9-1952-463b-9ff3-9c55a33e977d)

But on pipeline list view, pipeline level parameter form is always expanded.

![list-view](https://github.com/screwdriver-cd/ui/assets/43719835/c9541663-8efe-4714-bdca-0873330c6e5e)

And the parameter modal is not appear when user restart builds on list view.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

- Expands job's parameter form on list view
- Show pipeline parameter form on list view in restart case

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
