### PR TITLE
Update to ember data 4.11

### DIFF
--- a/app/components/pipeline-pr-view/component.js
+++ b/app/components/pipeline-pr-view/component.js
@@ -5,7 +5,7 @@ import { statusIcon } from 'screwdriver-ui/utils/build';
 export default Component.extend({
   classNameBindings: ['build.status'],
   async setBuild() {
-    set(this, 'build', (await this.job.builds).objectAt(0));
+    set(this, 'build', (await this.job.builds)[0]);
   },
   build: computed('_build', 'job.builds', {
     get() {

--- a/app/pipeline/metrics/route.js
+++ b/app/pipeline/metrics/route.js
@@ -126,7 +126,7 @@ export default Route.extend({
            */
           function getBuildId(type, index) {
             if (type === 'step') {
-              return +jobMetrics.objectAt(index).get('id');
+              return jobMetrics[index].id;
             }
 
             if (type === 'build') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "ember-component-css": "^0.8.1",
         "ember-copy": "^2.0.0",
         "ember-d3": "^0.5.1",
-        "ember-data": "~4.4.1",
+        "ember-data": "~4.11.3",
         "ember-data-codemod": "^0.1.1",
         "ember-export-application-global": "^2.0.1",
         "ember-flatpickr": "^3.2.3",
@@ -2201,491 +2201,162 @@
       }
     },
     "node_modules/@ember-data/adapter": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@ember-data/adapter/-/adapter-4.4.1.tgz",
-      "integrity": "sha512-VIEusESLxpe/M7DGcmb7KTFLB3Joi+x5fbx6mywvYDhzTzsq/U5RCuIkxs9G/PNSlXD3z691GnZVd4T8GtcJXA==",
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@ember-data/adapter/-/adapter-4.11.3.tgz",
+      "integrity": "sha512-G7dbaPnYMW8VYxIT75KAkzax2mkWTs2TYxS7+qbphs6esXpO9Y/iNp5fTqLaACb9JqUypwEA/rlfC7/zkcGbBw==",
       "dev": true,
       "dependencies": {
-        "@ember-data/private-build-infra": "4.4.1",
-        "@ember-data/store": "4.4.1",
+        "@ember-data/private-build-infra": "4.11.3",
         "@ember/edition-utils": "^1.2.0",
-        "@ember/string": "^3.0.0",
-        "ember-auto-import": "^2.2.4",
+        "@embroider/macros": "^1.10.0",
+        "ember-auto-import": "^2.4.3",
         "ember-cli-babel": "^7.26.11",
-        "ember-cli-test-info": "^1.0.0",
-        "ember-cli-typescript": "^5.0.0"
+        "ember-cli-test-info": "^1.0.0"
       },
       "engines": {
-        "node": "12.* || >= 14.*"
-      }
-    },
-    "node_modules/@ember-data/adapter/node_modules/ember-cli-typescript": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-5.2.1.tgz",
-      "integrity": "sha512-qqp5TAIuPHxHiGXJKL+78Euyhy0zSKQMovPh8sJpN/ZBYx0H90pONufHR3anaMcp1snVfx4B+mb9+7ijOik8ZA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-to-html": "^0.6.15",
-        "broccoli-stew": "^3.0.0",
-        "debug": "^4.0.0",
-        "execa": "^4.0.0",
-        "fs-extra": "^9.0.1",
-        "resolve": "^1.5.0",
-        "rsvp": "^4.8.1",
-        "semver": "^7.3.2",
-        "stagehand": "^1.0.0",
-        "walk-sync": "^2.2.0"
+        "node": "^14.8.0 || 16.* || >= 18.*"
       },
-      "engines": {
-        "node": ">= 12.*"
-      }
-    },
-    "node_modules/@ember-data/adapter/node_modules/execa": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
-      "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
-      "dev": true,
-      "dependencies": {
-        "cross-spawn": "^7.0.0",
-        "get-stream": "^5.0.0",
-        "human-signals": "^1.1.1",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.0",
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2",
-        "strip-final-newline": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/@ember-data/adapter/node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "dev": true,
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@ember-data/adapter/node_modules/human-signals": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
-      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
-      "dev": true,
-      "engines": {
-        "node": ">=8.12.0"
-      }
-    },
-    "node_modules/@ember-data/adapter/node_modules/rsvp": {
-      "version": "4.8.5",
-      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-      "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-      "dev": true,
-      "engines": {
-        "node": "6.* || >= 7.*"
-      }
-    },
-    "node_modules/@ember-data/adapter/node_modules/walk-sync": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
-      "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
-      "dev": true,
-      "dependencies": {
-        "@types/minimatch": "^3.0.3",
-        "ensure-posix-path": "^1.1.0",
-        "matcher-collection": "^2.0.0",
-        "minimatch": "^3.0.4"
-      },
-      "engines": {
-        "node": "8.* || >= 10.*"
+      "peerDependencies": {
+        "@ember-data/store": "4.11.3",
+        "@ember/string": "^3.0.1",
+        "ember-inflector": "^4.0.2"
       }
     },
     "node_modules/@ember-data/canary-features": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@ember-data/canary-features/-/canary-features-4.4.1.tgz",
-      "integrity": "sha512-st/MA0DuN/HX2JsE6jabS/ry9oE0tB4kkOqDmu6+uCcgup8gXK85Y9SYUvTKv/v5AlpGa06+ATIFxSVOUQDBtw==",
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@ember-data/canary-features/-/canary-features-4.11.3.tgz",
+      "integrity": "sha512-RTLY2N9t1SXr4e90VBKi+3PIitwjTMBU8BcEhnKovT//sGlywohHq7T36H6nJuITRtki3On9PpbJOhhQZuyAlQ==",
       "dev": true,
       "dependencies": {
-        "ember-cli-babel": "^7.26.11",
-        "ember-cli-typescript": "^5.0.0"
+        "@embroider/macros": "^1.10.0",
+        "ember-cli-babel": "^7.26.11"
       },
       "engines": {
-        "node": "12.* || >= 14.*"
-      }
-    },
-    "node_modules/@ember-data/canary-features/node_modules/ember-cli-typescript": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-5.2.1.tgz",
-      "integrity": "sha512-qqp5TAIuPHxHiGXJKL+78Euyhy0zSKQMovPh8sJpN/ZBYx0H90pONufHR3anaMcp1snVfx4B+mb9+7ijOik8ZA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-to-html": "^0.6.15",
-        "broccoli-stew": "^3.0.0",
-        "debug": "^4.0.0",
-        "execa": "^4.0.0",
-        "fs-extra": "^9.0.1",
-        "resolve": "^1.5.0",
-        "rsvp": "^4.8.1",
-        "semver": "^7.3.2",
-        "stagehand": "^1.0.0",
-        "walk-sync": "^2.2.0"
-      },
-      "engines": {
-        "node": ">= 12.*"
-      }
-    },
-    "node_modules/@ember-data/canary-features/node_modules/execa": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
-      "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
-      "dev": true,
-      "dependencies": {
-        "cross-spawn": "^7.0.0",
-        "get-stream": "^5.0.0",
-        "human-signals": "^1.1.1",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.0",
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2",
-        "strip-final-newline": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/@ember-data/canary-features/node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "dev": true,
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@ember-data/canary-features/node_modules/human-signals": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
-      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
-      "dev": true,
-      "engines": {
-        "node": ">=8.12.0"
-      }
-    },
-    "node_modules/@ember-data/canary-features/node_modules/rsvp": {
-      "version": "4.8.5",
-      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-      "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-      "dev": true,
-      "engines": {
-        "node": "6.* || >= 7.*"
-      }
-    },
-    "node_modules/@ember-data/canary-features/node_modules/walk-sync": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
-      "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
-      "dev": true,
-      "dependencies": {
-        "@types/minimatch": "^3.0.3",
-        "ensure-posix-path": "^1.1.0",
-        "matcher-collection": "^2.0.0",
-        "minimatch": "^3.0.4"
-      },
-      "engines": {
-        "node": "8.* || >= 10.*"
+        "node": "^14.8.0 || 16.* || >= 18.*"
       }
     },
     "node_modules/@ember-data/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@ember-data/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-x5LeVyYSPZQkieJUU26c9mP4Y2Jo+kTBehh6+RgLOkCuNLfJdU5/YIB56IgWPFV0SmEMSoZtWh1rB+SBWAHWgg==",
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@ember-data/debug/-/debug-4.11.3.tgz",
+      "integrity": "sha512-3pA5u3qy+pjtwcoyMzs7WijRrSQz5z+Vgn9b5Y4cEOHn8loS9riLCMScnFaQT3HjxQgq+3NkNb52sJafHPzs4Q==",
       "dev": true,
       "dependencies": {
-        "@ember-data/private-build-infra": "4.4.1",
+        "@ember-data/private-build-infra": "4.11.3",
         "@ember/edition-utils": "^1.2.0",
-        "@ember/string": "^3.0.0",
-        "ember-auto-import": "^2.2.4",
-        "ember-cli-babel": "^7.26.11",
-        "ember-cli-test-info": "^1.0.0",
-        "ember-cli-typescript": "^5.0.0"
+        "@embroider/macros": "^1.10.0",
+        "ember-auto-import": "^2.4.3",
+        "ember-cli-babel": "^7.26.11"
       },
       "engines": {
-        "node": "12.* || >= 14.*"
-      }
-    },
-    "node_modules/@ember-data/debug/node_modules/ember-cli-typescript": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-5.2.1.tgz",
-      "integrity": "sha512-qqp5TAIuPHxHiGXJKL+78Euyhy0zSKQMovPh8sJpN/ZBYx0H90pONufHR3anaMcp1snVfx4B+mb9+7ijOik8ZA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-to-html": "^0.6.15",
-        "broccoli-stew": "^3.0.0",
-        "debug": "^4.0.0",
-        "execa": "^4.0.0",
-        "fs-extra": "^9.0.1",
-        "resolve": "^1.5.0",
-        "rsvp": "^4.8.1",
-        "semver": "^7.3.2",
-        "stagehand": "^1.0.0",
-        "walk-sync": "^2.2.0"
+        "node": "^14.8.0 || 16.* || >= 18.*"
       },
-      "engines": {
-        "node": ">= 12.*"
-      }
-    },
-    "node_modules/@ember-data/debug/node_modules/execa": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
-      "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
-      "dev": true,
-      "dependencies": {
-        "cross-spawn": "^7.0.0",
-        "get-stream": "^5.0.0",
-        "human-signals": "^1.1.1",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.0",
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2",
-        "strip-final-newline": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/@ember-data/debug/node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "dev": true,
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@ember-data/debug/node_modules/human-signals": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
-      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
-      "dev": true,
-      "engines": {
-        "node": ">=8.12.0"
-      }
-    },
-    "node_modules/@ember-data/debug/node_modules/rsvp": {
-      "version": "4.8.5",
-      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-      "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-      "dev": true,
-      "engines": {
-        "node": "6.* || >= 7.*"
-      }
-    },
-    "node_modules/@ember-data/debug/node_modules/walk-sync": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
-      "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
-      "dev": true,
-      "dependencies": {
-        "@types/minimatch": "^3.0.3",
-        "ensure-posix-path": "^1.1.0",
-        "matcher-collection": "^2.0.0",
-        "minimatch": "^3.0.4"
-      },
-      "engines": {
-        "node": "8.* || >= 10.*"
+      "peerDependencies": {
+        "@ember/string": "^3.0.1"
       }
     },
     "node_modules/@ember-data/model": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@ember-data/model/-/model-4.4.1.tgz",
-      "integrity": "sha512-yLTX6lFOotAYgHB+zD9VRHuVxyrxH9bqBO/+rtL88QpHKixtZZjknLL6DXzkjejgom58PXmXulGcnopiicbd6w==",
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@ember-data/model/-/model-4.11.3.tgz",
+      "integrity": "sha512-nkDru5TZmOp4J1xp65D1bR3hBJ3u5KhKKfDpWeGnHW2YDCVUdLORRwW7vfrPnnXDIoJij42DwDVCiTY25Xhrqw==",
       "dev": true,
       "dependencies": {
-        "@ember-data/canary-features": "4.4.1",
-        "@ember-data/private-build-infra": "4.4.1",
-        "@ember-data/store": "4.4.1",
+        "@ember-data/canary-features": "4.11.3",
+        "@ember-data/private-build-infra": "4.11.3",
         "@ember/edition-utils": "^1.2.0",
-        "@ember/string": "^3.0.0",
-        "ember-auto-import": "^2.2.4",
-        "ember-cached-decorator-polyfill": "^0.1.4",
+        "@embroider/macros": "^1.10.0",
+        "ember-auto-import": "^2.4.3",
+        "ember-cached-decorator-polyfill": "^1.0.1",
         "ember-cli-babel": "^7.26.11",
         "ember-cli-string-utils": "^1.1.0",
         "ember-cli-test-info": "^1.0.0",
-        "ember-cli-typescript": "^5.0.0",
-        "ember-compatibility-helpers": "^1.2.0",
-        "inflection": "~1.13.1"
+        "ember-compatibility-helpers": "^1.2.6",
+        "inflection": "~2.0.0"
       },
       "engines": {
-        "node": "12.* || >= 14.*"
+        "node": "^14.8.0 || 16.* || >= 18.*"
+      },
+      "peerDependencies": {
+        "@ember-data/record-data": "4.11.3",
+        "@ember-data/store": "4.11.3",
+        "@ember-data/tracking": "4.11.3",
+        "@ember/string": "^3.0.1",
+        "ember-inflector": "^4.0.2"
+      },
+      "peerDependenciesMeta": {
+        "@ember-data/record-data": {
+          "optional": true
+        }
       }
     },
-    "node_modules/@ember-data/model/node_modules/ember-cli-typescript": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-5.2.1.tgz",
-      "integrity": "sha512-qqp5TAIuPHxHiGXJKL+78Euyhy0zSKQMovPh8sJpN/ZBYx0H90pONufHR3anaMcp1snVfx4B+mb9+7ijOik8ZA==",
+    "node_modules/@ember-data/model/node_modules/ember-cached-decorator-polyfill": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ember-cached-decorator-polyfill/-/ember-cached-decorator-polyfill-1.0.2.tgz",
+      "integrity": "sha512-hUX6OYTKltAPAu8vsVZK02BfMTV0OUXrPqvRahYPhgS7D0I6joLjlskd7mhqJMcaXLywqceIy8/s+x8bxF8bpQ==",
       "dev": true,
       "dependencies": {
-        "ansi-to-html": "^0.6.15",
-        "broccoli-stew": "^3.0.0",
-        "debug": "^4.0.0",
-        "execa": "^4.0.0",
-        "fs-extra": "^9.0.1",
-        "resolve": "^1.5.0",
-        "rsvp": "^4.8.1",
-        "semver": "^7.3.2",
-        "stagehand": "^1.0.0",
-        "walk-sync": "^2.2.0"
+        "@embroider/macros": "^1.8.3",
+        "@glimmer/tracking": "^1.1.2",
+        "babel-import-util": "^1.2.2",
+        "ember-cache-primitive-polyfill": "^1.0.1",
+        "ember-cli-babel": "^7.26.11",
+        "ember-cli-babel-plugin-helpers": "^1.1.1"
       },
       "engines": {
-        "node": ">= 12.*"
-      }
-    },
-    "node_modules/@ember-data/model/node_modules/execa": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
-      "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
-      "dev": true,
-      "dependencies": {
-        "cross-spawn": "^7.0.0",
-        "get-stream": "^5.0.0",
-        "human-signals": "^1.1.1",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.0",
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2",
-        "strip-final-newline": "^2.0.0"
+        "node": "14.* || >= 16"
       },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/@ember-data/model/node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "dev": true,
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@ember-data/model/node_modules/human-signals": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
-      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
-      "dev": true,
-      "engines": {
-        "node": ">=8.12.0"
-      }
-    },
-    "node_modules/@ember-data/model/node_modules/inflection": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.13.4.tgz",
-      "integrity": "sha512-6I/HUDeYFfuNCVS3td055BaXBwKYuzw7K3ExVMStBowKo9oOAMJIXIHvdyR3iboTCp1b+1i5DSkIZTcwIktuDw==",
-      "dev": true,
-      "engines": [
-        "node >= 0.4.0"
-      ]
-    },
-    "node_modules/@ember-data/model/node_modules/rsvp": {
-      "version": "4.8.5",
-      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-      "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-      "dev": true,
-      "engines": {
-        "node": "6.* || >= 7.*"
-      }
-    },
-    "node_modules/@ember-data/model/node_modules/walk-sync": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
-      "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
-      "dev": true,
-      "dependencies": {
-        "@types/minimatch": "^3.0.3",
-        "ensure-posix-path": "^1.1.0",
-        "matcher-collection": "^2.0.0",
-        "minimatch": "^3.0.4"
-      },
-      "engines": {
-        "node": "8.* || >= 10.*"
+      "peerDependencies": {
+        "ember-source": "^3.13.0 || ^4.0.0 || >= 5.0.0"
       }
     },
     "node_modules/@ember-data/private-build-infra": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@ember-data/private-build-infra/-/private-build-infra-4.4.1.tgz",
-      "integrity": "sha512-Yg50CZCU1Xll/6N+iUzzG+hqxK3BtiVJziRmWnOapSvExA6HxzD1hnxd/AB9+wECprHElBxLEKo85oNgFtC7zg==",
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@ember-data/private-build-infra/-/private-build-infra-4.11.3.tgz",
+      "integrity": "sha512-bXFQMEegUc+vKn/vD7FmAkq7ECE0okZ2sbtv/0RXqYn7TLk44rvGzpqSUXUowpCaGI/87MmaW8JaZMMdqF9wuw==",
       "dev": true,
       "dependencies": {
-        "@babel/plugin-transform-block-scoping": "^7.16.7",
-        "@ember-data/canary-features": "4.4.1",
+        "@babel/core": "^7.20.2",
+        "@babel/plugin-transform-block-scoping": "^7.20.2",
+        "@babel/runtime": "^7.20.1",
+        "@ember-data/canary-features": "4.11.3",
         "@ember/edition-utils": "^1.2.0",
+        "@embroider/macros": "^1.10.0",
+        "babel-import-util": "^1.3.0",
         "babel-plugin-debug-macros": "^0.3.4",
         "babel-plugin-filter-imports": "^4.0.0",
         "babel6-plugin-strip-class-callcheck": "^6.0.0",
         "broccoli-debug": "^0.6.5",
         "broccoli-file-creator": "^2.1.1",
-        "broccoli-funnel": "^3.0.3",
+        "broccoli-funnel": "^3.0.8",
         "broccoli-merge-trees": "^4.2.0",
         "broccoli-rollup": "^5.0.0",
         "calculate-cache-key-for-tree": "^2.0.0",
-        "chalk": "^4.0.0",
+        "chalk": "^4.1.2",
         "ember-cli-babel": "^7.26.11",
         "ember-cli-path-utils": "^1.0.0",
         "ember-cli-string-utils": "^1.1.0",
-        "ember-cli-typescript": "^5.0.0",
-        "ember-cli-version-checker": "^5.1.1",
-        "esm": "^3.2.25",
+        "ember-cli-version-checker": "^5.1.2",
         "git-repo-info": "^2.1.1",
-        "glob": "^7.1.6",
+        "glob": "^8.0.3",
         "npm-git-info": "^1.0.3",
         "rimraf": "^3.0.2",
         "rsvp": "^4.8.5",
-        "semver": "^7.1.3",
+        "semver": "^7.3.8",
         "silent-error": "^1.1.1"
       },
       "engines": {
-        "node": "12.* || >= 14.*"
+        "node": "^14.8.0 || 16.* || >= 18.*"
+      }
+    },
+    "node_modules/@ember-data/private-build-infra/node_modules/@babel/runtime": {
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.4.tgz",
+      "integrity": "sha512-dkxf7+hn8mFBwKjs9bvBlArzLVxVbS8usaPUDd5p2a9JCL9tB8OaOVN1isD4+Xyk4ns89/xeOmbQvgdK7IIVdA==",
+      "dev": true,
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@ember-data/private-build-infra/node_modules/@types/broccoli-plugin": {
@@ -2696,6 +2367,15 @@
       "dev": true,
       "dependencies": {
         "broccoli-plugin": "*"
+      }
+    },
+    "node_modules/@ember-data/private-build-infra/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/@ember-data/private-build-infra/node_modules/broccoli-funnel": {
@@ -2749,27 +2429,6 @@
         "node": ">=12.0"
       }
     },
-    "node_modules/@ember-data/private-build-infra/node_modules/ember-cli-typescript": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-5.2.1.tgz",
-      "integrity": "sha512-qqp5TAIuPHxHiGXJKL+78Euyhy0zSKQMovPh8sJpN/ZBYx0H90pONufHR3anaMcp1snVfx4B+mb9+7ijOik8ZA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-to-html": "^0.6.15",
-        "broccoli-stew": "^3.0.0",
-        "debug": "^4.0.0",
-        "execa": "^4.0.0",
-        "fs-extra": "^9.0.1",
-        "resolve": "^1.5.0",
-        "rsvp": "^4.8.1",
-        "semver": "^7.3.2",
-        "stagehand": "^1.0.0",
-        "walk-sync": "^2.2.0"
-      },
-      "engines": {
-        "node": ">= 12.*"
-      }
-    },
     "node_modules/@ember-data/private-build-infra/node_modules/ember-cli-version-checker": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-5.1.2.tgz",
@@ -2782,29 +2441,6 @@
       },
       "engines": {
         "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/@ember-data/private-build-infra/node_modules/execa": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
-      "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
-      "dev": true,
-      "dependencies": {
-        "cross-spawn": "^7.0.0",
-        "get-stream": "^5.0.0",
-        "human-signals": "^1.1.1",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.0",
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2",
-        "strip-final-newline": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
     "node_modules/@ember-data/private-build-infra/node_modules/fs-tree-diff": {
@@ -2823,29 +2459,42 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
-    "node_modules/@ember-data/private-build-infra/node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+    "node_modules/@ember-data/private-build-infra/node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
       "dev": true,
       "dependencies": {
-        "pump": "^3.0.0"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
       },
       "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/@ember-data/private-build-infra/node_modules/human-signals": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
-      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+    "node_modules/@ember-data/private-build-infra/node_modules/glob/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
       "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
       "engines": {
-        "node": ">=8.12.0"
+        "node": ">=10"
       }
+    },
+    "node_modules/@ember-data/private-build-infra/node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+      "dev": true
     },
     "node_modules/@ember-data/private-build-infra/node_modules/resolve-package-path": {
       "version": "3.1.0",
@@ -2870,6 +2519,26 @@
       },
       "bin": {
         "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@ember-data/private-build-infra/node_modules/rimraf/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -2915,114 +2584,23 @@
       }
     },
     "node_modules/@ember-data/record-data": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@ember-data/record-data/-/record-data-4.4.1.tgz",
-      "integrity": "sha512-5wmvcdxuVbA449UJzaMW/jovL3Sca/Yu+nVwiShic0GWcV72hbdO26/6Ii2dDCXqCf9WVXAl30egCGz/mGZgKQ==",
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@ember-data/record-data/-/record-data-4.11.3.tgz",
+      "integrity": "sha512-8NmeEZJ7or354NLZJgibJ1FuhWL70H6G24tGSEIzM8IV7wr6TreIyaWODaW372QwamWYgFIpfnFwWt5MTlY/gw==",
       "dev": true,
       "dependencies": {
-        "@ember-data/canary-features": "4.4.1",
-        "@ember-data/private-build-infra": "4.4.1",
-        "@ember-data/store": "4.4.1",
+        "@ember-data/canary-features": "4.11.3",
+        "@ember-data/private-build-infra": "4.11.3",
         "@ember/edition-utils": "^1.2.0",
-        "ember-auto-import": "^2.2.4",
-        "ember-cli-babel": "^7.26.11",
-        "ember-cli-test-info": "^1.0.0",
-        "ember-cli-typescript": "^5.0.0"
+        "@embroider/macros": "^1.10.0",
+        "ember-auto-import": "^2.4.3",
+        "ember-cli-babel": "^7.26.11"
       },
       "engines": {
-        "node": "12.* || >= 14.*"
-      }
-    },
-    "node_modules/@ember-data/record-data/node_modules/ember-cli-typescript": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-5.2.1.tgz",
-      "integrity": "sha512-qqp5TAIuPHxHiGXJKL+78Euyhy0zSKQMovPh8sJpN/ZBYx0H90pONufHR3anaMcp1snVfx4B+mb9+7ijOik8ZA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-to-html": "^0.6.15",
-        "broccoli-stew": "^3.0.0",
-        "debug": "^4.0.0",
-        "execa": "^4.0.0",
-        "fs-extra": "^9.0.1",
-        "resolve": "^1.5.0",
-        "rsvp": "^4.8.1",
-        "semver": "^7.3.2",
-        "stagehand": "^1.0.0",
-        "walk-sync": "^2.2.0"
+        "node": "^14.8.0 || 16.* || >= 18.*"
       },
-      "engines": {
-        "node": ">= 12.*"
-      }
-    },
-    "node_modules/@ember-data/record-data/node_modules/execa": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
-      "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
-      "dev": true,
-      "dependencies": {
-        "cross-spawn": "^7.0.0",
-        "get-stream": "^5.0.0",
-        "human-signals": "^1.1.1",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.0",
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2",
-        "strip-final-newline": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/@ember-data/record-data/node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "dev": true,
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@ember-data/record-data/node_modules/human-signals": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
-      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
-      "dev": true,
-      "engines": {
-        "node": ">=8.12.0"
-      }
-    },
-    "node_modules/@ember-data/record-data/node_modules/rsvp": {
-      "version": "4.8.5",
-      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-      "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-      "dev": true,
-      "engines": {
-        "node": "6.* || >= 7.*"
-      }
-    },
-    "node_modules/@ember-data/record-data/node_modules/walk-sync": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
-      "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
-      "dev": true,
-      "dependencies": {
-        "@types/minimatch": "^3.0.3",
-        "ensure-posix-path": "^1.1.0",
-        "matcher-collection": "^2.0.0",
-        "minimatch": "^3.0.4"
-      },
-      "engines": {
-        "node": "8.* || >= 10.*"
+      "peerDependencies": {
+        "@ember-data/store": "4.11.3"
       }
     },
     "node_modules/@ember-data/rfc395-data": {
@@ -3032,224 +2610,88 @@
       "dev": true
     },
     "node_modules/@ember-data/serializer": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@ember-data/serializer/-/serializer-4.4.1.tgz",
-      "integrity": "sha512-ffzHcWDJlX5epM8SzQMirRkBU2/N/enJwnJV28DzcxQcrbVfUWZqaPgQWpg8wADLETfumERzy7WIJlcSCGR5ow==",
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@ember-data/serializer/-/serializer-4.11.3.tgz",
+      "integrity": "sha512-Qnzrowinz14/onQfwd4TPwNG0sMTAwTWE0RajYo2fysF3CKyAua0nIzmFtXKx0CogD7TYd0C5xf6nMjFesT09Q==",
       "dev": true,
       "dependencies": {
-        "@ember-data/private-build-infra": "4.4.1",
-        "@ember-data/store": "4.4.1",
-        "ember-auto-import": "^2.2.4",
+        "@ember-data/private-build-infra": "4.11.3",
+        "@embroider/macros": "^1.10.0",
+        "ember-auto-import": "^2.4.3",
         "ember-cli-babel": "^7.26.11",
-        "ember-cli-test-info": "^1.0.0",
-        "ember-cli-typescript": "^5.0.0"
+        "ember-cli-test-info": "^1.0.0"
       },
       "engines": {
-        "node": "12.* || >= 14.*"
-      }
-    },
-    "node_modules/@ember-data/serializer/node_modules/ember-cli-typescript": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-5.2.1.tgz",
-      "integrity": "sha512-qqp5TAIuPHxHiGXJKL+78Euyhy0zSKQMovPh8sJpN/ZBYx0H90pONufHR3anaMcp1snVfx4B+mb9+7ijOik8ZA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-to-html": "^0.6.15",
-        "broccoli-stew": "^3.0.0",
-        "debug": "^4.0.0",
-        "execa": "^4.0.0",
-        "fs-extra": "^9.0.1",
-        "resolve": "^1.5.0",
-        "rsvp": "^4.8.1",
-        "semver": "^7.3.2",
-        "stagehand": "^1.0.0",
-        "walk-sync": "^2.2.0"
+        "node": "^14.8.0 || 16.* || >= 18.*"
       },
-      "engines": {
-        "node": ">= 12.*"
-      }
-    },
-    "node_modules/@ember-data/serializer/node_modules/execa": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
-      "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
-      "dev": true,
-      "dependencies": {
-        "cross-spawn": "^7.0.0",
-        "get-stream": "^5.0.0",
-        "human-signals": "^1.1.1",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.0",
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2",
-        "strip-final-newline": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/@ember-data/serializer/node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "dev": true,
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@ember-data/serializer/node_modules/human-signals": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
-      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
-      "dev": true,
-      "engines": {
-        "node": ">=8.12.0"
-      }
-    },
-    "node_modules/@ember-data/serializer/node_modules/rsvp": {
-      "version": "4.8.5",
-      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-      "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-      "dev": true,
-      "engines": {
-        "node": "6.* || >= 7.*"
-      }
-    },
-    "node_modules/@ember-data/serializer/node_modules/walk-sync": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
-      "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
-      "dev": true,
-      "dependencies": {
-        "@types/minimatch": "^3.0.3",
-        "ensure-posix-path": "^1.1.0",
-        "matcher-collection": "^2.0.0",
-        "minimatch": "^3.0.4"
-      },
-      "engines": {
-        "node": "8.* || >= 10.*"
+      "peerDependencies": {
+        "@ember-data/store": "4.11.3",
+        "@ember/string": "^3.0.1",
+        "ember-inflector": "^4.0.2"
       }
     },
     "node_modules/@ember-data/store": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@ember-data/store/-/store-4.4.1.tgz",
-      "integrity": "sha512-lfEQmm/xaqPdG6S4fSwm3XG/3g1s9R9ir5OcOytng/UNw7wZxDZnUA+wOiFup1gN3ZO/q5y4nCg8B6dC3NEFgA==",
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@ember-data/store/-/store-4.11.3.tgz",
+      "integrity": "sha512-ogwWy+VqMpkCGs4n30pzuB2vqv/dJRL6wdV3fdNKpXrDugffjuMPpLBQYF937qztDUZKxmnbWAZe5PbQOz8b1Q==",
       "dev": true,
       "dependencies": {
-        "@ember-data/canary-features": "4.4.1",
-        "@ember-data/private-build-infra": "4.4.1",
-        "@ember/string": "^3.0.0",
-        "@glimmer/tracking": "^1.0.4",
-        "ember-auto-import": "^2.2.4",
-        "ember-cached-decorator-polyfill": "^0.1.4",
+        "@ember-data/canary-features": "4.11.3",
+        "@ember-data/private-build-infra": "4.11.3",
+        "@embroider/macros": "^1.10.0",
+        "ember-auto-import": "^2.4.3",
+        "ember-cached-decorator-polyfill": "^1.0.1",
+        "ember-cli-babel": "^7.26.11"
+      },
+      "engines": {
+        "node": "^14.8.0 || 16.* || >= 18.*"
+      },
+      "peerDependencies": {
+        "@ember-data/model": "4.11.3",
+        "@ember-data/record-data": "4.11.3",
+        "@ember-data/tracking": "4.11.3",
+        "@ember/string": "^3.0.1",
+        "@glimmer/tracking": "^1.1.2"
+      },
+      "peerDependenciesMeta": {
+        "@ember-data/model": {
+          "optional": true
+        },
+        "@ember-data/record-data": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ember-data/store/node_modules/ember-cached-decorator-polyfill": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ember-cached-decorator-polyfill/-/ember-cached-decorator-polyfill-1.0.2.tgz",
+      "integrity": "sha512-hUX6OYTKltAPAu8vsVZK02BfMTV0OUXrPqvRahYPhgS7D0I6joLjlskd7mhqJMcaXLywqceIy8/s+x8bxF8bpQ==",
+      "dev": true,
+      "dependencies": {
+        "@embroider/macros": "^1.8.3",
+        "@glimmer/tracking": "^1.1.2",
+        "babel-import-util": "^1.2.2",
+        "ember-cache-primitive-polyfill": "^1.0.1",
         "ember-cli-babel": "^7.26.11",
-        "ember-cli-path-utils": "^1.0.0",
-        "ember-cli-typescript": "^5.0.0"
+        "ember-cli-babel-plugin-helpers": "^1.1.1"
       },
       "engines": {
-        "node": "12.* || >= 14.*"
+        "node": "14.* || >= 16"
+      },
+      "peerDependencies": {
+        "ember-source": "^3.13.0 || ^4.0.0 || >= 5.0.0"
       }
     },
-    "node_modules/@ember-data/store/node_modules/ember-cli-typescript": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-5.2.1.tgz",
-      "integrity": "sha512-qqp5TAIuPHxHiGXJKL+78Euyhy0zSKQMovPh8sJpN/ZBYx0H90pONufHR3anaMcp1snVfx4B+mb9+7ijOik8ZA==",
+    "node_modules/@ember-data/tracking": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@ember-data/tracking/-/tracking-4.11.3.tgz",
+      "integrity": "sha512-YZxFTMe2TBL8H8/GrnrvP7Wc/uuAijoSyiP2g6TMNRsL1e/3BWDT0EIl+B/5Wji+dchofY8iuMWfpY7VDvPIzA==",
       "dev": true,
       "dependencies": {
-        "ansi-to-html": "^0.6.15",
-        "broccoli-stew": "^3.0.0",
-        "debug": "^4.0.0",
-        "execa": "^4.0.0",
-        "fs-extra": "^9.0.1",
-        "resolve": "^1.5.0",
-        "rsvp": "^4.8.1",
-        "semver": "^7.3.2",
-        "stagehand": "^1.0.0",
-        "walk-sync": "^2.2.0"
+        "ember-cli-babel": "^7.26.11"
       },
       "engines": {
-        "node": ">= 12.*"
-      }
-    },
-    "node_modules/@ember-data/store/node_modules/execa": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
-      "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
-      "dev": true,
-      "dependencies": {
-        "cross-spawn": "^7.0.0",
-        "get-stream": "^5.0.0",
-        "human-signals": "^1.1.1",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.0",
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2",
-        "strip-final-newline": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/@ember-data/store/node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "dev": true,
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@ember-data/store/node_modules/human-signals": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
-      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
-      "dev": true,
-      "engines": {
-        "node": ">=8.12.0"
-      }
-    },
-    "node_modules/@ember-data/store/node_modules/rsvp": {
-      "version": "4.8.5",
-      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-      "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-      "dev": true,
-      "engines": {
-        "node": "6.* || >= 7.*"
-      }
-    },
-    "node_modules/@ember-data/store/node_modules/walk-sync": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
-      "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
-      "dev": true,
-      "dependencies": {
-        "@types/minimatch": "^3.0.3",
-        "ensure-posix-path": "^1.1.0",
-        "matcher-collection": "^2.0.0",
-        "minimatch": "^3.0.4"
-      },
-      "engines": {
-        "node": "8.* || >= 10.*"
+        "node": "14.* || 16.* || >= 18"
       }
     },
     "node_modules/@ember-decorators/component": {
@@ -3375,10 +2817,11 @@
       }
     },
     "node_modules/@ember/string": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@ember/string/-/string-3.0.1.tgz",
-      "integrity": "sha512-ntnmXS+upOWVXE+rVw2l03DjdMnaGdWbYVUxUBuPJqnIGZu2XFRsoXc7E6mOw62s8i1Xh1RgTuFHN41QGIolEQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@ember/string/-/string-3.1.1.tgz",
+      "integrity": "sha512-UbXJ+k3QOrYN4SRPHgXCqYIJ+yWWUg1+vr0H4DhdQPTy8LJfyqwZ2tc5uqpSSnEXE+/1KopHBE5J8GDagAg5cg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "ember-cli-babel": "^7.26.6"
       },
@@ -17458,29 +16901,32 @@
       }
     },
     "node_modules/ember-data": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/ember-data/-/ember-data-4.4.1.tgz",
-      "integrity": "sha512-Jc8a2OTX3rcnbmVwBjdeOYPSKUHWYRH+RMyDSLN3fpLp/A8pZp1Lkn3b5/ZEi9DmBRirxIDSSSPPZ6RDTMBYlQ==",
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/ember-data/-/ember-data-4.11.3.tgz",
+      "integrity": "sha512-7vir6Re3M3M6yJoCHy6UxEg3oSY1JEnsuTByY3lJquWPaUamn7qbPQvNr16Tqh8EKrt+e/+X26czFm4kRGhpVg==",
       "dev": true,
       "dependencies": {
-        "@ember-data/adapter": "4.4.1",
-        "@ember-data/debug": "4.4.1",
-        "@ember-data/model": "4.4.1",
-        "@ember-data/private-build-infra": "4.4.1",
-        "@ember-data/record-data": "4.4.1",
-        "@ember-data/serializer": "4.4.1",
-        "@ember-data/store": "4.4.1",
+        "@ember-data/adapter": "4.11.3",
+        "@ember-data/debug": "4.11.3",
+        "@ember-data/model": "4.11.3",
+        "@ember-data/private-build-infra": "4.11.3",
+        "@ember-data/record-data": "4.11.3",
+        "@ember-data/serializer": "4.11.3",
+        "@ember-data/store": "4.11.3",
+        "@ember-data/tracking": "4.11.3",
         "@ember/edition-utils": "^1.2.0",
-        "@ember/string": "^3.0.0",
+        "@embroider/macros": "^1.10.0",
         "@glimmer/env": "^0.1.7",
         "broccoli-merge-trees": "^4.2.0",
-        "ember-auto-import": "^2.2.4",
+        "ember-auto-import": "^2.4.3",
         "ember-cli-babel": "^7.26.11",
-        "ember-cli-typescript": "^5.0.0",
-        "ember-inflector": "^4.0.1"
+        "ember-inflector": "^4.0.2"
       },
       "engines": {
-        "node": "12.* || >= 14.*"
+        "node": "^14.8.0 || 16.* || >= 18.*"
+      },
+      "peerDependencies": {
+        "@ember/string": "^3.0.1"
       }
     },
     "node_modules/ember-data-codemod": {
@@ -17510,98 +16956,6 @@
       },
       "engines": {
         "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/ember-data/node_modules/ember-cli-typescript": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-5.2.1.tgz",
-      "integrity": "sha512-qqp5TAIuPHxHiGXJKL+78Euyhy0zSKQMovPh8sJpN/ZBYx0H90pONufHR3anaMcp1snVfx4B+mb9+7ijOik8ZA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-to-html": "^0.6.15",
-        "broccoli-stew": "^3.0.0",
-        "debug": "^4.0.0",
-        "execa": "^4.0.0",
-        "fs-extra": "^9.0.1",
-        "resolve": "^1.5.0",
-        "rsvp": "^4.8.1",
-        "semver": "^7.3.2",
-        "stagehand": "^1.0.0",
-        "walk-sync": "^2.2.0"
-      },
-      "engines": {
-        "node": ">= 12.*"
-      }
-    },
-    "node_modules/ember-data/node_modules/execa": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
-      "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
-      "dev": true,
-      "dependencies": {
-        "cross-spawn": "^7.0.0",
-        "get-stream": "^5.0.0",
-        "human-signals": "^1.1.1",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.0",
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2",
-        "strip-final-newline": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/ember-data/node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "dev": true,
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ember-data/node_modules/human-signals": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
-      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
-      "dev": true,
-      "engines": {
-        "node": ">=8.12.0"
-      }
-    },
-    "node_modules/ember-data/node_modules/rsvp": {
-      "version": "4.8.5",
-      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-      "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-      "dev": true,
-      "engines": {
-        "node": "6.* || >= 7.*"
-      }
-    },
-    "node_modules/ember-data/node_modules/walk-sync": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
-      "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
-      "dev": true,
-      "dependencies": {
-        "@types/minimatch": "^3.0.3",
-        "ensure-posix-path": "^1.1.0",
-        "matcher-collection": "^2.0.0",
-        "minimatch": "^3.0.4"
-      },
-      "engines": {
-        "node": "8.* || >= 10.*"
       }
     },
     "node_modules/ember-decorators": {
@@ -38428,387 +37782,122 @@
       }
     },
     "@ember-data/adapter": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@ember-data/adapter/-/adapter-4.4.1.tgz",
-      "integrity": "sha512-VIEusESLxpe/M7DGcmb7KTFLB3Joi+x5fbx6mywvYDhzTzsq/U5RCuIkxs9G/PNSlXD3z691GnZVd4T8GtcJXA==",
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@ember-data/adapter/-/adapter-4.11.3.tgz",
+      "integrity": "sha512-G7dbaPnYMW8VYxIT75KAkzax2mkWTs2TYxS7+qbphs6esXpO9Y/iNp5fTqLaACb9JqUypwEA/rlfC7/zkcGbBw==",
       "dev": true,
       "requires": {
-        "@ember-data/private-build-infra": "4.4.1",
-        "@ember-data/store": "4.4.1",
+        "@ember-data/private-build-infra": "4.11.3",
         "@ember/edition-utils": "^1.2.0",
-        "@ember/string": "^3.0.0",
-        "ember-auto-import": "^2.2.4",
+        "@embroider/macros": "^1.10.0",
+        "ember-auto-import": "^2.4.3",
         "ember-cli-babel": "^7.26.11",
-        "ember-cli-test-info": "^1.0.0",
-        "ember-cli-typescript": "^5.0.0"
-      },
-      "dependencies": {
-        "ember-cli-typescript": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-5.2.1.tgz",
-          "integrity": "sha512-qqp5TAIuPHxHiGXJKL+78Euyhy0zSKQMovPh8sJpN/ZBYx0H90pONufHR3anaMcp1snVfx4B+mb9+7ijOik8ZA==",
-          "dev": true,
-          "requires": {
-            "ansi-to-html": "^0.6.15",
-            "broccoli-stew": "^3.0.0",
-            "debug": "^4.0.0",
-            "execa": "^4.0.0",
-            "fs-extra": "^9.0.1",
-            "resolve": "^1.5.0",
-            "rsvp": "^4.8.1",
-            "semver": "^7.3.2",
-            "stagehand": "^1.0.0",
-            "walk-sync": "^2.2.0"
-          }
-        },
-        "execa": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
-          "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^7.0.0",
-            "get-stream": "^5.0.0",
-            "human-signals": "^1.1.1",
-            "is-stream": "^2.0.0",
-            "merge-stream": "^2.0.0",
-            "npm-run-path": "^4.0.0",
-            "onetime": "^5.1.0",
-            "signal-exit": "^3.0.2",
-            "strip-final-newline": "^2.0.0"
-          }
-        },
-        "get-stream": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-          "dev": true,
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        },
-        "human-signals": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
-          "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
-          "dev": true
-        },
-        "rsvp": {
-          "version": "4.8.5",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-          "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-          "dev": true
-        },
-        "walk-sync": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
-          "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
-          "dev": true,
-          "requires": {
-            "@types/minimatch": "^3.0.3",
-            "ensure-posix-path": "^1.1.0",
-            "matcher-collection": "^2.0.0",
-            "minimatch": "^3.0.4"
-          }
-        }
+        "ember-cli-test-info": "^1.0.0"
       }
     },
     "@ember-data/canary-features": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@ember-data/canary-features/-/canary-features-4.4.1.tgz",
-      "integrity": "sha512-st/MA0DuN/HX2JsE6jabS/ry9oE0tB4kkOqDmu6+uCcgup8gXK85Y9SYUvTKv/v5AlpGa06+ATIFxSVOUQDBtw==",
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@ember-data/canary-features/-/canary-features-4.11.3.tgz",
+      "integrity": "sha512-RTLY2N9t1SXr4e90VBKi+3PIitwjTMBU8BcEhnKovT//sGlywohHq7T36H6nJuITRtki3On9PpbJOhhQZuyAlQ==",
       "dev": true,
       "requires": {
-        "ember-cli-babel": "^7.26.11",
-        "ember-cli-typescript": "^5.0.0"
-      },
-      "dependencies": {
-        "ember-cli-typescript": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-5.2.1.tgz",
-          "integrity": "sha512-qqp5TAIuPHxHiGXJKL+78Euyhy0zSKQMovPh8sJpN/ZBYx0H90pONufHR3anaMcp1snVfx4B+mb9+7ijOik8ZA==",
-          "dev": true,
-          "requires": {
-            "ansi-to-html": "^0.6.15",
-            "broccoli-stew": "^3.0.0",
-            "debug": "^4.0.0",
-            "execa": "^4.0.0",
-            "fs-extra": "^9.0.1",
-            "resolve": "^1.5.0",
-            "rsvp": "^4.8.1",
-            "semver": "^7.3.2",
-            "stagehand": "^1.0.0",
-            "walk-sync": "^2.2.0"
-          }
-        },
-        "execa": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
-          "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^7.0.0",
-            "get-stream": "^5.0.0",
-            "human-signals": "^1.1.1",
-            "is-stream": "^2.0.0",
-            "merge-stream": "^2.0.0",
-            "npm-run-path": "^4.0.0",
-            "onetime": "^5.1.0",
-            "signal-exit": "^3.0.2",
-            "strip-final-newline": "^2.0.0"
-          }
-        },
-        "get-stream": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-          "dev": true,
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        },
-        "human-signals": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
-          "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
-          "dev": true
-        },
-        "rsvp": {
-          "version": "4.8.5",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-          "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-          "dev": true
-        },
-        "walk-sync": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
-          "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
-          "dev": true,
-          "requires": {
-            "@types/minimatch": "^3.0.3",
-            "ensure-posix-path": "^1.1.0",
-            "matcher-collection": "^2.0.0",
-            "minimatch": "^3.0.4"
-          }
-        }
+        "@embroider/macros": "^1.10.0",
+        "ember-cli-babel": "^7.26.11"
       }
     },
     "@ember-data/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@ember-data/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-x5LeVyYSPZQkieJUU26c9mP4Y2Jo+kTBehh6+RgLOkCuNLfJdU5/YIB56IgWPFV0SmEMSoZtWh1rB+SBWAHWgg==",
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@ember-data/debug/-/debug-4.11.3.tgz",
+      "integrity": "sha512-3pA5u3qy+pjtwcoyMzs7WijRrSQz5z+Vgn9b5Y4cEOHn8loS9riLCMScnFaQT3HjxQgq+3NkNb52sJafHPzs4Q==",
       "dev": true,
       "requires": {
-        "@ember-data/private-build-infra": "4.4.1",
+        "@ember-data/private-build-infra": "4.11.3",
         "@ember/edition-utils": "^1.2.0",
-        "@ember/string": "^3.0.0",
-        "ember-auto-import": "^2.2.4",
-        "ember-cli-babel": "^7.26.11",
-        "ember-cli-test-info": "^1.0.0",
-        "ember-cli-typescript": "^5.0.0"
-      },
-      "dependencies": {
-        "ember-cli-typescript": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-5.2.1.tgz",
-          "integrity": "sha512-qqp5TAIuPHxHiGXJKL+78Euyhy0zSKQMovPh8sJpN/ZBYx0H90pONufHR3anaMcp1snVfx4B+mb9+7ijOik8ZA==",
-          "dev": true,
-          "requires": {
-            "ansi-to-html": "^0.6.15",
-            "broccoli-stew": "^3.0.0",
-            "debug": "^4.0.0",
-            "execa": "^4.0.0",
-            "fs-extra": "^9.0.1",
-            "resolve": "^1.5.0",
-            "rsvp": "^4.8.1",
-            "semver": "^7.3.2",
-            "stagehand": "^1.0.0",
-            "walk-sync": "^2.2.0"
-          }
-        },
-        "execa": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
-          "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^7.0.0",
-            "get-stream": "^5.0.0",
-            "human-signals": "^1.1.1",
-            "is-stream": "^2.0.0",
-            "merge-stream": "^2.0.0",
-            "npm-run-path": "^4.0.0",
-            "onetime": "^5.1.0",
-            "signal-exit": "^3.0.2",
-            "strip-final-newline": "^2.0.0"
-          }
-        },
-        "get-stream": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-          "dev": true,
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        },
-        "human-signals": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
-          "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
-          "dev": true
-        },
-        "rsvp": {
-          "version": "4.8.5",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-          "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-          "dev": true
-        },
-        "walk-sync": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
-          "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
-          "dev": true,
-          "requires": {
-            "@types/minimatch": "^3.0.3",
-            "ensure-posix-path": "^1.1.0",
-            "matcher-collection": "^2.0.0",
-            "minimatch": "^3.0.4"
-          }
-        }
+        "@embroider/macros": "^1.10.0",
+        "ember-auto-import": "^2.4.3",
+        "ember-cli-babel": "^7.26.11"
       }
     },
     "@ember-data/model": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@ember-data/model/-/model-4.4.1.tgz",
-      "integrity": "sha512-yLTX6lFOotAYgHB+zD9VRHuVxyrxH9bqBO/+rtL88QpHKixtZZjknLL6DXzkjejgom58PXmXulGcnopiicbd6w==",
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@ember-data/model/-/model-4.11.3.tgz",
+      "integrity": "sha512-nkDru5TZmOp4J1xp65D1bR3hBJ3u5KhKKfDpWeGnHW2YDCVUdLORRwW7vfrPnnXDIoJij42DwDVCiTY25Xhrqw==",
       "dev": true,
       "requires": {
-        "@ember-data/canary-features": "4.4.1",
-        "@ember-data/private-build-infra": "4.4.1",
-        "@ember-data/store": "4.4.1",
+        "@ember-data/canary-features": "4.11.3",
+        "@ember-data/private-build-infra": "4.11.3",
         "@ember/edition-utils": "^1.2.0",
-        "@ember/string": "^3.0.0",
-        "ember-auto-import": "^2.2.4",
-        "ember-cached-decorator-polyfill": "^0.1.4",
+        "@embroider/macros": "^1.10.0",
+        "ember-auto-import": "^2.4.3",
+        "ember-cached-decorator-polyfill": "^1.0.1",
         "ember-cli-babel": "^7.26.11",
         "ember-cli-string-utils": "^1.1.0",
         "ember-cli-test-info": "^1.0.0",
-        "ember-cli-typescript": "^5.0.0",
-        "ember-compatibility-helpers": "^1.2.0",
-        "inflection": "~1.13.1"
+        "ember-compatibility-helpers": "^1.2.6",
+        "inflection": "~2.0.0"
       },
       "dependencies": {
-        "ember-cli-typescript": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-5.2.1.tgz",
-          "integrity": "sha512-qqp5TAIuPHxHiGXJKL+78Euyhy0zSKQMovPh8sJpN/ZBYx0H90pONufHR3anaMcp1snVfx4B+mb9+7ijOik8ZA==",
+        "ember-cached-decorator-polyfill": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/ember-cached-decorator-polyfill/-/ember-cached-decorator-polyfill-1.0.2.tgz",
+          "integrity": "sha512-hUX6OYTKltAPAu8vsVZK02BfMTV0OUXrPqvRahYPhgS7D0I6joLjlskd7mhqJMcaXLywqceIy8/s+x8bxF8bpQ==",
           "dev": true,
           "requires": {
-            "ansi-to-html": "^0.6.15",
-            "broccoli-stew": "^3.0.0",
-            "debug": "^4.0.0",
-            "execa": "^4.0.0",
-            "fs-extra": "^9.0.1",
-            "resolve": "^1.5.0",
-            "rsvp": "^4.8.1",
-            "semver": "^7.3.2",
-            "stagehand": "^1.0.0",
-            "walk-sync": "^2.2.0"
-          }
-        },
-        "execa": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
-          "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^7.0.0",
-            "get-stream": "^5.0.0",
-            "human-signals": "^1.1.1",
-            "is-stream": "^2.0.0",
-            "merge-stream": "^2.0.0",
-            "npm-run-path": "^4.0.0",
-            "onetime": "^5.1.0",
-            "signal-exit": "^3.0.2",
-            "strip-final-newline": "^2.0.0"
-          }
-        },
-        "get-stream": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-          "dev": true,
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        },
-        "human-signals": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
-          "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
-          "dev": true
-        },
-        "inflection": {
-          "version": "1.13.4",
-          "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.13.4.tgz",
-          "integrity": "sha512-6I/HUDeYFfuNCVS3td055BaXBwKYuzw7K3ExVMStBowKo9oOAMJIXIHvdyR3iboTCp1b+1i5DSkIZTcwIktuDw==",
-          "dev": true
-        },
-        "rsvp": {
-          "version": "4.8.5",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-          "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-          "dev": true
-        },
-        "walk-sync": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
-          "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
-          "dev": true,
-          "requires": {
-            "@types/minimatch": "^3.0.3",
-            "ensure-posix-path": "^1.1.0",
-            "matcher-collection": "^2.0.0",
-            "minimatch": "^3.0.4"
+            "@embroider/macros": "^1.8.3",
+            "@glimmer/tracking": "^1.1.2",
+            "babel-import-util": "^1.2.2",
+            "ember-cache-primitive-polyfill": "^1.0.1",
+            "ember-cli-babel": "^7.26.11",
+            "ember-cli-babel-plugin-helpers": "^1.1.1"
           }
         }
       }
     },
     "@ember-data/private-build-infra": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@ember-data/private-build-infra/-/private-build-infra-4.4.1.tgz",
-      "integrity": "sha512-Yg50CZCU1Xll/6N+iUzzG+hqxK3BtiVJziRmWnOapSvExA6HxzD1hnxd/AB9+wECprHElBxLEKo85oNgFtC7zg==",
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@ember-data/private-build-infra/-/private-build-infra-4.11.3.tgz",
+      "integrity": "sha512-bXFQMEegUc+vKn/vD7FmAkq7ECE0okZ2sbtv/0RXqYn7TLk44rvGzpqSUXUowpCaGI/87MmaW8JaZMMdqF9wuw==",
       "dev": true,
       "requires": {
-        "@babel/plugin-transform-block-scoping": "^7.16.7",
-        "@ember-data/canary-features": "4.4.1",
+        "@babel/core": "^7.20.2",
+        "@babel/plugin-transform-block-scoping": "^7.20.2",
+        "@babel/runtime": "^7.20.1",
+        "@ember-data/canary-features": "4.11.3",
         "@ember/edition-utils": "^1.2.0",
+        "@embroider/macros": "^1.10.0",
+        "babel-import-util": "^1.3.0",
         "babel-plugin-debug-macros": "^0.3.4",
         "babel-plugin-filter-imports": "^4.0.0",
         "babel6-plugin-strip-class-callcheck": "^6.0.0",
         "broccoli-debug": "^0.6.5",
         "broccoli-file-creator": "^2.1.1",
-        "broccoli-funnel": "^3.0.3",
+        "broccoli-funnel": "^3.0.8",
         "broccoli-merge-trees": "^4.2.0",
         "broccoli-rollup": "^5.0.0",
         "calculate-cache-key-for-tree": "^2.0.0",
-        "chalk": "^4.0.0",
+        "chalk": "^4.1.2",
         "ember-cli-babel": "^7.26.11",
         "ember-cli-path-utils": "^1.0.0",
         "ember-cli-string-utils": "^1.1.0",
-        "ember-cli-typescript": "^5.0.0",
-        "ember-cli-version-checker": "^5.1.1",
-        "esm": "^3.2.25",
+        "ember-cli-version-checker": "^5.1.2",
         "git-repo-info": "^2.1.1",
-        "glob": "^7.1.6",
+        "glob": "^8.0.3",
         "npm-git-info": "^1.0.3",
         "rimraf": "^3.0.2",
         "rsvp": "^4.8.5",
-        "semver": "^7.1.3",
+        "semver": "^7.3.8",
         "silent-error": "^1.1.1"
       },
       "dependencies": {
+        "@babel/runtime": {
+          "version": "7.24.4",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.4.tgz",
+          "integrity": "sha512-dkxf7+hn8mFBwKjs9bvBlArzLVxVbS8usaPUDd5p2a9JCL9tB8OaOVN1isD4+Xyk4ns89/xeOmbQvgdK7IIVdA==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.14.0"
+          }
+        },
         "@types/broccoli-plugin": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/@types/broccoli-plugin/-/broccoli-plugin-3.0.0.tgz",
@@ -38816,6 +37905,15 @@
           "dev": true,
           "requires": {
             "broccoli-plugin": "*"
+          }
+        },
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
           }
         },
         "broccoli-funnel": {
@@ -38860,24 +37958,6 @@
             "walk-sync": "^2.2.0"
           }
         },
-        "ember-cli-typescript": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-5.2.1.tgz",
-          "integrity": "sha512-qqp5TAIuPHxHiGXJKL+78Euyhy0zSKQMovPh8sJpN/ZBYx0H90pONufHR3anaMcp1snVfx4B+mb9+7ijOik8ZA==",
-          "dev": true,
-          "requires": {
-            "ansi-to-html": "^0.6.15",
-            "broccoli-stew": "^3.0.0",
-            "debug": "^4.0.0",
-            "execa": "^4.0.0",
-            "fs-extra": "^9.0.1",
-            "resolve": "^1.5.0",
-            "rsvp": "^4.8.1",
-            "semver": "^7.3.2",
-            "stagehand": "^1.0.0",
-            "walk-sync": "^2.2.0"
-          }
-        },
         "ember-cli-version-checker": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-5.1.2.tgz",
@@ -38887,23 +37967,6 @@
             "resolve-package-path": "^3.1.0",
             "semver": "^7.3.4",
             "silent-error": "^1.1.1"
-          }
-        },
-        "execa": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
-          "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^7.0.0",
-            "get-stream": "^5.0.0",
-            "human-signals": "^1.1.1",
-            "is-stream": "^2.0.0",
-            "merge-stream": "^2.0.0",
-            "npm-run-path": "^4.0.0",
-            "onetime": "^5.1.0",
-            "signal-exit": "^3.0.2",
-            "strip-final-newline": "^2.0.0"
           }
         },
         "fs-tree-diff": {
@@ -38919,19 +37982,34 @@
             "symlink-or-copy": "^1.1.8"
           }
         },
-        "get-stream": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+        "glob": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+          "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
           "dev": true,
           "requires": {
-            "pump": "^3.0.0"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^5.0.1",
+            "once": "^1.3.0"
+          },
+          "dependencies": {
+            "minimatch": {
+              "version": "5.1.6",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+              "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+              "dev": true,
+              "requires": {
+                "brace-expansion": "^2.0.1"
+              }
+            }
           }
         },
-        "human-signals": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
-          "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+        "regenerator-runtime": {
+          "version": "0.14.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+          "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
           "dev": true
         },
         "resolve-package-path": {
@@ -38951,6 +38029,22 @@
           "dev": true,
           "requires": {
             "glob": "^7.1.3"
+          },
+          "dependencies": {
+            "glob": {
+              "version": "7.2.3",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+              "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+              "dev": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            }
           }
         },
         "rollup": {
@@ -38983,89 +38077,17 @@
       }
     },
     "@ember-data/record-data": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@ember-data/record-data/-/record-data-4.4.1.tgz",
-      "integrity": "sha512-5wmvcdxuVbA449UJzaMW/jovL3Sca/Yu+nVwiShic0GWcV72hbdO26/6Ii2dDCXqCf9WVXAl30egCGz/mGZgKQ==",
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@ember-data/record-data/-/record-data-4.11.3.tgz",
+      "integrity": "sha512-8NmeEZJ7or354NLZJgibJ1FuhWL70H6G24tGSEIzM8IV7wr6TreIyaWODaW372QwamWYgFIpfnFwWt5MTlY/gw==",
       "dev": true,
       "requires": {
-        "@ember-data/canary-features": "4.4.1",
-        "@ember-data/private-build-infra": "4.4.1",
-        "@ember-data/store": "4.4.1",
+        "@ember-data/canary-features": "4.11.3",
+        "@ember-data/private-build-infra": "4.11.3",
         "@ember/edition-utils": "^1.2.0",
-        "ember-auto-import": "^2.2.4",
-        "ember-cli-babel": "^7.26.11",
-        "ember-cli-test-info": "^1.0.0",
-        "ember-cli-typescript": "^5.0.0"
-      },
-      "dependencies": {
-        "ember-cli-typescript": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-5.2.1.tgz",
-          "integrity": "sha512-qqp5TAIuPHxHiGXJKL+78Euyhy0zSKQMovPh8sJpN/ZBYx0H90pONufHR3anaMcp1snVfx4B+mb9+7ijOik8ZA==",
-          "dev": true,
-          "requires": {
-            "ansi-to-html": "^0.6.15",
-            "broccoli-stew": "^3.0.0",
-            "debug": "^4.0.0",
-            "execa": "^4.0.0",
-            "fs-extra": "^9.0.1",
-            "resolve": "^1.5.0",
-            "rsvp": "^4.8.1",
-            "semver": "^7.3.2",
-            "stagehand": "^1.0.0",
-            "walk-sync": "^2.2.0"
-          }
-        },
-        "execa": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
-          "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^7.0.0",
-            "get-stream": "^5.0.0",
-            "human-signals": "^1.1.1",
-            "is-stream": "^2.0.0",
-            "merge-stream": "^2.0.0",
-            "npm-run-path": "^4.0.0",
-            "onetime": "^5.1.0",
-            "signal-exit": "^3.0.2",
-            "strip-final-newline": "^2.0.0"
-          }
-        },
-        "get-stream": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-          "dev": true,
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        },
-        "human-signals": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
-          "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
-          "dev": true
-        },
-        "rsvp": {
-          "version": "4.8.5",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-          "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-          "dev": true
-        },
-        "walk-sync": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
-          "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
-          "dev": true,
-          "requires": {
-            "@types/minimatch": "^3.0.3",
-            "ensure-posix-path": "^1.1.0",
-            "matcher-collection": "^2.0.0",
-            "minimatch": "^3.0.4"
-          }
-        }
+        "@embroider/macros": "^1.10.0",
+        "ember-auto-import": "^2.4.3",
+        "ember-cli-babel": "^7.26.11"
       }
     },
     "@ember-data/rfc395-data": {
@@ -39075,174 +38097,55 @@
       "dev": true
     },
     "@ember-data/serializer": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@ember-data/serializer/-/serializer-4.4.1.tgz",
-      "integrity": "sha512-ffzHcWDJlX5epM8SzQMirRkBU2/N/enJwnJV28DzcxQcrbVfUWZqaPgQWpg8wADLETfumERzy7WIJlcSCGR5ow==",
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@ember-data/serializer/-/serializer-4.11.3.tgz",
+      "integrity": "sha512-Qnzrowinz14/onQfwd4TPwNG0sMTAwTWE0RajYo2fysF3CKyAua0nIzmFtXKx0CogD7TYd0C5xf6nMjFesT09Q==",
       "dev": true,
       "requires": {
-        "@ember-data/private-build-infra": "4.4.1",
-        "@ember-data/store": "4.4.1",
-        "ember-auto-import": "^2.2.4",
+        "@ember-data/private-build-infra": "4.11.3",
+        "@embroider/macros": "^1.10.0",
+        "ember-auto-import": "^2.4.3",
         "ember-cli-babel": "^7.26.11",
-        "ember-cli-test-info": "^1.0.0",
-        "ember-cli-typescript": "^5.0.0"
+        "ember-cli-test-info": "^1.0.0"
+      }
+    },
+    "@ember-data/store": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@ember-data/store/-/store-4.11.3.tgz",
+      "integrity": "sha512-ogwWy+VqMpkCGs4n30pzuB2vqv/dJRL6wdV3fdNKpXrDugffjuMPpLBQYF937qztDUZKxmnbWAZe5PbQOz8b1Q==",
+      "dev": true,
+      "requires": {
+        "@ember-data/canary-features": "4.11.3",
+        "@ember-data/private-build-infra": "4.11.3",
+        "@embroider/macros": "^1.10.0",
+        "ember-auto-import": "^2.4.3",
+        "ember-cached-decorator-polyfill": "^1.0.1",
+        "ember-cli-babel": "^7.26.11"
       },
       "dependencies": {
-        "ember-cli-typescript": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-5.2.1.tgz",
-          "integrity": "sha512-qqp5TAIuPHxHiGXJKL+78Euyhy0zSKQMovPh8sJpN/ZBYx0H90pONufHR3anaMcp1snVfx4B+mb9+7ijOik8ZA==",
+        "ember-cached-decorator-polyfill": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/ember-cached-decorator-polyfill/-/ember-cached-decorator-polyfill-1.0.2.tgz",
+          "integrity": "sha512-hUX6OYTKltAPAu8vsVZK02BfMTV0OUXrPqvRahYPhgS7D0I6joLjlskd7mhqJMcaXLywqceIy8/s+x8bxF8bpQ==",
           "dev": true,
           "requires": {
-            "ansi-to-html": "^0.6.15",
-            "broccoli-stew": "^3.0.0",
-            "debug": "^4.0.0",
-            "execa": "^4.0.0",
-            "fs-extra": "^9.0.1",
-            "resolve": "^1.5.0",
-            "rsvp": "^4.8.1",
-            "semver": "^7.3.2",
-            "stagehand": "^1.0.0",
-            "walk-sync": "^2.2.0"
-          }
-        },
-        "execa": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
-          "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^7.0.0",
-            "get-stream": "^5.0.0",
-            "human-signals": "^1.1.1",
-            "is-stream": "^2.0.0",
-            "merge-stream": "^2.0.0",
-            "npm-run-path": "^4.0.0",
-            "onetime": "^5.1.0",
-            "signal-exit": "^3.0.2",
-            "strip-final-newline": "^2.0.0"
-          }
-        },
-        "get-stream": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-          "dev": true,
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        },
-        "human-signals": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
-          "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
-          "dev": true
-        },
-        "rsvp": {
-          "version": "4.8.5",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-          "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-          "dev": true
-        },
-        "walk-sync": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
-          "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
-          "dev": true,
-          "requires": {
-            "@types/minimatch": "^3.0.3",
-            "ensure-posix-path": "^1.1.0",
-            "matcher-collection": "^2.0.0",
-            "minimatch": "^3.0.4"
+            "@embroider/macros": "^1.8.3",
+            "@glimmer/tracking": "^1.1.2",
+            "babel-import-util": "^1.2.2",
+            "ember-cache-primitive-polyfill": "^1.0.1",
+            "ember-cli-babel": "^7.26.11",
+            "ember-cli-babel-plugin-helpers": "^1.1.1"
           }
         }
       }
     },
-    "@ember-data/store": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@ember-data/store/-/store-4.4.1.tgz",
-      "integrity": "sha512-lfEQmm/xaqPdG6S4fSwm3XG/3g1s9R9ir5OcOytng/UNw7wZxDZnUA+wOiFup1gN3ZO/q5y4nCg8B6dC3NEFgA==",
+    "@ember-data/tracking": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@ember-data/tracking/-/tracking-4.11.3.tgz",
+      "integrity": "sha512-YZxFTMe2TBL8H8/GrnrvP7Wc/uuAijoSyiP2g6TMNRsL1e/3BWDT0EIl+B/5Wji+dchofY8iuMWfpY7VDvPIzA==",
       "dev": true,
       "requires": {
-        "@ember-data/canary-features": "4.4.1",
-        "@ember-data/private-build-infra": "4.4.1",
-        "@ember/string": "^3.0.0",
-        "@glimmer/tracking": "^1.0.4",
-        "ember-auto-import": "^2.2.4",
-        "ember-cached-decorator-polyfill": "^0.1.4",
-        "ember-cli-babel": "^7.26.11",
-        "ember-cli-path-utils": "^1.0.0",
-        "ember-cli-typescript": "^5.0.0"
-      },
-      "dependencies": {
-        "ember-cli-typescript": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-5.2.1.tgz",
-          "integrity": "sha512-qqp5TAIuPHxHiGXJKL+78Euyhy0zSKQMovPh8sJpN/ZBYx0H90pONufHR3anaMcp1snVfx4B+mb9+7ijOik8ZA==",
-          "dev": true,
-          "requires": {
-            "ansi-to-html": "^0.6.15",
-            "broccoli-stew": "^3.0.0",
-            "debug": "^4.0.0",
-            "execa": "^4.0.0",
-            "fs-extra": "^9.0.1",
-            "resolve": "^1.5.0",
-            "rsvp": "^4.8.1",
-            "semver": "^7.3.2",
-            "stagehand": "^1.0.0",
-            "walk-sync": "^2.2.0"
-          }
-        },
-        "execa": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
-          "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^7.0.0",
-            "get-stream": "^5.0.0",
-            "human-signals": "^1.1.1",
-            "is-stream": "^2.0.0",
-            "merge-stream": "^2.0.0",
-            "npm-run-path": "^4.0.0",
-            "onetime": "^5.1.0",
-            "signal-exit": "^3.0.2",
-            "strip-final-newline": "^2.0.0"
-          }
-        },
-        "get-stream": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-          "dev": true,
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        },
-        "human-signals": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
-          "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
-          "dev": true
-        },
-        "rsvp": {
-          "version": "4.8.5",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-          "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-          "dev": true
-        },
-        "walk-sync": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
-          "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
-          "dev": true,
-          "requires": {
-            "@types/minimatch": "^3.0.3",
-            "ensure-posix-path": "^1.1.0",
-            "matcher-collection": "^2.0.0",
-            "minimatch": "^3.0.4"
-          }
-        }
+        "ember-cli-babel": "^7.26.11"
       }
     },
     "@ember-decorators/component": {
@@ -39343,10 +38246,11 @@
       }
     },
     "@ember/string": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@ember/string/-/string-3.0.1.tgz",
-      "integrity": "sha512-ntnmXS+upOWVXE+rVw2l03DjdMnaGdWbYVUxUBuPJqnIGZu2XFRsoXc7E6mOw62s8i1Xh1RgTuFHN41QGIolEQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@ember/string/-/string-3.1.1.tgz",
+      "integrity": "sha512-UbXJ+k3QOrYN4SRPHgXCqYIJ+yWWUg1+vr0H4DhdQPTy8LJfyqwZ2tc5uqpSSnEXE+/1KopHBE5J8GDagAg5cg==",
       "dev": true,
+      "peer": true,
       "requires": {
         "ember-cli-babel": "^7.26.6"
       }
@@ -51102,26 +50006,26 @@
       }
     },
     "ember-data": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/ember-data/-/ember-data-4.4.1.tgz",
-      "integrity": "sha512-Jc8a2OTX3rcnbmVwBjdeOYPSKUHWYRH+RMyDSLN3fpLp/A8pZp1Lkn3b5/ZEi9DmBRirxIDSSSPPZ6RDTMBYlQ==",
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/ember-data/-/ember-data-4.11.3.tgz",
+      "integrity": "sha512-7vir6Re3M3M6yJoCHy6UxEg3oSY1JEnsuTByY3lJquWPaUamn7qbPQvNr16Tqh8EKrt+e/+X26czFm4kRGhpVg==",
       "dev": true,
       "requires": {
-        "@ember-data/adapter": "4.4.1",
-        "@ember-data/debug": "4.4.1",
-        "@ember-data/model": "4.4.1",
-        "@ember-data/private-build-infra": "4.4.1",
-        "@ember-data/record-data": "4.4.1",
-        "@ember-data/serializer": "4.4.1",
-        "@ember-data/store": "4.4.1",
+        "@ember-data/adapter": "4.11.3",
+        "@ember-data/debug": "4.11.3",
+        "@ember-data/model": "4.11.3",
+        "@ember-data/private-build-infra": "4.11.3",
+        "@ember-data/record-data": "4.11.3",
+        "@ember-data/serializer": "4.11.3",
+        "@ember-data/store": "4.11.3",
+        "@ember-data/tracking": "4.11.3",
         "@ember/edition-utils": "^1.2.0",
-        "@ember/string": "^3.0.0",
+        "@embroider/macros": "^1.10.0",
         "@glimmer/env": "^0.1.7",
         "broccoli-merge-trees": "^4.2.0",
-        "ember-auto-import": "^2.2.4",
+        "ember-auto-import": "^2.4.3",
         "ember-cli-babel": "^7.26.11",
-        "ember-cli-typescript": "^5.0.0",
-        "ember-inflector": "^4.0.1"
+        "ember-inflector": "^4.0.2"
       },
       "dependencies": {
         "broccoli-merge-trees": {
@@ -51132,74 +50036,6 @@
           "requires": {
             "broccoli-plugin": "^4.0.2",
             "merge-trees": "^2.0.0"
-          }
-        },
-        "ember-cli-typescript": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-5.2.1.tgz",
-          "integrity": "sha512-qqp5TAIuPHxHiGXJKL+78Euyhy0zSKQMovPh8sJpN/ZBYx0H90pONufHR3anaMcp1snVfx4B+mb9+7ijOik8ZA==",
-          "dev": true,
-          "requires": {
-            "ansi-to-html": "^0.6.15",
-            "broccoli-stew": "^3.0.0",
-            "debug": "^4.0.0",
-            "execa": "^4.0.0",
-            "fs-extra": "^9.0.1",
-            "resolve": "^1.5.0",
-            "rsvp": "^4.8.1",
-            "semver": "^7.3.2",
-            "stagehand": "^1.0.0",
-            "walk-sync": "^2.2.0"
-          }
-        },
-        "execa": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
-          "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^7.0.0",
-            "get-stream": "^5.0.0",
-            "human-signals": "^1.1.1",
-            "is-stream": "^2.0.0",
-            "merge-stream": "^2.0.0",
-            "npm-run-path": "^4.0.0",
-            "onetime": "^5.1.0",
-            "signal-exit": "^3.0.2",
-            "strip-final-newline": "^2.0.0"
-          }
-        },
-        "get-stream": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-          "dev": true,
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        },
-        "human-signals": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
-          "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
-          "dev": true
-        },
-        "rsvp": {
-          "version": "4.8.5",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-          "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-          "dev": true
-        },
-        "walk-sync": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
-          "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
-          "dev": true,
-          "requires": {
-            "@types/minimatch": "^3.0.3",
-            "ensure-posix-path": "^1.1.0",
-            "matcher-collection": "^2.0.0",
-            "minimatch": "^3.0.4"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "ember-component-css": "^0.8.1",
     "ember-copy": "^2.0.0",
     "ember-d3": "^0.5.1",
-    "ember-data": "~4.4.1",
+    "ember-data": "~4.11.3",
     "ember-data-codemod": "^0.1.1",
     "ember-export-application-global": "^2.0.1",
     "ember-flatpickr": "^3.2.3",


### PR DESCRIPTION
## Context
Ember data 4.12 introduces their new architecture which requires a number of changes.  4.11 contains a principle deprecation of `objectAt` no longer being the suggested method of accessing returned items from an array.

## Objective
Updates to Ember data 4.11 and changes array access to using native array access.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
