### PR TITLE
fix(3098): Workflow graph - Non stage jobs overlap into the stage

### DIFF
--- a/app/utils/graph-tools.js
+++ b/app/utils/graph-tools.js
@@ -270,7 +270,7 @@ const positionStage = (x, y, stage) => {
   const stageEndX = stageStartX + stageGraph.meta.width - 1;
 
   // Find a row with no items for all the stage columns
-  const stageStartY = Math.max(...y.slice(stageStartX, stageEndX));
+  const stageStartY = Math.max(...y.slice(stageStartX, stageEndX + 1));
 
   stage.pos = { x: stageStartX, y: stageStartY };
 

--- a/tests/unit/utils/graph-tools-test.js
+++ b/tests/unit/utils/graph-tools-test.js
@@ -1202,12 +1202,16 @@ module('Unit | Utility | graph tools', function () {
       stageStartY + decoratedIntegrationStage.graph.meta.height - 1;
 
     decoratedNodes.forEach(n => {
+      const isInsideStageMatrix =
+        n.pos.x >= stageStartX &&
+        n.pos.x <= stageEndX &&
+        n.pos.y >= stageStartY &&
+        n.pos.y <= stageEndY;
+
       if (n.stageName) {
-        assert.isTrue(n.pos.x >= stageStartX && n.pos.x <= stageEndX);
-        assert.isTrue(n.pos.y >= stageStartY && n.pos.x <= stageEndY);
+        assert.ok(isInsideStageMatrix);
       } else {
-        assert.isTrue(n.pos.x < stageStartX || n.pos.x > stageEndX);
-        assert.isTrue(n.pos.y < stageStartY || n.pos.x > stageEndY);
+        assert.notOk(isInsideStageMatrix);
       }
     });
   });


### PR DESCRIPTION
## Context

Non stage jobs are being positioned under stage on the workflow graph in the UI giving a false impression that those jobs are part of the stage.

**Example (screwdriver.yaml)**
```
## Stages by grouping
shared:
    image: node:20
    steps:
        - init: echo 'init'
jobs:
    triggering-stage:
        requires: [~pr, ~commit]
    overlapping-non-stage-job-at-start-1:
        requires: [triggering-stage]
    overlapping-non-stage-job-at-start-2a:
        requires: [ overlapping-non-stage-job-at-start-1 ]
    overlapping-non-stage-job-at-start-2b:
        requires: [ overlapping-non-stage-job-at-start-1 ]
    ci-deploy:
        requires: [ ~stage@integration:setup ]
    ci-test-batch-1:
        requires: [ ci-deploy ]
    ci-test-batch-2:
        requires: [ ci-deploy ]
    ci-certify:
        requires: [ ci-test-batch-1, ci-test-batch-2 ]
    overlapping-non-stage-job-at-end-1:
        requires: [ ci-test-batch-1 ]
    overlapping-non-stage-job-at-end-2:
        requires: [ ci-test-batch-2 ]
    triggered-by-stage:
        requires: [ ~stage@integration:teardown ]

stages:
    integration:
        requires: [triggering-stage]
        jobs: [ci-deploy, ci-test-batch-1, ci-test-batch-2, ci-certify]
        description: "This stage will deploy the latest application to CI environment and certifies it after the tests are passed."
```

**Workflow graph (Before)**
<img width="1404" alt="image" src="https://github.com/screwdriver-cd/ui/assets/2124590/43197d4c-812a-4cd8-9407-01c53b67c255">


## Objective

Non stage jobs must be positioned outside stage matrix.

**Workflow graph (After)**
<img width="1396" alt="image" src="https://github.com/screwdriver-cd/ui/assets/2124590/ca38120a-2261-4042-aa0c-a0a908eb7e4b">



## References

https://github.com/screwdriver-cd/screwdriver/issues/3098

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
