### PR TITLE
fix: job list view does not appear in Safari browser

### DIFF
--- a/app/components/pipeline-list-view/styles.scss
+++ b/app/components/pipeline-list-view/styles.scss
@@ -38,26 +38,23 @@
     height: 60vh;
   }
 
-  .models-table-wrapper thead {
-    position: sticky;
+  .models-table-wrapper thead th {
     top: 0;
+    position: sticky;
+    border-bottom: 0px;
 
-    &:after{
-      content: "";
+    &:before {
+      content: '';
       position: absolute;
       top: -1px;
-      left: -1px;
+      left: 0px;
       width: 100%;
       height: 100%;
-      border: 1px solid white;
-      border-bottom: 2px solid $sd-light-gray;;
+      border-top: 1px solid white;
+      border-bottom: 2px solid $sd-light-gray;
       background-color: white;
       z-index: -1;
     }
-  }
-
-  .models-table-wrapper thead th {
-    border-bottom: 0px;
   }
 
   .models-table-wrapper thead .table-header {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Job list view does not appear in Safari.

![safari](https://github.com/screwdriver-cd/ui/assets/43719835/17c96038-fe10-4688-b2f2-5b8f45c53447)

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Fix the CSS to ensure users can see the job list view on Safari.

![tobe](https://github.com/screwdriver-cd/ui/assets/43719835/3dcaea45-be1b-4b9d-bcc0-386802f3acbf)

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
