### PR TITLE
fix: remove redundant calls to collections API

### DIFF
--- a/app/application/route.js
+++ b/app/application/route.js
@@ -1,5 +1,5 @@
 import { inject as service } from '@ember/service';
-import { get, observer } from '@ember/object';
+import { observer } from '@ember/object';
 import Route from '@ember/routing/route';
 import ApplicationRouteMixin from 'ember-simple-auth/mixins/application-route-mixin';
 
@@ -15,15 +15,6 @@ export default Route.extend(ApplicationRouteMixin, {
   },
   model() {
     return this.scmService.createScms();
-  },
-  setupController(controller) {
-    this._super(...arguments);
-    if (
-      get(this, 'session.isAuthenticated') &&
-      !get(this, 'session.data.authenticated.isGuest')
-    ) {
-      controller.set('collections', this.store.findAll('collection'));
-    }
   },
   sessionInvalidated() {
     this.reloadPage();


### PR DESCRIPTION
## Context
The collections API is called multiple times for the `/pipeline/*` and `/dashboards` routes.  Those routes require the collections data, but they are already configured to fetch the data if required.  The main application route was configured to also request the collections API, even though many routes do not require the collections data.

## Objective
Pushes API calls for collections down to the actual routes that require the data.  Also removes the redundant API call as `setupController` is not async and the routes below are not aware that the API call has already been made.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
