### PR TITLE
fix: remove messageForSearching as it is not required

### DIFF
--- a/app/components/pipeline-create-form/component.js
+++ b/app/components/pipeline-create-form/component.js
@@ -25,16 +25,6 @@ export default Component.extend({
   isDisabled: or('isSaving', 'isInvalid'),
   autoKeysGeneration: false,
 
-  messageForSearching: computed('templates.[]', 'templates.options.length', {
-    get() {
-      if (this.templates.options.length) {
-        return 'Not found.';
-      }
-
-      return 'Loading...';
-    }
-  }),
-
   isValid: computed('scmUrl', {
     get() {
       const val = this.scmUrl;

--- a/app/components/pipeline-create-form/template.hbs
+++ b/app/components/pipeline-create-form/template.hbs
@@ -108,7 +108,8 @@
             @matcher={{this.searchInputMatcher}}
             @searchField="name"
             @searchEnabled=true
-            @noMatchesMessage={{this.messageForSearching}} as |template|
+            @noMatchesMessage="Not found."
+            as |template|
           >
             {{template.name}}
           </PowerSelect>


### PR DESCRIPTION
## Context
`messageForSearching` is not doing anything meaningful anymore as all the templates are already fetched via the API via the router model.  Additionally, `templates.options` does not exist and causes an error.

## Objective
Removes `messageForSearching` and updates the `PowerSelect` component to use a static string for displaying the message when an option isn't found.

## References
Related to #1043 

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
