### PR TITLE
fix(3048): dashboard for a collection page renders all collections in sidebar

### DIFF
--- a/app/dashboard/route.js
+++ b/app/dashboard/route.js
@@ -5,6 +5,7 @@ import { inject as service } from '@ember/service';
 
 export default Route.extend(AuthenticatedRouteMixin, {
   router: service(),
+  store: service(),
   routeAfterAuthentication: 'home',
 
   beforeModel(/* transition */) {
@@ -16,10 +17,14 @@ export default Route.extend(AuthenticatedRouteMixin, {
     }
   },
 
-  model() {
-    return this.controllerFor('application').get('collections') === undefined
-      ? []
-      : this.controllerFor('application').get('collections');
+  async model() {
+    let collections = this.store.peekAll('collection');
+
+    if (!collections.length) {
+      collections = await this.store.findAll('collection');
+    }
+
+    return collections;
   },
 
   actions: {

--- a/app/dashboard/show/route.js
+++ b/app/dashboard/show/route.js
@@ -7,17 +7,11 @@ export default Route.extend(AuthenticatedRouteMixin, {
   store: service(),
   router: service(),
   model(params) {
-    const collections =
-      this.controllerFor('application').get('collections') === undefined
-        ? []
-        : this.controllerFor('application').get('collections');
-
     return this.store
       .findRecord('collection', params.collection_id, { reload: true })
       .then(collection =>
         RSVP.hash({
-          collection,
-          collections
+          collection
         })
       );
   },


### PR DESCRIPTION
## Context
#1003 Removed loading of collections for the entire application in favor of loading them as needed depending on the route.  The unfortunate side-effect is that the collections dashboard view was expecting the collections to be stored in the application controller.

## Objective
Adds in the collection loading logic into the collections dashboard route to load collections data from the store if it exists or else load it via the API call.  

## References
https://github.com/screwdriver-cd/screwdriver/issues/3048

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
