### PR TITLE
fix: Only expand job related parameter

### DIFF
--- a/app/components/pipeline-parameterized-build/component.js
+++ b/app/components/pipeline-parameterized-build/component.js
@@ -173,13 +173,13 @@ export default Component.extend({
       });
     }
 
-    normalizedParameterGroups = normalizedParameterGroups.concat(
-      normalizedJobParameterGroups
-    );
-
     if (normalizedParameterGroups.length > 0) {
       normalizedParameterGroups[0].isOpen = true;
     }
+
+    normalizedParameterGroups = normalizedParameterGroups.concat(
+      normalizedJobParameterGroups
+    );
 
     return normalizedParameterGroups;
   },


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Currently, buildparameters are always expanded even if selected job has nether job-level build parameters nor pipeline-level parameters(That is, if there are no buildparameters used in the job).
We fix this behavior so that only buildparameters related to the job are expanded.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
`normalizedParameterGroups` only contains job related job-level parameter and pipeline-level parameters at L174.
Change the timing to determine if the parameters should be expanded at this time.
After determine if the parameters should be expanded or not, all other job-level parameters are added to return value.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
