### PR TITLE
fix: updating pipeline settings only requires 1 API call

### DIFF
--- a/app/components/pipeline-options/component.js
+++ b/app/components/pipeline-options/component.js
@@ -18,6 +18,7 @@ export default Component.extend({
   // Update the job status
   jobService: service('job'),
   shuttle: service(),
+  pipelineService: service('pipeline'),
   errorMessage: '',
   successMessage: '',
   scmUrl: '',
@@ -156,9 +157,10 @@ export default Component.extend({
 
     let showPRJobs = true;
 
-    const pipelinePreference = await this.shuttle.getUserPipelinePreference(
-      this.get('pipeline.id')
-    );
+    const pipelinePreference =
+      await this.pipelineService.getUserPipelinePreference(
+        this.get('pipeline.id')
+      );
 
     if (pipelinePreference) {
       showPRJobs =

--- a/app/preference/pipeline/adapter.js
+++ b/app/preference/pipeline/adapter.js
@@ -1,10 +1,13 @@
 import Adapter from 'ember-local-storage/adapters/local';
 import { inject as service } from '@ember/service';
+import { preparePayload } from 'screwdriver-ui/preference/user/serializer';
 
 export default class PreferencePipelineAdapter extends Adapter {
   modelNamespace = 'preference';
 
   @service shuttle;
+
+  @service userSettings;
 
   async createRecord(store, type, snapshot) {
     const serializer = store.serializerFor(type.modelName);
@@ -14,19 +17,22 @@ export default class PreferencePipelineAdapter extends Adapter {
       snapshot,
       { includeId: true }
     );
+    const data = await this.createPayload();
 
-    return this.shuttle.updateUserPreference(id, pipelinePreference);
+    data[id] = pipelinePreference;
+
+    return this.shuttle.updateUserSetting(data);
   }
 
-  async updateRecord(store, type, snapshot) {
-    const serializer = store.serializerFor(type.modelName);
-    const { id, pipelinePreference } = serializer.serializeIntoHash(
-      {},
-      type,
-      snapshot,
-      { includeId: true }
-    );
+  async updateRecord() {
+    const data = await this.createPayload();
 
-    return this.shuttle.updateUserPreference(id, pipelinePreference);
+    return this.shuttle.updateUserSetting(data);
+  }
+
+  async createPayload() {
+    const userPreferences = await this.userSettings.getUserPreference();
+
+    return preparePayload(userPreferences.serialize());
   }
 }

--- a/app/shuttle/service.js
+++ b/app/shuttle/service.js
@@ -1,4 +1,4 @@
-import { get, computed } from '@ember/object';
+import { computed } from '@ember/object';
 import Service, { inject as service } from '@ember/service';
 import $ from 'jquery';
 import ENV from 'screwdriver-ui/config/environment';
@@ -257,76 +257,6 @@ export default Service.extend({
     const url = `/users/settings`;
 
     const data = { settings };
-
-    return this.fetchFromApi(method, url, data);
-  },
-
-  /**
-   * getUserPipelinePreference
-   * @param  {Number} pipelineId  pipeline Id
-   * @return {Promise}
-   */
-  async getUserPipelinePreference(pipelineId) {
-    if (pipelineId === undefined) {
-      return {};
-    }
-
-    const remotePreferences = await this.getUserSetting();
-    const remotePipelineConfig =
-      get(remotePreferences, pipelineId) === undefined
-        ? {}
-        : get(remotePreferences, pipelineId);
-    const localPipelinePreference = await this.store
-      .peekAll('preference/pipeline')
-      .findBy('id', pipelineId);
-
-    // local preference takes precedence
-    if (localPipelinePreference && remotePipelineConfig) {
-      localPipelinePreference.setProperties(remotePipelineConfig);
-      localPipelinePreference.save();
-
-      return localPipelinePreference;
-    }
-
-    const pipelinePreference = await this.store.createRecord(
-      'preference/pipeline',
-      {
-        id: pipelineId,
-        ...remotePipelineConfig
-      }
-    );
-
-    return pipelinePreference;
-  },
-
-  /**
-   * getUserPreference
-   * @return {Promise}
-   */
-  async getUserPreference() {
-    const userSetting = await this.getUserSetting();
-
-    return userSetting;
-  },
-
-  /**
-   * updateUserPreference
-   * @param  {Number}  [pipelineId]
-   * @param  {Object}  pipelineSettings
-   * @param  {Boolean} [pipelineSettings.showPRJobs]
-   * @return {Promise}
-   */
-  async updateUserPreference(pipelineId, pipelineSettings) {
-    const method = 'put';
-    const url = `/users/settings`;
-    const userSettings = await this.getUserSetting();
-
-    let data = {
-      settings: {
-        ...userSettings,
-        [pipelineId]: pipelineSettings
-      }
-    };
 
     return this.fetchFromApi(method, url, data);
   },

--- a/tests/integration/components/pipeline-options/component-test.js
+++ b/tests/integration/components/pipeline-options/component-test.js
@@ -257,7 +257,7 @@ module('Integration | Component | pipeline options', function (hooks) {
   });
 
   test('it opens job toggle modal', async function (assert) {
-    assert.expect(10);
+    assert.expect(11);
 
     injectSessionStub(this);
 
@@ -702,7 +702,10 @@ module('Integration | Component | pipeline options', function (hooks) {
         });
 
         return resolve({});
-      },
+      }
+    });
+
+    const pipelineServiceStub = Service.extend({
       getUserPipelinePreference(pipelineId) {
         assert.ok(true, 'getUserPipelinePreference called');
         assert.equal(pipelineId, 'abc1234');
@@ -713,6 +716,8 @@ module('Integration | Component | pipeline options', function (hooks) {
 
     this.owner.unregister('service:shuttle');
     this.owner.register('service:shuttle', shuttleStub);
+    this.owner.unregister('service:pipeline');
+    this.owner.register('service:pipeline', pipelineServiceStub);
 
     await render(hbs`<PipelineOptions @pipeline={{this.mockPipeline}} />`);
 
@@ -766,7 +771,10 @@ module('Integration | Component | pipeline options', function (hooks) {
         });
 
         return resolve({});
-      },
+      }
+    });
+
+    const pipelineServiceStub = Service.extend({
       getUserPipelinePreference(pipelineId) {
         assert.ok(true, 'getUserPipelinePreference called');
         assert.equal(pipelineId, 'abc1234');
@@ -777,6 +785,8 @@ module('Integration | Component | pipeline options', function (hooks) {
 
     this.owner.unregister('service:shuttle');
     this.owner.register('service:shuttle', shuttleStub);
+    this.owner.unregister('service:pipeline');
+    this.owner.register('service:pipeline', pipelineServiceStub);
 
     await render(hbs`<PipelineOptions @pipeline={{this.mockPipeline}} />`);
 
@@ -823,7 +833,10 @@ module('Integration | Component | pipeline options', function (hooks) {
         });
 
         return resolve({});
-      },
+      }
+    });
+
+    const pipelineServiceStub = Service.extend({
       getUserPipelinePreference(pipelineId) {
         assert.ok(true, 'getUserPipelinePreference called');
         assert.equal(pipelineId, 'abc1234');
@@ -834,6 +847,8 @@ module('Integration | Component | pipeline options', function (hooks) {
 
     this.owner.unregister('service:shuttle');
     this.owner.register('service:shuttle', shuttleStub);
+    this.owner.unregister('service:pipeline');
+    this.owner.register('service:pipeline', pipelineServiceStub);
 
     await render(hbs`<PipelineOptions @pipeline={{this.mockPipeline}} />`);
 


### PR DESCRIPTION
## Context
Updating pipeline settings requires 2 API calls.  Currently, to update the pipeline settings 2 API calls are required because the pipeline setting adapter does not serialize the user settings.  As a result, the current implementation makes an API call to get the current settings and update only the modified pipeline's settings.  As there is no `PATCH` API endpoint, the full settings body must be recreated.

## Objective
Updates the pipeline setting adapter to serialize the user settings to remove the need for an API call.

## References

## License
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
