### PR TITLE
fix: left and right padding on pipeline routes

### DIFF
--- a/app/application/template.hbs
+++ b/app/application/template.hbs
@@ -9,9 +9,7 @@
 />
 <NavBanner />
 
-<div id="appContainer" class="container-fluid">
-  {{outlet}}
-</div>
+<AppBody />
 
 {{#if this.showCreatePipeline}}
   <CreatePipeline @showCreatePipeline={{this.showCreatePipeline}} />

--- a/app/components/app-body/component.js
+++ b/app/components/app-body/component.js
@@ -1,0 +1,10 @@
+import Component from '@ember/component';
+import { service } from '@ember/service';
+
+export default class AppBody extends Component {
+  @service router;
+
+  get isPipelineRoute() {
+    return this.router.currentRouteName.startsWith('pipeline');
+  }
+}

--- a/app/components/app-body/template.hbs
+++ b/app/components/app-body/template.hbs
@@ -1,0 +1,3 @@
+<div id="appContainer" class='{{if this.isPipelineRoute '' 'container-fluid'}}'>
+  {{outlet}}
+</div>

--- a/app/components/build-banner/styles.scss
+++ b/app/components/build-banner/styles.scss
@@ -1,5 +1,5 @@
 & {
-  padding: 0 25px;
+  padding: 0 40px;
 }
 
 summary {

--- a/app/components/build-step-collection/styles.scss
+++ b/app/components/build-step-collection/styles.scss
@@ -4,6 +4,10 @@
 
   background-color: $grey-200;
 
+  .step-container {
+    display: flex;
+  }
+
   .setup-spinner {
     float: right;
     font-size: 14px;

--- a/app/components/build-step-collection/template.hbs
+++ b/app/components/build-step-collection/template.hbs
@@ -1,4 +1,4 @@
-<div class="row">
+<div class="step-container">
   <div class="col-3 step-list no-padding column-tabs-view partial-view">
     <BsTab @customTabs={{true}} as |tab|>
       <BsNav @type="tabs" as |nav|>

--- a/app/components/pipeline-events/style.scss
+++ b/app/components/pipeline-events/style.scss
@@ -1,10 +1,13 @@
 & {
-
   .x-toggle-component {
     display: inline-flex;
   }
 
   .x-toggle:checked + label > .x-toggle-default.x-toggle-btn {
     background-color: $sd-success;
+  }
+
+  .pipeline-container {
+    display: flex;
   }
 }

--- a/app/components/pipeline-events/template.hbs
+++ b/app/components/pipeline-events/template.hbs
@@ -4,50 +4,52 @@
   {{/if}}
 {{/if}}
 
-<InfoMessage
-  @message={{this.errorMessage}}
-  @type="warning"
-  @icon="exclamation-triangle"
-  @scmContext={{this.pipeline.scmContext}}
-/>
+<div class="padded-container">
+  <InfoMessage
+    @message={{this.errorMessage}}
+    @type="warning"
+    @icon="exclamation-triangle"
+    @scmContext={{this.pipeline.scmContext}}
+  />
 
-{{#if this.isInactivePipeline}}
-<InfoMessage
-  @message="Pipeline is inactive and no new events can be started. You can activate the pipeline by adding the SCM URL in the parent pipeline yaml configuration."
-  @type="info"
-  @icon="exclamation-triangle"
-/>
-{{/if}}
+  {{#if this.isInactivePipeline}}
+    <InfoMessage
+      @message="Pipeline is inactive and no new events can be started. You can activate the pipeline by adding the SCM URL in the parent pipeline yaml configuration."
+      @type="info"
+      @icon="exclamation-triangle"
+    />
+  {{/if}}
 
-{{#unless this.hasAdmins}}
-  <BsAlert @type="warning" @dismissible={{false}}>
-    <p>
-      This repo has no admins, click
-      <span class="text-info" onclick={{action "syncAdmins"}}>
-        here
-      </span>
-      to sync from git repo, you must be an admin to do so.
-    </p>
-  </BsAlert>
-{{/unless}}
+  {{#unless this.hasAdmins}}
+    <BsAlert @type="warning" @dismissible={{false}}>
+      <p>
+        This repo has no admins, click
+        <span class="text-info" onclick={{action "syncAdmins"}}>
+          here
+        </span>
+        to sync from git repo, you must be an admin to do so.
+      </p>
+    </BsAlert>
+  {{/unless}}
 
-{{#if (eq this.syncAdmins "success")}}
-  <BsAlert @type="success">
-    <p>
-      Good job, pipeline's admins are in sync
-    </p>
-  </BsAlert>
-{{/if}}
+  {{#if (eq this.syncAdmins "success")}}
+    <BsAlert @type="success">
+      <p>
+        Good job, pipeline's admins are in sync
+      </p>
+    </BsAlert>
+  {{/if}}
 
-{{#if (eq this.syncAdmins "failure")}}
-  <BsAlert @type="danger">
-    <p>
-      Something went wrong, please try syncing again
-    </p>
-  </BsAlert>
-{{/if}}
+  {{#if (eq this.syncAdmins "failure")}}
+    <BsAlert @type="danger">
+      <p>
+        Something went wrong, please try syncing again
+      </p>
+    </BsAlert>
+  {{/if}}
+</div>
 
-<div class="row">
+<div class="pipeline-container">
   <div class="col-12 col-md-9 separator partial-view">
     <PipelineGraphNav
       @pipeline={{this.pipeline}}

--- a/app/components/pipeline-header/styles.scss
+++ b/app/components/pipeline-header/styles.scss
@@ -3,7 +3,7 @@
   color: $grey-800;
   min-height: 50px;
   margin: 0;
-  padding: 20px 25px;
+  padding: 20px 40px;
   white-space: nowrap;
 
   .img {
@@ -70,5 +70,5 @@ a.active {
 }
 
 .dropdown {
-  display:inline-block;
+  display: inline-block;
 }

--- a/app/components/pipeline-nav/styles.scss
+++ b/app/components/pipeline-nav/styles.scss
@@ -1,5 +1,5 @@
 & {
-  padding-left: 25px;
+  padding-left: 40px;
   background-color: $brand-100;
 
   .nav-pills a {

--- a/app/pipeline/build/template.hbs
+++ b/app/pipeline/build/template.hbs
@@ -41,27 +41,30 @@
   </ModalDialog>
 {{/if}}
 
-<InfoMessage
-  @message={{this.errorMessage}}
-  @type="warning"
-  @icon="exclamation-triangle"
-/>
-{{#if this.build.statusMessage}}
+<div class="padded-container">
   <InfoMessage
-    @message={{this.build.statusMessage}}
+    @message={{this.errorMessage}}
     @type="warning"
     @icon="exclamation-triangle"
   />
-{{/if}}
-{{#if this.build.meta.build.warning}}
-  {{#each-in this.build.meta.build.warning as |name value|}}
+  {{#if this.build.statusMessage}}
     <InfoMessage
-      @message="{{name}} - {{value}}"
+      @message={{this.build.statusMessage}}
       @type="warning"
       @icon="exclamation-triangle"
     />
-  {{/each-in}}
-{{/if}}
+  {{/if}}
+  {{#if this.build.meta.build.warning}}
+    {{#each-in this.build.meta.build.warning as |name value|}}
+      <InfoMessage
+        @message="{{name}} - {{value}}"
+        @type="warning"
+        @icon="exclamation-triangle"
+      />
+    {{/each-in}}
+  {{/if}}
+</div>
+
 
 {{#if this.stepList}}
   <BuildStepCollection

--- a/app/pipeline/child-pipelines/template.hbs
+++ b/app/pipeline/child-pipelines/template.hbs
@@ -3,10 +3,13 @@
 {{#if this.session.isAuthenticated}}
   <PipelineNav @pipeline={{this.pipeline}} />
 {{/if}}
-{{#if this.hasInactivePipelines}}
-  {{info-message message="You have one or more inactive pipelines. You can activate these by adding back the corresponding SCM URL in the yaml configuration." type="info" icon="exclamation-triangle"}}
-{{/if}}
 
-<PipelineList @pipelines={{this.pipelines}} @pipeline={{this.pipeline}} @onDeleteChildPipeline={{action "onDeleteChildPipeline"}}/>
+<div class="padded-container">
+  {{#if this.hasInactivePipelines}}
+    {{info-message message="You have one or more inactive pipelines. You can activate these by adding back the corresponding SCM URL in the yaml configuration." type="info" icon="exclamation-triangle"}}
+  {{/if}}
+
+  <PipelineList @pipelines={{this.pipelines}} @pipeline={{this.pipeline}} @onDeleteChildPipeline={{action "onDeleteChildPipeline"}}/>
+</div>
 
 {{outlet}}

--- a/app/pipeline/jobs/index/template.hbs
+++ b/app/pipeline/jobs/index/template.hbs
@@ -4,34 +4,36 @@
   {{/if}}
 {{/if}}
 
-<InfoMessage
-  @message={{this.errorMessage}}
-  @type="warning"
-  @icon="exclamation-triangle"
-  @scmContext={{this.pipeline.scmContext}}
-/>
-
-{{#if this.isInactivePipeline}}
+<div class="padded-container">
   <InfoMessage
-    @message="Pipeline is inactive and no new events can be started. You can activate the pipeline by adding the SCM URL in the parent pipeline yaml configuration."
-    @type="info"
+    @message={{this.errorMessage}}
+    @type="warning"
     @icon="exclamation-triangle"
+    @scmContext={{this.pipeline.scmContext}}
   />
-{{/if}}
 
-<div class="row">
-  <div class="col-12 separator partial-view">
-    <PipelineListView
-      @pipeline={{this.pipeline}}
-      @jobs={{this.jobs}}
-      @jobsDetails={{this.jobsDetails}}
-      @updateListViewJobs={{action "updateListViewJobs"}}
-      @startSingleBuild={{action "startSingleBuild"}}
-      @stopBuild={{action "stopBuild"}}
-      @showListView={{this.showListView}}
-      @setShowListView={{action "setShowListView"}}
-      @refreshListViewJobs={{action "refreshListViewJobs"}}
+  {{#if this.isInactivePipeline}}
+    <InfoMessage
+      @message="Pipeline is inactive and no new events can be started. You can activate the pipeline by adding the SCM URL in the parent pipeline yaml configuration."
+      @type="info"
+      @icon="exclamation-triangle"
     />
+  {{/if}}
+
+  <div class="row">
+    <div class="col-12 separator partial-view">
+      <PipelineListView
+        @pipeline={{this.pipeline}}
+        @jobs={{this.jobs}}
+        @jobsDetails={{this.jobsDetails}}
+        @updateListViewJobs={{action "updateListViewJobs"}}
+        @startSingleBuild={{action "startSingleBuild"}}
+        @stopBuild={{action "stopBuild"}}
+        @showListView={{this.showListView}}
+        @setShowListView={{action "setShowListView"}}
+        @refreshListViewJobs={{action "refreshListViewJobs"}}
+      />
+    </div>
   </div>
 </div>
 

--- a/app/pipeline/metrics/template.hbs
+++ b/app/pipeline/metrics/template.hbs
@@ -2,80 +2,81 @@
   <PipelineNav @pipeline={{this.pipeline}} />
 {{/if}}
 
-<InfoMessage
-  @message={{this.errorMessage}}
-  @type="warning"
-  @icon="exclamation-triangle"
-/>
+<div class="padded-container">
+  <InfoMessage
+    @message={{this.errorMessage}}
+    @type="warning"
+    @icon="exclamation-triangle"
+  />
 
-<div class="chart-controls">
-  <div class="chart-control range-selection">
+  <div class="chart-controls">
+    <div class="chart-control range-selection">
     <span class="title">
       Time Range
     </span>
-    <BsButtonGroup
-      @value={{this.selectedRange}}
-      @type="radio"
-      @onChange={{action "setTimeRange"}} as |bg|
-    >
-      {{#each this.timeRanges as |range|}}
-        <bg.button @value={{range.value}}>
-          {{range.alias}}
-        </bg.button>
-      {{/each}}
-    </BsButtonGroup>
-  </div>
+      <BsButtonGroup
+        @value={{this.selectedRange}}
+        @type="radio"
+        @onChange={{action "setTimeRange"}} as |bg|
+      >
+        {{#each this.timeRanges as |range|}}
+          <bg.button @value={{range.value}}>
+            {{range.alias}}
+          </bg.button>
+        {{/each}}
+      </BsButtonGroup>
+    </div>
 
-  <div class="chart-control custom-date-selection">
+    <div class="chart-control custom-date-selection">
     <span class="title">
       Custom Date Range
     </span>
-    <EmberFlatpickr
-      @clickOpens={{true}}
-      @dateFormat="m/d/Y"
-      @date={{this.customRange}}
-      @locale="en"
-      @mode="range"
-      @onChange={{action (mut this.dateValues)}}
-      @onClose={{action "setCustomRange"}}
-      placeholder="Choose Start & End Date Time"
-    />
-  </div>
+      <EmberFlatpickr
+        @clickOpens={{true}}
+        @dateFormat="m/d/Y"
+        @date={{this.customRange}}
+        @locale="en"
+        @mode="range"
+        @onChange={{action (mut this.dateValues)}}
+        @onClose={{action "setCustomRange"}}
+        placeholder="Choose Start & End Date Time"
+      />
+    </div>
 
-  <XToggle
-    @size="small"
-    @theme="material"
-    @showLabels={{true}}
-    @value={{this.isUTC}}
-    @offLabel="Local"
-    @onLabel="UTC"
-    @onToggle={{action (mut this.isUTC)}}
-  />
-
-  <label class="chart-control filters-selection">
     <XToggle
       @size="small"
       @theme="material"
-      @value={{this.successOnly}}
-      @onToggle={{action "toggleSuccessOnly"}}
+      @showLabels={{true}}
+      @value={{this.isUTC}}
+      @offLabel="Local"
+      @onLabel="UTC"
+      @onToggle={{action (mut this.isUTC)}}
     />
-    <div class="success-only">
-      Success Only
-    </div>
-  </label>
-</div>
 
-<div class="chart-pipeline-info">
-  <div class="col">
+    <label class="chart-control filters-selection">
+      <XToggle
+        @size="small"
+        @theme="material"
+        @value={{this.successOnly}}
+        @onToggle={{action "toggleSuccessOnly"}}
+      />
+      <div class="success-only">
+        Success Only
+      </div>
+    </label>
+  </div>
+
+  <div class="chart-pipeline-info">
+    <div class="col">
     <span class="measure">
       {{if this.measures.total this.measures.total "N/A"}}
     </span>
-    <br />
-    <span class="title">
+      <br />
+      <span class="title">
       Total Events
     </span>
-  </div>
-  <div class="col">
+    </div>
+    <div class="col">
     <span class="measure">
       {{#if this.measures.total}}
         <span class="passed">
@@ -89,190 +90,190 @@
         N/A
       {{/if}}
     </span>
-    <br />
-    <span class="title">
+      <br />
+      <span class="title">
       Passed / Failed Jobs
     </span>
-  </div>
-  <div class="col">
+    </div>
+    <div class="col">
     <span class="measure">
       {{if this.measures.total this.measures.avgs.duration "N/A"}}
     </span>
-    <br />
-    <span class="title">
+      <br />
+      <span class="title">
       Avg. Build Time
     </span>
-  </div>
-  <div class="col">
+    </div>
+    <div class="col">
     <span class="measure">
       {{if this.measures.total this.measures.avgs.imagePullTime "N/A"}}
     </span>
-    <br />
-    <span class="title">
+      <br />
+      <span class="title">
       Avg. Image Pull Time
     </span>
-  </div>
-  <div class="col">
+    </div>
+    <div class="col">
     <span class="measure">
       {{if this.measures.total this.measures.avgs.queuedTime "N/A"}}
     </span>
-    <br />
-    <span class="title">
+      <br />
+      <span class="title">
       Avg. Queued Time
     </span>
+    </div>
   </div>
-</div>
 
-{{#if this.measures.total}}
-  {{#if (is-fulfilled this.downtimeJobsMetrics)}}
-    {{#if this.downtimeJobsChartData}}
-      <Metrics::Chart
-        @chartTitle="Downtime vs Build Count"
-        @chartName={{this.downtimeJobsChartName}}
-        @legends={{this.downtimeJobsLegends}}
-        @resetZoom={{action "resetZoom"}}
-        @name={{this.downtimeJobsChartName}}
-        @metrics={{await this.downtimeJobsMetrics}}
-        @axis={{this.downtimeJobsAxis}}
-        @tooltip={{this.tooltip}}
-        @onrendered={{this.onrendered}}
-        @onresized={{this.onresized}}
-        @oninit={{get this.onInitFns this.downtimeJobsChartName}}
-      />
+  {{#if this.measures.total}}
+    {{#if (is-fulfilled this.downtimeJobsMetrics)}}
+      {{#if this.downtimeJobsChartData}}
+        <Metrics::Chart
+          @chartTitle="Downtime vs Build Count"
+          @chartName={{this.downtimeJobsChartName}}
+          @legends={{this.downtimeJobsLegends}}
+          @resetZoom={{action "resetZoom"}}
+          @name={{this.downtimeJobsChartName}}
+          @metrics={{await this.downtimeJobsMetrics}}
+          @axis={{this.downtimeJobsAxis}}
+          @tooltip={{this.tooltip}}
+          @onrendered={{this.onrendered}}
+          @onresized={{this.onresized}}
+          @oninit={{get this.onInitFns this.downtimeJobsChartName}}
+        />
+      {{else}}
+        <div class="chart-cta">
+          Not enough metric available for Downtime Jobs!
+        </div>
+      {{/if}}
     {{else}}
-      <div class="chart-cta">
-        Not enough metric available for Downtime Jobs!
-      </div>
+      {{#if (is-pending this.downtimeJobsMetrics)}}
+        <div class="chart-cta">
+          Loading...
+        </div>
+      {{else}}
+        <div class="chart-cta">
+          No metric available for Downtime Jobs!
+        </div>
+      {{/if}}
     {{/if}}
-  {{else}}
-    {{#if (is-pending this.downtimeJobsMetrics)}}
-      <div class="chart-cta">
-        Loading...
-      </div>
-    {{else}}
-      <div class="chart-cta">
-        No metric available for Downtime Jobs!
-      </div>
-    {{/if}}
-  {{/if}}
-  <div class="chart-c3">
-    <p class="chart-title">
-      Events
-    </p>
-    <label class="toggle-trend">
-      <XToggle
-        @size="small"
-        @theme="material"
-        @value={{this.inTrendlineView}}
-        @onToggle={{action "toggleTrendlineView"}}
-      />
-      <div class="trendline-view">
-        Trendline View
-      </div>
-    </label>
-    <ul class="list-inline chart-legend">
-      {{#each this.eventLegend as |lg|}}
-        <li
-          style={{lg.style}}
-          onclick={{action "onLegendClick" lg.key this.eventsChartName}}
-          onmouseenter={{action "onLegendHover" lg.key this.eventsChartName}}
-          onmouseleave={{action "onLegendHoverOut" this.eventsChartName}}
-        >
-          {{lg.name}}
-          <a>
-            only
-          </a>
-        </li>
-      {{/each}}
-    </ul>
-    <p class="y-axis-label">
-      TIME (MIN)
-    </p>
-    <ChartC3
-      @name={{this.eventsChartName}}
-      @data={{this.eventMetrics}}
-      @axis={{this.eventsAxis}}
-      @grid={{this.grid}}
-      @interaction={{this.interaction}}
-      @bar={{this.bar}}
-      @legend={{this.legend}}
-      @tooltip={{this.tooltip}}
-      @subchart={{this.subchart}}
-      @point={{this.point}}
-      @size={{this.size}}
-      @transition={{this.transition}}
-      @color={{this.color}}
-      @padding={{this.padding}}
-      @zoom={{this.zoom}}
-      @onrendered={{this.onrendered}}
-      @onresized={{this.onresized}}
-      @oninit={{get this.onInitFns this.eventsChartName}}
-    />
-    <p
-      class="reset-button"
-      onClick={{action "resetZoom" this.eventsChartName this.buildsChartName}}
-      title="Reset Zoom Level"
-    >
-      <FaIcon @icon="sync" />
-    </p>
-  </div>
-
-  <div class="chart-c3">
-    <p class="chart-title">
-      Build Breakdown Per Event
-    </p>
-    <ul class="list-inline chart-legend">
-      {{#each this.buildLegend as |lg|}}
-        <li
-          style={{lg.style}}
-          class={{lg.class}}
-          onclick={{action "onLegendClick" lg.key this.buildsChartName}}
-          onmouseenter={{action "onLegendHover" lg.key this.buildsChartName}}
-          onmouseleave={{action "onLegendHoverOut" this.buildsChartName}}
-        >
-          {{lg.name}}
-          <a>
-            only
-          </a>
-        </li>
-      {{/each}}
-    </ul>
-    <p class="y-axis-label">
-      TIME (MIN)
-    </p>
-    <ChartC3
-      @name={{this.buildsChartName}}
-      @data={{this.buildMetrics}}
-      @axis={{this.eventsAxis}}
-      @grid={{this.grid}}
-      @interaction={{this.interaction}}
-      @bar={{this.bar}}
-      @legend={{this.legend}}
-      @tooltip={{this.tooltip}}
-      @subchart={{this.subchart}}
-      @point={{this.point}}
-      @size={{this.size}}
-      @transition={{this.transition}}
-      @color={{this.color}}
-      @padding={{this.padding}}
-      @zoom={{this.zoom}}
-      @onrendered={{this.onrendered}}
-      @onresized={{this.onresized}}
-      @oninit={{get this.onInitFns this.buildsChartName}}
-    />
-    <p
-      class="reset-button"
-      onClick={{action "resetZoom" this.buildsChartName this.eventsChartName}}
-      title="Reset Zoom Level"
-    >
-      <FaIcon @icon="sync" />
-    </p>
-  </div>
-
-  {{#if this.metrics.stepGroup}}
     <div class="chart-c3">
       <p class="chart-title">
-        Step Breakdown Per Build
+        Events
+      </p>
+      <label class="toggle-trend">
+        <XToggle
+          @size="small"
+          @theme="material"
+          @value={{this.inTrendlineView}}
+          @onToggle={{action "toggleTrendlineView"}}
+        />
+        <div class="trendline-view">
+          Trendline View
+        </div>
+      </label>
+      <ul class="list-inline chart-legend">
+        {{#each this.eventLegend as |lg|}}
+          <li
+            style={{lg.style}}
+            onclick={{action "onLegendClick" lg.key this.eventsChartName}}
+            onmouseenter={{action "onLegendHover" lg.key this.eventsChartName}}
+            onmouseleave={{action "onLegendHoverOut" this.eventsChartName}}
+          >
+            {{lg.name}}
+            <a>
+              only
+            </a>
+          </li>
+        {{/each}}
+      </ul>
+      <p class="y-axis-label">
+        TIME (MIN)
+      </p>
+      <ChartC3
+        @name={{this.eventsChartName}}
+        @data={{this.eventMetrics}}
+        @axis={{this.eventsAxis}}
+        @grid={{this.grid}}
+        @interaction={{this.interaction}}
+        @bar={{this.bar}}
+        @legend={{this.legend}}
+        @tooltip={{this.tooltip}}
+        @subchart={{this.subchart}}
+        @point={{this.point}}
+        @size={{this.size}}
+        @transition={{this.transition}}
+        @color={{this.color}}
+        @padding={{this.padding}}
+        @zoom={{this.zoom}}
+        @onrendered={{this.onrendered}}
+        @onresized={{this.onresized}}
+        @oninit={{get this.onInitFns this.eventsChartName}}
+      />
+      <p
+        class="reset-button"
+        onClick={{action "resetZoom" this.eventsChartName this.buildsChartName}}
+        title="Reset Zoom Level"
+      >
+        <FaIcon @icon="sync" />
+      </p>
+    </div>
+
+    <div class="chart-c3">
+      <p class="chart-title">
+        Build Breakdown Per Event
+      </p>
+      <ul class="list-inline chart-legend">
+        {{#each this.buildLegend as |lg|}}
+          <li
+            style={{lg.style}}
+            class={{lg.class}}
+            onclick={{action "onLegendClick" lg.key this.buildsChartName}}
+            onmouseenter={{action "onLegendHover" lg.key this.buildsChartName}}
+            onmouseleave={{action "onLegendHoverOut" this.buildsChartName}}
+          >
+            {{lg.name}}
+            <a>
+              only
+            </a>
+          </li>
+        {{/each}}
+      </ul>
+      <p class="y-axis-label">
+        TIME (MIN)
+      </p>
+      <ChartC3
+        @name={{this.buildsChartName}}
+        @data={{this.buildMetrics}}
+        @axis={{this.eventsAxis}}
+        @grid={{this.grid}}
+        @interaction={{this.interaction}}
+        @bar={{this.bar}}
+        @legend={{this.legend}}
+        @tooltip={{this.tooltip}}
+        @subchart={{this.subchart}}
+        @point={{this.point}}
+        @size={{this.size}}
+        @transition={{this.transition}}
+        @color={{this.color}}
+        @padding={{this.padding}}
+        @zoom={{this.zoom}}
+        @onrendered={{this.onrendered}}
+        @onresized={{this.onresized}}
+        @oninit={{get this.onInitFns this.buildsChartName}}
+      />
+      <p
+        class="reset-button"
+        onClick={{action "resetZoom" this.buildsChartName this.eventsChartName}}
+        title="Reset Zoom Level"
+      >
+        <FaIcon @icon="sync" />
+      </p>
+    </div>
+
+    {{#if this.metrics.stepGroup}}
+      <div class="chart-c3">
+        <p class="chart-title">
+          Step Breakdown Per Build
         <div class="job-selector">
           <select onchange={{action "selectJob" value="target.value"}}>
             {{#each this.jobs as |job|}}
@@ -291,79 +292,80 @@
             <FaIcon @icon="caret-down" />
           </span>
         </div>
-      </p>
-      <ul class="list-inline chart-legend">
-        {{#each this.stepLegend as |lg|}}
-          <li
-            style={{lg.style}}
-            onclick={{action "onLegendClick" lg.key this.stepsChartName}}
-            onmouseenter={{action "onLegendHover" lg.key this.stepsChartName}}
-            onmouseleave={{action "onLegendHoverOut" this.stepsChartName}}
-          >
-            {{lg.name}}
-            <a>
-              only
-            </a>
-          </li>
-        {{/each}}
-      </ul>
-      <p class="y-axis-label">
-        TIME (MIN)
-      </p>
-      <ChartC3
-        @name={{this.stepsChartName}}
-        @data={{this.stepMetrics}}
-        @axis={{this.stepsAxis}}
-        @grid={{this.grid}}
-        @interaction={{this.interaction}}
-        @bar={{this.bar}}
-        @legend={{this.legend}}
-        @tooltip={{this.tooltip}}
-        @subchart={{this.subchart}}
-        @point={{this.point}}
-        @size={{this.size}}
-        @transition={{this.transition}}
-        @color={{this.color}}
-        @padding={{this.padding}}
-        @zoom={{this.zoom}}
-        @onrendered={{this.onrendered}}
-        @onresized={{this.onresized}}
-        @oninit={{get this.onInitFns this.stepsChartName}}
-      />
-      <p
-        class="reset-button"
-        onClick={{action "resetZoom" this.stepsChartName}}
-        title="Reset Zoom Level"
-      >
-        <FaIcon @icon="sync" />
-      </p>
-    </div>
-  {{else}}
-    <div class="chart-cta">
-      Please select a job below to see step breakdown per build
-      <br />
-      <br />
-      <div class="job-selector">
-        <select onchange={{action "selectJob" value="target.value"}}>
-          <option value="">
-            Select a job
-          </option>
-          {{#each this.jobs as |job|}}
-            <option value={{job}}>
-              {{job}}
-            </option>
+        </p>
+        <ul class="list-inline chart-legend">
+          {{#each this.stepLegend as |lg|}}
+            <li
+              style={{lg.style}}
+              onclick={{action "onLegendClick" lg.key this.stepsChartName}}
+              onmouseenter={{action "onLegendHover" lg.key this.stepsChartName}}
+              onmouseleave={{action "onLegendHoverOut" this.stepsChartName}}
+            >
+              {{lg.name}}
+              <a>
+                only
+              </a>
+            </li>
           {{/each}}
-        </select>
-        <span class="control-icon">
+        </ul>
+        <p class="y-axis-label">
+          TIME (MIN)
+        </p>
+        <ChartC3
+          @name={{this.stepsChartName}}
+          @data={{this.stepMetrics}}
+          @axis={{this.stepsAxis}}
+          @grid={{this.grid}}
+          @interaction={{this.interaction}}
+          @bar={{this.bar}}
+          @legend={{this.legend}}
+          @tooltip={{this.tooltip}}
+          @subchart={{this.subchart}}
+          @point={{this.point}}
+          @size={{this.size}}
+          @transition={{this.transition}}
+          @color={{this.color}}
+          @padding={{this.padding}}
+          @zoom={{this.zoom}}
+          @onrendered={{this.onrendered}}
+          @onresized={{this.onresized}}
+          @oninit={{get this.onInitFns this.stepsChartName}}
+        />
+        <p
+          class="reset-button"
+          onClick={{action "resetZoom" this.stepsChartName}}
+          title="Reset Zoom Level"
+        >
+          <FaIcon @icon="sync" />
+        </p>
+      </div>
+    {{else}}
+      <div class="chart-cta">
+        Please select a job below to see step breakdown per build
+        <br />
+        <br />
+        <div class="job-selector">
+          <select onchange={{action "selectJob" value="target.value"}}>
+            <option value="">
+              Select a job
+            </option>
+            {{#each this.jobs as |job|}}
+              <option value={{job}}>
+                {{job}}
+              </option>
+            {{/each}}
+          </select>
+          <span class="control-icon">
           <FaIcon @icon="caret-down" />
         </span>
+        </div>
       </div>
+    {{/if}}
+  {{else}}
+    <div class="chart-cta">
+      No metric available for the chosen time range!
     </div>
   {{/if}}
-{{else}}
-  <div class="chart-cta">
-    No metric available for the chosen time range!
-  </div>
-{{/if}}
+</div>
 
 {{outlet}}

--- a/app/pipeline/options/template.hbs
+++ b/app/pipeline/options/template.hbs
@@ -2,6 +2,7 @@
   <PipelineNav @pipeline={{this.pipeline}} />
 {{/if}}
 <PipelineOptions
+  class="padded-container"
   @username={{this.session.data.authenticated.username}}
   @pipeline={{this.pipeline}}
   @jobs={{this.jobs}}

--- a/app/pipeline/secrets/template.hbs
+++ b/app/pipeline/secrets/template.hbs
@@ -4,21 +4,23 @@
   <PipelineNav @pipeline={{this.pipeline}} />
 {{/if}}
 
-<PipelineSecretSettings
-  @secrets={{this.secrets}}
-  @onCreateSecret={{action "createSecret"}}
-  @pipeline={{this.pipeline}}
-  @errorMessage={{this.errorMessage}}
-/>
+<div class="padded-container">
+  <PipelineSecretSettings
+    @secrets={{this.secrets}}
+    @onCreateSecret={{action "createSecret"}}
+    @pipeline={{this.pipeline}}
+    @errorMessage={{this.errorMessage}}
+  />
 
-<TokenList
-  @tokens={{this.pipelineTokens}}
-  @newToken={{this.newToken}}
-  @pipelineId={{this.pipelineId}}
-  @onCreateToken={{action "createPipelineToken"}}
-  @onRefreshToken={{action "refreshPipelineToken"}}
-  @tokenName="Pipeline"
-  @tokenScope="this pipeline"
-/>
+  <TokenList
+    @tokens={{this.pipelineTokens}}
+    @newToken={{this.newToken}}
+    @pipelineId={{this.pipelineId}}
+    @onCreateToken={{action "createPipelineToken"}}
+    @onRefreshToken={{action "refreshPipelineToken"}}
+    @tokenName="Pipeline"
+    @tokenScope="this pipeline"
+  />
+</div>
 
 {{outlet}}

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -72,6 +72,10 @@ $weight-bold: 600;
   box-sizing: border-box;
   overflow: hidden;
 }
+.padded-container {
+  padding-left: 15px;
+  padding-right: 15px;
+}
 
 .SUCCESS {
   .status svg {


### PR DESCRIPTION
## Context
The application template by default uses the `container-fluid` class which has a built in left and right padding of 15px.  This causes the pipeline route pages to have some extra white margins across the navigation bars.

![Screenshot 2024-03-08 at 17-32-54 minghay_commit-join](https://github.com/screwdriver-cd/ui/assets/157658916/ddf50315-e75a-4203-a0c4-acf5bd1d4e66)

## Objective
Remove the whitespace showing up in the pipeline routes.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
