### PR TITLE
fix: background-color for profile icon when focused

### DIFF
--- a/app/components/app-header/styles.scss
+++ b/app/components/app-header/styles.scss
@@ -134,7 +134,8 @@
     }
 
     &.profile-outline {
-      &:hover {
+      &:hover,
+      &:focus {
         background-color: transparent;
       }
     }


### PR DESCRIPTION
## Context
Same issue as #1024 but for the focus state of the profile icon.

## Objective
Fixed background color for the profile icon when focused.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
