### PR TITLE
fix: delete pipeline by version only delete the latest one

### DIFF
--- a/app/templates/pipeline/detail/controller.js
+++ b/app/templates/pipeline/detail/controller.js
@@ -161,7 +161,7 @@ export default class TemplatesPipelineDetailController extends Controller {
   }
 
   @action
-  removeVersion(fullName, version) {
+  removeVersion(_, version) {
     const { namespace, name } = this.selectedVersionTemplate;
 
     return (

--- a/app/templates/pipeline/detail/controller.js
+++ b/app/templates/pipeline/detail/controller.js
@@ -161,8 +161,8 @@ export default class TemplatesPipelineDetailController extends Controller {
   }
 
   @action
-  removeVersion() {
-    const { namespace, name, version } = this.selectedVersionTemplate;
+  removeVersion(fullName, version) {
+    const { namespace, name } = this.selectedVersionTemplate;
 
     return (
       this.isAdmin &&

--- a/tests/unit/templates/pipeline/detail/controller-test.js
+++ b/tests/unit/templates/pipeline/detail/controller-test.js
@@ -211,12 +211,25 @@ module('Unit | Controller | templates/pipeline/detail', function (hooks) {
       'target',
       Controller.extend({
         actions: {
-          reloadModel: () => assert.ok(true, 'reloadModel action bubbled')
+          reloadModel() {
+            assert.ok(true, 'reloadModel action bubbled');
+          }
         }
       }).create()
     );
 
-    controller.send('removeVersion');
+    controller.set(
+      'template.deletePipelineTemplateByVersion',
+      (namespace, name, version) => {
+        assert.equal(namespace, 'adong');
+        assert.equal(name, 'sd-job-template-builder');
+        assert.equal(version, '1.0.0');
+
+        return resolve();
+      }
+    );
+
+    controller.send('removeVersion', 'adong/sd-job-template-builder', '1.0.0');
   });
 
   test('it handles template update trust', function (assert) {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Currently, delete pipeline template version only deletes the latest one.

## Objective
1) delete the pipeline template by version by the target version from table
2) Add more tests

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
