### PR TITLE
fix: Clean up the new v2 layout

### DIFF
--- a/app/v2/pipeline/events/index/template.hbs
+++ b/app/v2/pipeline/events/index/template.hbs
@@ -1,3 +1,2 @@
 {{page-title "Index"}}
-<div>v2 event index route</div>
 {{outlet}}

--- a/app/v2/pipeline/events/show/template.hbs
+++ b/app/v2/pipeline/events/show/template.hbs
@@ -1,3 +1,2 @@
 {{page-title "Show"}}
-<div>v2 event show route</div>
 {{outlet}}

--- a/app/v2/pipeline/events/styles.scss
+++ b/app/v2/pipeline/events/styles.scss
@@ -1,0 +1,132 @@
+@use 'screwdriver-colors' as colors;
+
+@mixin styles {
+  display: grid;
+
+  grid-template-areas:
+    'pipeline-tab pipeline-tab'
+    'pipeline-events pipeline-event-main-content';
+
+  grid-template-rows: 3.75rem;
+  grid-template-columns: 26rem;
+
+  .pipeline-tab {
+    grid-area: pipeline-tab;
+
+    display: grid;
+    padding-top: 8px;
+    padding-bottom: 1px;
+
+    ul.nav-tabs.nav {
+      border: none;
+
+      li {
+        border-bottom: 0.2rem solid colors.$sd-white;
+        padding-left: 1rem;
+        padding-right: 1rem;
+        text-align: center;
+
+        &.active {
+          border-bottom-color: #1c64f2;
+        }
+
+        a {
+          &.active {
+            color: #1c64f2;
+          }
+
+          color: #6b7280;
+          border: none;
+          padding: 8px 16px 9px 16px;
+        }
+      }
+    }
+  }
+
+  .pipeline-events {
+    grid-area: pipeline-events;
+
+    border: 1px solid #cbd5e1;
+    background-color: white;
+
+    // scroll
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+
+    .search-filter-bar {
+      display: flex;
+      padding: 12px 24px;
+      justify-content: space-between;
+
+      .search-filter {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+
+        .search {
+        }
+        .filter {
+        }
+      }
+
+      .new-event {
+        cursor: pointer;
+      }
+
+      .img {
+        width: 18px;
+        height: 18px;
+      }
+    }
+
+    .event-cards {
+      overflow-y: scroll;
+
+      .event-card {
+        border-top: 1px solid #cbd5e1;
+      }
+      .event-card:first-child {
+        border-top: none;
+      }
+
+      .event-card-group {
+        // padding-bottom: 10px;
+        // margin: 0.5rem 0.25rem;
+        margin-top: 0.75rem;
+        margin-bottom: 0.75rem;
+
+        // border: 1px solid #cbd5e1;
+        border-top: 1px solid #cbd5e1;
+        border-bottom: 1px solid #cbd5e1;
+        // border-radius: 0.25rem;
+
+        position: relative;
+
+        .event-card-group-toggle {
+          position: absolute;
+
+          display: flex;
+          width: 100%;
+          flex-wrap: wrap;
+          justify-content: flex-end;
+
+          cursor: pointer;
+
+          .badge {
+            color: #007bff;
+          }
+        }
+
+        div.event-card:nth-child(1),
+        div.event-card:nth-child(2) {
+          border-top: none;
+        }
+      }
+    }
+  }
+
+  .pipeline-workflow-graph {
+    grid-area: pipeline-event-main-content;
+  }
+}

--- a/app/v2/pipeline/events/template.hbs
+++ b/app/v2/pipeline/events/template.hbs
@@ -1,6 +1,20 @@
 {{page-title "Events"}}
 
-<div class="pipeline-content">
+<div class="pipeline-tab">
+  <BsNav @type="tabs" as |nav|>
+    <nav.item>
+      <nav.link-to @route="v2.pipeline.events">Events</nav.link-to>
+    </nav.item>
+    <nav.item>
+      <nav.link-to @route="v2.pipeline.pulls">Pull Requests</nav.link-to>
+    </nav.item>
+    <nav.item>
+      <nav.link-to @route="v2.pipeline.jobs">Jobs</nav.link-to>
+    </nav.item>
+  </BsNav>
+</div>
+
+<div class="pipeline-events">
   <div class="search-filter-bar">
 
     <span class="search-filter">
@@ -22,7 +36,7 @@
   {{#if this.isGroupedEvents}}
     {{#each this.groupedEvents as |eventGroup| }}
       <Newui::EventCardGroup
-       @selectedEventId={{this.selectedEventId}} 
+       @selectedEventId={{this.selectedEventId}}
        @pipelineId={{this.pipelineId}}
        @lastSuccessful={{this.lastSuccessful}}
        @latestCommit={{this.latestCommit}}
@@ -31,8 +45,8 @@
     {{/each}}
   {{else}}
     {{#each this.events as |event|}}
-      <Newui::EventCard @event={{event}} 
-       @selectedEventId={{this.selectedEventId}} 
+      <Newui::EventCard @event={{event}}
+       @selectedEventId={{this.selectedEventId}}
        @pipelineId={{this.pipelineId}}
        @lastSuccessful={{this.lastSuccessful}}
        @latestCommit={{this.latestCommit}}
@@ -40,11 +54,8 @@
     {{/each}}
   {{/if}}
   </div>
-  {{outlet}}
 </div>
 
-<div class="pipeline-workflowgraph">
-  <div class="workflowgraph-chart">
-    WorkflowGraph placeholder for event {{this.selectedEventId}} 
-  </div> 
-</div>
+<div class="pipeline-workflow-graph" />
+
+{{outlet}}

--- a/app/v2/pipeline/styles.scss
+++ b/app/v2/pipeline/styles.scss
@@ -1,150 +1,28 @@
-@use 'screwdriver-colors' as colors;
+@use 'events/styles' as events;
 
 @mixin styles {
-  .pipeline-content {
+  .pipeline-page {
     display: grid;
     height: 100%;
 
-    grid-template-columns: 50px;
-    grid-template-rows: auto;
+    grid-template-columns: 4rem;
+    grid-auto-rows: min-content auto;
 
-    grid-template-areas: 'pipeline-nav pipeline-main';
+    grid-template-areas:
+      'pipeline-nav pipeline-header'
+      'pipeline-nav pipeline-main';
 
-    .pipeline-main-content {
-      .pipeline-header {
-        grid-area: pipeline-header;
-      }
-
-      .pipeline-tab {
-        grid-area: pipeline-tab;
-
-        display: grid;
-        padding-top: 8px;
-        padding-bottom: 1px;
-
-        ul.nav-tabs.nav {
-          border: none;
-
-          li {
-            border-bottom: 3px solid colors.$sd-white;
-            padding-left: 1rem;
-            padding-right: 1rem;
-            text-align: center;
-
-            &.active {
-              border-bottom-color: #1c64f2;
-            }
-
-            a {
-              &.active {
-                color: #1c64f2;
-              }
-
-              color: #6b7280;
-              border: none;
-              padding: 8px 16px 9px 16px;
-            }
-          }
-        }
-      }
-
-      .pipeline-content {
-        grid-area: pipeline-content;
-
-        border: 1px solid #cbd5e1;
-        background-color: white;
-
-        // scroll
-        height: 100dvh;
-        display: flex;
-        flex-direction: column;
-        overflow: hidden;
-
-        .search-filter-bar {
-          display: flex;
-          padding: 12px 24px;
-          justify-content: space-between;
-
-          .search-filter {
-            display: flex;
-            align-items: center;
-            gap: 12px;
-
-            .search {
-            }
-            .filter {
-            }
-          }
-
-          .new-event {
-            cursor: pointer;
-          }
-
-          .img {
-            width: 18px;
-            height: 18px;
-          }
-        }
-
-        .event-cards {
-          overflow-y: scroll;
-
-          .event-card {
-            border-top: 1px solid #cbd5e1;
-          }
-          .event-card:first-child {
-            border-top: none;
-          }
-
-          .event-card-group {
-            // padding-bottom: 10px;
-            // margin: 0.5rem 0.25rem;
-            margin-top: 0.75rem;
-            margin-bottom: 0.75rem;
-
-            // border: 1px solid #cbd5e1;
-            border-top: 1px solid #cbd5e1;
-            border-bottom: 1px solid #cbd5e1;
-            // border-radius: 0.25rem;
-
-            position: relative;
-
-            .event-card-group-toggle {
-              position: absolute;
-
-              display: flex;
-              width: 100%;
-              flex-wrap: wrap;
-              justify-content: flex-end;
-
-              cursor: pointer;
-
-              .badge {
-                color: #007bff;
-              }
-            }
-
-            div.event-card:nth-child(1),
-            div.event-card:nth-child(2) {
-              border-top: none;
-            }
-          }
-        }
-      }
+    .pipeline-header {
+      grid-area: pipeline-header;
     }
 
-    .pipeline-main-content.grid {
+    .pipeline-main-content {
       grid-area: pipeline-main;
-      min-width: 300px;
-      display: grid;
+      overflow: scroll;
 
-      grid-template-areas:
-        'pipeline-header pipeline-header'
-        'pipeline-tab pipeline-tab'
-        'pipeline-content pipeline-workflowgraph';
-
-      grid-template-rows: 80px 52px 1fr;
-      grid-template-columns: 366px 8fr;
+      &.grid {
+        @include events.styles;
+      }
     }
   }
 }

--- a/app/v2/pipeline/template.hbs
+++ b/app/v2/pipeline/template.hbs
@@ -1,30 +1,16 @@
 {{page-title "Pipeline"}}
-<div class="pipeline-content">
+<div class="pipeline-page">
   <Pipeline::Nav />
-  <div class="pipeline-main-content {{if this.isEventsPullsJobsRoute "grid"}}" 
-  >
-    <div class="pipeline-header">
-      <PipelineHeader
-        @pipeline={{this.pipeline}}
-        @collections={{this.collections}}
-        @addToCollection={{action "addToCollection"}}
-      />
-    </div>
-    {{#if this.isEventsPullsJobsRoute}}
-    <div class="pipeline-tab">
-      <BsNav @type="tabs" as |nav|>
-        <nav.item>
-          <nav.link-to @route="v2.pipeline.events">Events</nav.link-to>
-        </nav.item>
-        <nav.item>
-          <nav.link-to @route="v2.pipeline.pulls">Pull Requests</nav.link-to>
-        </nav.item>
-        <nav.item>
-          <nav.link-to @route="v2.pipeline.jobs">Jobs</nav.link-to>
-        </nav.item>
-      </BsNav>
-    </div>
-    {{/if}}
+
+  <div class="pipeline-header">
+    <PipelineHeader
+      @pipeline={{this.pipeline}}
+      @collections={{this.collections}}
+      @addToCollection={{action "addToCollection"}}
+    />
+  </div>
+
+  <div class="pipeline-main-content {{if this.isEventsPullsJobsRoute "grid"}}">
     {{outlet}}
   </div>
 </div>


### PR DESCRIPTION
## Context
Cleans up the templates and CSS for the new V2 pipeline UI.

## Objective
Refactor the templates and CSS for the V2 pipeline UI.  Now that more of the subroutes for a pipeline are in place, we should clean up the templates and CSS so that the respective routes and templates components live closer their actual routes.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
