### PR TITLE
fix(3123): Show username on event-row

### DIFF
--- a/app/components/pipeline-event-row/template.hbs
+++ b/app/components/pipeline-event-row/template.hbs
@@ -80,7 +80,7 @@
             </LinkTo>
           {{/if}}
         {{else}}
-          <a href={{this.event.creator.url}}>
+          <a href={{this.event.creator.url}} title={{this.event.creator.username}}>
             {{this.event.creator.name}}
           </a>
         {{/if}}
@@ -96,7 +96,7 @@
           <span>
             Started and committed by:
           </span>
-          <a href={{this.event.creator.url}}>
+          <a href={{this.event.creator.url}} title={{this.event.creator.username}}>
             {{this.event.creator.name}}
           </a>
         {{/if}}

--- a/tests/integration/components/pipeline-event-row/component-test.js
+++ b/tests/integration/components/pipeline-event-row/component-test.js
@@ -221,7 +221,7 @@ module('Integration | Component | pipeline event row', function (hooks) {
     assert.dom('svg').exists({ count: 2 });
     assert.dom('.graph-node').exists({ count: 4 });
     assert.dom('.graph-edge').exists({ count: 3 });
-    assert.dom('.by').hasText('Started and committed by: ');
+    assert.dom('.by').hasText('Started and committed by: batman');
     assert
       .dom('.date')
       .hasText(

--- a/tests/integration/components/pipeline-event-row/component-test.js
+++ b/tests/integration/components/pipeline-event-row/component-test.js
@@ -26,7 +26,8 @@ const event = {
   },
   creator: {
     url: '#',
-    name: 'batman'
+    name: 'batman',
+    username: 'FooBar'
   },
   createTime: '06/30/2021, 04:39 PM',
   createTimeWords: 'now',
@@ -77,7 +78,8 @@ const eventWithLabel = {
   },
   creator: {
     url: '#',
-    name: 'batman'
+    name: 'batman',
+    username: 'FooBar'
   },
   createTime: '06/30/2021, 04:39 PM',
   createTimeWords: 'now',
@@ -128,7 +130,8 @@ const eventWithLinksInLabel = {
   },
   creator: {
     url: '#',
-    name: 'batman'
+    name: 'batman',
+    username: 'FooBar'
   },
   createTime: '06/30/2021, 04:39 PM',
   createTimeWords: 'now',
@@ -218,7 +221,7 @@ module('Integration | Component | pipeline event row', function (hooks) {
     assert.dom('svg').exists({ count: 2 });
     assert.dom('.graph-node').exists({ count: 4 });
     assert.dom('.graph-edge').exists({ count: 3 });
-    assert.dom('.by').hasText('Started and committed by: batman');
+    assert.dom('.by').hasText('Started and committed by: ');
     assert
       .dom('.date')
       .hasText(


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Show username who creates event on hover.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Add title element to creator who creates event.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

screwdriver-cd/screwdriver#3123

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
