### PR TITLE
feat: New confirm action modal UI

### DIFF
--- a/app/components/pipeline/modal/confirm-action/component.js
+++ b/app/components/pipeline/modal/confirm-action/component.js
@@ -1,0 +1,124 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import {
+  buildPostBody,
+  capitalizeFirstLetter,
+  initializeParameters,
+  truncateMessage
+} from './util';
+
+export default class PipelineModalConfirmActionComponent extends Component {
+  @service shuttle;
+
+  @service session;
+
+  @tracked isAwaitingResponse = false;
+
+  @tracked wasActionSuccessful = false;
+
+  @tracked reason = '';
+
+  parameters;
+
+  constructor() {
+    super(...arguments);
+
+    this.parameters = initializeParameters(this.args.event);
+  }
+
+  get action() {
+    return this.args.job.status ? 'restart' : 'start';
+  }
+
+  get truncatedMessage() {
+    return truncateMessage(this.args.event.commit.message);
+  }
+
+  get isLatestCommitEvent() {
+    return this.args.event.sha === this.args.latestCommitEvent.sha;
+  }
+
+  get commitUrl() {
+    return this.args.event.commit.url;
+  }
+
+  get truncatedSha() {
+    return this.args.event.sha.substring(0, 7);
+  }
+
+  get isLatestNonPrCommitEvent() {
+    return this.args.event.type === 'pr' ? true : this.isLatestCommitEvent;
+  }
+
+  get isFrozen() {
+    return this.args.job.status === 'FROZEN';
+  }
+
+  get isParameterized() {
+    if (this.args.pipeline.parameters) {
+      return Object.keys(this.args.pipeline.parameters).length > 0;
+    }
+
+    return false;
+  }
+
+  get isSubmitButtonDisabled() {
+    if (this.wasActionSuccessful || this.isAwaitingResponse) {
+      return true;
+    }
+
+    if (this.isFrozen) {
+      return this.reason.length === 0;
+    }
+
+    return false;
+  }
+
+  get pendingAction() {
+    return `${capitalizeFirstLetter(this.action)}ing...`;
+  }
+
+  get completedAction() {
+    return this.wasActionSuccessful
+      ? `${capitalizeFirstLetter(this.action)}ed`
+      : 'Yes';
+  }
+
+  @action
+  onUpdateParameters(parameters) {
+    this.parameters = parameters;
+  }
+
+  @action
+  async startBuild() {
+    this.isAwaitingResponse = true;
+
+    const data = buildPostBody(
+      this.session.data.authenticated.username,
+      this.args.pipeline.id,
+      this.args.job,
+      this.args.event,
+      this.parameters,
+      this.isFrozen,
+      this.reason
+    );
+
+    return new Promise((resolve, reject) => {
+      this.shuttle
+        .fetchFromApi('POST', '/events', data)
+        .then(() => {
+          this.wasActionSuccessful = true;
+          resolve();
+        })
+        .catch(err => {
+          this.wasActionSuccessful = false;
+          reject(err);
+        })
+        .finally(() => {
+          this.isAwaitingResponse = false;
+        });
+    });
+  }
+}

--- a/app/components/pipeline/modal/confirm-action/styles.scss
+++ b/app/components/pipeline/modal/confirm-action/styles.scss
@@ -1,0 +1,73 @@
+@use 'screwdriver-colors' as colors;
+
+@mixin styles {
+  #ember-bootstrap-wormhole {
+    .modal.confirm-action {
+      .modal-dialog {
+        max-width: 50%;
+
+        .modal-body {
+          display: flex;
+          flex-direction: column;
+
+          .modal-title {
+            font-size: 1.75rem;
+            padding-bottom: 0.75rem;
+          }
+
+          .alert {
+            margin-bottom: 0.5rem;
+          }
+
+          .frozen-reason {
+            display: flex;
+            justify-content: space-between;
+
+            label {
+              margin: auto;
+              padding-right: 0.25rem;
+            }
+
+            input {
+              flex: 1;
+              border-radius: 4px;
+              border: 1px solid colors.$sd-text-med;
+              padding-left: 8px;
+            }
+          }
+
+          .pipeline-parameters {
+            padding-top: 2.5rem;
+          }
+        }
+
+        .modal-footer {
+          display: flex;
+          justify-content: space-between;
+
+          button {
+            width: 10rem;
+
+            color: colors.$sd-link;
+            border-color: colors.$sd-link;
+
+            &:hover {
+              background-color: colors.$sd-info-bg;
+            }
+
+            &.confirm {
+              color: colors.$sd-white;
+              background-color: colors.$sd-running;
+              border-color: colors.$sd-running;
+
+              &:hover {
+                background-color: colors.$sd-link;
+                border-color: colors.$sd-link;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/components/pipeline/modal/confirm-action/template.hbs
+++ b/app/components/pipeline/modal/confirm-action/template.hbs
@@ -1,0 +1,66 @@
+<BsModal
+  class="confirm-action"
+  @onHide={{fn @closeModal}}
+  as |modal|
+>
+  <modal.body>
+    <div class="modal-title">Are you sure you want to {{this.action}}?</div>
+    <div id="confirm-action-job">Job: <code>{{@job.name}}</code></div>
+    <div id="confirm-action-commit">
+      Commit: <code>{{this.truncatedMessage}}</code>
+      <a
+        id="confirm-action-commit-link"
+        class={{if this.isLatestCommitEvent "latest-commit"}}
+        href={{this.commitUrl}}
+      >
+        #{{this.truncatedSha}}
+      </a>
+      {{#unless this.isLatestNonPrCommitEvent}}
+        <div class="alert alert-warning">
+          <FaIcon @icon="exclamation-triangle" />
+          This is <strong>NOT</strong> the latest commit.
+        </div>
+      {{/unless}}
+    </div>
+
+    {{#if this.isFrozen}}
+      <div class="frozen-reason">
+        <label>
+          Reason:
+        </label>
+        <Input @type="text" @value={{this.reason}} placeholder="Please enter a reason"/>
+      </div>
+    {{/if}}
+
+    {{#if this.isParameterized}}
+      <Pipeline::Parameters
+        @action={{this.action}}
+        @job={{@job}}
+        @event={{@event}}
+        @pipeline={{@pipeline}}
+        @jobs={{@jobs}}
+        @onUpdateParameters={{this.onUpdateParameters}}
+      />
+    {{/if}}
+  </modal.body>
+  <modal.footer>
+    <BsButton
+      class="confirm"
+      disabled={{this.isSubmitButtonDisabled}}
+      @defaultText="Yes"
+      @pendingText={{this.pendingAction}}
+      @fulfilledText={{this.completedAction}}
+      @onClick={{this.startBuild}}
+    />
+    <BsButton
+      @outline={{true}}
+      @onClick={{modal.close}}
+    >
+      {{#if this.wasActionSuccessful}}
+        Close
+      {{else}}
+        No
+      {{/if}}
+    </BsButton>
+  </modal.footer>
+</BsModal>

--- a/app/components/pipeline/modal/confirm-action/util.js
+++ b/app/components/pipeline/modal/confirm-action/util.js
@@ -1,0 +1,80 @@
+import { flattenParameters } from 'screwdriver-ui/utils/pipeline/parameters';
+
+/**
+ * Initialize parameters from an event API response object
+ * @param event
+ * @returns {undefined|*}
+ */
+export function initializeParameters(event) {
+  if (event.meta?.parameters && event.meta.parameters.length > 0) {
+    return flattenParameters(event.meta.parameters);
+  }
+
+  return undefined;
+}
+
+/**
+ * Truncate commit message to 150 characters
+ * @param commitMessage
+ * @returns {string|*}
+ */
+export function truncateMessage(commitMessage) {
+  const cutOff = 150;
+
+  return commitMessage.length > cutOff
+    ? `${commitMessage.substring(0, cutOff)}...`
+    : commitMessage;
+}
+
+/**
+ * Capitalize first letter of string
+ * @param string
+ * @returns {string}
+ */
+export function capitalizeFirstLetter(string) {
+  return string.charAt(0).toUpperCase() + string.slice(1);
+}
+
+/**
+ * Build post body for starting a job
+ * @param username
+ * @param pipeline
+ * @param job
+ * @param event
+ * @param parameters
+ * @param isFrozen
+ * @param reason
+ * @returns {{causeMessage: string, pipelineId}}
+ */
+export function buildPostBody(
+  username,
+  pipelineId,
+  job,
+  event,
+  parameters,
+  isFrozen,
+  reason
+) {
+  const data = {
+    pipelineId,
+    causeMessage: `Manually started by ${username}`
+  };
+
+  if (job.status) {
+    data.startFrom = job.name;
+    data.groupEventId = event.groupEventId;
+    data.parentEventId = event.id;
+  } else {
+    data.startFrom = '~commit';
+  }
+
+  if (parameters) {
+    data.meta = { parameters };
+  }
+
+  if (isFrozen) {
+    data.causeMessage = `[force start]${reason}`;
+  }
+
+  return data;
+}

--- a/app/components/pipeline/styles.scss
+++ b/app/components/pipeline/styles.scss
@@ -1,9 +1,11 @@
 @use 'nav/styles' as nav;
+@use 'modal/confirm-action/styles' as confirm-action-modal;
 @use 'modal/toggle-job/styles' as toggle-job;
 @use 'parameters/styles' as parameters;
 
 @mixin styles {
   @include nav.styles;
+  @include confirm-action-modal.styles;
   @include toggle-job.styles;
   @include parameters.styles;
 }

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -1,4 +1,5 @@
 @use 'variables';
+@use 'bootstrap-modal' as bootstrapModal;
 @use 'components/styles' as components;
 @use 'v2/pipeline/styles' as pipeline;
 
@@ -204,6 +205,7 @@ html {
     font-family: Helvetica, Arial, sans-serif;
     font-weight: variables.$weight-normal;
 
+    @include bootstrapModal.styles;
     @include components.styles;
     @include pipeline.styles;
   }

--- a/app/styles/bootstrap-modal.scss
+++ b/app/styles/bootstrap-modal.scss
@@ -1,0 +1,15 @@
+@use 'screwdriver-colors' as colors;
+
+@mixin styles {
+  #ember-bootstrap-wormhole {
+    .modal-backdrop.fade.show {
+      background-color: rgba(128, 128, 128, 0.77);
+      opacity: 1;
+    }
+
+    .modal-content {
+      border-radius: 8px;
+      box-shadow: 0 0 10px colors.$sd-black;
+    }
+  }
+}

--- a/tests/integration/components/pipeline/modal/confirm-action/component-test.js
+++ b/tests/integration/components/pipeline/modal/confirm-action/component-test.js
@@ -1,0 +1,261 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
+import { fillIn, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module(
+  'Integration | Component | pipeline/modal/confirm-action',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test('it renders start action', async function (assert) {
+      this.setProperties({
+        pipeline: { parameters: {} },
+        event: {
+          commit: { message: 'commit message', url: 'http://foo.com' },
+          sha: 'deadbeef0123456789'
+        },
+        jobs: [],
+        latestCommitEvent: { sha: 'deadbeef0123456789' },
+        job: { name: 'main' },
+        closeModal: () => {}
+      });
+      await render(
+        hbs`<Pipeline::Modal::ConfirmAction
+            @pipeline={{this.pipeline}}
+            @event={{this.event}}
+            @jobs={{this.jobs}}
+            @latestCommitEvent={{this.latestCommitEvent}}
+            @job={{this.job}}
+            @closeModal={{this.closeModal}}
+        />`
+      );
+
+      assert.dom('.modal-title').hasText('Are you sure you want to start?');
+      assert.dom('#confirm-action-job').hasText('Job: main');
+      assert
+        .dom('#confirm-action-commit')
+        .hasText('Commit: commit message #deadbee');
+      assert
+        .dom('#confirm-action-commit-link')
+        .hasAttribute('href', 'http://foo.com');
+    });
+
+    test('it renders restart action', async function (assert) {
+      this.setProperties({
+        pipeline: { parameters: {} },
+        event: {
+          commit: { message: 'commit message', url: 'http://foo.com' },
+          sha: 'deadbeef0123456789'
+        },
+        jobs: [],
+        latestCommitEvent: { sha: 'deadbeef0123456789' },
+        job: { name: 'main', status: 'SUCCESS' },
+        closeModal: () => {}
+      });
+      await render(
+        hbs`<Pipeline::Modal::ConfirmAction
+            @pipeline={{this.pipeline}}
+            @event={{this.event}}
+            @jobs={{this.jobs}}
+            @latestCommitEvent={{this.latestCommitEvent}}
+            @job={{this.job}}
+            @closeModal={{this.closeModal}}
+        />`
+      );
+
+      assert.dom('.modal-title').hasText('Are you sure you want to restart?');
+    });
+
+    test('it renders warning message for non-latest commit event', async function (assert) {
+      this.setProperties({
+        pipeline: { parameters: {} },
+        event: {
+          commit: { message: 'commit message', url: 'http://foo.com' },
+          sha: '0123456789deadbeef'
+        },
+        jobs: [],
+        latestCommitEvent: { sha: 'deadbeef0123456789' },
+        job: { name: 'main' },
+        closeModal: () => {}
+      });
+      await render(
+        hbs`<Pipeline::Modal::ConfirmAction
+            @pipeline={{this.pipeline}}
+            @event={{this.event}}
+            @jobs={{this.jobs}}
+            @latestCommitEvent={{this.latestCommitEvent}}
+            @job={{this.job}}
+            @closeModal={{this.closeModal}}
+        />`
+      );
+
+      assert.dom('.alert').hasText('This is NOT the latest commit.');
+    });
+
+    test('it does not render warning message for pr commit event', async function (assert) {
+      this.setProperties({
+        pipeline: { parameters: {} },
+        event: {
+          commit: { message: 'commit message', url: 'http://foo.com' },
+          sha: 'deadbeef0123456789',
+          type: 'pr'
+        },
+        jobs: [],
+        latestCommitEvent: { sha: 'deadbeef0123456789' },
+        job: { name: 'main' },
+        closeModal: () => {}
+      });
+      await render(
+        hbs`<Pipeline::Modal::ConfirmAction
+            @pipeline={{this.pipeline}}
+            @event={{this.event}}
+            @jobs={{this.jobs}}
+            @latestCommitEvent={{this.latestCommitEvent}}
+            @job={{this.job}}
+            @closeModal={{this.closeModal}}
+        />`
+      );
+
+      assert.dom('.modal-body .alert').doesNotExist();
+
+      this.setProperties({
+        pipeline: { parameters: {} },
+        event: {
+          commit: { message: 'commit message', url: 'http://foo.com' },
+          sha: 'abc123',
+          type: 'pr'
+        },
+        jobs: [],
+        latestCommitEvent: { sha: 'deadbeef0123456789' },
+        job: { name: 'main' },
+        closeModal: () => {}
+      });
+      await render(
+        hbs`<Pipeline::Modal::ConfirmAction
+            @pipeline={{this.pipeline}}
+            @event={{this.event}}
+            @jobs={{this.jobs}}
+            @latestCommitEvent={{this.latestCommitEvent}}
+            @job={{this.job}}
+            @closeModal={{this.closeModal}}
+        />`
+      );
+
+      assert.dom('.modal-body .alert').doesNotExist();
+    });
+
+    test('it renders reason input for frozen job', async function (assert) {
+      this.setProperties({
+        pipeline: { parameters: {} },
+        event: {
+          commit: { message: 'commit message', url: 'http://foo.com' },
+          sha: 'deadbeef0123456789'
+        },
+        jobs: [],
+        latestCommitEvent: { sha: 'deadbeef0123456789' },
+        job: { name: 'main', status: 'FROZEN' },
+        closeModal: () => {}
+      });
+      await render(
+        hbs`<Pipeline::Modal::ConfirmAction
+            @pipeline={{this.pipeline}}
+            @event={{this.event}}
+            @jobs={{this.jobs}}
+            @latestCommitEvent={{this.latestCommitEvent}}
+            @job={{this.job}}
+            @closeModal={{this.closeModal}}
+        />`
+      );
+
+      assert.dom('.frozen-reason').exists({ count: 1 });
+      assert.dom('.frozen-reason label').exists({ count: 1 });
+      assert.dom('.frozen-reason input').exists({ count: 1 });
+    });
+
+    test('it renders parameter input for parameterized job', async function (assert) {
+      this.setProperties({
+        pipeline: { parameters: { param1: 'abc' } },
+        event: {
+          commit: { message: 'commit message', url: 'http://foo.com' },
+          sha: 'deadbeef0123456789',
+          meta: {
+            parameters: {
+              param1: { value: 'abc' }
+            }
+          }
+        },
+        jobs: [],
+        latestCommitEvent: { sha: 'deadbeef0123456789' },
+        job: { name: 'main' },
+        closeModal: () => {}
+      });
+      await render(
+        hbs`<Pipeline::Modal::ConfirmAction
+            @pipeline={{this.pipeline}}
+            @event={{this.event}}
+            @jobs={{this.jobs}}
+            @latestCommitEvent={{this.latestCommitEvent}}
+            @job={{this.job}}
+            @closeModal={{this.closeModal}}
+        />`
+      );
+
+      assert.dom('.pipeline-parameters').exists({ count: 1 });
+    });
+
+    test('it disables submit button when no reason is provided for frozen job', async function (assert) {
+      this.setProperties({
+        pipeline: { parameters: {} },
+        event: {
+          commit: { message: 'commit message', url: 'http://foo.com' },
+          sha: 'deadbeef0123456789'
+        },
+        jobs: [],
+        latestCommitEvent: { sha: 'deadbeef0123456789' },
+        job: { name: 'main', status: 'FROZEN' },
+        closeModal: () => {}
+      });
+      await render(
+        hbs`<Pipeline::Modal::ConfirmAction
+            @pipeline={{this.pipeline}}
+            @event={{this.event}}
+            @jobs={{this.jobs}}
+            @latestCommitEvent={{this.latestCommitEvent}}
+            @job={{this.job}}
+            @closeModal={{this.closeModal}}
+        />`
+      );
+
+      assert.dom('.modal-footer button.confirm').isDisabled();
+    });
+
+    test('it enables submit button when reason is provided for frozen job', async function (assert) {
+      this.setProperties({
+        pipeline: { parameters: {} },
+        event: {
+          commit: { message: 'commit message', url: 'http://foo.com' },
+          sha: 'deadbeef0123456789'
+        },
+        jobs: [],
+        latestCommitEvent: { sha: 'deadbeef0123456789' },
+        job: { name: 'main', status: 'FROZEN' },
+        closeModal: () => {}
+      });
+      await render(
+        hbs`<Pipeline::Modal::ConfirmAction
+            @pipeline={{this.pipeline}}
+            @event={{this.event}}
+            @jobs={{this.jobs}}
+            @latestCommitEvent={{this.latestCommitEvent}}
+            @job={{this.job}}
+            @closeModal={{this.closeModal}}
+        />`
+      );
+
+      await fillIn('.frozen-reason input', 'Some reason');
+
+      assert.dom('.modal-footer button.confirm').isEnabled();
+    });
+  }
+);

--- a/tests/unit/components/pipeline/modal/confirm-action/util-test.js
+++ b/tests/unit/components/pipeline/modal/confirm-action/util-test.js
@@ -1,0 +1,93 @@
+import { module, test } from 'qunit';
+import {
+  buildPostBody,
+  capitalizeFirstLetter,
+  initializeParameters,
+  truncateMessage
+} from 'screwdriver-ui/components/pipeline/modal/confirm-action/util';
+
+module('Unit | Component | pipeline/modal/confirm-action/util', function () {
+  test('initializeParameters initializes correctly', function (assert) {
+    assert.deepEqual(initializeParameters({ id: 123 }, undefined));
+    assert.deepEqual(initializeParameters({ id: 123, meta: {} }, undefined));
+    assert.deepEqual(
+      initializeParameters(
+        { id: 123, meta: { parameters: { foo: 'bar' } } },
+        { foo: 'bar' }
+      )
+    );
+  });
+
+  test('truncateMessage truncates string', function (assert) {
+    const shortMessage = 'short message';
+
+    assert.equal(truncateMessage(shortMessage), shortMessage);
+
+    const longMessage =
+      'This commit message is really long and will exceed the expected character length; as such, it will be truncated in order to fit within the expected character length';
+
+    assert.equal(
+      truncateMessage(longMessage),
+      'This commit message is really long and will exceed the expected character length; as such, it will be truncated in order to fit within the expected ch...'
+    );
+  });
+
+  test('capitalizeFirstLetter capitalizes first letter of string', function (assert) {
+    assert.equal(capitalizeFirstLetter('foo'), 'Foo');
+  });
+
+  test('buildPostBody sets core values', function (assert) {
+    assert.deepEqual(
+      buildPostBody('foobar', 123, {}, null, null, false, null),
+      {
+        pipelineId: 123,
+        causeMessage: 'Manually started by foobar',
+        startFrom: '~commit'
+      }
+    );
+  });
+
+  test('buildPostBody sets correct values for restart', function (assert) {
+    assert.deepEqual(
+      buildPostBody(
+        'foobar',
+        123,
+        { name: 'main', status: 'SUCCESS' },
+        { id: 999, groupEventId: 54321 },
+        null,
+        false,
+        null
+      ),
+      {
+        pipelineId: 123,
+        causeMessage: 'Manually started by foobar',
+        startFrom: 'main',
+        groupEventId: 54321,
+        parentEventId: 999
+      }
+    );
+  });
+
+  test('buildPostBody sets parameters', function (assert) {
+    assert.deepEqual(
+      buildPostBody('foobar', 123, {}, null, { param: 4 }, false, null),
+      {
+        pipelineId: 123,
+        causeMessage: 'Manually started by foobar',
+        startFrom: '~commit',
+        meta: { parameters: { param: 4 } }
+      }
+    );
+  });
+
+  test('buildPostBody sets reason if frozen', function (assert) {
+    assert.deepEqual(
+      buildPostBody('foobar', 123, {}, null, null, true, 'testing'),
+      {
+        pipelineId: 123,
+        causeMessage: '[force start]testing',
+        startFrom: '~commit'
+      }
+    );
+  });
+});


### PR DESCRIPTION
## Context
New UI for the modal to confirm start/restarting of a job from the workflow graph.

## Objective
As part of the new UI work, this provides a new modal that is a Glimmer component and leverages the pipeline parameters component from #1068.

The new component also properly displays the desired action that is to be taken with the job (e.g., start or restarting a job)
![Screenshot 2024-06-27 at 14-52-08 New Pipeline Events Show](https://github.com/screwdriver-cd/ui/assets/157658916/dd57de93-140e-4c6e-8b47-69172d802fc2)

![Screenshot 2024-06-27 at 14-52-21 New Pipeline Events Show](https://github.com/screwdriver-cd/ui/assets/157658916/7cf944e6-67d9-4e80-9732-2c9fc13e81f4)

![Screenshot 2024-06-27 at 14-52-30 New Pipeline Events Show](https://github.com/screwdriver-cd/ui/assets/157658916/6338fac9-2c65-45e7-b54a-ca26c4ab2039)


## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
