### PR TITLE
fix: PR graph for non-chainPR configurations

### DIFF
--- a/app/components/pipeline-events/template.hbs
+++ b/app/components/pipeline-events/template.hbs
@@ -84,6 +84,7 @@
       @stopBuild={{action "stopBuild"}}
       @setJobState={{action "setJobState"}}
       @authenticated={{this.session.isAuthenticated}}
+      @prChainEnabled={{this.prChainEnabled}}
     />
   </div>
   <div

--- a/app/components/pipeline-workflow/template.hbs
+++ b/app/components/pipeline-workflow/template.hbs
@@ -15,6 +15,7 @@
     @causeMessage={{this.selectedEventObj.causeMessage}}
     @graphClicked={{action "graphClicked"}}
     @isSkipped={{this.selectedEventObj.isSkipped}}
+    @prChainEnabled={{this.prChainEnabled}}
   >
     <WorkflowTooltip
       @pipeline={{this.pipeline}}

--- a/app/components/workflow-graph-d3/component.js
+++ b/app/components/workflow-graph-d3/component.js
@@ -24,6 +24,7 @@ export default Component.extend({
     'jobs.@each.{isDisabled,state,stateChanger}',
     'minified',
     'prJobs',
+    'selectedEventObj.status',
     'selectedEventObj.prNum',
     'showDownstreamTriggers',
     'showPRJobs',

--- a/app/components/workflow-graph-d3/component.js
+++ b/app/components/workflow-graph-d3/component.js
@@ -24,11 +24,12 @@ export default Component.extend({
     'jobs.@each.{isDisabled,state,stateChanger}',
     'minified',
     'prJobs',
-    'selectedEventObj.status',
+    'selectedEventObj.prNum',
     'showDownstreamTriggers',
     'showPRJobs',
     'startFrom',
     'workflowGraph',
+    'prChainEnabled',
     {
       get() {
         const showDownstreamTriggers =
@@ -106,7 +107,9 @@ export default Component.extend({
           inputGraph: this.minified ? subgraphFilter(graph, startFrom) : graph,
           builds,
           jobs,
-          start: startFrom
+          start: startFrom,
+          chainPR: this.prChainEnabled,
+          prNum: this.selectedEventObj?.prNum
         });
       }
     }

--- a/app/utils/graph-tools.js
+++ b/app/utils/graph-tools.js
@@ -196,9 +196,9 @@ const hasProcessedDest = (graph, name) => {
  * @param  {Object}      inputGraph A directed graph representation { nodes: [], edges: [] }
  * @param  {Array|DS.PromiseArray|DS.PromiseManyArray}  [builds]     A list of build metadata
  * @param  {Array|DS.PromiseArray|DS.PromiseManyArray}  [jobs]       A list of job metadata
- * @param  {String}   start     Node name that indicates what started the graph
- * @param  {Boolean}  chainPR   Boolean flag for the chainPR setting
- * @param  {number}   prNum     The pull request number
+ * @param  {String}   [start]     Node name that indicates what started the graph
+ * @param  {Boolean}  [chainPR]   Boolean flag for the chainPR setting
+ * @param  {number}   [prNum]     The pull request number
  * @return {Object}                 A graph representation with row/column coordinates for drawing, and meta information for scaling
  */
 const decorateGraph = ({ inputGraph, builds, jobs, start, chainPR, prNum }) => {

--- a/app/utils/graph-tools.js
+++ b/app/utils/graph-tools.js
@@ -51,6 +51,17 @@ const build = (builds, jobId) =>
 const job = (jobs, jobId) => jobs.find(j => j && `${j.id}` === `${jobId}`);
 
 /**
+ * Find a PR job for the given PR number and job name
+ * @method prJob
+ * @param  {Array}  jobs    List of job objects
+ * @param  {number} prNum   The pull request number of the job
+ * @param  {String} name    The name of the pull request job
+ * @return {Object}         Reference to the job object from the list if found
+ */
+const prJob = (jobs, prNum, name) =>
+  jobs.find(j => j && j.group === prNum && j.name.endsWith(name));
+
+/**
  * Find the icon to set as the text for a node
  * @method icon
  * @param  {String} status Text that denotes a build status
@@ -185,10 +196,12 @@ const hasProcessedDest = (graph, name) => {
  * @param  {Object}      inputGraph A directed graph representation { nodes: [], edges: [] }
  * @param  {Array|DS.PromiseArray|DS.PromiseManyArray}  [builds]     A list of build metadata
  * @param  {Array|DS.PromiseArray|DS.PromiseManyArray}  [jobs]       A list of job metadata
- * @param  {String}      [start]    Node name that indicates what started the graph
+ * @param  {String}   start     Node name that indicates what started the graph
+ * @param  {Boolean}  chainPR   Boolean flag for the chainPR setting
+ * @param  {number}   prNum     The pull request number
  * @return {Object}                 A graph representation with row/column coordinates for drawing, and meta information for scaling
  */
-const decorateGraph = ({ inputGraph, builds, jobs, start }) => {
+const decorateGraph = ({ inputGraph, builds, jobs, start, chainPR, prNum }) => {
   // deep clone
   const graph = JSON.parse(JSON.stringify(inputGraph));
   const { nodes } = graph;
@@ -226,10 +239,15 @@ const decorateGraph = ({ inputGraph, builds, jobs, start }) => {
     }
 
     // Get job information
-    const jobId = n.id;
+    let jobId = n.id;
 
     if (jobsAvailable) {
-      const j = job(jobs, jobId);
+      let j = job(jobs, jobId);
+
+      if (!jobId && !chainPR && prNum) {
+        j = prJob(jobs, prNum, n.name);
+        jobId = j?.id;
+      }
 
       // eslint-disable-next-line no-nested-ternary
       n.isDisabled = j


### PR DESCRIPTION
## Context
Pipeline configurations with the `chainPR` setting as false do not display the pipeline graph correctly in the Pull Request view.
![Screenshot 2024-02-06 at 14-30-51 minghay_pr-simple](https://github.com/screwdriver-cd/ui/assets/157658916/c46c3787-e1bf-46ae-a949-7997b28f7828)
![Screenshot 2024-02-06 at 14-31-29 minghay_pr-multiple](https://github.com/screwdriver-cd/ui/assets/157658916/8b2d47b8-407b-4685-a8a6-72e8c3345519)

## Objective
Fix the pipeline graph for Pull Requests with the `chainPR` setting as `false`.  The pipeline graph will also have graph nodes fully clickable with their dropdown menu options to select.
![Screenshot 2024-02-06 at 14-34-37 minghay_pr-simple](https://github.com/screwdriver-cd/ui/assets/157658916/09e0e0a4-f147-4ddf-aad5-48646e9822b7)
![Screenshot 2024-02-06 at 14-34-55 minghay_pr-multiple](https://github.com/screwdriver-cd/ui/assets/157658916/affa427d-a7fa-47fd-9814-41ae950df86b)


## References
https://github.com/screwdriver-cd/screwdriver/issues/2660

## License
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.