### PR TITLE
fix: background color on hover for profile icon

### DIFF
--- a/app/components/app-header/styles.scss
+++ b/app/components/app-header/styles.scss
@@ -132,6 +132,12 @@
         opacity: 0.6;
       }
     }
+
+    &.profile-outline {
+      &:hover {
+        background-color: transparent;
+      }
+    }
   }
 
   .dropdown {


### PR DESCRIPTION
## Context
When not logged in, the profile icon has a background color set when hovering.
![Screenshot 2024-03-26 at 13-21-11 Login](https://github.com/screwdriver-cd/ui/assets/157658916/0751c2ef-f318-4b72-83a5-43fc7494e6bd)

## Objective
Remove the background color when hovering
![Screenshot 2024-03-26 at 13-21-29 Login](https://github.com/screwdriver-cd/ui/assets/157658916/fbb8f4ac-3d20-4d47-abde-baf77eba883c)

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
