### PR TITLE
feat(3022): Show stage setup/teardown nodes in workflow graph when setup/teardown is explicitly specified in pipeline configuration

### DIFF
--- a/app/job/model.js
+++ b/app/job/model.js
@@ -68,6 +68,13 @@ export default Model.extend({
       return get(this, 'permutations.0.annotations') || {};
     }
   }),
+  virtualJob: computed('annotations', 'permutations.0.annotations', {
+    get() {
+      const annotations = get(this, 'annotations');
+
+      return annotations && annotations['screwdriver.cd/virtualJob'] === true;
+    }
+  }),
   description: computed('permutations.0.description', {
     get() {
       return get(this, 'permutations.0.description') || {};


### PR DESCRIPTION
## Context
Current implementation hides all the nodes/edges corresponding to stage `setup`/`teardown` jobs even when setup/teardown is explitctly configured in the `screwdriver.yaml`.

With https://github.com/screwdriver-cd/config-parser/pull/151, we can now distinguish implicitly vs explicitly created setup or teardown for a stage. This allows us to selectively hide nodes/edges corresponding to stage `setup`/`teardown` jobs.

## Objective

Hide `setup`/`teardown` nodes, if the corresponding jobs have the annotation `'screwdriver.cd/virtualJob': true`.

**Example:**
https://github.com/sagar1312/screwdriver-config/blob/main/stage-alpha-parallel/screwdriver.yaml

```
stages:
  integration:
    jobs: [ci-deploy, ci-test, ci-certify]
    requires: [ publish ]
    description: "This stage will deploy the latest application to CI environment and certifies it after the tests are passed."
  production-blue:
    jobs: [ prod-blue-deploy, prod-blue-test, prod-blue-certify ]
    requires: [ stage@integration:teardown ]
    description: "This stage will deploy the CI certified application to production BLUE environment and certifies it after the tests are passed."
  production-green:
    jobs: [ prod-green-deploy, prod-green-test, prod-green-certify ]
    requires: [ stage@integration:teardown ]
    description: "This stage will deploy the CI certified application to production GREEN environment and certifies it after the tests are passed."
    setup:
      image: node:14
      steps:
        - init: echo 'prod setup'
    teardown:
      image: node:14
      steps:
        - init: echo 'prod teardown'
```

<img width="1289" alt="image" src="https://github.com/screwdriver-cd/ui/assets/2124590/2c103901-f047-4071-a992-4aa34c05ce1b">



## References

https://github.com/screwdriver-cd/screwdriver/issues/3022

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
