### PR TITLE
feat: add validator ui support for pipeline templates

### DIFF
--- a/app/components/pipeline-header/component.js
+++ b/app/components/pipeline-header/component.js
@@ -59,7 +59,7 @@ export default Component.extend({
       };
     }
   }),
-  sameRepoPipeline: computed('pipeline', {
+  sameRepoPipeline: computed('pipeline.scmRepo.name', 'pipeline.{id,scmUri}', {
     get() {
       const [scm, repositoryId] = this.pipeline.scmUri.split(':');
 

--- a/app/components/validator-job/component.js
+++ b/app/components/validator-job/component.js
@@ -27,6 +27,38 @@ export default Component.extend({
       return this.get('job.environment.SD_TEMPLATE_VERSION');
     }
   }),
+  getPipelineTemplateName: computed(
+    'job.environment.SD_PIPELINE_TEMPLATE_FULLNAME',
+    {
+      get() {
+        return this.get('job.environment.SD_PIPELINE_TEMPLATE_FULLNAME');
+      }
+    }
+  ),
+  getPipelineTemplateLink: computed(
+    'job.environment.{SD_PIPELINE_TEMPLATE_NAME,SD_PIPELINE_TEMPLATE_NAMESPACE,SD_PIPELINE_TEMPLATE_VERSION}',
+    {
+      get() {
+        const namespace = this.get(
+          'job.environment.SD_PIPELINE_TEMPLATE_NAMESPACE'
+        );
+        const name = this.get('job.environment.SD_PIPELINE_TEMPLATE_NAME');
+        const version = this.get(
+          'job.environment.SD_PIPELINE_TEMPLATE_VERSION'
+        );
+
+        return `/pipeline/template/${namespace}/${name}/${version}`;
+      }
+    }
+  ),
+  getPipelineTemplateVersion: computed(
+    'job.environment.{SD_PIPELINE_TEMPLATE_VERSION,SD_TEMPLATE_VERSION}',
+    {
+      get() {
+        return this.get('job.environment.SD_PIPELINE_TEMPLATE_VERSION');
+      }
+    }
+  ),
   hasParseError: computed('job.commands.0.name', {
     get() {
       return this.get('job.commands.0.name') === 'config-parse-error';

--- a/app/components/validator-job/template.hbs
+++ b/app/components/validator-job/template.hbs
@@ -23,6 +23,25 @@
     </h4>
   {{/if}}
 {{/if}}
+{{#if this.getPipelineTemplateName}}
+  {{#if this.template}}
+    <h4>
+      This template extends
+      <a href={{this.getPipelineTemplateLink}}>
+        {{this.getPipelineTemplateName}}
+      </a>
+      pipeline template.
+    </h4>
+  {{else}}
+    <h4>
+      This job is inherited from
+      <a href={{this.getPipelineTemplateLink}}>
+        {{this.getPipelineTemplateName}}
+      </a>
+      pipeline template.
+    </h4>
+  {{/if}}
+{{/if}}
 {{#if this.template.description}}
   <div
     class="template-description"

--- a/app/components/validator-pipeline/template.hbs
+++ b/app/components/validator-pipeline/template.hbs
@@ -1,7 +1,24 @@
 <h4 class="pipeline" {{action "nameClick"}}>
   <FaIcon @icon={{if this.isOpen "minus-square" "plus-square"}} />
-  Pipeline Settings
+  {{#if this.template.name}}
+    {{this.name}}
+  {{else}}
+    Pipeline Settings
+  {{/if}}
 </h4>
+{{#if this.template.description}}
+  <div
+    class="template-description"
+    title="This is the description of the template"
+  >
+    <span class="label">
+      Template Description:
+    </span>
+    <span class="value">
+      {{this.template.description}}
+    </span>
+  </div>
+{{/if}}
 <div
   class="annotations"
   title="These are the pipeline-level annotations that the user has defined."

--- a/app/components/validator-results/component.js
+++ b/app/components/validator-results/component.js
@@ -81,5 +81,13 @@ export default Component.extend({
 
       return `${fullName}@${get(this, 'results.template.version')}`;
     }
+  }),
+  pipelineTemplateJobs: reads('results.template.config.jobs'),
+  pipelineTemplateJobKeys: computed('results.template.config.jobs', {
+    get() {
+      return get(this, 'results.template.config.jobs') === undefined
+        ? []
+        : Object.keys(this.get('results.template.config.jobs'));
+    }
   })
 });

--- a/app/components/validator-results/component.js
+++ b/app/components/validator-results/component.js
@@ -1,5 +1,5 @@
 import { computed, get } from '@ember/object';
-import { map } from '@ember/object/computed';
+import { map, reads } from '@ember/object/computed';
 import Component from '@ember/component';
 import { inject as service } from '@ember/service';
 import templateHelper from 'screwdriver-ui/utils/template';

--- a/app/components/validator-results/template.hbs
+++ b/app/components/validator-results/template.hbs
@@ -8,7 +8,24 @@
     {{msg}}
   </div>
 {{/each}}
-{{#if this.isJobTemplate}}
+{{#if this.isPipelineTemplate}}
+  <ValidatorPipeline
+    @name={{this.templateName}}
+    @template={{this.results.template}}
+    @annotations={{this.results.template.config.shared.annotations}}
+    @parameters={{this.results.template.config.parameters}}
+    @isOpen={{unbound this.isOpen}}
+  />
+  {{#each this.pipelineTemplateJobKeys as | node index|}}
+      <ValidatorJob
+        @name={{node}}
+        @job={{get this.pipelineTemplateJobs node}}
+        @template={{this.results.template}}
+        @index={{index}}
+        @isOpen={{unbound this.isOpen}}
+      />
+  {{/each}}
+{{else if this.isJobTemplate}}
   <ValidatorJob
     @name={{this.templateName}}
     @job={{this.results.template.config}}

--- a/tests/integration/components/validator-results/component-test.js
+++ b/tests/integration/components/validator-results/component-test.js
@@ -447,6 +447,37 @@ module('Integration | Component | validator results', function (hooks) {
     assert.dom('h4').hasText('batman/batmobile@1.0.0');
   });
 
+  test('it renders a pipeline template', async function (assert) {
+    this.set('validationMock', {
+      errors: [],
+      template: {
+        namespace: 'batman',
+        name: 'batmobile',
+        version: '1.0.0',
+        config: {
+          shared: {
+            image: 'int-test:1'
+          },
+          jobs: {
+            main: {
+              steps: [{ forgreatjustice: 'ba.sh' }]
+            },
+            publish: {
+              steps: [{ joker: 'ha' }]
+            }
+          }
+        }
+      }
+    });
+
+    await render(
+      hbs`<ValidatorResults @results={{this.validationMock}} @isPipelineTemplate={{true}} />`
+    );
+
+    assert.dom('.error').doesNotExist();
+    assert.dom('h4').hasText('batman/batmobile@1.0.0');
+  });
+
   test('it renders joi error results', async function (assert) {
     this.set('validationMock', {
       errors: [{ message: 'there is an error' }],


### PR DESCRIPTION
## Context

Added validator support to display pipeline template and pipeline template usage

## Objective

The validator should correctly display the pipeline template name, namespace, jobs, etc.
The validator should correctly display the pipeline template used in a pipeline

Template:
<img width="1672" alt="Screenshot 2024-03-06 at 7 17 55 PM" src="https://github.com/screwdriver-cd/ui/assets/4926830/4b6af553-00d6-49d7-ac0a-6ba60b183bb3">
<img width="1680" alt="Screenshot 2024-03-06 at 7 18 03 PM" src="https://github.com/screwdriver-cd/ui/assets/4926830/37316f1b-2fee-495b-8e7f-f6dd12036e06">

Usage:
<img width="1914" alt="Screenshot 2024-03-07 at 2 41 11 PM" src="https://github.com/screwdriver-cd/ui/assets/4926830/5e8c30b3-dda4-45ca-b9f0-8c79295dd59b">


## References
https://github.com/screwdriver-cd/screwdriver/issues/3052

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
