### PR TITLE
fix: update nav banner style

### DIFF
--- a/app/application/template.hbs
+++ b/app/application/template.hbs
@@ -7,7 +7,6 @@
   @onInvalidate={{action "invalidateSession"}}
   @searchPipelines={{action "search"}}
 />
-<NavBanner />
 
 <AppBody />
 

--- a/app/components/app-body/styles.scss
+++ b/app/components/app-body/styles.scss
@@ -1,0 +1,11 @@
+& {
+  height: calc(100vh - $app-header-height);
+  display: flex;
+  flex-direction: column;
+
+  #appContainer {
+    flex: 1;
+    min-height: calc(100% - $nav-banner-height);
+    max-height: 100%;
+  }
+}

--- a/app/components/app-body/template.hbs
+++ b/app/components/app-body/template.hbs
@@ -1,3 +1,5 @@
+<NavBanner />
+
 <div id="appContainer" class='{{if this.isPipelineRoute '' 'container-fluid'}}'>
   {{outlet}}
 </div>

--- a/app/components/nav-banner/style.scss
+++ b/app/components/nav-banner/style.scss
@@ -1,7 +1,8 @@
 & {
   .banner .alert {
+    height: $nav-banner-height;
     border: 0px;
-    margin-bottom: 2px;
+    margin-bottom: 0;
     border-radius: 0px;
   }
 
@@ -15,8 +16,21 @@
     color: $sd-info-fg;
   }
 
-  .banner svg {
-    padding-right: 7px;
-    font-size: 20px;
+  .banner {
+    svg {
+      padding-right: 7px;
+      font-size: 20px;
+    }
+
+    .banner-message-container {
+      height: 2.25rem;
+
+      display: flex;
+      align-content: center;
+
+      .banner-message {
+        overflow: scroll;
+      }
+    }
   }
 }

--- a/app/components/nav-banner/template.hbs
+++ b/app/components/nav-banner/template.hbs
@@ -1,17 +1,20 @@
 {{#each this.banners as |banner|}}
   <div class="banner">
     <BsAlert @type={{banner.type}}>
-      <FaIcon
-        @icon={{if
-          (eq banner.type "info")
-          "info-circle"
-          "exclamation-triangle"
-        }}
-      />
-      {{! template-lint-disable no-triple-curlies }}
-      <span>
-        {{{banner.message}}}
-      </span>
+      <div class="banner-message-container">
+        <FaIcon
+          @icon={{if
+            (eq banner.type "info")
+            "info-circle"
+            "exclamation-triangle"
+          }}
+        />
+        <div class="banner-message">
+          <span>
+            {{banner.message}}
+          </span>
+        </div>
+      </div>
     </BsAlert>
   </div>
 {{/each}}

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -5,6 +5,7 @@ $weight-normal: 400;
 $weight-bold: 600;
 
 $app-header-height: 55px;
+$nav-banner-height: 42px;
 
 @mixin transition($prop, $duration, $delay: 0ms, $easing: ease) {
   -webkit-transition: $prop $duration $delay $easing;


### PR DESCRIPTION
## Context
Updating the nav banner style to better handle long messages and also vertically aligning the individual components.  The updated style also keeps the height at a constant value so that the remaining space in the window can be more accurately calculated.

## Objective
Vertically aligns the nav banner components and sets the height to be constant.  Long messages will also vertically scroll rather than overflowing.  Also adjusts the remaining vertical space on the page to account for whether a nav banner exists.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
