### PR TITLE
fix: sets application navbar to a constant height

### DIFF
--- a/app/components/app-header/styles.scss
+++ b/app/components/app-header/styles.scss
@@ -15,6 +15,7 @@
     border-radius: 0;
     background-color: $grey-800;
     border-color: $grey-800;
+    height: $app-header-height;
   }
 
   .navbar-dark .navbar-nav .nav-link {

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -4,6 +4,8 @@ $animate-done: 600ms;
 $weight-normal: 400;
 $weight-bold: 600;
 
+$app-header-height: 55px;
+
 @mixin transition($prop, $duration, $delay: 0ms, $easing: ease) {
   -webkit-transition: $prop $duration $delay $easing;
   -moz-transition: $prop $duration $delay $easing;


### PR DESCRIPTION
## Context
The navbar changes heights based on window size, but the difference in height is fairly minor.  Setting the navbar height to a constant size will remove the height difference and also make height calculations for other components easier.

## Objective
Sets the navbar to a constant height as there is currently no use case for having a variable height navbar.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
