### PR TITLE
fix(2672): build parameters scroll behavior

### DIFF
--- a/app/components/pipeline-parameterized-build/component.js
+++ b/app/components/pipeline-parameterized-build/component.js
@@ -371,8 +371,8 @@ export default Component.extend({
      * @param {import('ember-power-select/components/power-select').Select} value
      */
     onOpen(value) {
+      // Wait until select-options frame is displayed
       setTimeout(() => {
-        // Wait until select-options frame is displayed
         const collections = document.getElementsByClassName(
           'parameter-group-list'
         );
@@ -407,6 +407,7 @@ export default Component.extend({
      * Therefore, it is necessary to cause a recalculation of the scroll position when closing.
      */
     onClose() {
+      // Wait until select-options frame is hidden and scrollbar of parameter-group-list height is recalculated.
       setTimeout(() => {
         const collections = document.getElementsByClassName(
           'parameter-group-list'
@@ -416,7 +417,6 @@ export default Component.extend({
           return;
         }
         const scrollFrame = collections[0];
-        // Wait until select-options frame is hidden and scrollbar of parameter-group-list height is recalculated.
         const scrollRatio =
           scrollFrame.scrollTop /
           (scrollFrame.scrollHeight - scrollFrame.clientHeight);

--- a/app/components/pipeline-parameterized-build/component.js
+++ b/app/components/pipeline-parameterized-build/component.js
@@ -87,10 +87,10 @@ export default Component.extend({
   },
 
   /**
-   * Get Shared parameters
-   * @return {Record<string, ParameterValue>} Parameter name and value (optional: description) pairs
+   * Get Pipeline parameters
+   * @return {Record<string, PipelineParameterValue>} Pipeline parameter name and value (optional: description) pairs
    * @example
-   *    >>> getDefaultJobParameters(...)
+   *    >>> getDefaultPipelineParameters(...)
    *    {
    *      namespace: 'sandbox'
    *      ...,

--- a/app/components/pipeline-parameterized-build/component.js
+++ b/app/components/pipeline-parameterized-build/component.js
@@ -422,7 +422,7 @@ export default Component.extend({
           (scrollFrame.scrollHeight - scrollFrame.clientHeight);
 
         if (scrollRatio === 1) {
-          scrollFrame.scrollBy({ top: -0.001 });
+          scrollFrame.scrollBy({ top: -1 });
         }
       }, 100);
     },

--- a/app/components/pipeline-parameterized-build/component.js
+++ b/app/components/pipeline-parameterized-build/component.js
@@ -2,6 +2,31 @@ import { set } from '@ember/object';
 import Component from '@ember/component';
 
 /**
+ * @typedef {Object} ParameterOption          Parameter name and value(s) (optional: description) pairs in Yaml
+ * @property {string|Array<string>} value     Default parameter value(s) defined in Yaml
+ * @property {string|undefined} description   Parameter description defined in Yaml
+ */
+/**
+ * @typedef {string|Array<string>|ParameterOption} ParameterValue   Parameter Value(s) defined in Yaml
+ */
+/**
+ * @typedef {Record<string, ParameterValue>} JobParameterValue      Job Parameter Value(s) defined in Yaml
+ */
+/**
+ * @typedef {Object} Parameter                      Parameter information
+ * @property {string|Array<string>} defaultValues   Default value(s) in Yaml
+ * @property {string} description                   Parameter description ('' when unset)
+ * @property {string} name                          Parameter name
+ * @property {string|Array<string>} value           Current Value(s)
+ */
+/**
+ * @typedef {Object} ParameterGroup           Parameter information with UI state
+ * @property {boolean} isOpen                 Open/Closed state of parameter-group
+ * @property {string|null} jobName            Job name (null when Shared parameter group)
+ * @property {string} paramGroupTitle         'Shared' or 'Job: <Job name>'
+ * @property {Array<Parameter>} parameters    Parameter array
+ */
+/**
  @class PipelineParameterizedBuild
  @namespace Components
  @extends Ember.Component
@@ -39,8 +64,7 @@ export default Component.extend({
   startFrom: null,
 
   /**
-   * parameters expected to be an object
-   * @type {String}
+   * Initialization
    */
   init() {
     this._super(...arguments);
@@ -62,12 +86,35 @@ export default Component.extend({
     });
   },
 
+  /**
+   * Get Shared parameters
+   * @return {Record<string, ParameterValue>} Parameter name and value (optional: description) pairs
+   * @example
+   *    >>> getDefaultJobParameters(...)
+   *    {
+   *      namespace: 'sandbox'
+   *      ...,
+   *    }
+   */
   getDefaultPipelineParameters() {
     return this.get('pipeline.parameters') === undefined
       ? {}
       : this.get('pipeline.parameters');
   },
 
+  /**
+   * Get Job parameters
+   * @return {Record<string, JobParameterValue>} Job name and parameters pairs
+   * @example
+   *    >>> getDefaultJobParameters(...)
+   *    {
+   *      build: {
+   *        image: 'alpine',
+   *        tag: '1.0'
+   *      },
+   *      deploy: {...}
+   *    }
+   */
   getDefaultJobParameters() {
     return this.get('pipeline.jobParameters') === undefined
       ? {}
@@ -77,39 +124,28 @@ export default Component.extend({
   /**
    * normalizeParameters transform given parameters from object into array of objects
    * this method also backfills with default properties
-   * For example:
-   * parameters = {
-        "_started_at": "simple",
-        "user": {
-          "value": "adong",
-          "description": "User running build"
-        }
-    }
-    defaultParameters = {
-        "user": {
-          "value": "dummy",
-          "description": "User running build"
-        }
-   * }
-   * to
-   * [
-   *  {
-        name: "_started_at":
-        value: "simple",
-        defaultValues: "simple"
-        description: ""
-      }, {
-        name: "user"
-        value: "adong",
-        defaultValues: "dummy"
-        description: "User running build"
-      }
-   * ]
-   * @param  {Object} parameters        [description]
-   * @param  {Object} defaultParameters [description]
-   * @return {[type]}                   [description]
+   * @param  {Record<string, ParameterValue>} [parameters]          Parameter name and value pairs
+   * @param  {Record<string, ParameterValue>} [defaultParameters]   Default parameter name and value pairs
+   * @return {Array<Record<string, Parameter>>}                     Parameter information array
+   * @example
+   *    [{
+   *      0: {
+   *        name: 'image',
+   *        value: 'alpine',
+   *        defaultValues: 'alpine',
+   *        description: ''
+   *      },
+   *      1: {
+   *        name: 'tag',
+   *        value: '1.0',
+   *        defaultValues: ['1.0', '2.0', 'latest'],
+   *        description: 'image version'
+   *      },
+   *      ...,
+   *    }]
    */
   normalizeParameters(parameters = {}, defaultParameters = {}) {
+    /** @type {Array<Record<string, Parameter>>} */
     const normalizedParameters = [];
 
     Object.entries(parameters).forEach(([propertyName, propertyVal]) => {
@@ -133,6 +169,45 @@ export default Component.extend({
     return normalizedParameters;
   },
 
+  /**
+   * Get normalized parameter groups
+   * @param {Record<string, ParameterValue>} pipelineParameters         Pipeline parameters
+   * @param {Record<string, ParameterValue>} defaultPipelineParameters  Default pipeline parameters
+   * @param {Record<string, JobParameterValue>} jobParameters           Job parameters
+   * @param {Record<string, JobParameterValue>} defaultJobParameters    Default job parameters
+   * @param {string|null} startFrom                                     Starting job name (null when from the Start button)
+   * @return {Array<Record<string, ParameterGroup>>}                    Job or Shared name and parameter information pairs
+   * @example
+   *    [
+   *      {
+   *        0: {
+   *          isOpen: true,
+   *          jobName: null,
+   *          paramGroupTitle: 'Shared',
+   *          parameters: {
+   *            0: {
+   *              name: 'namespace',
+   *              value: 'sandbox',
+   *              defaultValues: '',
+   *              description: ''
+   *            },
+   *            1: {...},
+   *          }
+   *        }
+   *      },
+   *      {
+   *        1: {
+   *          isOpen: false,
+   *          jobName: build,
+   *          paramGroupTitle: 'Job: build',
+   *          parameters: {...}
+   *        }
+   *      },
+   *      {
+   *        2: {...}
+   *      }
+   *    ]
+   */
   getNormalizedParameterGroups(
     pipelineParameters = {},
     defaultPipelineParameters = {},
@@ -140,7 +215,9 @@ export default Component.extend({
     defaultJobParameters = {},
     startFrom
   ) {
+    /** @type {Array<Record<string, ParameterGroup>>} */
     let normalizedParameterGroups = [];
+    /** @type {Array<Record<string, ParameterGroup>>} */
     const normalizedJobParameterGroups = [];
 
     Object.entries(jobParameters).forEach(([jobName, parameters]) => {
@@ -184,7 +261,18 @@ export default Component.extend({
     return normalizedParameterGroups;
   },
 
+  /**
+   * Get pairs of parameter name and value
+   * @param {Array<Parameter>} normalizedParameters
+   * @return {Record<string, string>}
+   * @example
+   *    {
+   *      image: 'alpine'
+   *      tag: '1.0'
+   *    }
+   */
   normalizedParameterizedModel(normalizedParameters = []) {
+    /** @type {Record<string, string>} */
     const normalizedParameterizedModel = {};
 
     normalizedParameters.forEach(normalizedParam => {
@@ -200,11 +288,23 @@ export default Component.extend({
     return normalizedParameterizedModel;
   },
 
+  /**
+   * Get initial values of Shared parameters and Job parameters.
+   * @param {Array<ParameterGroup>} [normalizedParameters]    Parameter group array
+   * @return {Record<string, string|Record<string, string>>}  Parameter name and value pair (Summarized when job parameters)
+   * @example
+   *    {
+   *      build: {image: 'alpine', tag: '1.0'}
+   *      namespace: 'sandbox'
+   *    }
+   */
   getNormalizedParameterizedModel(normalizedParameters = []) {
+    /** @type {Record<string, string|Record<string, string>>} */
     const normalizedParameterizedModel = {};
 
     normalizedParameters.forEach(entry => {
       if (entry.jobName === null) {
+        // When Shared parameters
         Object.assign(
           normalizedParameterizedModel,
           this.normalizedParameterizedModel(entry.parameters)
@@ -263,6 +363,70 @@ export default Component.extend({
           value: value.searchText
         });
       }
+    },
+
+    /**
+     * Callback when clicked and opened ember-power-select-options
+     * @param {string} propertyName
+     * @param {import('ember-power-select/components/power-select').Select} value
+     */
+    onOpen(value) {
+      // Wait until select-options frame is displayed
+      const collections = document.getElementsByClassName(
+        'parameter-group-list'
+      );
+
+      if (collections.length === 0) {
+        return;
+      }
+      const scrollFrame = collections[0];
+
+      setTimeout(() => {
+        const optionsBox = document.getElementById(
+          `ember-power-select-options-${value.uniqueId}`
+        );
+
+        if (optionsBox === null) {
+          return;
+        }
+        const optionsBoxRect = optionsBox.getBoundingClientRect();
+        const scrollFrameRect = scrollFrame.getBoundingClientRect();
+        const hiddenAreaHeight = optionsBoxRect.bottom - scrollFrameRect.bottom;
+
+        if (hiddenAreaHeight > 0) {
+          scrollFrame.scrollBy({ top: hiddenAreaHeight + 10 });
+        }
+      }, 10);
+    },
+
+    /**
+     * Callback when closed ember-power-select-options
+     * In the following cases, the scroll function does not work properly
+     * 1. the scrollbar is at the bottom when the box is closed.
+     * 2. after 1, the box is opened again without changing the position of the scrollbars.
+     * This is because the position of the scrollbar is saved behind the scenes, so when the select-options is reopened, it automatically scrolls to the previous scrollbar position.
+     * Therefore, it is necessary to cause a recalculation of the scroll position when closing.
+     */
+    onClose() {
+      const collections = document.getElementsByClassName(
+        'parameter-group-list'
+      );
+
+      if (collections.length === 0) {
+        return;
+      }
+      const scrollFrame = collections[0];
+      // Wait until select-options frame is hidden and scrollbar of parameter-group-list height is recalculated.
+
+      setTimeout(() => {
+        const scrollRatio =
+          scrollFrame.scrollTop /
+          (scrollFrame.scrollHeight - scrollFrame.clientHeight);
+
+        if (scrollRatio === 1) {
+          scrollFrame.scrollBy({ top: -0.001 });
+        }
+      }, 10);
     },
 
     onUpdateValue(model, jobName, propertyName, value) {

--- a/app/components/pipeline-parameterized-build/component.js
+++ b/app/components/pipeline-parameterized-build/component.js
@@ -367,27 +367,31 @@ export default Component.extend({
 
     /**
      * Callback when clicked and opened ember-power-select-options
-     * @param {string} propertyName
      * @param {import('ember-power-select/components/power-select').Select} value
      */
     onOpen(value) {
-      // Wait until select-options frame is displayed
-      setTimeout(() => {
+      // Try until ember-power-select-options is displayed
+      let counter = 0;
+      const nTry = 100;
+      const intervalId = setInterval(() => {
+        counter += 1;
+        if (counter > nTry) {
+          clearInterval(intervalId);
+
+          return;
+        }
         const collections = document.getElementsByClassName(
           'parameter-group-list'
         );
-
-        if (collections.length === 0) {
-          return;
-        }
-        const scrollFrame = collections[0];
         const optionsBox = document.getElementById(
           `ember-power-select-options-${value.uniqueId}`
         );
 
-        if (optionsBox === null) {
+        if (optionsBox === null || collections.length === 0) {
           return;
         }
+        clearInterval(intervalId);
+        const scrollFrame = collections[0];
         const optionsBoxRect = optionsBox.getBoundingClientRect();
         const scrollFrameRect = scrollFrame.getBoundingClientRect();
         const hiddenAreaHeight = optionsBoxRect.bottom - scrollFrameRect.bottom;
@@ -424,7 +428,7 @@ export default Component.extend({
         if (scrollRatio === 1) {
           scrollFrame.scrollBy({ top: -0.001 });
         }
-      }, 10);
+      }, 100);
     },
 
     onUpdateValue(model, jobName, propertyName, value) {

--- a/app/components/pipeline-parameterized-build/component.js
+++ b/app/components/pipeline-parameterized-build/component.js
@@ -367,31 +367,27 @@ export default Component.extend({
 
     /**
      * Callback when clicked and opened ember-power-select-options
+     * @param {string} propertyName
      * @param {import('ember-power-select/components/power-select').Select} value
      */
     onOpen(value) {
-      // Try until ember-power-select-options is displayed
-      let counter = 0;
-      const nTry = 100;
-      const intervalId = setInterval(() => {
-        counter += 1;
-        if (counter > nTry) {
-          clearInterval(intervalId);
-
-          return;
-        }
+      setTimeout(() => {
+        // Wait until select-options frame is displayed
         const collections = document.getElementsByClassName(
           'parameter-group-list'
         );
+
+        if (collections.length === 0) {
+          return;
+        }
+        const scrollFrame = collections[0];
         const optionsBox = document.getElementById(
           `ember-power-select-options-${value.uniqueId}`
         );
 
-        if (optionsBox === null || collections.length === 0) {
+        if (optionsBox === null) {
           return;
         }
-        clearInterval(intervalId);
-        const scrollFrame = collections[0];
         const optionsBoxRect = optionsBox.getBoundingClientRect();
         const scrollFrameRect = scrollFrame.getBoundingClientRect();
         const hiddenAreaHeight = optionsBoxRect.bottom - scrollFrameRect.bottom;
@@ -399,7 +395,7 @@ export default Component.extend({
         if (hiddenAreaHeight > 0) {
           scrollFrame.scrollBy({ top: hiddenAreaHeight + 10 });
         }
-      }, 10);
+      }, 100);
     },
 
     /**
@@ -411,7 +407,6 @@ export default Component.extend({
      * Therefore, it is necessary to cause a recalculation of the scroll position when closing.
      */
     onClose() {
-      // Wait until select-options frame is hidden and scrollbar of parameter-group-list height is recalculated.
       setTimeout(() => {
         const collections = document.getElementsByClassName(
           'parameter-group-list'
@@ -421,6 +416,7 @@ export default Component.extend({
           return;
         }
         const scrollFrame = collections[0];
+        // Wait until select-options frame is hidden and scrollbar of parameter-group-list height is recalculated.
         const scrollRatio =
           scrollFrame.scrollTop /
           (scrollFrame.scrollHeight - scrollFrame.clientHeight);

--- a/app/components/pipeline-parameterized-build/component.js
+++ b/app/components/pipeline-parameterized-build/component.js
@@ -372,16 +372,15 @@ export default Component.extend({
      */
     onOpen(value) {
       // Wait until select-options frame is displayed
-      const collections = document.getElementsByClassName(
-        'parameter-group-list'
-      );
-
-      if (collections.length === 0) {
-        return;
-      }
-      const scrollFrame = collections[0];
-
       setTimeout(() => {
+        const collections = document.getElementsByClassName(
+          'parameter-group-list'
+        );
+
+        if (collections.length === 0) {
+          return;
+        }
+        const scrollFrame = collections[0];
         const optionsBox = document.getElementById(
           `ember-power-select-options-${value.uniqueId}`
         );
@@ -408,17 +407,16 @@ export default Component.extend({
      * Therefore, it is necessary to cause a recalculation of the scroll position when closing.
      */
     onClose() {
-      const collections = document.getElementsByClassName(
-        'parameter-group-list'
-      );
-
-      if (collections.length === 0) {
-        return;
-      }
-      const scrollFrame = collections[0];
       // Wait until select-options frame is hidden and scrollbar of parameter-group-list height is recalculated.
-
       setTimeout(() => {
+        const collections = document.getElementsByClassName(
+          'parameter-group-list'
+        );
+
+        if (collections.length === 0) {
+          return;
+        }
+        const scrollFrame = collections[0];
         const scrollRatio =
           scrollFrame.scrollTop /
           (scrollFrame.scrollHeight - scrollFrame.clientHeight);

--- a/app/components/pipeline-parameterized-build/styles.scss
+++ b/app/components/pipeline-parameterized-build/styles.scss
@@ -16,6 +16,7 @@ button.start-with-parameters-button {
 .parameter-group-list {
   max-height: 70vh;
   overflow-y: scroll;
+  scroll-behavior: smooth;
 
   .parameter-group {
     margin: 10px 10px 0 0;

--- a/app/components/pipeline-parameterized-build/template.hbs
+++ b/app/components/pipeline-parameterized-build/template.hbs
@@ -58,6 +58,12 @@
                         @renderInPlace={{true}}
                         @searchEnabled={{true}}
                         @selected={{value}}
+                        @onOpen={{ action
+                            "onOpen"
+                        }}
+                        @onClose={{ action
+                            "onClose"
+                        }}
                         @onChange={{ action
                             "onUpdateValue"
                             this.parameterizedModel


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
The parameter list is hidden outside the scroll range when the drop-down is displayed.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Scrolls the screen automatically until the bottom of the dropdown is visible when the drop-down is displayed for better visibility.
(Additional jsdoc fixes.)

The main modifications are as follows
[app/components/pipeline-parameterized-build/component.js/R368-R429](https://github.com/screwdriver-cd/ui/pull/1037/files#diff-c32e55d57b1466e497b57e8c4b27cb6b608602048c28874caa305d0f0c752af1R368-R429)

https://github.com/screwdriver-cd/ui/assets/138551445/61ff234a-e6d6-41a3-a923-74cc68bc6716

https://github.com/screwdriver-cd/ui/assets/138551445/8485afaf-47e9-413f-b486-0c87396eb964

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/2672

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
