### PR TITLE
fix: stretch the side bar on collection page

### DIFF
--- a/app/components/collections-flyout/styles.scss
+++ b/app/components/collections-flyout/styles.scss
@@ -8,6 +8,7 @@
     background-color: $sd-flyout-bg;
     color: $sd-text;
     display: block;
+    height: 100%;
     min-height: calc(100vh - 56px);
   }
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

The side bar on collections page is cut off as below.

<img width="1838" alt="side-bar" src="https://github.com/screwdriver-cd/ui/assets/43719835/6dc387c6-2ef7-49a1-95c4-6eff2b1f11d2">

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Stretch the side bar height.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
