### PR TITLE
fix: graph render race condition

### DIFF
--- a/app/components/workflow-graph-d3/component.js
+++ b/app/components/workflow-graph-d3/component.js
@@ -138,7 +138,7 @@ export default Component.extend({
   },
 
   // Listen for changes to workflow and update graph accordingly.
-  didReceiveAttrs() {
+  didUpdateAttrs() {
     this._super(...arguments);
     const dg = this.decoratedGraph;
 
@@ -352,9 +352,11 @@ export default Component.extend({
           const text = d3.select(this);
           const textWidth = text.node().getBBox().width;
           const maxWidth = X_WIDTH - EDGE_GAP / 2;
+
           if (textWidth > maxWidth) {
-            const fontSize = TITLE_SIZE * maxWidth / textWidth; // calculate the new font-size based on the maximum width
-            text.style("font-size", fontSize + "px");
+            const fontSize = (TITLE_SIZE * maxWidth) / textWidth; // calculate the new font-size based on the maximum width
+
+            text.style('font-size', `${fontSize}px`);
           }
         })
         .style('text-anchor', 'middle')


### PR DESCRIPTION
## Context
There's a race condition when rendering graphs based on whether or not the data is already in the ember data store.

## Objective
Changing the lifecycle back to `didUpdateAttrs` fixes the race condition on the graph being rendered multiple times in a single update.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
