### PR TITLE
Remove redundant network calls

### DIFF
--- a/app/pipeline/events/route.js
+++ b/app/pipeline/events/route.js
@@ -36,7 +36,7 @@ export default Route.extend({
       controller.set('errorMessage', '');
     }
   },
-  model() {
+  async model() {
     const pipelineId = this.get('pipeline.id');
     const pipelineEventsController = this.controllerFor('pipeline.events');
 
@@ -68,8 +68,10 @@ export default Route.extend({
         count: ENV.APP.NUM_EVENTS_LISTED
       }),
       triggers: this.triggerService.getDownstreamTriggers(pipelineId),
-      pipelinePreference: this.shuttle.getUserPipelinePreference(pipelineId),
-      desiredJobNameLength: this.userSettings.getDisplayJobNameLength()
+      pipelinePreference: await this.pipelineService.getUserPipelinePreference(
+        pipelineId
+      ),
+      desiredJobNameLength: await this.userSettings.getDisplayJobNameLength()
     }).catch(err => {
       const errorMessage = getErrorMessage(err);
 

--- a/app/pipeline/service.js
+++ b/app/pipeline/service.js
@@ -1,8 +1,10 @@
+import { get } from '@ember/object';
 import Service, { inject as service } from '@ember/service';
 import ENV from 'screwdriver-ui/config/environment';
 
 export default Service.extend({
   store: service(),
+  userSettings: service(),
   buildsLink: `pipeline.events`,
 
   setBuildsLink(buildsLink) {
@@ -19,5 +21,35 @@ export default Service.extend({
     };
 
     return this.store.query('pipeline', pipelineListConfig);
+  },
+
+  async getUserPipelinePreference(pipelineId) {
+    if (!pipelineId) {
+      return {};
+    }
+
+    const userPreferences = await this.userSettings.getUserPreference();
+    const pipelinePreferences = get(userPreferences, pipelineId);
+    const localPipelinePreference = await this.store
+      .peekAll('preference/pipeline')
+      .findBy('id', pipelineId);
+
+    // If preferences for the pipeline already exist, use them.
+    if (localPipelinePreference) {
+      return localPipelinePreference;
+    }
+
+    // No preferences for the pipeline exist, so we will create the default set.
+    // Note: the newly created preferences for this pipeline are not saved back on the server as they are just default settings.
+    // When a user changes the options in the options view of the pipeline, then the settings are saved.
+    const pipelinePreference = await this.store.createRecord(
+      'preference/pipeline',
+      {
+        id: pipelineId,
+        ...pipelinePreferences
+      }
+    );
+
+    return pipelinePreference;
   }
 });

--- a/tests/unit/pipeline/service-test.js
+++ b/tests/unit/pipeline/service-test.js
@@ -1,13 +1,41 @@
+import { A } from '@ember/array';
 import EmberObject from '@ember/object';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import Service from '@ember/service';
+import { resolve } from 'rsvp';
 
 let pipelines;
 
+const userPreference = EmberObject.create({
+  id: 123,
+  showPRJobs: true
+});
+
 const storeServiceStub = Service.extend({
   query() {
-    return pipelines
+    return pipelines;
+  },
+  peekAll() {
+    /* eslint new-cap: ["error", { "capIsNewExceptions": ["A"] }] */
+    return A([
+      EmberObject.create({
+        id: 200,
+        showPRJobs: true
+      })
+    ]);
+  },
+  createRecord() {
+    return EmberObject.create({
+      id: userPreference.id,
+      showPRJobs: userPreference.showPRJobs
+    });
+  }
+});
+
+const userSettingsServiceStub = Service.extend({
+  getUserPreference() {
+    return resolve(userPreference);
   }
 });
 
@@ -17,6 +45,8 @@ module('Unit | Service | pipeline', function (hooks) {
   hooks.beforeEach(function () {
     this.owner.unregister('service:store');
     this.owner.register('service:store', storeServiceStub);
+    this.owner.unregister('service:userSettings');
+    this.owner.register('service:userSettings', userSettingsServiceStub);
   });
 
   test('it exists', function (assert) {
@@ -26,14 +56,46 @@ module('Unit | Service | pipeline', function (hooks) {
   });
 
   test('it handles updating job state', function (assert) {
-    pipelines = EmberObject.create([{
-      id: 123456,
-      name: 'screwdriver-cd/screwdriver'
-    }]);
+    pipelines = EmberObject.create([
+      {
+        id: 123456,
+        name: 'screwdriver-cd/screwdriver'
+      }
+    ]);
 
     const service = this.owner.lookup('service:pipeline');
     const value = service.getSiblingPipeline('screwdriver-cd/screwdriver');
 
     assert.equal(value, pipelines);
+  });
+
+  test('it returns an empty object if no pipeline was specified', async function (assert) {
+    const service = this.owner.lookup('service:pipeline');
+    const pipelinePreference = await service.getUserPipelinePreference();
+
+    assert.equal(Object.keys(pipelinePreference).length, 0);
+  });
+
+  test('it returns pipeline preferences if they exist', async function (assert) {
+    const pipelineId = 200;
+    const service = this.owner.lookup('service:pipeline');
+    const pipelinePreference = await service.getUserPipelinePreference(
+      pipelineId
+    );
+
+    assert.equal(Object.keys(pipelinePreference).length, 2);
+    assert.equal(pipelinePreference.id, pipelineId);
+    assert.equal(pipelinePreference.showPRJobs, true);
+  });
+
+  test('it creates preferences if none exist', async function (assert) {
+    const service = this.owner.lookup('service:pipeline');
+    const pipelinePreference = await service.getUserPipelinePreference(
+      userPreference.id
+    );
+
+    assert.equal(Object.keys(pipelinePreference).length, 2);
+    assert.equal(pipelinePreference.id, userPreference.id);
+    assert.equal(pipelinePreference.showPRJobs, userPreference.showPRJobs);
   });
 });


### PR DESCRIPTION
## Context
Multiple calls to the `/settings` endpoint are being made when the events view is loaded.

## Objective
Ensures that the API data returned from `/settings` is cached and that subsequent calls for the data uses the cached data rather than making an API call.  In 5e0244fe6d19086fbe46ba2e5cb2345eaaa95d3f, I have largely duplicated the code that currently exists in the `shuttle` service.  There is future work to refactor the remaining call to the `getUserPipelinePreference` in shuttle service that is outside of the scope of this pull request.  ffe7f662b0e11538bdca421a61254b076763d01e refactors the events view model to be async as that prevents 2 API calls being made due to `getDisplayJobNameLength` reading data in the user settings.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
