### PR TITLE
fix: Converts parameters into a format ready for API use

### DIFF
--- a/app/components/pipeline/parameters/component.js
+++ b/app/components/pipeline/parameters/component.js
@@ -6,6 +6,7 @@ import {
   extractEventParameters,
   getNormalizedParameterGroups
 } from 'screwdriver-ui/utils/pipeline/parameters';
+import { flattenParameters } from './util';
 
 export default class PipelineParametersComponent extends Component {
   @tracked parameters;
@@ -91,8 +92,6 @@ export default class PipelineParametersComponent extends Component {
       this.selectedParameters.pipeline[parameter.name] = { value };
     }
 
-    const { pipeline, job } = this.selectedParameters;
-
-    this.args.onUpdateParameters({ ...pipeline, ...job });
+    this.args.onUpdateParameters(flattenParameters(this.selectedParameters));
   }
 }

--- a/app/components/pipeline/parameters/util.js
+++ b/app/components/pipeline/parameters/util.js
@@ -1,0 +1,49 @@
+/**
+ * Flattens value key to the parent object
+ * @param parameters
+ * @returns {{}}
+ */
+export function flattenParameterGroup(parameters) {
+  const flattened = {};
+
+  Object.entries(parameters).forEach(([key, value]) => {
+    flattened[key] = value.value;
+  });
+
+  return flattened;
+}
+
+/**
+ * Flattens the parameter group of a job
+ * @param parameters
+ * @returns {{}}
+ */
+export function flattenJobParameters(parameters) {
+  const flattened = {};
+
+  Object.entries(parameters).forEach(([group, groupParameters]) => {
+    flattened[group] = flattenParameterGroup(groupParameters);
+  });
+
+  return flattened;
+}
+
+/**
+ * Flattens parameters for use in the API request body
+ * @param parameters
+ * @returns {{}}
+ */
+export function flattenParameters(parameters) {
+  let flattened = {};
+  const { pipeline, job } = parameters;
+
+  if (pipeline) {
+    flattened = flattenParameterGroup(pipeline);
+  }
+
+  if (job) {
+    flattened = { ...flattened, ...flattenJobParameters(job) };
+  }
+
+  return flattened;
+}

--- a/tests/integration/components/pipeline/parameters/component-test.js
+++ b/tests/integration/components/pipeline/parameters/component-test.js
@@ -185,8 +185,8 @@ module('Integration | Component | pipeline/parameters', function (hooks) {
     assert.equal(onUpdateParameters.callCount, 1);
     assert.true(
       onUpdateParameters.calledWith({
-        foo: { value: 'foobar' },
-        job1: { p1: { value: 'abc' } }
+        foo: 'foobar',
+        job1: { p1: 'abc' }
       })
     );
   });
@@ -233,8 +233,8 @@ module('Integration | Component | pipeline/parameters', function (hooks) {
     assert.equal(onUpdateParameters.callCount, 1);
     assert.true(
       onUpdateParameters.calledWith({
-        foo: { value: 'foozy' },
-        job1: { p1: { value: 'job123abc' } }
+        foo: 'foozy',
+        job1: { p1: 'job123abc' }
       })
     );
   });
@@ -274,7 +274,7 @@ module('Integration | Component | pipeline/parameters', function (hooks) {
     assert.equal(onUpdateParameters.callCount, 1);
     assert.true(
       onUpdateParameters.calledWith({
-        foo: { value: 'bar' }
+        foo: 'bar'
       })
     );
   });

--- a/tests/unit/components/pipeline/parameters/util-test.js
+++ b/tests/unit/components/pipeline/parameters/util-test.js
@@ -1,0 +1,76 @@
+import { module, test } from 'qunit';
+import {
+  flattenJobParameters,
+  flattenParameters,
+  flattenParameterGroup
+} from 'screwdriver-ui/components/pipeline/parameters/util';
+
+module('Unit | Component | pipeline/parameters/util', function () {
+  test('flattenParameterGroup flattens correctly', function (assert) {
+    assert.deepEqual(flattenParameterGroup({ param: { value: 123 } }), {
+      param: 123
+    });
+
+    assert.deepEqual(
+      flattenParameterGroup({
+        param1: { value: 123 },
+        param2: { value: 'abc' }
+      }),
+      {
+        param1: 123,
+        param2: 'abc'
+      }
+    );
+  });
+
+  test('flattenJobParameters flattens correctly', function (assert) {
+    assert.deepEqual(
+      flattenJobParameters({
+        job1: { p1: { value: 'abc' }, p2: { value: 'xyz' } },
+        job2: { p1: { value: 123 }, p2: { value: 987 } }
+      }),
+      { job1: { p1: 'abc', p2: 'xyz' }, job2: { p1: 123, p2: 987 } }
+    );
+  });
+
+  test('flattenParameters flattens correctly', function (assert) {
+    assert.deepEqual(
+      flattenParameters({
+        pipeline: { p1: { value: 'pipeline' }, p2: { value: 'pipeline2' } }
+      }),
+      { p1: 'pipeline', p2: 'pipeline2' }
+    );
+
+    assert.deepEqual(
+      flattenParameters({
+        job: { main: { j1: { value: 123 }, j2: { value: 'abc' } } }
+      }),
+      { main: { j1: 123, j2: 'abc' } }
+    );
+
+    assert.deepEqual(
+      flattenParameters({
+        pipeline: {
+          p1: { value: 'pipeline' },
+          p2: { value: 'pipeline2' }
+        },
+        job: {
+          main: {
+            j1: { value: 123 },
+            j2: { value: 'abc' }
+          },
+          secondary: {
+            j1: { value: 'xyz' },
+            j2: { value: 987 }
+          }
+        }
+      }),
+      {
+        p1: 'pipeline',
+        p2: 'pipeline2',
+        main: { j1: 123, j2: 'abc' },
+        secondary: { j1: 'xyz', j2: 987 }
+      }
+    );
+  });
+});


### PR DESCRIPTION
## Context
The API consumes parameters in a concise form.  Through the various layers of UI components, the API responses are massaged into a shape that the UI can use.  In reverse, when the UI needs to send parameters back to the API, the parameters need to get massaged back into a shape that the API expects.  The ownership of this massaging is now part of the `PipelineParametersComponent`.

## Objective
Moves ownership of returning parameters in a form that can be used by the API endpoint to live with the `PipelineParametersComponent`.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
