### PR TITLE
fix: template name on the usage page

### DIFF
--- a/app/templates/job/template-usage/template.hbs
+++ b/app/templates/job/template-usage/template.hbs
@@ -1,7 +1,7 @@
 <br>
 {{#if (await this.hasUsers)}}
 
-<h1>Pipelines using {{await this.templateName}}/{{await this.templateNamespace}}@{{await this.templateVersion}}</h1>
+<h1>Pipelines using {{await this.templateNamespace}}/{{await this.templateName}}@{{await this.templateVersion}}</h1>
 
 <TemplateVersionPipelineUsage
   @templateName={{this.templateName}}


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Template name on the usage page is wrong.

https://cd.screwdriver.cd/templates/job/sd/dind/2.0.23/usage

![template](https://github.com/screwdriver-cd/ui/assets/43719835/bf913b4e-4d4d-42cc-bc72-cd9a0b11b29d)

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Fix template name to `<namespace>/<name>` from `<name>/<namespace>`

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
