### PR TITLE
fix: update pull request view model

### DIFF
--- a/app/pipeline/pulls/route.js
+++ b/app/pipeline/pulls/route.js
@@ -15,7 +15,8 @@ export default EventsRoute.extend({
     });
     this.pipelineService.setBuildsLink('pipeline.pulls');
   },
-  model() {
+  async model() {
+    const pipelineId = this.get('pipeline.id');
     const pipelineEventsController = this.controllerFor('pipeline.events');
 
     pipelineEventsController.setProperties({
@@ -69,7 +70,11 @@ export default EventsRoute.extend({
 
     return RSVP.hash({
       jobs: jobsPromise,
-      events
+      events,
+      pipelinePreference: await this.pipelineService.getUserPipelinePreference(
+        pipelineId
+      ),
+      desiredJobNameLength: await this.userSettings.getDisplayJobNameLength()
     });
   },
   actions: {


### PR DESCRIPTION
## Context
The pull request view makes a lot of API calls to `/user/settings` instead of using the cached value.

## Objective
Change the pull request view's model to make a request for `user/settings` and cache the values for any subcomponents to use.  The model was previously not making any API calls leading to all subcomponents making those requests instead.  The model is updated to be async which ensures that the API call is only called once when the view is loaded and that any subcomponents will use the cached data.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
