### PR TITLE
fix(3098): Mini workflow in the event card is not rendered when there are stages

### DIFF
--- a/app/utils/graph-tools.js
+++ b/app/utils/graph-tools.js
@@ -403,13 +403,14 @@ const hasProcessedDest = (graph, name) => {
 const positionGraphNodes = graph => {
   const { nodes, edges, stages } = graph;
 
-  const stageNameToStageMap = stages
-    ? stages.reduce((map, s) => {
-        map.set(s.name, s);
+  const stageNameToStageMap =
+    stages && stages.length > 0
+      ? stages.reduce((map, s) => {
+          map.set(s.name, s);
 
-        return map;
-      }, new Map())
-    : null;
+          return map;
+        }, new Map())
+      : null;
 
   let y = [0]; // accumulator for column heights
 


### PR DESCRIPTION
## Context

Changes made in https://github.com/screwdriver-cd/ui/pull/1045 introduced a regression due to which mini workflow graph are not rendered in the event card as shown below
<img width="1725" alt="image" src="https://github.com/screwdriver-cd/ui/assets/2124590/70cabff6-df4f-4ef7-a22c-5c9e331e4ab0">

## Objective

Add check to skip the logic to assign position to stage when stages is empty
<img width="865" alt="image" src="https://github.com/screwdriver-cd/ui/assets/2124590/5c1ddec8-7c25-4e0c-ae27-aa85509ddcc9">



## References

https://github.com/screwdriver-cd/screwdriver/issues/3098

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
