### PR TITLE
fix: event list does not fetch new data

### DIFF
--- a/app/components/pipeline-events/template.hbs
+++ b/app/components/pipeline-events/template.hbs
@@ -94,7 +94,6 @@
 </div>
 <div
   class="events-sidebar column-tabs-view {{if this.showListView "disabled"}}"
-  onScroll={{action "onEventListScroll"}}
 >
   <BsTab @customTabs={{true}} as |tab|>
     <BsNav @type="tabs" as |nav|>
@@ -110,7 +109,10 @@
       </nav.item>
     </BsNav>
   </BsTab>
-  <div class="tab-content">
+  <div
+    class="tab-content"
+    onScroll={{action "onEventListScroll"}}
+  >
     {{#if (eq this.activeTab "events")}}
         <PipelineEventsList
           @pipeline={{this.pipeline}}


### PR DESCRIPTION
## Context
#1023 modified the layout a bit and the event handler for scrolling the events sidebar list is not getting fired.

## Objective
Fix the scroll event handler to be attached to the correct scrollable parent element.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
