### PR TITLE
fix: Use Sass-embedded

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -23,7 +23,8 @@ module.exports = function (defaults) {
     },
 
     sassOptions: {
-      implementation: sass
+      implementation: sass,
+      includePaths: ['app/styles', 'app']
     },
 
     svg: {

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
+const sass = require('sass-embedded');
 
 module.exports = function (defaults) {
   const app = new EmberApp(defaults, {
@@ -19,6 +20,10 @@ module.exports = function (defaults) {
 
     fingerprint: {
       exclude: ['supplementary_config', 'unknown_user']
+    },
+
+    sassOptions: {
+      implementation: sass
     },
 
     svg: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,7 +95,7 @@
         "prettier": "^2.6.2",
         "qunit": "^2.19.1",
         "qunit-dom": "^2.0.0",
-        "sass": "^1.49.9",
+        "sass-embedded": "^1.77.0",
         "webpack": "^5.76.2"
       },
       "engines": {
@@ -2174,6 +2174,12 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.9.0.tgz",
+      "integrity": "sha512-W7gp8Q/v1NlCZLsv8pQ3Y0uCu/SHgXOVFK+eUluUKWXmsb6VHkpNx0apdOWWcDbB9sJoKeP8uPrjmehJz6xETQ==",
+      "dev": true
     },
     "node_modules/@cnakazawa/watch": {
       "version": "1.0.4",
@@ -9354,6 +9360,12 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
       }
+    },
+    "node_modules/buffer-builder": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/buffer-builder/-/buffer-builder-0.2.0.tgz",
+      "integrity": "sha512-7VPMEPuYznPSoR21NE1zvd2Xna6c/CloiZCfcMXR1Jny6PjX0N4Nsa38zcBFo/FMK+BlA+FLKbJCQ0i2yxp+Xg==",
+      "dev": true
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -32203,6 +32215,377 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/sass-embedded": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.77.0.tgz",
+      "integrity": "sha512-4GOuLIWQ3vm1XnmRlBz8Rj11rCBceqvkSvEy+ZZGjsR2Y9/+75Dh+zXCtPwOuJFHZsV7qbCqCCSxbpUA0TiQ3w==",
+      "dev": true,
+      "dependencies": {
+        "@bufbuild/protobuf": "^1.0.0",
+        "buffer-builder": "^0.2.0",
+        "immutable": "^4.0.0",
+        "rxjs": "^7.4.0",
+        "supports-color": "^8.1.1",
+        "varint": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "optionalDependencies": {
+        "sass-embedded-android-arm": "1.77.0",
+        "sass-embedded-android-arm64": "1.77.0",
+        "sass-embedded-android-ia32": "1.77.0",
+        "sass-embedded-android-x64": "1.77.0",
+        "sass-embedded-darwin-arm64": "1.77.0",
+        "sass-embedded-darwin-x64": "1.77.0",
+        "sass-embedded-linux-arm": "1.77.0",
+        "sass-embedded-linux-arm64": "1.77.0",
+        "sass-embedded-linux-ia32": "1.77.0",
+        "sass-embedded-linux-musl-arm": "1.77.0",
+        "sass-embedded-linux-musl-arm64": "1.77.0",
+        "sass-embedded-linux-musl-ia32": "1.77.0",
+        "sass-embedded-linux-musl-x64": "1.77.0",
+        "sass-embedded-linux-x64": "1.77.0",
+        "sass-embedded-win32-arm64": "1.77.0",
+        "sass-embedded-win32-ia32": "1.77.0",
+        "sass-embedded-win32-x64": "1.77.0"
+      }
+    },
+    "node_modules/sass-embedded-android-arm": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm/-/sass-embedded-android-arm-1.77.0.tgz",
+      "integrity": "sha512-T/7CXMrRyvb+9FHwXNL53tAnj2z8KqQXpo3XkPXzgB+RFqXhSWsnkfehcefDGm81EsggyYXnkLo6f4xcapZvYw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "bin": {
+        "sass": "dart-sass/sass"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-android-arm64": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.77.0.tgz",
+      "integrity": "sha512-TrKS0AlFu1ZtXR26V8YMnycyE8CR5FPGd+cPkZZeMMXKI8FpbM9W7fz6b+kDJuBZoDmzuHJPoGWSAq+R5k3Hug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "bin": {
+        "sass": "dart-sass/sass"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-android-ia32": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-ia32/-/sass-embedded-android-ia32-1.77.0.tgz",
+      "integrity": "sha512-T12iRF3sZ/gRgsEBH6y+eSn12+3VokL6n1+VVlwJ9pYz8Q8iE9gALyvy71Cvm9j130LV4X+pxq53xQl5GA6VQg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "bin": {
+        "sass": "dart-sass/sass"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-android-x64": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-x64/-/sass-embedded-android-x64-1.77.0.tgz",
+      "integrity": "sha512-qmUoSBywRQkzrFMK6ouifFSCSSb+rK0ykQaD2abeeJ3C9nbEFMUP2M9u6Ny4y1GS9t83MU3LZxwTeEMh7y5/xg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "bin": {
+        "sass": "dart-sass/sass"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-darwin-arm64": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.77.0.tgz",
+      "integrity": "sha512-ccLfsrzyS49Em99geabqxueKzEcpIrhUj3oek2+/Ccxllhhwj9LrZFaWlvpHLgzCt/qZldqA4sltqqpczJdHMw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "sass": "dart-sass/sass"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-darwin-x64": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.77.0.tgz",
+      "integrity": "sha512-qRDMXlxibTSDyZKDzgHhTCiooCJxodXg1QyE1izcdnSCDX5wOwaK/AShkkmyBQqLM3MQLXTeTgkmV58vEGHeGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "sass": "dart-sass/sass"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-linux-arm": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.77.0.tgz",
+      "integrity": "sha512-+Jyiy+ZVjo9dJZbAF8rC0tsmubHbQ6ydv0kWEaiwnEdj2BgpKx/5f2LDlCFgvZkGlPUdKWYNcW6bISUsJjyuJQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "sass": "dart-sass/sass"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-linux-arm64": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.77.0.tgz",
+      "integrity": "sha512-rK1sH+CyMHkYnIkYWVgrHiRI3slpIcBNazQ2vXzRgz8Y0R3+PrOYA8N1QtOoW3ccZPql8/X3NrkopeJbFWCuRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "sass": "dart-sass/sass"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-linux-ia32": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.77.0.tgz",
+      "integrity": "sha512-SH/RpqFny/2MttLVLBNO2x+D6X7Y/CG3NS2q80RuOlrQvpqgQasw8SqMSx4a07ps1PlOIG5ngYf0agJ3USenJg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "sass": "dart-sass/sass"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-linux-musl-arm": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.77.0.tgz",
+      "integrity": "sha512-CguyYPc25n/+oIVqbSPX6FTwTPjwd71bt7oZTGZerw8ZocvRDJo6SwjRK2iA8RbHcg0YbFhEwQ9U9SLczykTmA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-linux-musl-arm64": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.77.0.tgz",
+      "integrity": "sha512-2mvAKTqXRRrrnRvUFw/iLozoOW2sj2Q1rOaGFbvXUXYOHYzlVnDTGGVPty+gTN2f1YgUSRe433MtE103Wp9Ekw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-linux-musl-ia32": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-ia32/-/sass-embedded-linux-musl-ia32-1.77.0.tgz",
+      "integrity": "sha512-uABIlsNvq7U3wFlpQy5rZ7AsEc7/aKHY4P396YLs52FF/T0NcTx4TjKZwECVHjC+X13ltnmYcAWP8lf8fk5vuQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-linux-musl-x64": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-x64/-/sass-embedded-linux-musl-x64-1.77.0.tgz",
+      "integrity": "sha512-nqf9svqjzrL2i2nu9/hUxE3K4kM0QVegiXiqfw0CoSbwAOQvAaBQxi0k/BgXvurQwJS0ukSs7Zwon5iJ+WDqAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-linux-x64": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.77.0.tgz",
+      "integrity": "sha512-KvEE4x0esp0GfGjWGs65AHrHjvxeC5gMKW0VFmWCtH4yT/o5G0eVdgaDXgQqkeLjIOPn5ULFuF2h2euXBuBagw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "sass": "dart-sass/sass"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-win32-arm64": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-arm64/-/sass-embedded-win32-arm64-1.77.0.tgz",
+      "integrity": "sha512-dcv09TftEIZQ4LorkrRMYdbUkMiWTpn4nC8i9nKNhjMQ22EE8Jh1SNrR18YTqiYA3YGSc1oEgmDP9cCHHz5HFA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "sass": "dart-sass/sass.bat"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-win32-ia32": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.77.0.tgz",
+      "integrity": "sha512-j1AStvWCA4RAqDfe12AM7mAYUmSUxDhDktdcPQ2kPo4EiFvjlVFW7CvFM9/MiZ8VvAtop06fyIy8rr+VY8OR2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "sass": "dart-sass/sass.bat"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-win32-x64": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.77.0.tgz",
+      "integrity": "sha512-J3sjLF0mk1jYD/y3tqxZy3LfoYeyhYAhwJAS6zF9utMb5JIJ+dHscgmuVr87qHCrtOtaV6JRG0oLWi7Uka4nTg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "sass": "dart-sass/sass.bat"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded/node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/sass-embedded/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
@@ -35300,6 +35683,12 @@
         "node": "10.* || >= 12"
       }
     },
+    "node_modules/varint": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
+      "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==",
+      "dev": true
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -37618,6 +38007,12 @@
         "@babel/helper-validator-identifier": "^7.22.20",
         "to-fast-properties": "^2.0.0"
       }
+    },
+    "@bufbuild/protobuf": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.9.0.tgz",
+      "integrity": "sha512-W7gp8Q/v1NlCZLsv8pQ3Y0uCu/SHgXOVFK+eUluUKWXmsb6VHkpNx0apdOWWcDbB9sJoKeP8uPrjmehJz6xETQ==",
+      "dev": true
     },
     "@cnakazawa/watch": {
       "version": "1.0.4",
@@ -43595,6 +43990,12 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
       }
+    },
+    "buffer-builder": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/buffer-builder/-/buffer-builder-0.2.0.tgz",
+      "integrity": "sha512-7VPMEPuYznPSoR21NE1zvd2Xna6c/CloiZCfcMXR1Jny6PjX0N4Nsa38zcBFo/FMK+BlA+FLKbJCQ0i2yxp+Xg==",
+      "dev": true
     },
     "buffer-from": {
       "version": "1.1.2",
@@ -61819,6 +62220,176 @@
         "source-map-js": ">=0.6.2 <2.0.0"
       }
     },
+    "sass-embedded": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.77.0.tgz",
+      "integrity": "sha512-4GOuLIWQ3vm1XnmRlBz8Rj11rCBceqvkSvEy+ZZGjsR2Y9/+75Dh+zXCtPwOuJFHZsV7qbCqCCSxbpUA0TiQ3w==",
+      "dev": true,
+      "requires": {
+        "@bufbuild/protobuf": "^1.0.0",
+        "buffer-builder": "^0.2.0",
+        "immutable": "^4.0.0",
+        "rxjs": "^7.4.0",
+        "sass-embedded-android-arm": "1.77.0",
+        "sass-embedded-android-arm64": "1.77.0",
+        "sass-embedded-android-ia32": "1.77.0",
+        "sass-embedded-android-x64": "1.77.0",
+        "sass-embedded-darwin-arm64": "1.77.0",
+        "sass-embedded-darwin-x64": "1.77.0",
+        "sass-embedded-linux-arm": "1.77.0",
+        "sass-embedded-linux-arm64": "1.77.0",
+        "sass-embedded-linux-ia32": "1.77.0",
+        "sass-embedded-linux-musl-arm": "1.77.0",
+        "sass-embedded-linux-musl-arm64": "1.77.0",
+        "sass-embedded-linux-musl-ia32": "1.77.0",
+        "sass-embedded-linux-musl-x64": "1.77.0",
+        "sass-embedded-linux-x64": "1.77.0",
+        "sass-embedded-win32-arm64": "1.77.0",
+        "sass-embedded-win32-ia32": "1.77.0",
+        "sass-embedded-win32-x64": "1.77.0",
+        "supports-color": "^8.1.1",
+        "varint": "^6.0.0"
+      },
+      "dependencies": {
+        "rxjs": {
+          "version": "7.8.1",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+          "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "supports-color": {
+          "version": "8.1.1",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "sass-embedded-android-arm": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm/-/sass-embedded-android-arm-1.77.0.tgz",
+      "integrity": "sha512-T/7CXMrRyvb+9FHwXNL53tAnj2z8KqQXpo3XkPXzgB+RFqXhSWsnkfehcefDGm81EsggyYXnkLo6f4xcapZvYw==",
+      "dev": true,
+      "optional": true
+    },
+    "sass-embedded-android-arm64": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.77.0.tgz",
+      "integrity": "sha512-TrKS0AlFu1ZtXR26V8YMnycyE8CR5FPGd+cPkZZeMMXKI8FpbM9W7fz6b+kDJuBZoDmzuHJPoGWSAq+R5k3Hug==",
+      "dev": true,
+      "optional": true
+    },
+    "sass-embedded-android-ia32": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-ia32/-/sass-embedded-android-ia32-1.77.0.tgz",
+      "integrity": "sha512-T12iRF3sZ/gRgsEBH6y+eSn12+3VokL6n1+VVlwJ9pYz8Q8iE9gALyvy71Cvm9j130LV4X+pxq53xQl5GA6VQg==",
+      "dev": true,
+      "optional": true
+    },
+    "sass-embedded-android-x64": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-x64/-/sass-embedded-android-x64-1.77.0.tgz",
+      "integrity": "sha512-qmUoSBywRQkzrFMK6ouifFSCSSb+rK0ykQaD2abeeJ3C9nbEFMUP2M9u6Ny4y1GS9t83MU3LZxwTeEMh7y5/xg==",
+      "dev": true,
+      "optional": true
+    },
+    "sass-embedded-darwin-arm64": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.77.0.tgz",
+      "integrity": "sha512-ccLfsrzyS49Em99geabqxueKzEcpIrhUj3oek2+/Ccxllhhwj9LrZFaWlvpHLgzCt/qZldqA4sltqqpczJdHMw==",
+      "dev": true,
+      "optional": true
+    },
+    "sass-embedded-darwin-x64": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.77.0.tgz",
+      "integrity": "sha512-qRDMXlxibTSDyZKDzgHhTCiooCJxodXg1QyE1izcdnSCDX5wOwaK/AShkkmyBQqLM3MQLXTeTgkmV58vEGHeGg==",
+      "dev": true,
+      "optional": true
+    },
+    "sass-embedded-linux-arm": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.77.0.tgz",
+      "integrity": "sha512-+Jyiy+ZVjo9dJZbAF8rC0tsmubHbQ6ydv0kWEaiwnEdj2BgpKx/5f2LDlCFgvZkGlPUdKWYNcW6bISUsJjyuJQ==",
+      "dev": true,
+      "optional": true
+    },
+    "sass-embedded-linux-arm64": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.77.0.tgz",
+      "integrity": "sha512-rK1sH+CyMHkYnIkYWVgrHiRI3slpIcBNazQ2vXzRgz8Y0R3+PrOYA8N1QtOoW3ccZPql8/X3NrkopeJbFWCuRg==",
+      "dev": true,
+      "optional": true
+    },
+    "sass-embedded-linux-ia32": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.77.0.tgz",
+      "integrity": "sha512-SH/RpqFny/2MttLVLBNO2x+D6X7Y/CG3NS2q80RuOlrQvpqgQasw8SqMSx4a07ps1PlOIG5ngYf0agJ3USenJg==",
+      "dev": true,
+      "optional": true
+    },
+    "sass-embedded-linux-musl-arm": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.77.0.tgz",
+      "integrity": "sha512-CguyYPc25n/+oIVqbSPX6FTwTPjwd71bt7oZTGZerw8ZocvRDJo6SwjRK2iA8RbHcg0YbFhEwQ9U9SLczykTmA==",
+      "dev": true,
+      "optional": true
+    },
+    "sass-embedded-linux-musl-arm64": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.77.0.tgz",
+      "integrity": "sha512-2mvAKTqXRRrrnRvUFw/iLozoOW2sj2Q1rOaGFbvXUXYOHYzlVnDTGGVPty+gTN2f1YgUSRe433MtE103Wp9Ekw==",
+      "dev": true,
+      "optional": true
+    },
+    "sass-embedded-linux-musl-ia32": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-ia32/-/sass-embedded-linux-musl-ia32-1.77.0.tgz",
+      "integrity": "sha512-uABIlsNvq7U3wFlpQy5rZ7AsEc7/aKHY4P396YLs52FF/T0NcTx4TjKZwECVHjC+X13ltnmYcAWP8lf8fk5vuQ==",
+      "dev": true,
+      "optional": true
+    },
+    "sass-embedded-linux-musl-x64": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-x64/-/sass-embedded-linux-musl-x64-1.77.0.tgz",
+      "integrity": "sha512-nqf9svqjzrL2i2nu9/hUxE3K4kM0QVegiXiqfw0CoSbwAOQvAaBQxi0k/BgXvurQwJS0ukSs7Zwon5iJ+WDqAA==",
+      "dev": true,
+      "optional": true
+    },
+    "sass-embedded-linux-x64": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.77.0.tgz",
+      "integrity": "sha512-KvEE4x0esp0GfGjWGs65AHrHjvxeC5gMKW0VFmWCtH4yT/o5G0eVdgaDXgQqkeLjIOPn5ULFuF2h2euXBuBagw==",
+      "dev": true,
+      "optional": true
+    },
+    "sass-embedded-win32-arm64": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-arm64/-/sass-embedded-win32-arm64-1.77.0.tgz",
+      "integrity": "sha512-dcv09TftEIZQ4LorkrRMYdbUkMiWTpn4nC8i9nKNhjMQ22EE8Jh1SNrR18YTqiYA3YGSc1oEgmDP9cCHHz5HFA==",
+      "dev": true,
+      "optional": true
+    },
+    "sass-embedded-win32-ia32": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.77.0.tgz",
+      "integrity": "sha512-j1AStvWCA4RAqDfe12AM7mAYUmSUxDhDktdcPQ2kPo4EiFvjlVFW7CvFM9/MiZ8VvAtop06fyIy8rr+VY8OR2w==",
+      "dev": true,
+      "optional": true
+    },
+    "sass-embedded-win32-x64": {
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.77.0.tgz",
+      "integrity": "sha512-J3sjLF0mk1jYD/y3tqxZy3LfoYeyhYAhwJAS6zF9utMb5JIJ+dHscgmuVr87qHCrtOtaV6JRG0oLWi7Uka4nTg==",
+      "dev": true,
+      "optional": true
+    },
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
@@ -64329,6 +64900,12 @@
           }
         }
       }
+    },
+    "varint": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
+      "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==",
+      "dev": true
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "prettier": "^2.6.2",
     "qunit": "^2.19.1",
     "qunit-dom": "^2.0.0",
-    "sass": "^1.49.9",
+    "sass-embedded": "^1.77.0",
     "webpack": "^5.76.2"
   }
 }


### PR DESCRIPTION
## Context
Switch to using `sass-embedded` as it is more performant than `sass`.

## Objective
Provide some additional performance improvements around stylesheet compilation.  This is one step in a migration plan to use Glimmer components.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
