### PR TITLE
fix(3093): show commands instead of templates on commands route

### DIFF
--- a/app/commands/index/template.hbs
+++ b/app/commands/index/template.hbs
@@ -2,8 +2,6 @@
   @model={{this.model}}
   @filteringNamespace={{this.targetNamespace}}
   @collectionType="Commands"
->
-  Commands share binaries (or scripts) across multiple jobs.
-</TcCollectionList>
+></TcCollectionList>
 
 {{outlet}}

--- a/app/commands/template.hbs
+++ b/app/commands/template.hbs
@@ -1,5 +1,24 @@
+<div class="commands">
 {{page-title "Commands"}}
-
+<header class="commands-header">
+  <h4>Commands
+    <a
+      href="http://docs.screwdriver.cd/user-guide/commands"
+      title="More Information"
+      target="_blank"
+      rel="noopener"
+      class="doc-link float-right"
+      style="font-size: 1.25rem; font-weight: normal; color: #3697f2;"
+    >
+      Commands Docs
+      <FaIcon @icon="question-circle" />
+    </a>
+  </h4>
+  <div class="command-description">
+    Commands share binaries (or scripts) across multiple jobs.
+  </div>
+</header>
 <BreadCrumbs @crumbs={{this.crumbs}} />
 
 {{outlet}}
+</div>

--- a/app/components/tc-collection-list/component.js
+++ b/app/components/tc-collection-list/component.js
@@ -33,6 +33,17 @@ export default Component.extend({
       };
     }
   }),
+  placeholder: computed('collectionType', {
+    get() {
+      const collectionType = this.collectionType.toLowerCase();
+
+      if (collectionType === 'commands') {
+        return 'Search commands';
+      }
+
+      return `Search ${collectionType} templates`;
+    }
+  }),
   filteringNamespace: null,
   filteringMaintainer: null,
   sort: 'createTime',

--- a/app/components/tc-collection-list/template.hbs
+++ b/app/components/tc-collection-list/template.hbs
@@ -1,7 +1,11 @@
 <section>
   <h5>
     <b>
-      {{this.collectionType}} Templates
+      {{#if (eq this.collectionType "Commands")}}
+        Commands
+      {{else}}
+        {{this.collectionType}} Templates
+      {{/if}}
     </b>
     <span class="float-right">
       <span class="text-uppercase total">
@@ -73,7 +77,7 @@
     <div class="col-sm-4">
       <input
         value=""
-        placeholder="Search {{this.collectionType}} Templates"
+        placeholder="{{this.placeholder}}"
         type="search"
         oninput={{action (mut this.query) value="target.value"}}
       />

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -73,7 +73,7 @@ $pipeline-header-height-max: 134px;
 @import 'app/styles/chart';
 @import 'app/styles/user-settings';
 @import 'app/styles/create';
-@import 'app/styles/templates';
+@import 'app/styles/commands-templates';
 
 .container {
   box-sizing: border-box;

--- a/app/styles/commands-templates.scss
+++ b/app/styles/commands-templates.scss
@@ -1,5 +1,7 @@
-.templates {
-  header.templates-header {
+.templates,
+.commands {
+  header.templates-header,
+  header.commands-header {
     padding-top: 12px;
     padding-bottom: 12px;
   }

--- a/tests/acceptance/commands-test.js
+++ b/tests/acceptance/commands-test.js
@@ -102,4 +102,20 @@ module('Acceptance | commands', function (hooks) {
       'Page title is correct'
     );
   });
+
+  test('visiting /commands has headers and description', async assert => {
+    await authenticateSession({ token: adminJWT });
+    await visit('/commands');
+
+    assert.strictEqual(currentURL(), '/commands');
+
+    assert.equal(currentURL(), '/commands');
+    assert.dom('.commands-header > h4').includesText('Commands');
+    assert.dom('.commands-header > h4 > a').includesText('Commands Docs');
+    assert
+      .dom('.commands-header > .command-description')
+      .includesText(
+        'Commands share binaries (or scripts) across multiple jobs.'
+      );
+  });
 });


### PR DESCRIPTION
## Context
<!-- Why do we need this PR? What was the reason that led you to make this change? -->
1. abstract placeholder to a computed property
2. show commands instead of templates

## Objective
Add header to `/commands` just as we have for pipeline/job templates 
![image](https://github.com/screwdriver-cd/ui/assets/15989893/80187b81-c34e-4231-91d4-514a0a551fa6)

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/screwdriver/issues/3093
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
