### PR TITLE
fix: Display commit and branch when scrollbar is always displayed

### DIFF
--- a/app/components/pipeline-graph-nav/styles.scss
+++ b/app/components/pipeline-graph-nav/styles.scss
@@ -1,4 +1,4 @@
-$pipeline-graph-nav-height: 156px;
+$pipeline-graph-nav-height: 166px;
 
 & {
   padding: 15px 0 15px 10px;
@@ -112,7 +112,7 @@ $pipeline-graph-nav-height: 156px;
 
   .event-info-container {
     display: flex;
-    height: 4.5rem;
+    height: 6rem;
     margin: 15px 0;
     overflow: scroll;
 
@@ -131,6 +131,8 @@ $pipeline-graph-nav-height: 156px;
       }
 
       &.info-col-commit {
+        display: flex;
+        flex-direction: column;
         min-width: 7rem;
       }
 
@@ -141,7 +143,8 @@ $pipeline-graph-nav-height: 156px;
         min-width: 10rem;
 
         .commit-message {
-          overflow: scroll;
+          overflow-y: scroll;
+          word-break: break-all;
         }
       }
 
@@ -152,17 +155,31 @@ $pipeline-graph-nav-height: 156px;
 
         .branch-name {
           height: 100%;
-          overflow: scroll;
+          overflow-y: scroll;
           word-break: break-all;
         }
       }
 
       &.info-col-status {
+        display: flex;
+        flex-direction: column;
         min-width: 8.5rem;
       }
 
+      &.info-col-committer {
+        display: flex;
+        flex-direction: column;
+      }
+
       &.info-col-build-date {
+        display: flex;
+        flex-direction: column;
         min-width: 9rem;
+      }
+
+      &.info-col-build-duration {
+        display: flex;
+        flex-direction: column;
       }
 
       &.info-col-label {

--- a/app/components/pipeline-graph-nav/template.hbs
+++ b/app/components/pipeline-graph-nav/template.hbs
@@ -71,7 +71,6 @@
       <span class="title">
         Commit
       </span>
-      <br />
       <span>
         <a
           class={{if
@@ -88,7 +87,6 @@
       <span class="title">
         Message
       </span>
-      <br />
       <div class="commit-message" title={{this.selectedEventObj.commit.message}}>
         {{this.selectedEventObj.truncatedMessage}}
       </div>
@@ -97,7 +95,6 @@
       <span class="title">
         Branch
       </span>
-      <br />
       <span class="branch-name">
         {{this.selectedEventObj.baseBranch}}
       </span>
@@ -106,7 +103,6 @@
       <span class="title">
         Status
       </span>
-      <br />
       <span class="status">
         <FaIcon
           @icon={{this.icon.name}}
@@ -122,7 +118,6 @@
       <span class="title">
         Committer
       </span>
-      <br />
       <span>
         <a href={{this.selectedEventObj.commit.author.url}}>
           {{this.selectedEventObj.commit.author.name}}
@@ -133,7 +128,6 @@
       <span class="title">
         Start Date
       </span>
-      <br />
       <span>
         {{this.startDate.content}}
       </span>
@@ -142,7 +136,6 @@
       <span class="title">
         Duration
       </span>
-      <br />
       <span>
         {{this.selectedEventObj.durationText}}
       </span>

--- a/app/components/pipeline-header/styles.scss
+++ b/app/components/pipeline-header/styles.scss
@@ -80,6 +80,9 @@
       .branch-dropdown {
         padding-left: 10px;
         padding-right: 10px;
+        overflow: scroll;
+        max-width: 40rem;
+        max-height: calc(100vh - 120px);
 
         .branch-item {
           padding: 1px 0;

--- a/tests/integration/components/pipeline-graph-nav/component-test.js
+++ b/tests/integration/components/pipeline-graph-nav/component-test.js
@@ -72,7 +72,7 @@ module('Integration | Component | pipeline graph nav', function (hooks) {
       '.event-info-container .info-col .title'
     );
     const $columnValues = this.element.querySelectorAll(
-      '.event-info-container .info-col .title ~ :nth-child(3)'
+      '.event-info-container .info-col .title ~ :nth-child(2)'
     );
     const $links = this.element.querySelectorAll(
       '.event-info-container .info-col a'

--- a/tests/integration/components/pipeline-graph-nav/component-test.js
+++ b/tests/integration/components/pipeline-graph-nav/component-test.js
@@ -180,7 +180,7 @@ module('Integration | Component | pipeline graph nav', function (hooks) {
       '.event-info-container .info-col .title'
     );
     const $columnValues = this.element.querySelectorAll(
-      '.event-info-container .info-col .title ~ :nth-child(3)'
+      '.event-info-container .info-col .title ~ :nth-child(2)'
     );
 
     const compare = (elem, expected) => {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
On a Mac PC, if you set the scrollbars to always visible in the appearance settings, the commit message and branches are not visible by the scrollbars.
One of the causes is that the display position is lowered by `<br>`.

In addition, the list window of other pipelines in the same repository, which is displayed from the branch button, has no scrolling set up.
Therefore, it occupies the edge of the screen when there is a pipeline with a long branch name or a large number of pipelines in the same repository, and continues further off the screen.

## Objective
Therefore, fix it so that they are visible and correct.

Before

<img src=https://github.com/screwdriver-cd/ui/assets/138551445/96ece20a-4fba-4635-92d2-262b287f66ec width="50%" /><img src=https://github.com/screwdriver-cd/ui/assets/138551445/22043f14-b72b-4596-a3af-aa526d2d404f width="50%" />

After
<img src=https://github.com/screwdriver-cd/ui/assets/138551445/23baf03e-cdfd-4e9a-b7a1-bbc08fa9ff51 width="50%" /><img src=https://github.com/screwdriver-cd/ui/assets/138551445/07568bd8-cf82-4e0e-a97e-bbac4cb1cba8 width="50%" />

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
