### PR TITLE
feat(3041): Validator UI - Show stages in workflow graph if configured

### DIFF
--- a/app/components/validator-pipeline/template.hbs
+++ b/app/components/validator-pipeline/template.hbs
@@ -88,6 +88,6 @@
   <span class="label" title="This is the order that the jobs will run in.">
     Workflow:
   </span>
-  <WorkflowGraphD3 @workflowGraph={{this.workflowGraph}} />
+  <WorkflowGraphD3 @workflowGraph={{this.workflowGraph}} @stages={{this.stages}} @jobs={{this.jobs}}/>
 </div>
 {{yield}}

--- a/app/components/validator-results/component.js
+++ b/app/components/validator-results/component.js
@@ -1,12 +1,48 @@
 import { computed, get } from '@ember/object';
-import { reads, map } from '@ember/object/computed';
+import { map } from '@ember/object/computed';
 import Component from '@ember/component';
+import { inject as service } from '@ember/service';
 import templateHelper from 'screwdriver-ui/utils/template';
 const { getFullName } = templateHelper;
 
 export default Component.extend({
+  store: service(),
   results: null,
-  jobs: reads('results.jobs'),
+  jobs: computed('results.jobs', {
+    get() {
+      const configJobs = get(this, 'results.jobs') || {};
+      const jobs = [];
+
+      Object.entries(configJobs).forEach(([jobName, jobConfig]) => {
+        jobs.push(
+          this.store.createRecord('job', {
+            name: jobName,
+            permutations: jobConfig,
+            archived: false
+          })
+        );
+      });
+
+      return jobs;
+    }
+  }),
+  stages: computed('results.stages', {
+    get() {
+      const configStages = get(this, 'results.stages') || {};
+      const stages = [];
+
+      Object.entries(configStages).forEach(([stageName, stageConfig]) => {
+        stages.push(
+          this.store.createRecord('stage', {
+            name: stageName,
+            description: stageConfig.description
+          })
+        );
+      });
+
+      return stages;
+    }
+  }),
   errors: map('results.errors', e => (typeof e === 'string' ? e : e.message)),
   workflowGraph: computed('results.workflowGraph', {
     get() {

--- a/app/components/validator-results/template.hbs
+++ b/app/components/validator-results/template.hbs
@@ -18,16 +18,18 @@
 {{else}}
   <ValidatorPipeline
     @name={{this.pipelineName}}
+    @jobs={{this.jobs}}
+    @stages={{this.stages}}
     @workflowGraph={{this.workflowGraph}}
     @annotations={{this.annotations}}
     @parameters={{this.parameters}}
     @isOpen={{unbound this.isOpen}}
   />
-  {{#each this.workflowGraph.nodes as |node|}}
-    {{#if (get this.jobs node.name)}}
-      {{#each (get this.jobs node.name) as |jobConfig index|}}
+  {{#each this.jobs as |job|}}
+    {{#if (not job.virtualJob) }}
+      {{#each job.permutations as |jobConfig index|}}
         <ValidatorJob
-          @name={{node.name}}
+          @name={{job.name}}
           @job={{jobConfig}}
           @index={{index}}
           @isOpen={{unbound this.isOpen}}

--- a/app/components/workflow-graph-d3/component.js
+++ b/app/components/workflow-graph-d3/component.js
@@ -278,8 +278,6 @@ export default Component.extend({
     // gap between stages
     const STAGE_GAP = ICON_SIZE / 9;
 
-    const stagesGroupedByRowPosition = groupBy(data.stages, 'pos.y');
-
     const verticalDisplacementByRowPosition = {};
     const getVerticalDisplacementByRowPosition = pos => {
       return verticalDisplacementByRowPosition[pos] || 0;
@@ -333,6 +331,7 @@ export default Component.extend({
 
     // stages
     if (this.showStages) {
+      const stagesGroupedByRowPosition = groupBy(data.stages, 'pos.y');
       const calcStageY = (stage, yDisplacement = 0) => {
         return (
           calcPos(stage.pos.y, Y_SPACING) -

--- a/tests/integration/components/validator-results/component-test.js
+++ b/tests/integration/components/validator-results/component-test.js
@@ -60,11 +60,348 @@ module('Integration | Component | validator results', function (hooks) {
     await render(hbs`<ValidatorResults @results={{this.validationMock}} />`);
     const jobs = findAll('h4.job');
 
-    assert.dom(jobs[0]).hasText('main');
-    assert.dom(jobs[1]).hasText('main.1');
-    assert.dom(jobs[2]).hasText('foo');
+    assert.equal(jobs.length, 3);
+    assert.dom(jobs[0]).hasText('foo');
+    assert.dom(jobs[1]).hasText('main');
+    assert.dom(jobs[2]).hasText('main.1');
     assert.dom('.error').hasText('got an error');
     assert.dom('h4.pipeline').hasText('Pipeline Settings');
+  });
+
+  /**
+   * Do not show configs of implicit stage setup/teardown jobs
+   * Should render stages in the workflow graph
+   */
+  test('it renders stages', async function (assert) {
+    this.set('validationMock', {
+      errors: ['got an error'],
+      annotations: {},
+      jobs: {
+        component: [
+          {
+            annotations: {
+              'screwdriver.cd/displayName': 'compJob'
+            },
+            commands: [
+              {
+                name: 'init',
+                command: "echo 'init'"
+              }
+            ],
+            environment: {},
+            image: 'node:14',
+            secrets: [],
+            settings: {},
+            requires: ['~pr', '~commit']
+          }
+        ],
+        publish: [
+          {
+            annotations: {},
+            commands: [
+              {
+                name: 'init',
+                command: "echo 'init'"
+              }
+            ],
+            environment: {},
+            image: 'node:14',
+            secrets: [],
+            settings: {},
+            requires: ['component']
+          }
+        ],
+        'ci-deploy': [
+          {
+            annotations: {},
+            commands: [
+              {
+                name: 'init',
+                command: "echo 'init'"
+              }
+            ],
+            environment: {},
+            image: 'node:14',
+            secrets: [],
+            settings: {},
+            requires: ['~stage@integration:setup'],
+            stage: {
+              name: 'integration'
+            }
+          }
+        ],
+        'ci-test': [
+          {
+            annotations: {},
+            commands: [
+              {
+                name: 'init',
+                command: "echo 'init'"
+              }
+            ],
+            environment: {},
+            image: 'node:14',
+            secrets: [],
+            settings: {},
+            requires: ['ci-deploy'],
+            stage: {
+              name: 'integration'
+            }
+          }
+        ],
+        'ci-certify': [
+          {
+            annotations: {},
+            commands: [
+              {
+                name: 'init',
+                command: "echo 'init'"
+              }
+            ],
+            environment: {},
+            image: 'node:14',
+            secrets: [],
+            settings: {},
+            requires: ['ci-test'],
+            stage: {
+              name: 'integration'
+            }
+          }
+        ],
+        'prod-deploy': [
+          {
+            annotations: {},
+            commands: [
+              {
+                name: 'init',
+                command: "echo 'init'"
+              }
+            ],
+            environment: {},
+            image: 'node:14',
+            secrets: [],
+            settings: {},
+            requires: ['~stage@production:setup'],
+            stage: {
+              name: 'production'
+            }
+          }
+        ],
+        'prod-test': [
+          {
+            annotations: {},
+            commands: [
+              {
+                name: 'init',
+                command: "echo 'init'"
+              }
+            ],
+            environment: {},
+            image: 'node:14',
+            secrets: [],
+            settings: {},
+            requires: ['prod-deploy'],
+            stage: {
+              name: 'production'
+            }
+          }
+        ],
+        'prod-certify': [
+          {
+            annotations: {},
+            commands: [
+              {
+                name: 'init',
+                command: "echo 'init'"
+              }
+            ],
+            environment: {},
+            image: 'node:14',
+            secrets: [],
+            settings: {},
+            requires: ['prod-test'],
+            stage: {
+              name: 'production'
+            }
+          }
+        ],
+        'stage@integration:setup': [
+          {
+            annotations: {
+              'screwdriver.cd/virtualJob': true
+            },
+            commands: [
+              {
+                name: 'noop',
+                command: 'echo noop'
+              }
+            ],
+            environment: {},
+            image: 'node:18',
+            secrets: [],
+            settings: {},
+            requires: ['publish'],
+            stage: {
+              name: 'integration'
+            }
+          }
+        ],
+        'stage@integration:teardown': [
+          {
+            annotations: {
+              'screwdriver.cd/virtualJob': true
+            },
+            commands: [
+              {
+                name: 'noop',
+                command: 'echo noop'
+              }
+            ],
+            environment: {},
+            image: 'node:18',
+            secrets: [],
+            settings: {},
+            requires: ['ci-certify'],
+            stage: {
+              name: 'integration'
+            }
+          }
+        ],
+        'stage@production:setup': [
+          {
+            annotations: {},
+            commands: [
+              {
+                name: 'init',
+                command: "echo 'prod setup'"
+              }
+            ],
+            environment: {},
+            image: 'node:14',
+            secrets: [],
+            settings: {},
+            requires: ['~stage@integration:teardown'],
+            stage: {
+              name: 'production'
+            }
+          }
+        ],
+        'stage@production:teardown': [
+          {
+            annotations: {},
+            commands: [
+              {
+                name: 'init',
+                command: "echo 'prod teardown'"
+              }
+            ],
+            environment: {},
+            image: 'node:14',
+            secrets: [],
+            settings: {},
+            requires: ['prod-certify'],
+            stage: {
+              name: 'production'
+            }
+          }
+        ]
+      },
+      workflowGraph: {
+        nodes: [
+          { name: '~pr' },
+          { name: '~commit' },
+          { name: 'component', displayName: 'compJob' },
+          { name: 'publish' },
+          { name: 'ci-deploy', stageName: 'integration' },
+          { name: 'stage@integration:setup', stageName: 'integration' },
+          { name: 'ci-test', stageName: 'integration' },
+          { name: 'ci-certify', stageName: 'integration' },
+          { name: 'prod-deploy', stageName: 'production' },
+          { name: 'stage@production:setup', stageName: 'production' },
+          { name: 'prod-test', stageName: 'production' },
+          { name: 'prod-certify', stageName: 'production' },
+          { name: 'stage@integration:teardown', stageName: 'integration' },
+          { name: 'stage@production:teardown', stageName: 'production' }
+        ],
+        edges: [
+          { src: '~pr', dest: 'component' },
+          { src: '~commit', dest: 'component' },
+          { src: 'component', dest: 'publish', join: true },
+          { src: 'stage@integration:setup', dest: 'ci-deploy' },
+          { src: 'ci-deploy', dest: 'ci-test', join: true },
+          { src: 'ci-test', dest: 'ci-certify', join: true },
+          { src: 'stage@production:setup', dest: 'prod-deploy' },
+          { src: 'prod-deploy', dest: 'prod-test', join: true },
+          { src: 'prod-test', dest: 'prod-certify', join: true },
+          { src: 'publish', dest: 'stage@integration:setup', join: true },
+          { src: 'ci-certify', dest: 'stage@integration:teardown', join: true },
+          { src: 'stage@integration:teardown', dest: 'stage@production:setup' },
+          { src: 'prod-certify', dest: 'stage@production:teardown', join: true }
+        ]
+      },
+      parameters: {},
+      subscribe: {},
+      stages: {
+        integration: {
+          jobs: ['ci-deploy', 'ci-test', 'ci-certify'],
+          requires: ['publish'],
+          description:
+            'This stage will deploy the latest application to CI environment and certifies it after the tests are passed.'
+        },
+        production: {
+          jobs: ['prod-deploy', 'prod-test', 'prod-certify'],
+          requires: ['~stage@integration:teardown'],
+          description:
+            'This stage will deploy the CI certified application to production environment and certifies it after the tests are passed.'
+        }
+      }
+    });
+
+    await render(hbs`<ValidatorResults @results={{this.validationMock}} />`);
+
+    assert.dom('.error').hasText('got an error');
+    assert.dom('h4.pipeline').hasText('Pipeline Settings');
+
+    const jobs = findAll('h4.job');
+
+    assert.equal(jobs.length, 10);
+    assert.dom(jobs[0]).hasText('component');
+    assert.dom(jobs[1]).hasText('publish');
+    assert.dom(jobs[2]).hasText('ci-deploy');
+    assert.dom(jobs[3]).hasText('ci-test');
+    assert.dom(jobs[4]).hasText('ci-certify');
+    assert.dom(jobs[5]).hasText('prod-deploy');
+    assert.dom(jobs[6]).hasText('prod-test');
+    assert.dom(jobs[7]).hasText('prod-certify');
+    assert.dom(jobs[8]).hasText('stage@production:setup');
+    assert.dom(jobs[9]).hasText('stage@production:teardown');
+
+    assert.equal(this.element.querySelectorAll('div.workflow svg').length, 1);
+    assert.equal(
+      this.element.querySelectorAll('svg > g.graph-node').length,
+      12
+    );
+    assert.equal(
+      this.element.querySelectorAll('svg > path.graph-edge').length,
+      11
+    );
+
+    assert.equal(
+      this.element.querySelectorAll('svg > .stage-container').length,
+      2
+    );
+    assert.equal(
+      this.element.querySelectorAll(
+        'svg > .stage-info-wrapper .stage-info .stage-name'
+      ).length,
+      2
+    );
+    assert
+      .dom('svg > .stage-info-wrapper:nth-of-type(1) .stage-info .stage-name')
+      .hasText('integration');
+    assert
+      .dom('svg > .stage-info-wrapper:nth-of-type(2) .stage-info .stage-name')
+      .hasText('production');
   });
 
   test('it renders templates', async function (assert) {

--- a/tests/integration/components/workflow-graph-d3/component-test.js
+++ b/tests/integration/components/workflow-graph-d3/component-test.js
@@ -259,23 +259,35 @@ module('Integration | Component | workflow graph d3', function (hooks) {
         { name: '~commit' },
         { name: 'component', id: 1 },
         { name: 'publish', id: 2 },
+        { name: 'stage@integration:setup', id: 28, stageName: 'integration' },
         { name: 'ci-deploy', id: 21, stageName: 'integration' },
         { name: 'ci-test', id: 22, stageName: 'integration' },
         { name: 'ci-certify', id: 23, stageName: 'integration' },
+        {
+          name: 'stage@integration:teardown',
+          id: 29,
+          stageName: 'integration'
+        },
+        { name: 'stage@production:setup', id: 38, stageName: 'production' },
         { name: 'prod-deploy', id: 31, stageName: 'production' },
         { name: 'prod-test', id: 32, stageName: 'production' },
-        { name: 'prod-certify', id: 33, stageName: 'production' }
+        { name: 'prod-certify', id: 33, stageName: 'production' },
+        { name: 'stage@production:teardown', id: 39, stageName: 'production' }
       ],
       edges: [
         { src: '~pr', dest: 'component' },
         { src: '~commit', dest: 'component' },
         { src: 'component', dest: 'publish' },
-        { src: 'publish', dest: 'ci-deploy' },
+        { src: 'publish', dest: 'stage@integration:setup' },
+        { src: 'stage@integration:setup', dest: 'ci-deploy' },
         { src: 'ci-deploy', dest: 'ci-test' },
         { src: 'ci-test', dest: 'ci-certify' },
-        { src: 'ci-certify', dest: 'prod-deploy' },
+        { src: 'ci-certify', dest: 'stage@integration:teardown' },
+        { src: 'stage@integration:teardown', dest: 'stage@production:setup' },
+        { src: 'stage@production:setup', dest: 'prod-deploy' },
         { src: 'prod-deploy', dest: 'prod-test' },
-        { src: 'prod-test', dest: 'prod-certify' }
+        { src: 'prod-test', dest: 'prod-certify' },
+        { src: 'prod-certify', dest: 'stage@production:teardown' }
       ]
     });
 
@@ -284,13 +296,17 @@ module('Integration | Component | workflow graph d3', function (hooks) {
         id: 7,
         name: 'integration',
         jobs: [{ id: 21 }, { id: 22 }, { id: 23 }],
-        description: STAGE_INT_DESC
+        description: STAGE_INT_DESC,
+        setup: 28,
+        teardown: 29
       },
       {
         id: 8,
         name: 'production',
         jobs: [{ id: 31 }, { id: 32 }, { id: 33 }],
-        description: STAGE_PROD_DESC
+        description: STAGE_PROD_DESC,
+        setup: 38,
+        teardown: 39
       }
     ]);
 
@@ -301,11 +317,11 @@ module('Integration | Component | workflow graph d3', function (hooks) {
     assert.equal(this.element.querySelectorAll('svg').length, 1);
     assert.equal(
       this.element.querySelectorAll('svg > g.graph-node').length,
-      10
+      14
     );
     assert.equal(
       this.element.querySelectorAll('svg > path.graph-edge').length,
-      9
+      13
     );
 
     assert.equal(
@@ -356,23 +372,35 @@ module('Integration | Component | workflow graph d3', function (hooks) {
         { name: '~commit' },
         { name: 'component', id: 1 },
         { name: 'publish', id: 2 },
+        { name: 'stage@integration:setup', id: 28, stageName: 'integration' },
         { name: 'ci-deploy', id: 21, stageName: 'integration' },
         { name: 'ci-test', id: 22, stageName: 'integration' },
         { name: 'ci-certify', id: 23, stageName: 'integration' },
+        {
+          name: 'stage@integration:teardown',
+          id: 29,
+          stageName: 'integration'
+        },
+        { name: 'stage@production:setup', id: 38, stageName: 'production' },
         { name: 'prod-deploy', id: 31, stageName: 'production' },
         { name: 'prod-test', id: 32, stageName: 'production' },
-        { name: 'prod-certify', id: 33, stageName: 'production' }
+        { name: 'prod-certify', id: 33, stageName: 'production' },
+        { name: 'stage@production:teardown', id: 39, stageName: 'production' }
       ],
       edges: [
         { src: '~pr', dest: 'component' },
         { src: '~commit', dest: 'component' },
         { src: 'component', dest: 'publish' },
-        { src: 'publish', dest: 'ci-deploy' },
+        { src: 'publish', dest: 'stage@integration:setup' },
+        { src: 'stage@integration:setup', dest: 'ci-deploy' },
         { src: 'ci-deploy', dest: 'ci-test' },
         { src: 'ci-test', dest: 'ci-certify' },
-        { src: 'ci-certify', dest: 'prod-deploy' },
+        { src: 'ci-certify', dest: 'stage@integration:teardown' },
+        { src: 'stage@integration:teardown', dest: 'stage@production:setup' },
+        { src: 'stage@production:setup', dest: 'prod-deploy' },
         { src: 'prod-deploy', dest: 'prod-test' },
-        { src: 'prod-test', dest: 'prod-certify' }
+        { src: 'prod-test', dest: 'prod-certify' },
+        { src: 'prod-certify', dest: 'stage@production:teardown' }
       ]
     });
 
@@ -381,13 +409,17 @@ module('Integration | Component | workflow graph d3', function (hooks) {
         id: 7,
         name: 'integration',
         jobs: [{ id: 21 }, { id: 22 }, { id: 23 }],
-        description: STAGE_INT_DESC
+        description: STAGE_INT_DESC,
+        setup: 28,
+        teardown: 29
       },
       {
         id: 8,
         name: 'production',
         jobs: [{ id: 31 }, { id: 32 }, { id: 33 }],
-        description: STAGE_PROD_DESC
+        description: STAGE_PROD_DESC,
+        setup: 38,
+        teardown: 39
       }
     ]);
 
@@ -398,11 +430,11 @@ module('Integration | Component | workflow graph d3', function (hooks) {
     assert.equal(this.element.querySelectorAll('svg').length, 1);
     assert.equal(
       this.element.querySelectorAll('svg > g.graph-node').length,
-      10
+      14
     );
     assert.equal(
       this.element.querySelectorAll('svg > path.graph-edge').length,
-      9
+      13
     );
 
     assert.equal(

--- a/tests/unit/utils/graph-tools-test.js
+++ b/tests/unit/utils/graph-tools-test.js
@@ -94,6 +94,7 @@ module('Unit | Utility | graph tools', function () {
           to: { x: 1, y: 0 }
         }
       ],
+      stages: [],
       meta: {
         height: 2,
         width: 2
@@ -129,6 +130,7 @@ module('Unit | Utility | graph tools', function () {
         { src: 'B', dest: 'D', from: { x: 2, y: 1 }, to: { x: 4, y: 0 } },
         { src: 'C', dest: 'D', from: { x: 3, y: 0 }, to: { x: 4, y: 0 } }
       ],
+      stages: [],
       meta: {
         height: 2,
         width: 5
@@ -232,6 +234,7 @@ module('Unit | Utility | graph tools', function () {
           status: 'SUCCESS'
         }
       ],
+      stages: [],
       meta: {
         height: 2,
         width: 5
@@ -337,6 +340,7 @@ module('Unit | Utility | graph tools', function () {
         { src: 'B', dest: 'D', from: { x: 2, y: 1 }, to: { x: 4, y: 0 } },
         { src: 'C', dest: 'D', from: { x: 3, y: 0 }, to: { x: 4, y: 0 } }
       ],
+      stages: [],
       meta: {
         height: 2,
         width: 5
@@ -422,6 +426,7 @@ module('Unit | Utility | graph tools', function () {
           to: { x: 2, y: 0 }
         }
       ],
+      stages: [],
       meta: {
         height: 2,
         width: 3
@@ -470,6 +475,7 @@ module('Unit | Utility | graph tools', function () {
           to: { x: 1, y: 0 }
         }
       ],
+      stages: [],
       meta: {
         height: 4,
         width: 2
@@ -550,6 +556,7 @@ module('Unit | Utility | graph tools', function () {
           to: { x: 1, y: 3 }
         }
       ],
+      stages: [],
       meta: {
         width: 3,
         height: 5
@@ -921,14 +928,18 @@ module('Unit | Utility | graph tools', function () {
           ]
         },
         id: 7,
-        jobIds: [21, 22, 23],
+        jobs: [
+          { id: 21, name: 'ci-deploy' },
+          { id: 22, name: 'ci-test' },
+          { id: 23, name: 'ci-certify' }
+        ],
         name: 'integration',
         pos: {
           x: 3,
           y: 0
         },
-        setup: 28,
-        teardown: 29
+        setup: { id: 28, name: 'stage@integration:setup' },
+        teardown: { id: 29, name: 'stage@integration:teardown' }
       },
       {
         description: undefined,
@@ -952,14 +963,18 @@ module('Unit | Utility | graph tools', function () {
           ]
         },
         id: 8,
-        jobIds: [31, 32, 33],
+        jobs: [
+          { id: 31, name: 'prod-deploy' },
+          { id: 32, name: 'prod-test' },
+          { id: 33, name: 'prod-certify' }
+        ],
         name: 'production',
         pos: {
           x: 6,
           y: 0
         },
-        setup: 38,
-        teardown: 39
+        setup: { id: 38, name: 'stage@production:setup' },
+        teardown: { id: 39, name: 'stage@production:teardown' }
       }
     ];
 


### PR DESCRIPTION
## Context
Validator UI does not render stages in the workflow graph.
Also the implicit stage/setup teardown jobs are not hidden .

```
## Stages by grouping
shared:
  image: node:14
  steps:
    - init: echo 'init'
jobs:
  component:
    requires: [~pr, ~commit]
    annotations:
      screwdriver.cd/displayName: compJob
  publish:
    requires: [ component ]
  ci-deploy:
    requires: [ ]
  ci-test:
    requires: [ ci-deploy ]
  ci-certify:
    requires: [ci-test]
  prod-deploy:
    requires: [ ]
  prod-test:
    requires: [ prod-deploy ]
  prod-certify:
    requires: [ prod-test ]

stages:
  integration:
    jobs: [ci-deploy, ci-test, ci-certify]
    requires: [ publish ]
    description: "This stage will deploy the latest application to CI environment and certifies it after the tests are passed."
  production:
    jobs: [ prod-deploy, prod-test, prod-certify ]
    requires: [ ~stage@integration:teardown ]
    description: "This stage will deploy the CI certified application to production environment and certifies it after the tests are passed."
    setup:
      image: node:14
      steps:
        - init: echo 'prod setup'
    teardown:
      image: node:14
      steps:
        - init: echo 'prod teardown'
```
![image](https://github.com/screwdriver-cd/ui/assets/2124590/dfdc3c1c-3889-45ba-a559-3d33b2d149cc)



## Objective
Workflow graph should render stages
<img width="1711" alt="image" src="https://github.com/screwdriver-cd/ui/assets/2124590/d6efe373-380f-4c6b-9570-ca091b005a0f">



## References

https://github.com/screwdriver-cd/screwdriver/issues/3041

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
