### PR TITLE
Fix cache checking of event

### DIFF
--- a/app/pipeline/events/show/route.js
+++ b/app/pipeline/events/show/route.js
@@ -31,7 +31,13 @@ export default class PipelineEventsShowRoute extends Route {
 
   async beforeModel() {
     const { event_id: eventId } = this.paramsFor(this.routeName);
-    const event = await this.store.findRecord('event', eventId);
+
+    let event = this.store.peekRecord('event', eventId);
+
+    if (!event) {
+      event = await this.store.findRecord('event', eventId);
+    }
+
     const { pipeline_id: pipelineId } = this.paramsFor('pipeline');
 
     if (event.get('pipelineId') !== pipelineId) {
@@ -50,7 +56,11 @@ export default class PipelineEventsShowRoute extends Route {
     );
 
     if (!desiredEvent) {
-      const event = await this.store.findRecord('event', eventId);
+      let event = await this.store.peekRecord('event', eventId);
+
+      if (!event) {
+        event = await this.store.findRecord('event', eventId);
+      }
 
       pipelineEventsController.paginateEvents.pushObject(event);
     } else {


### PR DESCRIPTION
## Context
When loading the pipeline page, multiple API calls are being made to the `/events/{eventId}` endpoint.  Limit the number of API calls to the `events/{eventId}` endpoint by properly checking the store cache first.

## Objective
`Peek` into the ember store cache to get the event data and only make an API call if the store cache does not contain the event.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
