### PR TITLE
fix dropdown for other repos

### DIFF
--- a/app/components/pipeline-header/component.js
+++ b/app/components/pipeline-header/component.js
@@ -59,7 +59,9 @@ export default Component.extend({
       };
     }
   }),
-  sameRepoPipeline: computed('pipeline.scmRepo.name', 'pipeline.{id,scmUri}', {
+  // Disabling the eslint rule for computed properties as that causes rendering issues and an infinite loop to the API call with the current setup of ember data
+  // eslint-disable-next-line ember/require-computed-property-dependencies
+  sameRepoPipeline: computed('pipeline', {
     get() {
       const [scm, repositoryId] = this.pipeline.scmUri.split(':');
 


### PR DESCRIPTION
## Context
#1010 accidentally introduced a bug with the associated repos not being rendered.  As another side effect,  when the dropdown is activated, API calls are infinitely called.  These abnormal behaviors were caused by the eslint rule around computed properties.

## Objective
Disable the eslint rule for computed properties as that does not play nicely with the currently configuration of the ember data cache.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
