### PR TITLE
fix(3114): Add cache and subscribe config into validator

### DIFF
--- a/app/components/validator-pipeline/template.hbs
+++ b/app/components/validator-pipeline/template.hbs
@@ -101,6 +101,93 @@
   </span>
 </div>
 
+{{!-- should follow this pattern from data-schema: --}}
+{{!-- https://github.com/screwdriver-cd/data-schema/blob/af17ddbdd63bc0c18d8867f39b23c07660b598d7/config/base.js#L14-L18 --}}
+<div
+  class="cache"
+  title="These are the pipeline-level cache that the user has defined."
+>
+  <span class="label">
+    Cache:
+  </span>
+  <span class="value">
+    <ul>
+      {{#each-in this.cache as |name value|}}
+        {{#if value.length}}
+          <li>
+            <span class="name">
+              {{name}}:
+            </span>
+            {{#if (is-array value)}}
+            <span class="value">
+              [{{value}}]
+            </span>
+            {{else}}
+            <span class="value">
+              {{value}}
+            </span>
+            {{/if}}
+          </li>
+        {{/if}}
+      {{else}}
+        <li>
+          None defined
+        </li>
+      {{/each-in}}
+    </ul>
+  </span>
+</div>
+
+{{!-- should follow this pattern from data-schema: --}}
+{{!-- https://github.com/screwdriver-cd/data-schema/blob/af17ddbdd63bc0c18d8867f39b23c07660b598d7/config/base.js#L60-L64 --}}
+<div
+  class="subscribe"
+  title="These are the pipeline-level subscribe config that the user has defined."
+>
+  <span class="label">
+    Subscribe:
+  </span>
+  <span class="value">
+    <ul>
+      {{#each-in this.subscribe as |name value|}}
+        <li>
+          <span class="name">
+            {{name}}:
+          </span>
+          {{#if (is-array value)}}
+          <ul>
+            {{#each value as |url|}}
+              {{#each-in url as |name value|}}
+              <li>
+                <span class="name">
+                  {{name}}:
+                </span>
+                <span class="value">
+                  {{#if (is-array value)}}
+                    [{{value}}]
+                  {{else}}
+                    {{value}}
+                  {{/if}}
+                </span>
+              </li>
+              {{/each-in}}
+            {{/each}}
+          </ul>
+          {{else}}
+          <span class="value">
+            {{value}}
+          </span>
+          {{/if}}
+        </li>
+      {{else}}
+        <li>
+          None defined
+        </li>
+      {{/each-in}}
+    </ul>
+  </span>
+</div>
+
 <div class="workflow">
   <span class="label" title="This is the order that the jobs will run in.">
     Workflow:

--- a/app/components/validator-results/component.js
+++ b/app/components/validator-results/component.js
@@ -68,6 +68,13 @@ export default Component.extend({
         : get(this, 'results.parameters');
     }
   }),
+  cache: computed('results.cache', {
+    get() {
+      return get(this, 'results.cache') === undefined
+        ? {}
+        : get(this, 'results.cache');
+    }
+  }),
   warnMessages: map('results.warnMessages', w =>
     typeof w === 'string' ? w : w.message
   ),

--- a/app/components/validator-results/component.js
+++ b/app/components/validator-results/component.js
@@ -75,6 +75,13 @@ export default Component.extend({
         : get(this, 'results.cache');
     }
   }),
+  subscribe: computed('results.subscribe', {
+    get() {
+      return get(this, 'results.subscribe') === undefined
+        ? {}
+        : get(this, 'results.subscribe');
+    }
+  }),
   warnMessages: map('results.warnMessages', w =>
     typeof w === 'string' ? w : w.message
   ),

--- a/app/components/validator-results/template.hbs
+++ b/app/components/validator-results/template.hbs
@@ -14,6 +14,8 @@
     @template={{this.results.template}}
     @annotations={{this.results.template.config.shared.annotations}}
     @parameters={{this.results.template.config.parameters}}
+    @cache={{this.results.template.config.cache}}
+    @subscribe={{this.results.template.config.subscribe}}
     @isOpen={{unbound this.isOpen}}
   />
   {{#each this.pipelineTemplateJobKeys as | node index|}}
@@ -40,6 +42,8 @@
     @workflowGraph={{this.workflowGraph}}
     @annotations={{this.annotations}}
     @parameters={{this.parameters}}
+    @cache={{this.cache}}
+    @subscribe={{this.subscribe}}
     @isOpen={{unbound this.isOpen}}
   />
   {{#each this.jobs as |job|}}

--- a/app/helpers/is-array.js
+++ b/app/helpers/is-array.js
@@ -1,0 +1,14 @@
+import { helper } from '@ember/component/helper';
+
+/**
+ * return whether inupt is an array or not
+ * @param  {Any}
+ * @return {Boolean}
+ */
+export function isarray(params) {
+  const [value] = params;
+
+  return Array.isArray(value);
+}
+
+export default helper(isarray);

--- a/app/shuttle/service.js
+++ b/app/shuttle/service.js
@@ -3,10 +3,6 @@ import Service, { inject as service } from '@ember/service';
 import $ from 'jquery';
 import ENV from 'screwdriver-ui/config/environment';
 
-function delay(ms) {
-  return new Promise(resolve => setTimeout(resolve, ms));
-}
-
 /**
  * Screwdriver Shuttle Service
  * Only certain methods are allowed: get, request, post, put, patch, del, raw

--- a/tests/integration/components/validator-results/component-test.js
+++ b/tests/integration/components/validator-results/component-test.js
@@ -466,6 +466,12 @@ module('Integration | Component | validator results', function (hooks) {
           cache: {
             pipeline: ['node_modules']
           },
+          parameters: {
+            nameA: 'value1'
+          },
+          subscribe: {
+            scmUrls: [{ 'https://github.com/test/hello-world.git': ['~pr'] }]
+          },
           shared: {
             image: 'int-test:1'
           },
@@ -487,8 +493,9 @@ module('Integration | Component | validator results', function (hooks) {
 
     assert.dom('.error').doesNotExist();
     assert.dom('h4').hasText('batman/batmobile@1.0.0');
-    assert.dom('div').hasClass('cache');
-    assert.dom('span').hasText('node_modules');
+    assert.dom('.cache').exists({ count: 1 });
+    assert.dom('.parameters').exists({ count: 1 });
+    assert.dom('.subscribe').exists({ count: 1 });
   });
 
   test('it renders joi error results', async function (assert) {

--- a/tests/integration/components/validator-results/component-test.js
+++ b/tests/integration/components/validator-results/component-test.js
@@ -494,7 +494,6 @@ module('Integration | Component | validator results', function (hooks) {
     assert.dom('.error').doesNotExist();
     assert.dom('h4').hasText('batman/batmobile@1.0.0');
     assert.dom('.cache').exists({ count: 1 });
-    assert.dom('.parameters').exists({ count: 1 });
     assert.dom('.subscribe').exists({ count: 1 });
   });
 

--- a/tests/integration/components/validator-results/component-test.js
+++ b/tests/integration/components/validator-results/component-test.js
@@ -487,6 +487,7 @@ module('Integration | Component | validator results', function (hooks) {
 
     assert.dom('.error').doesNotExist();
     assert.dom('h4').hasText('batman/batmobile@1.0.0');
+    assert.dom('div').hasClass('cache');
     assert.dom('span').hasText('node_modules');
   });
 
@@ -508,7 +509,7 @@ module('Integration | Component | validator results', function (hooks) {
     );
 
     assert.dom('.error').hasText('there is an error');
-    assert.dom('span').hasText('batman/batmobile@1.0.0');
+    assert.dom('h4').hasText('batman/batmobile@1.0.0');
   });
 
   test('it renders warnMessages results', async function (assert) {

--- a/tests/integration/components/validator-results/component-test.js
+++ b/tests/integration/components/validator-results/component-test.js
@@ -463,6 +463,9 @@ module('Integration | Component | validator results', function (hooks) {
         name: 'batmobile',
         version: '1.0.0',
         config: {
+          cache: {
+            pipeline: ['node_modules']
+          },
           shared: {
             image: 'int-test:1'
           },
@@ -484,6 +487,7 @@ module('Integration | Component | validator results', function (hooks) {
 
     assert.dom('.error').doesNotExist();
     assert.dom('h4').hasText('batman/batmobile@1.0.0');
+    assert.dom('span').hasText('node_modules');
   });
 
   test('it renders joi error results', async function (assert) {
@@ -504,7 +508,7 @@ module('Integration | Component | validator results', function (hooks) {
     );
 
     assert.dom('.error').hasText('there is an error');
-    assert.dom('h4').hasText('batman/batmobile@1.0.0');
+    assert.dom('span').hasText('batman/batmobile@1.0.0');
   });
 
   test('it renders warnMessages results', async function (assert) {

--- a/tests/integration/helpers/is-array-test.js
+++ b/tests/integration/helpers/is-array-test.js
@@ -1,0 +1,17 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Helper | is-array', function (hooks) {
+  setupRenderingTest(hooks);
+
+  // TODO: Replace this with your real tests.
+  test('it renders', async function (assert) {
+    this.set('inputValue', '1234');
+
+    await render(hbs`{{is-array this.inputValue}}`);
+
+    assert.dom(this.element).hasText('1234');
+  });
+});

--- a/tests/integration/helpers/is-array-test.js
+++ b/tests/integration/helpers/is-array-test.js
@@ -6,12 +6,19 @@ import { hbs } from 'ember-cli-htmlbars';
 module('Integration | Helper | is-array', function (hooks) {
   setupRenderingTest(hooks);
 
-  // TODO: Replace this with your real tests.
-  test('it renders', async function (assert) {
-    this.set('inputValue', '1234');
+  test('it is array', async function (assert) {
+    this.set('inputValue', [1, 2, 3, 4]);
 
     await render(hbs`{{is-array this.inputValue}}`);
 
-    assert.dom(this.element).hasText('1234');
+    assert.dom(this.element).hasText('true');
+  });
+
+  test('it is not array', async function (assert) {
+    this.set('inputValue', 'hello world');
+
+    await render(hbs`{{is-array this.inputValue}}`);
+
+    assert.dom(this.element).hasText('false');
   });
 });


### PR DESCRIPTION
## Context

Cache and subscribe configs are missing from validator.

## Objective

This PR is to add those configs into validator. 

## References

https://github.com/screwdriver-cd/screwdriver/issues/3114

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
