### PR TITLE
fix(3082): show build parameter tooltip

### DIFF
--- a/app/components/pipeline-graph-nav/styles.scss
+++ b/app/components/pipeline-graph-nav/styles.scss
@@ -86,7 +86,7 @@ $pipeline-graph-nav-height: 156px;
     display: flex;
     align-content: center;
     justify-content: space-between;
-    overflow: scroll;
+    // overflow: scroll;
 
     .button-container {
       margin: auto;


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

To resolve the following Issue, this PR will apply a patch fix.

https://github.com/screwdriver-cd/screwdriver/issues/3082

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

The navigation bar has become scrollable, but this also includes scrolling downwards.

https://github.com/screwdriver-cd/ui/pull/1023

https://github.com/screwdriver-cd/ui/assets/43719835/9418a467-84a6-4224-85a5-bc4b594681f5

Since it's not possible to make only one direction visible, this PR will disable it as a patch.

https://stackoverflow.com/questions/6421966/css-overflow-x-visible-and-overflow-y-hidden-causing-scrollbar-issue

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

https://github.com/screwdriver-cd/screwdriver/issues/3082

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
