### PR TITLE
fix(3086): job template info now shows up on build-banner

### DIFF
--- a/app/components/build-banner/template.hbs
+++ b/app/components/build-banner/template.hbs
@@ -162,7 +162,7 @@
     {{#if this.template}}
       <li class="template-info">
         <LinkTo
-          @route="templates.detail.version"
+          @route="templates.job.detail.version"
           @models={{array this.template.namespace this.template.name this.template.version}}
         >
           <span class="banner-value">

--- a/app/templates/job/detail/index/route.js
+++ b/app/templates/job/detail/index/route.js
@@ -5,6 +5,6 @@ import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-rout
 export default Route.extend(AuthenticatedRouteMixin, {
   router: service(),
   model() {
-    return this.modelFor('templates.detail');
+    return this.modelFor('templates.job.detail');
   }
 });

--- a/tests/integration/components/build-banner/component-test.js
+++ b/tests/integration/components/build-banner/component-test.js
@@ -766,7 +766,7 @@ module('Integration | Component | build banner', function (hooks) {
   });
 
   test('it renders template info if user is using template', async function (assert) {
-    assert.expect(15);
+    assert.expect(16);
     this.owner.setupRouter();
 
     this.set('reloadCb', () => {
@@ -846,6 +846,9 @@ module('Integration | Component | build banner', function (hooks) {
     assert.dom('.user .banner-value').hasText('Bruce W');
     assert.dom('.docker-container .banner-value').hasText('node:6');
     assert.dom('.template-info .banner-value').hasText('test:2.0');
+    assert
+      .dom('.template-info > a')
+      .hasAttribute('href', '/templates/job/nodejs/test/2.0');
     assert.dom('button').doesNotExist();
   });
 


### PR DESCRIPTION
## Context
<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Fix job template info to show up on build-banner

## Objective
1) rename route "templates.detail.version" to "templates.job.detail.version" 
2) Add test to check hyper link

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/screwdriver/issues/3086
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
