### PR TITLE
fix: Default parameter icon

### DIFF
--- a/app/components/pipeline/parameters/styles.scss
+++ b/app/components/pipeline/parameters/styles.scss
@@ -43,6 +43,10 @@
                 margin-top: auto;
                 margin-bottom: auto;
                 padding-left: 0.25rem;
+
+                &.fa-exclamation-triangle {
+                  color: colors.$sd-warning;
+                }
               }
             }
 

--- a/app/components/pipeline/parameters/template.hbs
+++ b/app/components/pipeline/parameters/template.hbs
@@ -17,6 +17,13 @@
                 {{#if parameter.description}}
                   <FaIcon @icon="question-circle" @title={{parameter.description}}></FaIcon>
                 {{/if}}
+                {{#if (and
+                        (not (is-array parameter.defaultValues))
+                        (not (eq parameter.value parameter.defaultValues))
+                      )
+                }}
+                  <FaIcon @icon="exclamation-triangle" @title="Default value: {{parameter.defaultValues}}"></FaIcon>
+                {{/if}}
               </label>
               {{#if (is-array parameter.defaultValues)}}
                 <div class="dropdown-selection-container">

--- a/app/components/pipeline/styles.scss
+++ b/app/components/pipeline/styles.scss
@@ -1,7 +1,9 @@
 @use 'nav/styles' as nav;
 @use 'modal/toggle-job/styles' as toggle-job;
+@use 'parameters/styles' as parameters;
 
 @mixin styles {
   @include nav.styles;
   @include toggle-job.styles;
+  @include parameters.styles;
 }

--- a/tests/integration/components/pipeline/parameters/component-test.js
+++ b/tests/integration/components/pipeline/parameters/component-test.js
@@ -46,7 +46,7 @@ module('Integration | Component | pipeline/parameters', function (hooks) {
         meta: {
           parameters: {
             bar: { value: 'barzy' },
-            foo: { value: 'foozy' },
+            foo: { value: 'foo' },
             job1: { p1: { value: 'abc' }, p2: { value: 'xyz' } }
           }
         }
@@ -54,7 +54,7 @@ module('Integration | Component | pipeline/parameters', function (hooks) {
       pipeline: {
         parameters: {
           bar: ['barbar', 'bazbaz'],
-          foo: { value: 'foofoo', description: 'awesome' }
+          foo: { value: 'foo', description: 'awesome' }
         }
       },
       jobs: [
@@ -90,7 +90,7 @@ module('Integration | Component | pipeline/parameters', function (hooks) {
       .hasText('barzy');
     assert.dom(parameters[1].querySelector('label')).hasText('foo awesome');
     assert.dom(parameters[1].querySelector('label svg')).exists({ count: 1 });
-    assert.dom(parameters[1].querySelector('input')).hasValue('foozy');
+    assert.dom(parameters[1].querySelector('input')).hasValue('foo');
   });
 
   test('it renders parameters job group expanded', async function (assert) {
@@ -277,5 +277,53 @@ module('Integration | Component | pipeline/parameters', function (hooks) {
         foo: { value: 'bar' }
       })
     );
+  });
+
+  test('it adds icon when input is not equal to default value', async function (assert) {
+    this.setProperties({
+      event: {
+        meta: {
+          parameters: {
+            foo: { value: 'foobar' }
+          }
+        }
+      },
+      pipeline: {
+        parameters: {
+          foo: { value: 'foobar' }
+        }
+      },
+      jobs: [],
+      onUpdateParameters: () => {}
+    });
+
+    await render(
+      hbs`<Pipeline::Parameters
+        @action="start"
+        @event={{this.event}}
+        @pipeline={{this.pipeline}}
+        @jobs={{this.jobs}}
+        @onUpdateParameters={{this.onUpdateParameters}}
+      />`
+    );
+
+    assert
+      .dom(
+        '.parameter-list.expanded .parameter label svg.fa-exclamation-triangle'
+      )
+      .doesNotExist();
+
+    await fillIn('.parameter-list.expanded input', 'foofoofoo');
+
+    assert
+      .dom(
+        '.parameter-list.expanded .parameter label svg.fa-exclamation-triangle'
+      )
+      .exists({ count: 1 });
+    assert
+      .dom(
+        '.parameter-list.expanded .parameter label svg.fa-exclamation-triangle title'
+      )
+      .hasText('Default value: foobar');
   });
 });


### PR DESCRIPTION
## Context
#1068 had missed an existing feature where default values are noted by an icon.  This adds that functionality back in.  The default value is shown when the icon is moused-over.

## Objective
Add in icon with hover over to indicate that the parameter has a default value that is different that the current value in the text input
![Screenshot 2024-06-18 at 17-44-00 New Pipeline Events Show](https://github.com/screwdriver-cd/ui/assets/157658916/1f6bd068-2c05-4fbb-ae0f-3397dfc06b1a)
![mouse hover](https://github.com/screwdriver-cd/ui/assets/157658916/03330c0f-0250-457b-a336-836082eda5b8)

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
