### PR TITLE
fix: Avoid extra notifications when transitioning to other builds

### DIFF
--- a/app/components/build-banner/component.js
+++ b/app/components/build-banner/component.js
@@ -19,6 +19,7 @@ export default Component.extend({
   shuttle: service(),
   classNames: ['build-banner', 'grid'],
   classNameBindings: ['buildStatus'],
+  shouldSkipNextNotify: false,
   coverage: service(),
   coverageInfo: {},
   coverageStep: computed('buildSteps', {
@@ -83,6 +84,13 @@ export default Component.extend({
     }
   }),
   buildNotify: observer('buildStatus', function buildNotify() {
+    // Not to be notified when transitioning from a commit dropdown to another build
+    if (this.shouldSkipNextNotify) {
+      this.set('shouldSkipNextNotify', false);
+
+      return;
+    }
+
     if (Notification.permission === 'granted' && this.allowNotification) {
       if (['SUCCESS', 'FAILURE', 'ABORTED'].includes(this.buildStatus)) {
         const screwdriverIconPath = '/assets/icons/android-chrome-144x144.png';
@@ -307,6 +315,9 @@ export default Component.extend({
 
   actions: {
     changeCurPr(targetPr) {
+      if (Number(this.buildId) !== targetPr.build.id) {
+        this.set('shouldSkipNextNotify', true);
+      }
       this.changeBuild(targetPr.event.pipelineId, targetPr.build.id);
     },
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

On the PR build details screen, you can navigate to other builds from the `COMMIT` drop-down.
Unnecessary notifications are made when the status of the build being displayed is different from the status of the build to which the user is transitioning.

<img width="1372" alt="image" src="https://github.com/screwdriver-cd/ui/assets/59165943/a6330af8-feb1-4fc2-9a4b-bf02543763b8">


## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Fix so that notifications are not made when transitioning from the `COMMIT` drop-down to another build.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
