### PR TITLE
fix: update logic for determining when a node can start and restart

### DIFF
--- a/app/components/pipeline-events/template.hbs
+++ b/app/components/pipeline-events/template.hbs
@@ -86,6 +86,7 @@
       @authenticated={{this.session.isAuthenticated}}
       @prChainEnabled={{this.prChainEnabled}}
       @stages={{this.stages}}
+      @activeTab={{this.activeTab}}
     />
   </div>
   <div

--- a/app/components/pipeline-workflow/component.js
+++ b/app/components/pipeline-workflow/component.js
@@ -2,7 +2,11 @@ import { isActivePipeline } from 'screwdriver-ui/utils/pipeline';
 import Component from '@ember/component';
 import { get, computed, set, setProperties } from '@ember/object';
 import { reject } from 'rsvp';
-import { isRoot } from 'screwdriver-ui/utils/graph-tools';
+import {
+  isRoot,
+  reverseGraph,
+  subgraphFilter
+} from 'screwdriver-ui/utils/graph-tools';
 import { isActiveBuild } from 'screwdriver-ui/utils/build';
 import { copy } from 'ember-copy';
 
@@ -101,6 +105,40 @@ export default Component.extend({
       const { prNum } = selectedEvent;
 
       return prNum && buildExists.length !== 0;
+    }
+  ),
+
+  canJobStartFromView: computed(
+    'selectedEventObj.workflowGraph',
+    'tooltipData',
+    'activeTab',
+    function canJobStartFromView() {
+      const { tooltipData } = this;
+
+      if (tooltipData && tooltipData.job) {
+        const reversedGraph = reverseGraph(this.selectedEventObj.workflowGraph);
+        const subgraph = subgraphFilter(reversedGraph, tooltipData.job.name);
+
+        const isOnPrPath =
+          subgraph.nodes.filter(node => node.name === '~pr').length > 0;
+
+        if (this.activeTab === 'pulls') {
+          // In the pull request view, only allow restarting nodes that are reachable from the ~pr node
+          return isOnPrPath;
+        }
+        // In the events view:
+        const isOnCommitPath =
+          subgraph.nodes.filter(node => node.name === '~commit').length > 0;
+
+        // If the job is detached, allow restart:  isOnPrPath = false, isOnCommitPath = false
+        // If the job is only on the commit path, allow restart: isOnPrPath = false, isOnCommitPath = true
+        // If the job is on the commit and pr path, allow restart: isOnPrPath = true, isOnCommitPath = true
+        // If the job is only on the pr path, do not allow restart: isOnPrPath = true, isOnCommitPath = false
+        return !(isOnPrPath && !isOnCommitPath);
+      }
+
+      // job is not selected or upstream/downstream node are selected
+      return false;
     }
   ),
 

--- a/app/components/pipeline-workflow/component.js
+++ b/app/components/pipeline-workflow/component.js
@@ -65,49 +65,6 @@ export default Component.extend({
     });
   },
 
-  isPrChainJob: computed(
-    'pipeline.prChain',
-    'selectedEventObj',
-    'tooltipData',
-    function isPrChainJob() {
-      const selectedEvent =
-        this.selectedEventObj === undefined ? {} : this.selectedEventObj;
-      const { prNum } = selectedEvent;
-      const isPrChain = get(this, 'pipeline.prChain');
-
-      return prNum !== undefined && isPrChain;
-    }
-  ),
-
-  prBuildExists: computed(
-    'selectedEventObj',
-    'tooltipData',
-    function isStartablePrChainJob() {
-      const selectedEvent = this.selectedEventObj;
-
-      const { tooltipData } = this;
-
-      let selectedJobId;
-
-      if (tooltipData && tooltipData.job) {
-        selectedJobId = tooltipData.job.id
-          ? tooltipData.job.id.toString()
-          : null;
-      } else {
-        // job is not selected or upstream/downstream node are selected
-        return false;
-      }
-
-      const buildExists = selectedEvent.buildsSorted.filter(
-        b => b.jobId === selectedJobId
-      );
-
-      const { prNum } = selectedEvent;
-
-      return prNum && buildExists.length !== 0;
-    }
-  ),
-
   canJobStartFromView: computed(
     'selectedEventObj.workflowGraph',
     'tooltipData',

--- a/app/components/pipeline-workflow/template.hbs
+++ b/app/components/pipeline-workflow/template.hbs
@@ -21,8 +21,8 @@
     <WorkflowTooltip
       @pipeline={{this.pipeline}}
       @tooltipData={{this.tooltipData}}
-      @isPrChainJob={{this.isPrChainJob}}
-      @prBuildExists={{this.prBuildExists}}
+      @canJobStartFromView={{this.canJobStartFromView}}
+      @activeTab={{this.activeTab}}
       @canRestartPipeline={{this.canRestartPipeline}}
       @stopBuild={{this.stopBuild}}
       @showTooltip={{this.showTooltip}}

--- a/app/components/workflow-tooltip/template.hbs
+++ b/app/components/workflow-tooltip/template.hbs
@@ -37,20 +37,10 @@
             Disabled manually starting
           </p>
         {{else}}
-          {{#if (eq this.isPrChainJob false)}}
+          {{#if (eq this.canJobStartFromView true)}}
             <a href="#" {{action this.confirmStartBuild}}>
               {{if this.tooltipData.job.status "Restart" "Start"}} pipeline from here
             </a>
-          {{else}}
-            {{#if (eq this.prBuildExists true)}}
-              <a href="#" {{action this.confirmStartBuild}}>
-                {{if
-                  this.tooltipData.job.status
-                  "Restart"
-                  "Start"
-                }} pipeline from here
-              </a>
-            {{/if}}
           {{/if}}
         {{/if}}
       {{/if}}

--- a/app/utils/graph-tools.js
+++ b/app/utils/graph-tools.js
@@ -616,6 +616,25 @@ const removeBranch = (n, graph) => {
   }
 };
 
+/**
+ * Reverses a graph by flipping the edge source and destinations values
+ * @param {Graph} graph   A directed graph representation { nodes: [], edges: [] }
+ * @return {Graph}        A new graph representing the reversed graph
+ */
+const reverseGraph = graph => {
+  // deep clone
+  const reversedGraph = JSON.parse(JSON.stringify(graph));
+
+  reversedGraph.edges.forEach(edge => {
+    const { src } = edge;
+
+    edge.src = edge.dest;
+    edge.dest = src;
+  });
+
+  return reversedGraph;
+};
+
 export {
   node,
   icon,
@@ -624,5 +643,6 @@ export {
   isRoot,
   isTrigger,
   subgraphFilter,
-  removeBranch
+  removeBranch,
+  reverseGraph
 };

--- a/tests/integration/components/workflow-tooltip/component-test.js
+++ b/tests/integration/components/workflow-tooltip/component-test.js
@@ -161,13 +161,13 @@ module('Integration | Component | workflow tooltip', function (hooks) {
 
     this.set('data', data);
     this.set('confirmStartBuild', () => {});
-    this.set('isPrChainJob', false);
+    this.set('canJobStartFromView', true);
 
     await render(hbs`<WorkflowTooltip
         @tooltipData={{this.data}}
         @canRestartPipeline={{true}}
         @confirmStartBuild={{this.confirmStartBuild}}
-        @isPrChainJob={{this.isPrChainJob}}
+        @canJobStartFromView={{this.canJobStartFromView}}
       />`);
 
     assert.dom('.content a').exists({ count: 4 });
@@ -189,13 +189,13 @@ module('Integration | Component | workflow tooltip', function (hooks) {
 
     this.set('data', data);
     this.set('confirmStartBuild', () => {});
-    this.set('isPrChainJob', false);
+    this.set('canJobStartFromView', true);
 
     await render(hbs`<WorkflowTooltip
         @tooltipData={{this.data}}
         @canRestartPipeline={{true}}
         @confirmStartBuild={{this.confirmStartBuild}}
-        @isPrChainJob={{this.isPrChainJob}}
+        @canJobStartFromView={{this.canJobStartFromView}}
       />`);
 
     assert.dom('.content a').exists({ count: 4 });
@@ -216,13 +216,13 @@ module('Integration | Component | workflow tooltip', function (hooks) {
 
     this.set('data', data);
     this.set('confirmStartBuild', () => {});
-    this.set('isPrChainJob', false);
+    this.set('canJobStartFromView', true);
 
     await render(hbs`<WorkflowTooltip
         @tooltipData={{this.data}}
         @canRestartPipeline={{true}}
         @confirmStartBuild={{this.confirmStartBuild}}
-        @isPrChainJob={{this.isPrChainJob}}
+        @canJobStartFromView={{this.canJobStartFromView}}
       />`);
 
     assert.dom('.content a').exists({ count: 4 });
@@ -244,13 +244,13 @@ module('Integration | Component | workflow tooltip', function (hooks) {
 
     this.set('data', data);
     this.set('confirmStartBuild', () => {});
-    this.set('isPrChainJob', false);
+    this.set('canJobStartFromView', false);
 
     await render(hbs`<WorkflowTooltip
         @tooltipData={{this.data}}
         @canRestartPipeline={{true}}
         @confirmStartBuild={{this.confirmStartBuild}}
-        @isPrChainJob={{this.isPrChainJob}}
+        @canJobStartFromView={{this.canJobStartFromView}}
       />`);
 
     assert.dom('.content a').exists({ count: 3 });
@@ -271,15 +271,13 @@ module('Integration | Component | workflow tooltip', function (hooks) {
 
     this.set('data', data);
     this.set('confirmStartBuild', () => {});
-    this.set('isPrChainJob', true);
-    this.set('prBuildExists', false);
+    this.set('canJobStartFromView', false);
 
     await render(hbs`<WorkflowTooltip
         @tooltipData={{this.data}}
         @canRestartPipeline={{true}}
         @confirmStartBuild={{this.confirmStartBuild}}
-        @isPrChain={{this.isPrChain}}
-        @prBuildExists={{this.prBuildExists}}
+        @canJobStartFromView={{this.canJobStartFromView}}
       />`);
 
     assert.dom('.content a').exists({ count: 3 });
@@ -300,13 +298,13 @@ module('Integration | Component | workflow tooltip', function (hooks) {
 
     this.set('data', data);
     this.set('confirmStartBuild', () => {});
-    this.set('isPrChainJob', false);
+    this.set('canJobStartFromView', false);
 
     await render(hbs`<WorkflowTooltip
         @tooltipData={{this.data}}
         @canRestartPipeline={{true}}
         @confirmStartBuild={{this.confirmStartBuild}}
-        @isPrChainJob={{this.isPrChainJob}}
+        @canJobStartFromView={{this.canJobStartFromView}}
       />`);
 
     assert.dom('.content a').exists({ count: 3 });
@@ -328,13 +326,13 @@ module('Integration | Component | workflow tooltip', function (hooks) {
 
     this.set('data', data);
     this.set('confirmStartBuild', () => {});
-    this.set('isPrChainJob', false);
+    this.set('canJobStartFromView', false);
 
     await render(hbs`<WorkflowTooltip
         @tooltipData={{this.data}}
         @canRestartPipeline={{true}}
         @confirmStartBuild={{this.confirmStartBuild}}
-        @isPrChainJob={{this.isPrChainJob}}
+        @canJobStartFromView={{this.canJobStartFromView}}
       />`);
 
     assert.dom('.content a').exists({ count: 3 });
@@ -383,15 +381,13 @@ module('Integration | Component | workflow tooltip', function (hooks) {
 
     this.set('data', data);
     this.set('confirmStartBuild', () => {});
-    this.set('isPrChainJob', true);
-    this.set('prBuildExists', true);
+    this.set('canJobStartFromView', true);
 
     await render(hbs`<WorkflowTooltip
         @tooltipData={{this.data}}
         @canRestartPipeline={{true}}
         @confirmStartBuild={{this.confirmStartBuild}}
-        @isPrChain={{this.isPrChain}}
-        @prBuildExists={{this.prBuildExists}}
+        @canJobStartFromView={{this.canJobStartFromView}}
       />`);
 
     assert.dom('.content a').exists({ count: 4 });
@@ -511,13 +507,13 @@ module('Integration | Component | workflow tooltip', function (hooks) {
 
     this.set('data', data);
     this.set('confirmStartBuild', () => {});
-    this.set('isPrChainJob', false);
+    this.set('canJobStartFromView', true);
 
     await render(hbs`<WorkflowTooltip
         @tooltipData={{this.data}}
         @canRestartPipeline={{true}}
         @confirmStartBuild={{this.confirmStartBuild}}
-        @isPrChainJob={{this.isPrChainJob}}
+        @canJobStartFromView={{this.canJobStartFromView}}
       />`);
 
     assert.dom('.content a').exists({ count: 3 });
@@ -542,14 +538,14 @@ module('Integration | Component | workflow tooltip', function (hooks) {
 
     this.set('data', data);
     this.set('confirmStartBuild', () => {});
-    this.set('isPrChainJob', false);
+    this.set('canJobStartFromView', true);
     this.set('enableHiddenDescription', true);
 
     await render(hbs`<WorkflowTooltip
         @tooltipData={{this.data}}
         @canRestartPipeline={{true}}
         @confirmStartBuild={{this.confirmStartBuild}}
-        @isPrChainJob={{this.isPrChainJob}}
+        @canJobStartFromView={{this.canJobStartFromView}}
         @enableHiddenDescription={{this.enableHiddenDescription}}
       />`);
 

--- a/tests/unit/utils/graph-tools-test.js
+++ b/tests/unit/utils/graph-tools-test.js
@@ -5,7 +5,8 @@ import {
   subgraphFilter,
   graphDepth,
   isRoot,
-  isTrigger
+  isTrigger,
+  reverseGraph
 } from 'screwdriver-ui/utils/graph-tools';
 import { module, test } from 'qunit';
 
@@ -899,6 +900,17 @@ module('Unit | Utility | graph tools', function () {
     assert.deepEqual(subgraphFilter(MORE_COMPLEX_GRAPH, 'wow_new_main'), {
       nodes: [{ name: 'other_publish' }, { name: 'wow_new_main' }],
       edges: [{ src: 'wow_new_main', dest: 'other_publish' }]
+    });
+  });
+
+  test('it reverses a graph', function (assert) {
+    const reversedGraph = reverseGraph(COMPLEX_GRAPH);
+
+    assert.deepEqual(reversedGraph.nodes, COMPLEX_GRAPH.nodes);
+    assert.equal(reversedGraph.edges.length, COMPLEX_GRAPH.edges.length);
+    reversedGraph.edges.forEach((edge, index) => {
+      assert.equal(edge.src, COMPLEX_GRAPH.edges[index].dest);
+      assert.equal(edge.dest, COMPLEX_GRAPH.edges[index].src);
     });
   });
 });


### PR DESCRIPTION
## Context
The ability for a job to start or restart from the graph node depends on job data returned from the API.  If data is missing from the API, this prevents the UI from being able to create the tooltips correctly.

## Objective
Update the tooltip logic to only rely on the workflow graph information.  Additional logic around the current view is used to further determine which jobs, and their associated workflow graph, can be triggered.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3011

## License
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
