### PR TITLE
fix: revert logic for combining graph data

### DIFF
--- a/app/components/workflow-graph-d3/component.js
+++ b/app/components/workflow-graph-d3/component.js
@@ -5,7 +5,6 @@ import { inject as service } from '@ember/service';
 import {
   icon,
   decorateGraph,
-  node as findNode,
   subgraphFilter,
   removeBranch
 } from 'screwdriver-ui/utils/graph-tools';
@@ -71,50 +70,9 @@ export default Component.extend({
               }
             : this.completeWorkflowGraph;
 
-        let graph = showDownstreamTriggers ? completeGraph : workflowGraph;
+        const graph = showDownstreamTriggers ? completeGraph : workflowGraph;
 
         if (!this.minified && this.selectedEventObj?.prNum) {
-          // When initially onboarding the screwdriver configuration, there is a node named ~pr:/.*/ in completeGraph that must be merged with the node data in the workflow graph.  Additional edge data clean up must also be done.
-          const prJobWildcard = '~pr:/.*/';
-          const completePrGraph = JSON.parse(JSON.stringify(completeGraph));
-          const nodesAdded = [];
-
-          // Update the graph with the correct job id from the workflow graph
-          workflowGraph.nodes.forEach(workflowGraphNode => {
-            const nodeToUpdate = findNode(
-              completePrGraph.nodes,
-              workflowGraphNode.name
-            );
-
-            if (!this.prChainEnabled && !nodeToUpdate) {
-              nodesAdded.push(workflowGraphNode);
-            } else {
-              nodeToUpdate.id = workflowGraphNode.id;
-            }
-          });
-
-          // Nodes are only added when initially onboarding the screwdriver configuration.  Node and edge data will be merged with the workflow graph data for the placeholder node
-          if (nodesAdded.length > 0) {
-            const nodes = completeGraph.nodes.filter(
-              graphNode => graphNode.name !== prJobWildcard
-            );
-            const edges = completePrGraph.edges.filter(
-              edge => edge.src !== '~pr' && edge.src !== prJobWildcard
-            );
-
-            nodes.push(...nodesAdded);
-            nodesAdded.forEach(addedNode => {
-              edges.push({
-                src: '~pr',
-                dest: addedNode.name
-              });
-            });
-
-            completePrGraph.nodes = nodes;
-            completePrGraph.edges = edges;
-          }
-
-          graph = completePrGraph;
           showPRJobs = true;
         }
 


### PR DESCRIPTION
## Context
#1000 added new logic to merge graph data, but one unfortunate side effect is that it is unable to handle certain cases where the pipeline graph is modified in a pull request for the pull request page. 

## Objective
Remove the new logic that was introduced in #1000 so that the main pipeline graph displayed in the pull request page will display consistently.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
