### PR TITLE
feat: new power select component for parameters

### DIFF
--- a/app/components/pipeline/parameters/selectable/component.js
+++ b/app/components/pipeline/parameters/selectable/component.js
@@ -1,0 +1,41 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+export default class PipelineParametersSelectableComponent extends Component {
+  @tracked value;
+
+  inputValue;
+
+  constructor() {
+    super(...arguments);
+
+    this.value = this.args.parameter.value;
+  }
+
+  @action
+  selectOption(value) {
+    this.value = value;
+    this.args.onSelectValue(this.args.parameter, value);
+  }
+
+  @action
+  handleInput(value) {
+    this.inputValue = value;
+  }
+
+  @action
+  handleKeydown(_dropdown, e) {
+    switch (e.keyCode) {
+      case 13:
+        this.selectOption(this.inputValue);
+        break;
+      case 27:
+        // Escape key pressed - prevent further propagation of event
+        e.stopImmediatePropagation();
+        break;
+      default:
+        break;
+    }
+  }
+}

--- a/app/components/pipeline/parameters/selectable/template.hbs
+++ b/app/components/pipeline/parameters/selectable/template.hbs
@@ -1,0 +1,16 @@
+<PowerSelect
+  class="parameter-selector"
+  @options={{@parameter.defaultValues}}
+  @renderInPlace={{true}}
+  @searchEnabled={{true}}
+  @selected={{this.value}}
+  @searchPlaceholder="Type to filter"
+  @noMatchesMessage="Press enter to override"
+  @onOpen={{fn @onOpen}}
+  @onChange={{this.selectOption}}
+  @onInput={{this.handleInput}}
+  @onKeydown={{this.handleKeydown}}
+  as |selectedValue|
+>
+  {{selectedValue}}
+</PowerSelect>

--- a/tests/integration/components/pipeline/parameters/selectable/component-test.js
+++ b/tests/integration/components/pipeline/parameters/selectable/component-test.js
@@ -1,0 +1,114 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
+import { click, render, triggerKeyEvent } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { selectChoose, selectSearch } from 'ember-power-select/test-support';
+import sinon from 'sinon';
+
+module(
+  'Integration | Component | pipeline/parameters/selectable',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test('it renders', async function (assert) {
+      this.setProperties({
+        parameter: {
+          defaultValues: ['foo', 'bar'],
+          value: 'foo'
+        },
+        onOpen: () => {},
+        onSelectValue: () => {}
+      });
+
+      await render(
+        hbs`<Pipeline::Parameters::Selectable
+            @parameter={{this.parameter}}
+            @onOpen={{this.onOpen}}
+            @onSelectValue={{this.onSelectValue}}
+        />`
+      );
+
+      assert.dom(this.element).hasText('foo');
+    });
+
+    test('it calls onOpen callback', async function (assert) {
+      const onOpen = sinon.spy();
+
+      this.setProperties({
+        parameter: {
+          defaultValues: ['foo', 'bar'],
+          value: 'foo'
+        },
+        onOpen,
+        onSelectValue: () => {}
+      });
+
+      await render(
+        hbs`<Pipeline::Parameters::Selectable
+            @parameter={{this.parameter}}
+            @onOpen={{this.onOpen}}
+            @onSelectValue={{this.onSelectValue}}
+        />`
+      );
+      await click('.ember-power-select-trigger');
+
+      assert.equal(onOpen.callCount, 1);
+    });
+
+    test('it calls onSelectValue callback when selection is made', async function (assert) {
+      const parameter = {
+        defaultValues: ['foo', 'bar'],
+        value: 'foo'
+      };
+      const onSelectValue = sinon.spy();
+
+      this.setProperties({
+        parameter,
+        onOpen: () => {},
+        onSelectValue
+      });
+
+      await render(
+        hbs`<Pipeline::Parameters::Selectable
+            @parameter={{this.parameter}}
+            @onOpen={{this.onOpen}}
+            @onSelectValue={{this.onSelectValue}}
+        />`
+      );
+
+      await selectChoose('.parameter-selector', parameter.defaultValues[1]);
+
+      assert.equal(onSelectValue.callCount, 1);
+      assert.equal(
+        onSelectValue.calledWith(parameter, parameter.defaultValues[1]),
+        true
+      );
+    });
+
+    test('it overrides default values when enter key is pressed', async function (assert) {
+      const parameter = { defaultValues: ['foo', 'bar'], value: 'foo' };
+      const newValue = 'abc123';
+      const onSelectValue = sinon.spy();
+
+      this.setProperties({
+        parameter,
+        onOpen: () => {},
+        onSelectValue
+      });
+
+      await render(
+        hbs`<Pipeline::Parameters::Selectable
+            @parameter={{this.parameter}}
+            @onOpen={{this.onOpen}}
+            @onSelectValue={{this.onSelectValue}}
+        />`
+      );
+
+      await selectSearch('.parameter-selector', newValue);
+      await triggerKeyEvent('input', 'keydown', 13);
+
+      await assert.equal(onSelectValue.callCount, 1);
+      assert.equal(onSelectValue.calledWith(parameter, newValue), true);
+    });
+  }
+);


### PR DESCRIPTION
## Context
Parameters that are an array of values use the Ember Power Select component for rendering.  The parameter can be manually overridden to a value not specified in the supplied array.  This new component is a light wrapper around the Ember Power Select component and provides hooks so that actions and values can be passed up to a parent component.

## Objective
Create a glimmer component for array parameters.  This component allows us to build out a full set of job/pipeline parameters in a more composable fashion while making the handlebars template more legible.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
