### PR TITLE
fix(2369): Improve the content of notifications

### DIFF
--- a/app/components/build-banner/component.js
+++ b/app/components/build-banner/component.js
@@ -92,11 +92,11 @@ export default Component.extend({
           ABORTED: '⛔'
         };
 
-        const statusIcon = statusMap[this.buildStatus];
+        const notificationIcon = statusMap[this.buildStatus];
 
         // eslint-disable-next-line no-new
         new Notification(`SD.cd ${this.pipelineName}`, {
-          body: `${statusIcon} ${this.buildStatus}: ${this.jobName}`,
+          body: `${notificationIcon} ${this.buildStatus}: ${this.jobName}`,
           icon: screwdriverIconPath
         }).onclick = () => {
           window.focus();

--- a/app/components/build-banner/component.js
+++ b/app/components/build-banner/component.js
@@ -85,10 +85,22 @@ export default Component.extend({
   buildNotify: observer('buildStatus', function buildNotify() {
     if (Notification.permission === 'granted' && this.allowNotification) {
       if (['SUCCESS', 'FAILURE', 'ABORTED'].includes(this.buildStatus)) {
+        const screwdriverIconPath = '/assets/icons/android-chrome-144x144.png';
+        const statusMap = {
+          SUCCESS: '✅',
+          FAILURE: '❌',
+          ABORTED: '⛔'
+        };
+
+        const statusIcon = statusMap[this.buildStatus];
+
         // eslint-disable-next-line no-new
-        new Notification('Screwdriver.cd', {
-          body: `${this.buildStatus}`
-        });
+        new Notification(`SD.cd ${this.pipelineName}`, {
+          body: `${statusIcon} ${this.buildStatus}: ${this.jobName}`,
+          icon: screwdriverIconPath
+        }).onclick = () => {
+          window.focus();
+        };
       }
     }
   }),

--- a/app/components/pipeline-graph-nav/component.js
+++ b/app/components/pipeline-graph-nav/component.js
@@ -68,10 +68,24 @@ export default Component.extend({
         this.notificationReady &&
         this.notificationEventId === this.get('selectedEventObj.id')
       ) {
+        const screwdriverIconPath = '/assets/icons/android-chrome-144x144.png';
+        const statusMap = {
+          SUCCESS: '✅',
+          FAILURE: '❌',
+          ABORTED: '⛔'
+        };
+
+        const notificationIcon = statusMap[eventStatus];
+
         // eslint-disable-next-line no-new
-        new Notification(`Event: ${this.get('selectedEventObj.id')}`, {
-          body: `${eventStatus}`
-        });
+        new Notification(`SD.cd ${this.pipeline.name}`, {
+          body: `${notificationIcon} ${eventStatus}: Event ${this.get(
+            'selectedEventObj.id'
+          )}`,
+          icon: screwdriverIconPath
+        }).onclick = () => {
+          window.focus();
+        };
         this.set('notificationReady', false);
       } else {
         this.set('notificationReady', false);


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
This PR is follow up https://github.com/screwdriver-cd/ui/pull/992.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
- Displays pipeline name, job name, screwdriver icon, and status icons.
- Clicking on the notification should take you to the tab.

build detail page
<img width="1215" alt="image" src="https://github.com/screwdriver-cd/ui/assets/59165943/05e8782b-207d-4c22-af45-d1ef14520370">

pipeline page
<img width="1193" alt="image" src="https://github.com/screwdriver-cd/ui/assets/59165943/f0158630-25af-4d83-a5de-403b19fb1aa1">

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/2369

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
