### PR TITLE
fix: refactor app body to return class instead

### DIFF
--- a/app/components/app-body/component.js
+++ b/app/components/app-body/component.js
@@ -4,7 +4,11 @@ import { service } from '@ember/service';
 export default class AppBody extends Component {
   @service router;
 
-  get isPipelineRoute() {
-    return this.router.currentRouteName.startsWith('pipeline');
+  get class() {
+    if (this.router.currentRouteName.startsWith('pipeline')) {
+      return 'pipeline-page';
+    }
+
+    return 'container-fluid';
   }
 }

--- a/app/components/app-body/template.hbs
+++ b/app/components/app-body/template.hbs
@@ -1,5 +1,5 @@
 <NavBanner />
 
-<div id="appContainer" class='{{if this.isPipelineRoute 'pipeline-page' 'container-fluid'}}'>
+<div id="appContainer" class='{{this.class}}'>
   {{outlet}}
 </div>


### PR DESCRIPTION
## Context
The `AppBody` component should be more flexible in accepting various classes to be assigned onto it.

## Objective
Refactor the `AppBody` component to return a class value instead of a boolean.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
