### PR TITLE
fix: automatically display warning status on build details page

### DIFF
--- a/app/pipeline/build/controller.js
+++ b/app/pipeline/build/controller.js
@@ -163,7 +163,11 @@ export default Controller.extend({
         );
       } else {
         // refetch builds which are part of current event
-        this.event.hasMany('builds').reload();
+        this.event.hasMany('builds').reload().then(() => {
+          if (this.build.meta?.build?.warning && this.build.status === 'SUCCESS') {
+            this.build.status = 'WARNING';
+          }
+        });
       }
     }
   },

--- a/tests/unit/pipeline/build/controller-test.js
+++ b/tests/unit/pipeline/build/controller-test.js
@@ -276,7 +276,11 @@ module('Unit | Controller | pipeline/build', function (hooks) {
         assert.equal(key, 'builds');
 
         return {
-          reload: () => assert.ok(true)
+          reload: () => {
+            assert.ok(true);
+
+            return resolve();
+          }
         };
       }
     });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Warning status is not displayed on build details page when the build completed in this page.

https://github.com/screwdriver-cd/ui/assets/43719835/135a5d12-0c1e-4004-8627-d3f3f50ab2c4

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Display warning status automatically after the build completes.

https://github.com/screwdriver-cd/ui/assets/43719835/9f52f8e9-909a-4a72-ac7c-dee23a0aff65

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
