### PR TITLE
fix(3049): Add css to scroll workflow graph

### DIFF
--- a/app/components/pipeline-event-row/styles.scss
+++ b/app/components/pipeline-event-row/styles.scss
@@ -52,3 +52,11 @@
     color: $grey-800;
   }
 }
+
+.detail {
+  overflow: auto;
+
+  .workflow {
+    overflow-x: auto;
+  }
+}


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
When the workflow is long horizontally, the stop button is displayed out of the screen.
To prevent this behavior, make the workflow graph scrollable.

Before:
![event-overflow](https://github.com/screwdriver-cd/ui/assets/8113204/f9ece09a-d8de-45b5-a00f-1391dda266f2)

After:
<img width="365" alt="スクリーンショット 2024-03-08 15 07 30" src="https://github.com/screwdriver-cd/ui/assets/8113204/40a7db92-1cf8-460c-8f25-1c09a9d54908">

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Add css properties to make the workflow graph scrollable.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
screwdriver-cd/screwdriver#3049

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
