### PR TITLE
fix(3053): handle re/start with joins from a detached job

### DIFF
--- a/app/utils/pipeline-workflow.js
+++ b/app/utils/pipeline-workflow.js
@@ -1,0 +1,39 @@
+import { isRoot, reverseGraph, subgraphFilter } from './graph-tools';
+
+/**
+ * Determines if a job node can be triggered from the view indicated by the activeTab
+ * @param activeTab{string} The active tab that is selected
+ * @param pipelineGraph     Pipeline graph as {nodes, edges}
+ * @param jobName{string}   Job name of the node in question
+ * @returns {boolean}       True if the node can be started from the given view, false otherwise
+ */
+export default function canJobStart(activeTab, pipelineGraph, jobName) {
+  const reversedGraph = reverseGraph(pipelineGraph);
+  const subgraph = subgraphFilter(reversedGraph, jobName);
+
+  const isOnPrPath =
+    subgraph.nodes.filter(node => node.name === '~pr').length > 0;
+
+  if (activeTab === 'pulls') {
+    // In the pull request view, only allow restarting nodes that are reachable from the ~pr node
+    return isOnPrPath;
+  }
+
+  // In the events view:
+  if (isOnPrPath) {
+    // Jobs that can be triggered by ~pr need to be checked that they are not triggered by only ~pr (i.e., a job triggered by ~pr and a detached job)
+    const { nodes, edges } = reverseGraph(subgraph);
+
+    let numRoots = 0;
+
+    nodes.forEach(node => {
+      if (isRoot(edges, node.name)) {
+        numRoots += 1;
+      }
+    });
+
+    return numRoots > 1;
+  }
+
+  return true;
+}

--- a/tests/unit/utils/pipeline-workflow-test.js
+++ b/tests/unit/utils/pipeline-workflow-test.js
@@ -1,0 +1,62 @@
+import canJobStart from 'screwdriver-ui/utils/pipeline-workflow';
+import { module, test } from 'qunit';
+
+module('Unit | Components | pipeline-workflow', function () {
+  const workflowGraph = {
+    nodes: [
+      { name: '~pr' },
+      { name: '~commit' },
+      { name: 'p1' },
+      { name: 'p2' },
+      { name: 'c1' },
+      { name: 'c2' },
+      { name: 'd1' },
+      { name: 'd2' },
+      { name: 'pc1' },
+      { name: 'pc2' },
+      { name: 'pd1' },
+      { name: 'pd2' }
+    ],
+    edges: [
+      { src: '~pr', dest: 'p1' },
+      { src: '~pr', dest: 'pc1' },
+      { src: '~pr', dest: 'pd1' },
+      { src: 'p1', dest: 'p2' },
+      { src: '~commit', dest: 'c1' },
+      { src: '~commit', dest: 'pc1' },
+      { src: 'c1', dest: 'c2' },
+      { src: 'd1', dest: 'd2' },
+      { src: 'd1', dest: 'pd1' },
+      { src: 'pc1', dest: 'pc2' },
+      { src: 'pd1', dest: 'pd2' }
+    ]
+  };
+
+  test('can start a ~pr triggered job from pr view', assert => {
+    assert.equal(canJobStart('pulls', workflowGraph, 'p1'), true);
+    assert.equal(canJobStart('pulls', workflowGraph, 'p2'), true);
+    assert.equal(canJobStart('pulls', workflowGraph, 'pc1'), true);
+    assert.equal(canJobStart('pulls', workflowGraph, 'pc2'), true);
+    assert.equal(canJobStart('pulls', workflowGraph, 'pd1'), true);
+    assert.equal(canJobStart('pulls', workflowGraph, 'pd2'), true);
+
+    assert.equal(canJobStart('pulls', workflowGraph, 'c1'), false);
+    assert.equal(canJobStart('pulls', workflowGraph, 'c2'), false);
+    assert.equal(canJobStart('pulls', workflowGraph, 'd1'), false);
+    assert.equal(canJobStart('pulls', workflowGraph, 'd2'), false);
+  });
+
+  test('can start jobs not triggered by ~pr from events view', assert => {
+    assert.equal(canJobStart('events', workflowGraph, 'c1'), true);
+    assert.equal(canJobStart('events', workflowGraph, 'c2'), true);
+    assert.equal(canJobStart('events', workflowGraph, 'd1'), true);
+    assert.equal(canJobStart('events', workflowGraph, 'd2'), true);
+    assert.equal(canJobStart('events', workflowGraph, 'pc1'), true);
+    assert.equal(canJobStart('events', workflowGraph, 'pc2'), true);
+    assert.equal(canJobStart('events', workflowGraph, 'pd1'), true);
+    assert.equal(canJobStart('events', workflowGraph, 'pd2'), true);
+
+    assert.equal(canJobStart('events', workflowGraph, 'p1'), false);
+    assert.equal(canJobStart('events', workflowGraph, 'p2'), false);
+  });
+});


### PR DESCRIPTION
## Context
#991 did not account for jobs on the ~pr path that are also joined from a detached job.  This updates the start/re-start logic to be more robust so that any job reachable from the ~pr trigger are validated to have multiple routes to determine eligibility of being started/re-started from the pipeline views.
![Screenshot 2024-03-06 at 10-25-59 minghay_commit-join](https://github.com/screwdriver-cd/ui/assets/157658916/67c92cec-7538-45ce-9376-f65e9fff390f)
![Screenshot 2024-03-06 at 10-26-54 minghay_commit-join](https://github.com/screwdriver-cd/ui/assets/157658916/26df8719-87b3-42ab-9430-bd621ade8d5c)

## Objective
Adds an additional check on jobs reachable from the ~pr trigger to determine how many root jobs exist for the particular node.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3053

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
