### PR TITLE
fix: fit Display Job Name Length between minimum and maximum valuese

### DIFF
--- a/app/user-settings/preferences/controller.js
+++ b/app/user-settings/preferences/controller.js
@@ -55,6 +55,16 @@ export default Controller.extend({
 
   async updateUserSettings() {
     this.set('isSaving', true);
+
+    // Normalize display job name length between MINIMUM and MAXIMUM
+    let normalizedLength = this.displayJobNameLength;
+    normalizedLength = Math.max(normalizedLength, MINIMUM_JOBNAME_LENGTH);
+    normalizedLength = Math.min(normalizedLength, MAXIMUM_JOBNAME_LENGTH);
+
+    this.setProperties({
+      displayJobNameLength: normalizedLength
+    });
+
     this.userPreferences.set('displayJobNameLength', this.displayJobNameLength);
     this.userPreferences.set(
       'timestampFormat',

--- a/tests/acceptance/user-settings-test.js
+++ b/tests/acceptance/user-settings-test.js
@@ -97,6 +97,34 @@ module('Acceptance | user-settings', function (hooks) {
       .dom('.alert-success span:not(button span)')
       .hasText('User settings updated successfully!');
   });
+  test('update display job name length by overflowing value', async function (assert) {
+    server.put('http://localhost:8080/v4/users/settings', () => [
+      200,
+      { 'Content-Type': 'application/json' },
+      JSON.stringify({
+        id: '1'
+      })
+    ]);
+
+    server.get('http://localhost:8080/v4/users/settings', () => [
+      200,
+      { 'Content-Type': 'application/json' },
+      JSON.stringify({})
+    ]);
+
+    await authenticateSession({ token: 'faketoken' });
+    await visit('/user-settings/preferences');
+
+    assert.equal(currentURL(), '/user-settings/preferences');
+
+    await fillIn('.display-job-name', 300);
+    await click('button.blue-button');
+
+    assert.dom('.display-job-name').hasValue('99');
+    assert
+      .dom('.alert-success span:not(button span)')
+      .hasText('User settings updated successfully!');
+  });
   test('enable notifications', async function (assert) {
     server.put('http://localhost:8080/v4/users/settings', () => [
       200,

--- a/tests/acceptance/user-settings-test.js
+++ b/tests/acceptance/user-settings-test.js
@@ -125,6 +125,34 @@ module('Acceptance | user-settings', function (hooks) {
       .dom('.alert-success span:not(button span)')
       .hasText('User settings updated successfully!');
   });
+  test('update display job name length by underflow value', async function (assert) {
+    server.put('http://localhost:8080/v4/users/settings', () => [
+      200,
+      { 'Content-Type': 'application/json' },
+      JSON.stringify({
+        id: '1'
+      })
+    ]);
+
+    server.get('http://localhost:8080/v4/users/settings', () => [
+      200,
+      { 'Content-Type': 'application/json' },
+      JSON.stringify({})
+    ]);
+
+    await authenticateSession({ token: 'faketoken' });
+    await visit('/user-settings/preferences');
+
+    assert.equal(currentURL(), '/user-settings/preferences');
+
+    await fillIn('.display-job-name', -1);
+    await click('button.blue-button');
+
+    assert.dom('.display-job-name').hasValue('20');
+    assert
+      .dom('.alert-success span:not(button span)')
+      .hasText('User settings updated successfully!');
+  });
   test('enable notifications', async function (assert) {
     server.put('http://localhost:8080/v4/users/settings', () => [
       200,


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

The minimum and maximum values are set on the input form.
But user can input underflow or overflow values directly and store it.

![test](https://github.com/screwdriver-cd/ui/assets/43719835/3ef340f6-e884-4423-83ea-764011dd5772)

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Fit the input value between the minimum and the maximum values when user store it.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
