### PR TITLE
fix: Refactor testing to use helpers

### DIFF
--- a/tests/acceptance/commands-test.js
+++ b/tests/acceptance/commands-test.js
@@ -1,6 +1,6 @@
 import { visit, currentURL } from '@ember/test-helpers';
 import { module, test } from 'qunit';
-import { setupApplicationTest } from 'ember-qunit';
+import { setupApplicationTest } from 'screwdriver-ui/tests/helpers';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import Pretender from 'pretender';
 import { getPageTitle } from 'ember-page-title/test-support';

--- a/tests/acceptance/create-page-test.js
+++ b/tests/acceptance/create-page-test.js
@@ -7,7 +7,7 @@ import {
   waitFor
 } from '@ember/test-helpers';
 import { module, test } from 'qunit';
-import { setupApplicationTest } from 'ember-qunit';
+import { setupApplicationTest } from 'screwdriver-ui/tests/helpers';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import Pretender from 'pretender';
 import { getPageTitle } from 'ember-page-title/test-support';

--- a/tests/acceptance/dashboards-test.js
+++ b/tests/acceptance/dashboards-test.js
@@ -9,7 +9,7 @@ import {
   waitUntil
 } from '@ember/test-helpers';
 import { module, test } from 'qunit';
-import { setupApplicationTest } from 'ember-qunit';
+import { setupApplicationTest } from 'screwdriver-ui/tests/helpers';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import Pretender from 'pretender';
 import { getPageTitle } from 'ember-page-title/test-support';

--- a/tests/acceptance/login-test.js
+++ b/tests/acceptance/login-test.js
@@ -1,6 +1,6 @@
 import { visit, currentURL } from '@ember/test-helpers';
 import { module, test } from 'qunit';
-import { setupApplicationTest } from 'ember-qunit';
+import { setupApplicationTest } from 'screwdriver-ui/tests/helpers';
 import { getPageTitle } from 'ember-page-title/test-support';
 
 module('Acceptance | logins', function (hooks) {

--- a/tests/acceptance/metrics-test.js
+++ b/tests/acceptance/metrics-test.js
@@ -1,6 +1,6 @@
 import { visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
-import { setupApplicationTest } from 'ember-qunit';
+import { setupApplicationTest } from 'screwdriver-ui/tests/helpers';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import Pretender from 'pretender';
 

--- a/tests/acceptance/pipeline-builds-test.js
+++ b/tests/acceptance/pipeline-builds-test.js
@@ -1,6 +1,6 @@
 import { currentURL, visit, settled } from '@ember/test-helpers';
 import { module, test } from 'qunit';
-import { setupApplicationTest } from 'ember-qunit';
+import { setupApplicationTest } from 'screwdriver-ui/tests/helpers';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import Pretender from 'pretender';
 import { getPageTitle } from 'ember-page-title/test-support';

--- a/tests/acceptance/pipeline-childPipelines-test.js
+++ b/tests/acceptance/pipeline-childPipelines-test.js
@@ -1,6 +1,6 @@
 import { currentURL, visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
-import { setupApplicationTest } from 'ember-qunit';
+import { setupApplicationTest } from 'screwdriver-ui/tests/helpers';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import Pretender from 'pretender';
 import { getPageTitle } from 'ember-page-title/test-support';

--- a/tests/acceptance/pipeline-options-test.js
+++ b/tests/acceptance/pipeline-options-test.js
@@ -1,6 +1,6 @@
 import { currentURL, visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
-import { setupApplicationTest } from 'ember-qunit';
+import { setupApplicationTest } from 'screwdriver-ui/tests/helpers';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import Pretender from 'pretender';
 let server;

--- a/tests/acceptance/pipeline-pr-chain-test.js
+++ b/tests/acceptance/pipeline-pr-chain-test.js
@@ -1,6 +1,6 @@
 import { visit, waitFor } from '@ember/test-helpers';
 import { module, test } from 'qunit';
-import { setupApplicationTest } from 'ember-qunit';
+import { setupApplicationTest } from 'screwdriver-ui/tests/helpers';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import Pretender from 'pretender';
 

--- a/tests/acceptance/pipeline-visualizer-test.js
+++ b/tests/acceptance/pipeline-visualizer-test.js
@@ -1,6 +1,6 @@
 import { visit, currentURL } from '@ember/test-helpers';
 import { module, test } from 'qunit';
-import { setupApplicationTest } from 'ember-qunit';
+import { setupApplicationTest } from 'screwdriver-ui/tests/helpers';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { getPageTitle } from 'ember-page-title/test-support';
 import Pretender from 'pretender';

--- a/tests/acceptance/search-test.js
+++ b/tests/acceptance/search-test.js
@@ -1,6 +1,6 @@
 import { click, currentURL, visit, waitUntil, find } from '@ember/test-helpers';
 import { module, test } from 'qunit';
-import { setupApplicationTest } from 'ember-qunit';
+import { setupApplicationTest } from 'screwdriver-ui/tests/helpers';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import Pretender from 'pretender';
 import { getPageTitle } from 'ember-page-title/test-support';

--- a/tests/acceptance/secrets-test.js
+++ b/tests/acceptance/secrets-test.js
@@ -1,6 +1,6 @@
 import { currentURL, visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
-import { setupApplicationTest } from 'ember-qunit';
+import { setupApplicationTest } from 'screwdriver-ui/tests/helpers';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import Pretender from 'pretender';
 import { getPageTitle } from 'ember-page-title/test-support';

--- a/tests/acceptance/templates-test.js
+++ b/tests/acceptance/templates-test.js
@@ -1,6 +1,6 @@
 import { visit, currentURL } from '@ember/test-helpers';
 import { module, test } from 'qunit';
-import { setupApplicationTest } from 'ember-qunit';
+import { setupApplicationTest } from 'screwdriver-ui/tests/helpers';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import Pretender from 'pretender';
 import { getPageTitle } from 'ember-page-title/test-support';

--- a/tests/acceptance/tokens-test.js
+++ b/tests/acceptance/tokens-test.js
@@ -1,6 +1,6 @@
 import { visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
-import { setupApplicationTest } from 'ember-qunit';
+import { setupApplicationTest } from 'screwdriver-ui/tests/helpers';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import Pretender from 'pretender';
 import { hasCollections } from 'screwdriver-ui/tests/mock/collections';

--- a/tests/acceptance/user-settings-test.js
+++ b/tests/acceptance/user-settings-test.js
@@ -1,6 +1,6 @@
 import { currentURL, visit, fillIn, click } from '@ember/test-helpers';
 import { module, test } from 'qunit';
-import { setupApplicationTest } from 'ember-qunit';
+import { setupApplicationTest } from 'screwdriver-ui/tests/helpers';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import Pretender from 'pretender';
 import { getPageTitle } from 'ember-page-title/test-support';

--- a/tests/integration/components/app-header/component-test.js
+++ b/tests/integration/components/app-header/component-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import injectScmServiceStub from '../../../helpers/inject-scm';

--- a/tests/integration/components/artifact-preview/component-test.js
+++ b/tests/integration/components/artifact-preview/component-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 

--- a/tests/integration/components/artifact-tree/component-test.js
+++ b/tests/integration/components/artifact-tree/component-test.js
@@ -1,7 +1,7 @@
 import { resolve } from 'rsvp';
 import Service from '@ember/service';
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render, click, waitFor } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 

--- a/tests/integration/components/bread-crumbs/component-test.js
+++ b/tests/integration/components/bread-crumbs/component-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 

--- a/tests/integration/components/build-banner/component-test.js
+++ b/tests/integration/components/build-banner/component-test.js
@@ -1,7 +1,7 @@
 import EmberObject from '@ember/object';
 import hbs from 'htmlbars-inline-precompile';
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render, settled, click } from '@ember/test-helpers';
 import { resolve, Promise as EmberPromise } from 'rsvp';
 import Service from '@ember/service';

--- a/tests/integration/components/build-log/component-test.js
+++ b/tests/integration/components/build-log/component-test.js
@@ -1,7 +1,7 @@
 import { resolve } from 'rsvp';
 import Service from '@ember/service';
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render, settled, find } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import moment from 'moment';

--- a/tests/integration/components/build-step-collection/component-test.js
+++ b/tests/integration/components/build-step-collection/component-test.js
@@ -1,7 +1,7 @@
 import { resolve } from 'rsvp';
 import Service from '@ember/service';
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 

--- a/tests/integration/components/build-step-item/component-test.js
+++ b/tests/integration/components/build-step-item/component-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 

--- a/tests/integration/components/chart-c3/component-test.js
+++ b/tests/integration/components/chart-c3/component-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 

--- a/tests/integration/components/collection-dropdown/component-test.js
+++ b/tests/integration/components/collection-dropdown/component-test.js
@@ -1,6 +1,6 @@
 import { resolve, reject } from 'rsvp';
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render, click, findAll } from '@ember/test-helpers';
 import EmberObject from '@ember/object';
 import hbs from 'htmlbars-inline-precompile';

--- a/tests/integration/components/collection-modal/component-test.js
+++ b/tests/integration/components/collection-modal/component-test.js
@@ -1,7 +1,7 @@
 import Service from '@ember/service';
 import { Promise as EmberPromise } from 'rsvp';
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render, click, fillIn } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import injectSessionStub from '../../../helpers/inject-session';

--- a/tests/integration/components/collection-table-row/component-test.js
+++ b/tests/integration/components/collection-table-row/component-test.js
@@ -1,7 +1,7 @@
 import EmberObject from '@ember/object';
 import { Promise as EmberPromise } from 'rsvp';
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { click, render, waitFor } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';

--- a/tests/integration/components/collection-view/component-test.js
+++ b/tests/integration/components/collection-view/component-test.js
@@ -1,7 +1,7 @@
 import { resolve, reject } from 'rsvp';
 import EmberObject, { computed } from '@ember/object';
 import { module, test, todo } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import {
   render,
   click,

--- a/tests/integration/components/collections-flyout/component-test.js
+++ b/tests/integration/components/collections-flyout/component-test.js
@@ -3,7 +3,7 @@ import Service from '@ember/service';
 import $ from 'jquery';
 import { Promise as EmberPromise } from 'rsvp';
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render, click, findAll, fillIn } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';

--- a/tests/integration/components/command-format/component-test.js
+++ b/tests/integration/components/command-format/component-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 

--- a/tests/integration/components/command-header/component-test.js
+++ b/tests/integration/components/command-header/component-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import Service from '@ember/service';

--- a/tests/integration/components/command-versions/component-test.js
+++ b/tests/integration/components/command-versions/component-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 

--- a/tests/integration/components/create-pipeline/component-test.js
+++ b/tests/integration/components/create-pipeline/component-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { click, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import Service from '@ember/service';

--- a/tests/integration/components/error-view/component-test.js
+++ b/tests/integration/components/error-view/component-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 

--- a/tests/integration/components/events-thumbnail/component-test.js
+++ b/tests/integration/components/events-thumbnail/component-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import $ from 'jquery';

--- a/tests/integration/components/home-hero/component-test.js
+++ b/tests/integration/components/home-hero/component-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 

--- a/tests/integration/components/info-message/component-test.js
+++ b/tests/integration/components/info-message/component-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 

--- a/tests/integration/components/job-toggle-modal/component-test.js
+++ b/tests/integration/components/job-toggle-modal/component-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import injectSessionStub from '../../../helpers/inject-session';

--- a/tests/integration/components/loading-view/component-test.js
+++ b/tests/integration/components/loading-view/component-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render, find } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 

--- a/tests/integration/components/login-button/component-test.js
+++ b/tests/integration/components/login-button/component-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render, click, findAll } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import injectScmServiceStub from '../../../helpers/inject-scm';

--- a/tests/integration/components/metrics/base-chart/component-test.js
+++ b/tests/integration/components/metrics/base-chart/component-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/tests/integration/components/metrics/chart/component-test.js
+++ b/tests/integration/components/metrics/chart/component-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { Promise as EmberPromise } from 'rsvp';

--- a/tests/integration/components/nav-banner/component-test.js
+++ b/tests/integration/components/nav-banner/component-test.js
@@ -2,7 +2,7 @@ import EmberObject from '@ember/object';
 import Service from '@ember/service';
 import { resolve } from 'rsvp';
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 

--- a/tests/integration/components/pipeline-card/component-test.js
+++ b/tests/integration/components/pipeline-card/component-test.js
@@ -1,6 +1,6 @@
 import EmberObject from '@ember/object';
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { click, render, waitFor } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { resolve } from 'rsvp';

--- a/tests/integration/components/pipeline-create-form/component-test.js
+++ b/tests/integration/components/pipeline-create-form/component-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render, click, fillIn, triggerKeyEvent } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import Service from '@ember/service';

--- a/tests/integration/components/pipeline-event-row/component-test.js
+++ b/tests/integration/components/pipeline-event-row/component-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';

--- a/tests/integration/components/pipeline-events-list/component-test.js
+++ b/tests/integration/components/pipeline-events-list/component-test.js
@@ -1,6 +1,6 @@
 import EmberObject from '@ember/object';
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { click, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import Service from '@ember/service';

--- a/tests/integration/components/pipeline-events/component-test.js
+++ b/tests/integration/components/pipeline-events/component-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import EmberObject from '@ember/object';
 import { render, waitUntil } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';

--- a/tests/integration/components/pipeline-graph-nav/component-test.js
+++ b/tests/integration/components/pipeline-graph-nav/component-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { set } from '@ember/object';

--- a/tests/integration/components/pipeline-header/component-test.js
+++ b/tests/integration/components/pipeline-header/component-test.js
@@ -1,6 +1,6 @@
 import EmberObject from '@ember/object';
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { click, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import Service from '@ember/service';

--- a/tests/integration/components/pipeline-list-actions-cell/component-test.js
+++ b/tests/integration/components/pipeline-list-actions-cell/component-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { set } from '@ember/object';

--- a/tests/integration/components/pipeline-list-coverage-cell/component-test.js
+++ b/tests/integration/components/pipeline-list-coverage-cell/component-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render, waitFor } from '@ember/test-helpers';
 import Pretender from 'pretender';
 import ENV from 'screwdriver-ui/config/environment';

--- a/tests/integration/components/pipeline-list-history-cell/component-test.js
+++ b/tests/integration/components/pipeline-list-history-cell/component-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render, triggerEvent } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';

--- a/tests/integration/components/pipeline-list-job-cell/component-test.js
+++ b/tests/integration/components/pipeline-list-job-cell/component-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';

--- a/tests/integration/components/pipeline-list-view/component-test.js
+++ b/tests/integration/components/pipeline-list-view/component-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render, settled } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { set } from '@ember/object';

--- a/tests/integration/components/pipeline-list/component-test.js
+++ b/tests/integration/components/pipeline-list/component-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render, find } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';

--- a/tests/integration/components/pipeline-nav/component-test.js
+++ b/tests/integration/components/pipeline-nav/component-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';

--- a/tests/integration/components/pipeline-options/component-test.js
+++ b/tests/integration/components/pipeline-options/component-test.js
@@ -8,7 +8,7 @@ import Pretender from 'pretender';
 import Service from '@ember/service';
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import injectSessionStub from '../../../helpers/inject-session';
 
 /* eslint new-cap: ["error", { "capIsNewExceptions": ["A"] }] */

--- a/tests/integration/components/pipeline-parameterized-build/component-test.js
+++ b/tests/integration/components/pipeline-parameterized-build/component-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { click, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 

--- a/tests/integration/components/pipeline-pr-list/component-test.js
+++ b/tests/integration/components/pipeline-pr-list/component-test.js
@@ -1,6 +1,6 @@
 import EmberObject from '@ember/object';
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import Pretender from 'pretender';

--- a/tests/integration/components/pipeline-pr-view/component-test.js
+++ b/tests/integration/components/pipeline-pr-view/component-test.js
@@ -1,6 +1,6 @@
 import EmberObject from '@ember/object';
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render, find } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 

--- a/tests/integration/components/pipeline-rootdir/component-test.js
+++ b/tests/integration/components/pipeline-rootdir/component-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 

--- a/tests/integration/components/pipeline-search-panel/component-test.js
+++ b/tests/integration/components/pipeline-search-panel/component-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render, findAll, click, fillIn } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';

--- a/tests/integration/components/pipeline-secret-settings/component-test.js
+++ b/tests/integration/components/pipeline-secret-settings/component-test.js
@@ -1,6 +1,6 @@
 import EmberObject from '@ember/object';
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import {
   render,
   find,

--- a/tests/integration/components/pipeline-start/component-test.js
+++ b/tests/integration/components/pipeline-start/component-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 

--- a/tests/integration/components/pipeline-viz-chart/component-test.js
+++ b/tests/integration/components/pipeline-viz-chart/component-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import {

--- a/tests/integration/components/pipeline-viz-nav/component-test.js
+++ b/tests/integration/components/pipeline-viz-nav/component-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import {

--- a/tests/integration/components/pipeline-viz-row/component-test.js
+++ b/tests/integration/components/pipeline-viz-row/component-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import {

--- a/tests/integration/components/pipeline-workflow/component-test.js
+++ b/tests/integration/components/pipeline-workflow/component-test.js
@@ -1,6 +1,6 @@
 import EmberObject from '@ember/object';
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import rsvp from 'rsvp';

--- a/tests/integration/components/quickstart-guide/component-test.js
+++ b/tests/integration/components/quickstart-guide/component-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 

--- a/tests/integration/components/required-field-marker/component-test.js
+++ b/tests/integration/components/required-field-marker/component-test.js
@@ -1,5 +1,5 @@
 import { render } from '@ember/test-helpers';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { module, test } from 'qunit';
 

--- a/tests/integration/components/search-list/component-test.js
+++ b/tests/integration/components/search-list/component-test.js
@@ -1,6 +1,6 @@
 import EmberObject from '@ember/object';
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 

--- a/tests/integration/components/secret-view/component-test.js
+++ b/tests/integration/components/secret-view/component-test.js
@@ -1,6 +1,6 @@
 import EmberObject from '@ember/object';
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render, click, fillIn, triggerKeyEvent } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 

--- a/tests/integration/components/tc-collection-linker/component-test.js
+++ b/tests/integration/components/tc-collection-linker/component-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 

--- a/tests/integration/components/tc-collection-list/component-test.js
+++ b/tests/integration/components/tc-collection-list/component-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { setBreakpoint } from 'ember-responsive/test-support';

--- a/tests/integration/components/template-header/component-test.js
+++ b/tests/integration/components/template-header/component-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import Service from '@ember/service';

--- a/tests/integration/components/template-versions/component-test.js
+++ b/tests/integration/components/template-versions/component-test.js
@@ -1,6 +1,6 @@
 import { resolve } from 'rsvp';
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { click, render, waitFor } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import Service from '@ember/service';

--- a/tests/integration/components/token-list/component-test.js
+++ b/tests/integration/components/token-list/component-test.js
@@ -1,6 +1,6 @@
 import EmberObject from '@ember/object';
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 

--- a/tests/integration/components/token-view/component-test.js
+++ b/tests/integration/components/token-view/component-test.js
@@ -1,7 +1,7 @@
 import { resolve } from 'rsvp';
 import EmberObject from '@ember/object';
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render, click, fillIn, triggerEvent } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 

--- a/tests/integration/components/user-link/component-test.js
+++ b/tests/integration/components/user-link/component-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render, find } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 

--- a/tests/integration/components/validator-input/component-test.js
+++ b/tests/integration/components/validator-input/component-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 

--- a/tests/integration/components/validator-job/component-test.js
+++ b/tests/integration/components/validator-job/component-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 

--- a/tests/integration/components/validator-pipeline/component-test.js
+++ b/tests/integration/components/validator-pipeline/component-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 

--- a/tests/integration/components/validator-results/component-test.js
+++ b/tests/integration/components/validator-results/component-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render, findAll } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 

--- a/tests/integration/components/workflow-graph-d3/component-test.js
+++ b/tests/integration/components/workflow-graph-d3/component-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 

--- a/tests/integration/components/workflow-tooltip/component-test.js
+++ b/tests/integration/components/workflow-tooltip/component-test.js
@@ -1,6 +1,6 @@
 import EmberObject from '@ember/object';
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 

--- a/tests/integration/helpers/branch-url-encode-test.js
+++ b/tests/integration/helpers/branch-url-encode-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 

--- a/tests/integration/helpers/get-length-test.js
+++ b/tests/integration/helpers/get-length-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 

--- a/tests/integration/helpers/get-step-data-test.js
+++ b/tests/integration/helpers/get-step-data-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 

--- a/tests/integration/helpers/is-number-test.js
+++ b/tests/integration/helpers/is-number-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 

--- a/tests/integration/helpers/starts-with-test.js
+++ b/tests/integration/helpers/starts-with-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 

--- a/tests/integration/helpers/truncate-test.js
+++ b/tests/integration/helpers/truncate-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 

--- a/tests/integration/helpers/x-duration-test.js
+++ b/tests/integration/helpers/x-duration-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 

--- a/tests/unit/404/route-test.js
+++ b/tests/unit/404/route-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 
 module('Unit | Route | 404', function (hooks) {
   setupTest(hooks);

--- a/tests/unit/adapters/adapter-test.js
+++ b/tests/unit/adapters/adapter-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 
 module('Unit | Adapter | build history', function (hooks) {
   setupTest(hooks);

--- a/tests/unit/application/adapter-test.js
+++ b/tests/unit/application/adapter-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 import Pretender from 'pretender';
 import DS from 'ember-data';
 let server;

--- a/tests/unit/application/controller-test.js
+++ b/tests/unit/application/controller-test.js
@@ -1,6 +1,6 @@
 import Service from '@ember/service';
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 import { run } from '@ember/runloop';
 
 module('Unit | Controller | application', function (hooks) {

--- a/tests/unit/application/route-test.js
+++ b/tests/unit/application/route-test.js
@@ -1,4 +1,4 @@
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 import { module, test } from 'qunit';
 import { later } from '@ember/runloop';
 import sinon from 'sinon';

--- a/tests/unit/banner/service-test.js
+++ b/tests/unit/banner/service-test.js
@@ -1,6 +1,6 @@
 import Pretender from 'pretender';
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 const actualMessage = 'shutdown imminent';
 
 let server;

--- a/tests/unit/build-artifact/service-test.js
+++ b/tests/unit/build-artifact/service-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 import Pretender from 'pretender';
 import Service from '@ember/service';
 let server;

--- a/tests/unit/build-history/model-test.js
+++ b/tests/unit/build-history/model-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 
 import { run } from '@ember/runloop';
 

--- a/tests/unit/build-history/serializer-test.js
+++ b/tests/unit/build-history/serializer-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 
 module('Unit | Serializer | build history', function (hooks) {
   setupTest(hooks);

--- a/tests/unit/build-logs/service-test.js
+++ b/tests/unit/build-logs/service-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 import Service from '@ember/service';
 import Pretender from 'pretender';
 

--- a/tests/unit/build/model-test.js
+++ b/tests/unit/build/model-test.js
@@ -1,6 +1,6 @@
 import { run } from '@ember/runloop';
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 
 module('Unit | Model | build', function (hooks) {
   setupTest(hooks);

--- a/tests/unit/build/serializer-test.js
+++ b/tests/unit/build/serializer-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 import Pretender from 'pretender';
 let server;
 

--- a/tests/unit/builds/route-test.js
+++ b/tests/unit/builds/route-test.js
@@ -2,7 +2,7 @@ import EmberObject from '@ember/object';
 import Service from '@ember/service';
 import { Promise as EmberPromise } from 'rsvp';
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 
 module('Unit | Route | builds', function (hooks) {
   setupTest(hooks);

--- a/tests/unit/cache/service-test.js
+++ b/tests/unit/cache/service-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 import Pretender from 'pretender';
 import Service from '@ember/service';
 

--- a/tests/unit/collection/model-test.js
+++ b/tests/unit/collection/model-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 
 import { run } from '@ember/runloop';
 

--- a/tests/unit/collection/serializer-test.js
+++ b/tests/unit/collection/serializer-test.js
@@ -1,6 +1,6 @@
 import { run } from '@ember/runloop';
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 import Pretender from 'pretender';
 let server;
 

--- a/tests/unit/command/service-test.js
+++ b/tests/unit/command/service-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 import Pretender from 'pretender';
 import Service from '@ember/service';
 

--- a/tests/unit/commands/controller-test.js
+++ b/tests/unit/commands/controller-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 import { run } from '@ember/runloop';
 
 module('Unit | Controller | Commands', function (hooks) {

--- a/tests/unit/commands/detail/controller-test.js
+++ b/tests/unit/commands/detail/controller-test.js
@@ -1,7 +1,7 @@
 import { resolve } from 'rsvp';
 import { A } from '@ember/array';
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 import sinon from 'sinon';
 import Service from '@ember/service';
 

--- a/tests/unit/commands/detail/router-test.js
+++ b/tests/unit/commands/detail/router-test.js
@@ -1,7 +1,7 @@
 import { resolve } from 'rsvp';
 import Service from '@ember/service';
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 import sinon from 'sinon';
 
 const commandServiceStub = Service.extend({

--- a/tests/unit/commands/detail/version/router-test.js
+++ b/tests/unit/commands/detail/version/router-test.js
@@ -1,6 +1,6 @@
 import Service from '@ember/service';
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 import sinon from 'sinon';
 
 module('Unit | Route | commands/detail/version', function (hooks) {

--- a/tests/unit/commands/index/router-test.js
+++ b/tests/unit/commands/index/router-test.js
@@ -1,7 +1,7 @@
 import { resolve } from 'rsvp';
 import Service from '@ember/service';
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 
 const commandServiceStub = Service.extend({
   getAllCommands() {

--- a/tests/unit/commands/router-test.js
+++ b/tests/unit/commands/router-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 
 module('Unit | Route | commands', function (hooks) {
   setupTest(hooks);

--- a/tests/unit/coverage/service-test.js
+++ b/tests/unit/coverage/service-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 import Pretender from 'pretender';
 import Service from '@ember/service';
 

--- a/tests/unit/create/controller-test.js
+++ b/tests/unit/create/controller-test.js
@@ -1,6 +1,6 @@
 import { reject } from 'rsvp';
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 import Service from '@ember/service';
 import sinon from 'sinon';
 

--- a/tests/unit/create/route-test.js
+++ b/tests/unit/create/route-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 
 module('Unit | Route | create', function (hooks) {
   setupTest(hooks);

--- a/tests/unit/dashboard/route-test.js
+++ b/tests/unit/dashboard/route-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 
 module('Unit | Route | dashboard', function (hooks) {
   setupTest(hooks);

--- a/tests/unit/dashboard/show/controller-test.js
+++ b/tests/unit/dashboard/show/controller-test.js
@@ -1,6 +1,6 @@
 import { resolve } from 'rsvp';
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 import Service from '@ember/service';
 import sinon from 'sinon';
 import EmberObject from '@ember/object';

--- a/tests/unit/dashboard/show/route-test.js
+++ b/tests/unit/dashboard/show/route-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 
 module('Unit | Route | dashboard/show', function (hooks) {
   setupTest(hooks);

--- a/tests/unit/event-stop/service-test.js
+++ b/tests/unit/event-stop/service-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 import Pretender from 'pretender';
 let server;
 

--- a/tests/unit/event/model-test.js
+++ b/tests/unit/event/model-test.js
@@ -1,6 +1,6 @@
 import { run } from '@ember/runloop';
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 import { settled } from '@ember/test-helpers';
 
 module('Unit | Model | event', function (hooks) {

--- a/tests/unit/home/route-test.js
+++ b/tests/unit/home/route-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 
 module('Unit | Route | home', function (hooks) {
   setupTest(hooks);

--- a/tests/unit/job/model-test.js
+++ b/tests/unit/job/model-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 
 import { run } from '@ember/runloop';
 

--- a/tests/unit/job/serializer-test.js
+++ b/tests/unit/job/serializer-test.js
@@ -1,6 +1,6 @@
 import { run } from '@ember/runloop';
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 import { settled } from '@ember/test-helpers';
 import Pretender from 'pretender';
 let server;

--- a/tests/unit/job/service-test.js
+++ b/tests/unit/job/service-test.js
@@ -1,6 +1,6 @@
 import EmberObject from '@ember/object';
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 import Service from '@ember/service';
 import sinon from 'sinon';
 

--- a/tests/unit/login/controller-test.js
+++ b/tests/unit/login/controller-test.js
@@ -1,6 +1,6 @@
 import Service from '@ember/service';
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 let authType = null;
 
 const sessionServiceMock = Service.extend({

--- a/tests/unit/login/route-test.js
+++ b/tests/unit/login/route-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 
 module('Unit | Route | login', function (hooks) {
   setupTest(hooks);

--- a/tests/unit/metric/model-test.js
+++ b/tests/unit/metric/model-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 
 import { run } from '@ember/runloop';
 

--- a/tests/unit/mixins/model-reloader-test.js
+++ b/tests/unit/mixins/model-reloader-test.js
@@ -4,7 +4,7 @@ import ModelReloaderMixin, {
   SHOULD_RELOAD_YES
 } from 'screwdriver-ui/mixins/model-reloader';
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 import DS from 'ember-data';
 
 let subject;

--- a/tests/unit/models/model-test.js
+++ b/tests/unit/models/model-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 
 module('Unit | Model | build history', function (hooks) {
   setupTest(hooks);

--- a/tests/unit/pipeline-startall/service-test.js
+++ b/tests/unit/pipeline-startall/service-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 import Pretender from 'pretender';
 let server;
 

--- a/tests/unit/pipeline-triggers/service-test.js
+++ b/tests/unit/pipeline-triggers/service-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 import Pretender from 'pretender';
 let server;
 

--- a/tests/unit/pipeline-visualizer/route-test.js
+++ b/tests/unit/pipeline-visualizer/route-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 
 module('Unit | Route | pipeline-visualizer', function (hooks) {
   setupTest(hooks);

--- a/tests/unit/pipeline/build/artifacts/detail/route-test.js
+++ b/tests/unit/pipeline/build/artifacts/detail/route-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 import sinon from 'sinon';
 
 module('Unit | Route | pipeline/build/artifacts/detail', function (hooks) {

--- a/tests/unit/pipeline/build/artifacts/index/route-test.js
+++ b/tests/unit/pipeline/build/artifacts/index/route-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 import sinon from 'sinon';
 
 module('Unit | Route | pipeline/build/artifacts/index', function (hooks) {

--- a/tests/unit/pipeline/build/artifacts/route-test.js
+++ b/tests/unit/pipeline/build/artifacts/route-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 import { run } from '@ember/runloop';
 import EmberObject from '@ember/object';
 

--- a/tests/unit/pipeline/build/controller-test.js
+++ b/tests/unit/pipeline/build/controller-test.js
@@ -2,7 +2,7 @@ import { resolve } from 'rsvp';
 import EmberObject from '@ember/object';
 import { run } from '@ember/runloop';
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 import { settled, waitUntil } from '@ember/test-helpers';
 import Pretender from 'pretender';
 import Service from '@ember/service';

--- a/tests/unit/pipeline/build/route-test.js
+++ b/tests/unit/pipeline/build/route-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 import sinon from 'sinon';
 import Service from '@ember/service';
 import { getActiveStep } from 'screwdriver-ui/utils/build';

--- a/tests/unit/pipeline/build/step/route-test.js
+++ b/tests/unit/pipeline/build/step/route-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 import EmberObject from '@ember/object';
 import Service from '@ember/service';
 

--- a/tests/unit/pipeline/controller-test.js
+++ b/tests/unit/pipeline/controller-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 import EmberObject from '@ember/object';
 
 module('Unit | Controller | pipeline', function (hooks) {

--- a/tests/unit/pipeline/events/controller-test.js
+++ b/tests/unit/pipeline/events/controller-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 import Pretender from 'pretender';
 import Service from '@ember/service';
 

--- a/tests/unit/pipeline/events/route-test.js
+++ b/tests/unit/pipeline/events/route-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 
 module('Unit | Route | pipeline/events', function (hooks) {
   setupTest(hooks);

--- a/tests/unit/pipeline/events/show/route-test.js
+++ b/tests/unit/pipeline/events/show/route-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 import { later } from '@ember/runloop';
 import sinon from 'sinon';
 import ENV from 'screwdriver-ui/config/environment';

--- a/tests/unit/pipeline/index/route-test.js
+++ b/tests/unit/pipeline/index/route-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 
 module('Unit | Route | pipeline/index', function (hooks) {
   setupTest(hooks);

--- a/tests/unit/pipeline/job-latest-build/artifacts/detail/route-test.js
+++ b/tests/unit/pipeline/job-latest-build/artifacts/detail/route-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 import sinon from 'sinon';
 import Service from '@ember/service';
 

--- a/tests/unit/pipeline/job-latest-build/artifacts/index/route-test.js
+++ b/tests/unit/pipeline/job-latest-build/artifacts/index/route-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 import Service from '@ember/service';
 
 module(

--- a/tests/unit/pipeline/job-latest-build/artifacts/route-test.js
+++ b/tests/unit/pipeline/job-latest-build/artifacts/route-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 
 module('Unit | Route | pipeline/job-latest-build/artifacts', function (hooks) {
   setupTest(hooks);

--- a/tests/unit/pipeline/job-latest-build/index/route-test.js
+++ b/tests/unit/pipeline/job-latest-build/index/route-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 import Service from '@ember/service';
 
 module('Unit | Route | pipeline/job-latest-build/index', function (hooks) {

--- a/tests/unit/pipeline/job-latest-build/route-test.js
+++ b/tests/unit/pipeline/job-latest-build/route-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 import Pretender from 'pretender';
 import Service from '@ember/service';
 import sinon from 'sinon';

--- a/tests/unit/pipeline/job-latest-build/steps/route-test.js
+++ b/tests/unit/pipeline/job-latest-build/steps/route-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 import Service from '@ember/service';
 import sinon from 'sinon';
 

--- a/tests/unit/pipeline/jobs/controller-test.js
+++ b/tests/unit/pipeline/jobs/controller-test.js
@@ -2,7 +2,7 @@ import EmberObject from '@ember/object';
 import { A as newArray } from '@ember/array';
 import { run } from '@ember/runloop';
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 import { settled, waitUntil } from '@ember/test-helpers';
 import Pretender from 'pretender';
 import Service from '@ember/service';

--- a/tests/unit/pipeline/metrics/controller-test.js
+++ b/tests/unit/pipeline/metrics/controller-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 import { settled } from '@ember/test-helpers';
 import { run } from '@ember/runloop';
 import sinon from 'sinon';

--- a/tests/unit/pipeline/metrics/route-test.js
+++ b/tests/unit/pipeline/metrics/route-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 
 module('Unit | Route | pipeline/metrics', function (hooks) {
   setupTest(hooks);

--- a/tests/unit/pipeline/model-test.js
+++ b/tests/unit/pipeline/model-test.js
@@ -1,6 +1,6 @@
 import { run } from '@ember/runloop';
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 
 module('Unit | Model | pipeline', function (hooks) {
   setupTest(hooks);

--- a/tests/unit/pipeline/options/controller-test.js
+++ b/tests/unit/pipeline/options/controller-test.js
@@ -1,6 +1,6 @@
 import { run } from '@ember/runloop';
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 import { waitUntil } from '@ember/test-helpers';
 import Pretender from 'pretender';
 import sinon from 'sinon';

--- a/tests/unit/pipeline/options/route-test.js
+++ b/tests/unit/pipeline/options/route-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 
 module('Unit | Route | pipeline/options', function (hooks) {
   setupTest(hooks);

--- a/tests/unit/pipeline/pulls/route-test.js
+++ b/tests/unit/pipeline/pulls/route-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 
 module('Unit | Route | pipeline/pulls', function (hooks) {
   setupTest(hooks);

--- a/tests/unit/pipeline/route-test.js
+++ b/tests/unit/pipeline/route-test.js
@@ -1,7 +1,7 @@
 import Service from '@ember/service';
 import { Promise as EmberPromise } from 'rsvp';
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 import { run } from '@ember/runloop';
 
 module('Unit | Route | pipeline', function (hooks) {

--- a/tests/unit/pipeline/secrets/controller-test.js
+++ b/tests/unit/pipeline/secrets/controller-test.js
@@ -1,6 +1,6 @@
 import { run } from '@ember/runloop';
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 import { settled, waitUntil } from '@ember/test-helpers';
 import Pretender from 'pretender';
 let server;

--- a/tests/unit/pipeline/secrets/route-test.js
+++ b/tests/unit/pipeline/secrets/route-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 
 module('Unit | Route | pipeline/secrets', function (hooks) {
   setupTest(hooks);

--- a/tests/unit/pipeline/serializer-test.js
+++ b/tests/unit/pipeline/serializer-test.js
@@ -1,6 +1,6 @@
 import { run } from '@ember/runloop';
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 import { settled } from '@ember/test-helpers';
 import Pretender from 'pretender';
 let server;

--- a/tests/unit/pipeline/service-test.js
+++ b/tests/unit/pipeline/service-test.js
@@ -1,7 +1,7 @@
 import { A } from '@ember/array';
 import EmberObject from '@ember/object';
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 import Service from '@ember/service';
 import { resolve } from 'rsvp';
 

--- a/tests/unit/pr-events/service-test.js
+++ b/tests/unit/pr-events/service-test.js
@@ -1,7 +1,7 @@
 import Pretender from 'pretender';
 import Service from '@ember/service';
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 
 let server;
 

--- a/tests/unit/preference/pipeline/serializer-test.js
+++ b/tests/unit/preference/pipeline/serializer-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 import Pretender from 'pretender';
 let server;
 

--- a/tests/unit/preference/user/serializer-test.js
+++ b/tests/unit/preference/user/serializer-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 import Pretender from 'pretender';
 let server;
 

--- a/tests/unit/search/controller-test.js
+++ b/tests/unit/search/controller-test.js
@@ -1,6 +1,6 @@
 import { resolve } from 'rsvp';
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 import EmberObject from '@ember/object';
 import injectSessionStub from '../../helpers/inject-session';
 

--- a/tests/unit/search/route-test.js
+++ b/tests/unit/search/route-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import Service from '@ember/service';
 import { Promise as EmberPromise } from 'rsvp';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 import { run } from '@ember/runloop';
 
 module('Unit | Route | search', function (hooks) {

--- a/tests/unit/secret/model-test.js
+++ b/tests/unit/secret/model-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 
 import { run } from '@ember/runloop';
 

--- a/tests/unit/secret/serializer-test.js
+++ b/tests/unit/secret/serializer-test.js
@@ -1,6 +1,6 @@
 import { run } from '@ember/runloop';
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 import { settled } from '@ember/test-helpers';
 import Pretender from 'pretender';
 let server;

--- a/tests/unit/serializers/serializer-test.js
+++ b/tests/unit/serializers/serializer-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 
 module('Unit | Serializer | build history', function (hooks) {
   setupTest(hooks);

--- a/tests/unit/shuttle/service-test.js
+++ b/tests/unit/shuttle/service-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import Pretender from 'pretender';
 import ENV from 'screwdriver-ui/config/environment';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 
 let server;
 

--- a/tests/unit/store/service-test.js
+++ b/tests/unit/store/service-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 
 module('Unit | Service | store', function (hooks) {
   setupTest(hooks);

--- a/tests/unit/sync/service-test.js
+++ b/tests/unit/sync/service-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 import Pretender from 'pretender';
 let server;
 

--- a/tests/unit/template/service-test.js
+++ b/tests/unit/template/service-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 import Pretender from 'pretender';
 import Service from '@ember/service';
 

--- a/tests/unit/templates/job/detail/controller-test.js
+++ b/tests/unit/templates/job/detail/controller-test.js
@@ -1,7 +1,7 @@
 import { resolve } from 'rsvp';
 import { A } from '@ember/array';
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 import sinon from 'sinon';
 import Service from '@ember/service';
 

--- a/tests/unit/templates/job/detail/route-test.js
+++ b/tests/unit/templates/job/detail/route-test.js
@@ -1,7 +1,7 @@
 import { resolve } from 'rsvp';
 import Service from '@ember/service';
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 import sinon from 'sinon';
 
 const templateServiceStub = Service.extend({

--- a/tests/unit/templates/job/detail/version/router-test.js
+++ b/tests/unit/templates/job/detail/version/router-test.js
@@ -1,6 +1,6 @@
 import Service from '@ember/service';
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 import sinon from 'sinon';
 
 module('Unit | Route | templates/job/detail/version', function (hooks) {

--- a/tests/unit/templates/job/index/route-test.js
+++ b/tests/unit/templates/job/index/route-test.js
@@ -1,7 +1,7 @@
 import { resolve } from 'rsvp';
 import Service from '@ember/service';
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 
 const templateServiceStub = Service.extend({
   getAllTemplates() {

--- a/tests/unit/templates/route-test.js
+++ b/tests/unit/templates/route-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 
 module('Unit | Route | templates', function (hooks) {
   setupTest(hooks);

--- a/tests/unit/token/model-test.js
+++ b/tests/unit/token/model-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 
 import { run } from '@ember/runloop';
 

--- a/tests/unit/token/serializer-test.js
+++ b/tests/unit/token/serializer-test.js
@@ -1,6 +1,6 @@
 import { run } from '@ember/runloop';
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 import { settled } from '@ember/test-helpers';
 import Pretender from 'pretender';
 let server;

--- a/tests/unit/user-settings/access-tokens/route-test.js
+++ b/tests/unit/user-settings/access-tokens/route-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 
 module('Unit | Route | user-settings/access-tokens', function (hooks) {
   setupTest(hooks);

--- a/tests/unit/user-settings/index/route-test.js
+++ b/tests/unit/user-settings/index/route-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 
 module('Unit | Route | user-settings/index', function (hooks) {
   setupTest(hooks);

--- a/tests/unit/user-settings/preferences/controller-test.js
+++ b/tests/unit/user-settings/preferences/controller-test.js
@@ -1,6 +1,6 @@
 import Service from '@ember/service';
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 import { settled } from '@ember/test-helpers';
 import { Promise as EmberPromise } from 'rsvp';
 import sinon from 'sinon';

--- a/tests/unit/user-settings/preferences/route-test.js
+++ b/tests/unit/user-settings/preferences/route-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 import Service from '@ember/service';
 
 const userSettingsMock = {

--- a/tests/unit/validator/controller-test.js
+++ b/tests/unit/validator/controller-test.js
@@ -2,7 +2,7 @@ import { run } from '@ember/runloop';
 import { resolve } from 'rsvp';
 import Service from '@ember/service';
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 import { settled } from '@ember/test-helpers';
 import sinon from 'sinon';
 

--- a/tests/unit/validator/route-test.js
+++ b/tests/unit/validator/route-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 
 module('Unit | Route | validator', function (hooks) {
   setupTest(hooks);

--- a/tests/unit/validator/service-test.js
+++ b/tests/unit/validator/service-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupTest } from 'ember-qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
 import Pretender from 'pretender';
 import Service from '@ember/service';
 


### PR DESCRIPTION
## Context
Lots of tests are using the base setup function provided by qunit.  We should use the helper setups generated by ember so that we can add in any additional shared setup steps.

## Objective
Use the helper setup functions so that we can add in additional shared setup steps for all tests.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
