### PR TITLE
fix(2822): Increase the maximum number of columns for build-banner

### DIFF
--- a/app/components/build-banner/styles.scss
+++ b/app/components/build-banner/styles.scss
@@ -11,11 +11,11 @@ ul {
   padding: 0;
   margin: 0;
   display: grid;
-  grid-template-columns: repeat(8, 1fr) 2fr;
+  grid-template-columns: repeat(9, 1fr) 2fr;
 }
 
 .button-right {
-  grid-column: 9;
+  grid-column: 10;
 }
 
 li .subsection {


### PR DESCRIPTION
## Context
The build details page now allows viewing template information in the build banner. However, the CSS settings were not updated, resulting in the components being arranged into two columns when at maximum capacity.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->
<img width="1206" alt="build-banner" src="https://github.com/screwdriver-cd/ui/assets/22903716/96794d68-d7e9-46de-84b9-2b535c6fc212">

## Objective
I've updated the CSS to ensure that all components stay in a single column even when all components are present.
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/screwdriver/issues/2822
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
