### PR TITLE
Fix local options not being reset

### DIFF
--- a/app/user-settings/preferences/controller.js
+++ b/app/user-settings/preferences/controller.js
@@ -80,6 +80,14 @@ export default Controller.extend({
       this.set('isSaving', true);
 
       try {
+        const localPipelinePreferences = await this.store.peekAll(
+          'preference/pipeline'
+        );
+
+        localPipelinePreferences.forEach(pipelinePreference => {
+          pipelinePreference.unloadRecord();
+        });
+
         // can be replaced with destroyRecord after ember-data 3.28
         this.store.deleteRecord(this.userPreferences);
         await this.userPreferences.save();

--- a/tests/unit/user-settings/preferences/controller-test.js
+++ b/tests/unit/user-settings/preferences/controller-test.js
@@ -25,7 +25,7 @@ module('Unit | Controller | user-settings/preferences', function (hooks) {
   });
 
   test('it calls resetUserSettings', async function (assert) {
-    assert.expect(4);
+    assert.expect(5);
 
     const userSettingsServiceMock = Service.extend({
       getUserPreference() {
@@ -53,6 +53,77 @@ module('Unit | Controller | user-settings/preferences', function (hooks) {
         assert.ok('deleteRecord called');
 
         return new EmberPromise(resolve => resolve({}));
+      },
+      peekAll() {
+        assert.ok('peekAll called');
+
+        return new EmberPromise(resolve => resolve([]));
+      }
+    });
+
+    this.owner.register('service:store', storeStub);
+
+    const controller = this.owner.lookup(
+      'controller:user-settings/preferences'
+    );
+
+    const resetUserSettingsActionStub = sinon.spy(
+      controller.actions,
+      'resetUserSettings'
+    );
+
+    await settled();
+
+    controller.send('resetUserSettings');
+
+    assert.ok(
+      resetUserSettingsActionStub.calledOnce,
+      'action resetUserSettings called once'
+    );
+  });
+
+  test('it unloads pipeline settings when resetUserSettings executes', async function (assert) {
+    assert.expect(6);
+
+    const userSettingsServiceMock = Service.extend({
+      getUserPreference() {
+        const record = {
+          save() {
+            assert.ok('save called');
+
+            return EmberPromise.resolve();
+          },
+          unloadRecord() {
+            assert.ok('unloadRecord called');
+
+            return EmberPromise.resolve();
+          }
+        };
+
+        return record;
+      }
+    });
+
+    this.owner.register('service:userSettings', userSettingsServiceMock);
+
+    const storeStub = Service.extend({
+      deleteRecord(/* record */) {
+        assert.ok('deleteRecord called');
+
+        return new EmberPromise(resolve => resolve({}));
+      },
+      peekAll() {
+        assert.ok('peekAll called');
+
+        return new EmberPromise(resolve =>
+          resolve([
+            {
+              unloadRecord() {
+                assert.ok('unload record called');
+              }
+            }
+          ])
+        );
       }
     });
 


### PR DESCRIPTION
## Context
In the `User Settings` page, the `DELETE` method of the `/user/settings` API is used to reset all user settings.  The local settings for pipelines are currently still preserved when they should be reset.

## Objective
Fix the reset logic to also clear out pipeline settings from the ember store when user settings are reset.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
