### PR TITLE
fix: PR graph rendering bug when switching to PR tab

### DIFF
--- a/app/pipeline/pulls/route.js
+++ b/app/pipeline/pulls/route.js
@@ -20,6 +20,7 @@ export default EventsRoute.extend({
 
     pipelineEventsController.setProperties({
       pipeline: this.pipeline,
+      showDownstreamTriggers: false,
       showPRJobs: true
     });
 


### PR DESCRIPTION
## Context
For pipelines with lots of build data, and especially pipelines with the `chainPR` setting configured, switching to the Pull Request view from the Events view may not render the Pull Request graph properly.

## Objective
When switching to the Pull Request view from the Events view, the `showDownstreamTriggers` field is not properly configured.  This fix pins the `showDownstreamTriggers` to `false` when the Pull Request view is rendered so that `chainPR` configured pipelines will always properly render the pipeline graphs.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
