### PR TITLE
feat(3022): Hide nodes marked as virtual in the workflow graph

### DIFF
--- a/app/utils/graph-tools.js
+++ b/app/utils/graph-tools.js
@@ -456,16 +456,6 @@ const decorateGraph = ({
       jobs instanceof DS.PromiseManyArray) &&
     jobs.length;
 
-  const jobNameToJobMap = jobsAvailable
-    ? jobs.reduce(
-        (obj, job) => ({
-          ...obj,
-          [job.name]: job
-        }),
-        {}
-      )
-    : {};
-
   const eventStages =
     pipelineStages && pipelineStages.length > 0
       ? extractEventStages(inputGraph, pipelineStages)
@@ -481,12 +471,11 @@ const decorateGraph = ({
 
   // Remove setup and teardown nodes
   originalNodes.forEach(n => {
-    const jobName = n.name;
-    const job = jobNameToJobMap[jobName];
+    const { name: jobName, virtual } = n;
 
-    if (isStageSetupJob(jobName) && job && job.virtualJob) {
+    if (virtual && isStageSetupJob(jobName)) {
       virtualSetupNodes.push(n);
-    } else if (isStageTeardownJob(jobName) && job && job.virtualJob) {
+    } else if (virtual && isStageTeardownJob(jobName)) {
       virtualTeardownNodes.push(n);
     } else {
       nodes.push(n);

--- a/tests/integration/components/validator-results/component-test.js
+++ b/tests/integration/components/validator-results/component-test.js
@@ -313,14 +313,22 @@ module('Integration | Component | validator results', function (hooks) {
           { name: 'component', displayName: 'compJob' },
           { name: 'publish' },
           { name: 'ci-deploy', stageName: 'integration' },
-          { name: 'stage@integration:setup', stageName: 'integration' },
+          {
+            name: 'stage@integration:setup',
+            stageName: 'integration',
+            virtual: true
+          },
           { name: 'ci-test', stageName: 'integration' },
           { name: 'ci-certify', stageName: 'integration' },
           { name: 'prod-deploy', stageName: 'production' },
           { name: 'stage@production:setup', stageName: 'production' },
           { name: 'prod-test', stageName: 'production' },
           { name: 'prod-certify', stageName: 'production' },
-          { name: 'stage@integration:teardown', stageName: 'integration' },
+          {
+            name: 'stage@integration:teardown',
+            stageName: 'integration',
+            virtual: true
+          },
           { name: 'stage@production:teardown', stageName: 'production' }
         ],
         edges: [

--- a/tests/unit/utils/graph-tools-test.js
+++ b/tests/unit/utils/graph-tools-test.js
@@ -580,14 +580,20 @@ module('Unit | Utility | graph tools', function () {
         { name: '~commit' },
         { name: 'component', id: 1 },
         { name: 'publish', id: 2 },
-        { name: 'stage@integration:setup', id: 28, stageName: 'integration' },
+        {
+          name: 'stage@integration:setup',
+          id: 28,
+          stageName: 'integration',
+          virtual: true
+        },
         { name: 'ci-deploy', id: 21, stageName: 'integration' },
         { name: 'ci-test', id: 22, stageName: 'integration' },
         { name: 'ci-certify', id: 23, stageName: 'integration' },
         {
           name: 'stage@integration:teardown',
           id: 29,
-          stageName: 'integration'
+          stageName: 'integration',
+          virtual: true
         },
         { name: 'stage@production:setup', id: 38, stageName: 'production' },
         { name: 'prod-deploy', id: 31, stageName: 'production' },


### PR DESCRIPTION
## Context

Workflow graph node (Ex: implicit setup/teardown job of a stage) for an event is identified as virtual based on the presence/value of `screwdriver.cd/virtualJob` annotation in the corresponding job definition.

Since the job definition reflects the latest configuration from `screwdriver.yaml`, referring to current annotations of the job may not be reliable to identify it as virtual for an event.

Changes are made in the workflow-parser https://github.com/screwdriver-cd/workflow-parser/pull/51 to include a flag in the workflow graph node to preserve whether the job is virtual or not when the event is created.

## Objective

Use this new `virtual` flag to hide implicit stage setup/teardown jobs/nodes in the workflow graph

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
