### PR TITLE
fix: start job dropdown

### DIFF
--- a/app/components/app-body/styles.scss
+++ b/app/components/app-body/styles.scss
@@ -11,6 +11,7 @@
     &.pipeline-page {
       display: flex;
       flex-direction: column;
+      min-width: 900px;
     }
   }
 }

--- a/app/components/pipeline-graph-nav/styles.scss
+++ b/app/components/pipeline-graph-nav/styles.scss
@@ -86,7 +86,6 @@ $pipeline-graph-nav-height: 156px;
     display: flex;
     align-content: center;
     justify-content: space-between;
-    overflow: scroll;
 
     .button-container {
       margin: auto;


### PR DESCRIPTION
## Context
#1023 made the buttons scrollable on overflow, however the overflow prevents the dropdown from being easily accessible.

## Objective
Removes the overflow behavior in favor of a minimum width so that the dropdown will display properly.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
