### PR TITLE
fix: Redirect to correct pipeline secrets route

### DIFF
--- a/app/v2/pipeline/secrets/route.js
+++ b/app/v2/pipeline/secrets/route.js
@@ -15,7 +15,7 @@ export default class NewPipelineSecretsRoute extends Route {
 
     // Guests should not access this page
     if (get(this, 'session.data.authenticated.isGuest')) {
-      this.router.transitionTo('pipeline');
+      this.router.transitionTo('v2.pipeline');
     }
 
     const { pipeline } = this.modelFor('v2.pipeline');


### PR DESCRIPTION
## Context
The new V2 UI for pipeline secrets path redirects to the v1 version of the pipeline events.

## Objective
All of the new V2 UI work should always redirect to a V2 route.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
