### PR TITLE
feat: spread the validator page's view

### DIFF
--- a/app/components/validator-input/styles.scss
+++ b/app/components/validator-input/styles.scss
@@ -2,4 +2,30 @@
   margin: 10px 10px 0 0;
   border: 1px solid #f1f1f5;
   padding: 10px;
+
+  .header .btn:not(:disabled):not(.disabled) {
+    border-radius: 3px;
+    padding: 5px 10px;
+    color: $brand-600;
+    background-color: $sd-white;
+    border-color: $brand-600;
+    font-weight: $weight-normal;
+
+    &:hover,
+    &:focus,
+    &.active,
+    &.active:hover,
+    &.active:focus {
+      outline: none;
+      box-shadow: none;
+      color: $brand-600;
+      background-color: $button-background;
+      border-color: $brand-600;
+    }
+
+    &:hover,
+    &.active:hover {
+      color: $brand-700;
+    }
+  }
 }

--- a/app/components/validator-input/template.hbs
+++ b/app/components/validator-input/template.hbs
@@ -1,7 +1,24 @@
-<h4 class="pipeline" {{action "nameClick"}}>
-  <FaIcon @icon={{if this.isOpen "minus-square" "plus-square"}} />
-  Validate Screwdriver Configuration
-</h4>
+<div class="header row">
+  <h4 class="pipeline col-10" {{action "nameClick"}}>
+    <FaIcon @icon={{if this.isOpen "minus-square" "plus-square"}} />
+    Validate Screwdriver Configuration
+  </h4>
+  <div class="col-2 text-right">
+    <BsButtonGroup
+      class="view-toggle"
+      @value={{this.spreadView}}
+      @type="radio"
+      @onChange={{action (mut this.spreadView)}} as |bg|
+    >
+      <bg.button @value={{false}} @type="primary" @outline={{true}}>
+        <FaIcon @icon="compress" />
+      </bg.button>
+      <bg.button @value={{true}} @type="primary" @outline={{true}}>
+        <FaIcon @icon="expand" />
+      </bg.button>
+    </BsButtonGroup>
+  </div>
+</div>
 <h5 class="pipeline">
   Paste a screwdriver.yaml or a template yaml below to verify.<br />Template yamls must contain the "name" field.
 </h5>

--- a/app/validator/controller.js
+++ b/app/validator/controller.js
@@ -20,6 +20,7 @@ export default Controller.extend({
   validator: service(),
   yaml: '',
   results: '',
+  spreadView: false,
   isTemplate: computed('yaml', {
     get() {
       return this.validator.isTemplate(this.yaml);

--- a/app/validator/template.hbs
+++ b/app/validator/template.hbs
@@ -1,8 +1,11 @@
 <div class="row">
-  <div class="col-12 col-md-6">
-    <ValidatorInput @yaml={{mut this.yaml}} />
+  <div class="col-12 col-md-{{if this.spreadView '12' '6' }}">
+    <ValidatorInput
+      @yaml={{mut this.yaml}}
+      @spreadView={{this.spreadView}}
+    />
   </div>
-  <div class="col-12 col-md-6">
+  <div class="col-12 col-md-{{if this.spreadView '12' '6' }}">
     <ValidatorResults
       @results={{this.results}}
       @isTemplate={{this.isTemplate}}


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

The validator input form, workflow graph, job details are narrow when users use vertical display.

<img width="1490" alt="before" src="https://github.com/screwdriver-cd/ui/assets/43719835/366acc6d-37d9-4a3d-a31b-fe20a9269929">

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

This PR will add the button that can switch split view / spread view.

https://github.com/screwdriver-cd/ui/assets/43719835/0dff75db-113b-4adf-a2d1-0da1d40cbd49

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
