### PR TITLE
fix: fix scrollbar in pipeline screen

### DIFF
--- a/app/components/pipeline-graph-nav/styles.scss
+++ b/app/components/pipeline-graph-nav/styles.scss
@@ -114,7 +114,7 @@ $pipeline-graph-nav-height: 166px;
     display: flex;
     height: 6rem;
     margin: 15px 0;
-    overflow: scroll;
+    overflow: auto;
 
     .info-col {
       max-height: 4rem;
@@ -143,7 +143,7 @@ $pipeline-graph-nav-height: 166px;
         min-width: 10rem;
 
         .commit-message {
-          overflow-y: scroll;
+          overflow: auto;
           word-break: break-all;
         }
       }
@@ -155,7 +155,7 @@ $pipeline-graph-nav-height: 166px;
 
         .branch-name {
           height: 100%;
-          overflow-y: scroll;
+          overflow: auto;
           word-break: break-all;
         }
       }
@@ -189,7 +189,7 @@ $pipeline-graph-nav-height: 166px;
 
         .customize-label {
           height: 100%;
-          overflow: scroll;
+          overflow: auto;
           word-break: break-all;
         }
       }

--- a/app/components/pipeline-header/styles.scss
+++ b/app/components/pipeline-header/styles.scss
@@ -63,7 +63,7 @@
 
         .branch {
           padding-left: 0.25rem;
-          overflow-x: scroll;
+          overflow: auto;
         }
 
         .dropdown-toggle {
@@ -80,7 +80,7 @@
       .branch-dropdown {
         padding-left: 10px;
         padding-right: 10px;
-        overflow: scroll;
+        overflow: auto;
         max-width: 40rem;
         max-height: calc(100vh - 120px);
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Additional fix from #1056 
Scrollbar is always displayed even if the size does not cause scrolling, regardless of the Mac settings.
Especially for short Branch names, commit messages, etc.

(In the Mac settings, you can switch between always displaying the scroller only when the size requires scrolling, and only displaying the scroller when scrolling.)

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Do not show scrollbars if you do not need scrolling apart from the Mac settings.

Mainly fixed the following
- Pipeline Transition Button
- Overall graph-nav

Before
<img src=https://github.com/screwdriver-cd/ui/assets/138551445/1140c6d3-bc27-4fe2-b46a-0077f4988962 width="50%" /><img src=https://github.com/screwdriver-cd/ui/assets/138551445/56dad552-d3d1-4119-b0b6-877fe01b916b width="50%" />


After
<img src=https://github.com/screwdriver-cd/ui/assets/138551445/a0c2151b-0c03-4b9e-8f0b-146b6a0cd94b width="50%" /><img src=https://github.com/screwdriver-cd/ui/assets/138551445/5ea9dcc4-a117-48d0-ad55-f41c73a4d5d5 width="50%" />

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
