### PR TITLE
fix: height on PR list element

### DIFF
--- a/app/components/pipeline-pr-list/styles.scss
+++ b/app/components/pipeline-pr-list/styles.scss
@@ -39,8 +39,6 @@
       color: $grey-800;
     }
   }
-
-  height: 100%;
 }
 
 .startButton {


### PR DESCRIPTION
## Context
In the PR view, the height of the sidebar elements are now misconfigured for non-chained pipelines.
![Screenshot 2024-03-28 at 10-25-17 minghay_multiple-non-chained](https://github.com/screwdriver-cd/ui/assets/157658916/a648643c-4f45-412c-a460-1d5f34edf37a)


## Objective
Fix the height of the sidebar element for non-chained pipelines.
![Screenshot 2024-03-28 at 10-25-44 minghay_multiple-non-chained](https://github.com/screwdriver-cd/ui/assets/157658916/4e1afc4f-aca4-4ccd-88ff-c2bb7ebd23a3)

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
