### PR TITLE
fix: Refactor pipeline secrets to not use ember data

### DIFF
--- a/app/v2/pipeline/secrets/route.js
+++ b/app/v2/pipeline/secrets/route.js
@@ -1,42 +1,49 @@
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
-import { get } from '@ember/object';
 
 export default class NewPipelineSecretsRoute extends Route {
-  @service session;
-
-  @service store;
-
   @service router;
 
-  model() {
+  @service session;
+
+  @service shuttle;
+
+  async beforeModel() {
+    // Guests should not access this page
+    if (this.session.data.authenticated.isGuest) {
+      this.router.transitionTo('v2.pipeline');
+    }
+  }
+
+  async model() {
     // Refresh error message
     this.controllerFor('v2.pipeline.secrets').set('errorMessage', '');
 
-    // Guests should not access this page
-    if (get(this, 'session.data.authenticated.isGuest')) {
-      this.router.transitionTo('pipeline');
-    }
-
     const { pipeline } = this.modelFor('v2.pipeline');
-    const secrets = pipeline.get('secrets');
+    const pipelineId = pipeline.id;
 
-    this.store.unloadAll('token');
-
-    return this.store
-      .findAll('token', { adapterOptions: { pipelineId: pipeline.get('id') } })
-      .then(tokens => ({
-        tokens,
-        secrets,
-        pipeline
-      }))
-      .catch(error => {
-        this.controllerFor('pipeline.secrets').set(
+    const secrets = await this.shuttle
+      .fetchFromApi('get', `/pipelines/${pipelineId}/secrets`)
+      .catch(err => {
+        this.controllerFor('v2.pipeline.secrets').set(
           'errorMessage',
-          error.errors[0].detail
+          err.message
         );
 
-        return { secrets, pipeline };
+        return [];
       });
+
+    const tokens = await this.shuttle
+      .fetchFromApi('get', `/pipelines/${pipelineId}/tokens`)
+      .catch(err => {
+        this.controllerFor('v2.pipeline.secrets').set(
+          'errorMessage',
+          err.message
+        );
+
+        return [];
+      });
+
+    return { pipeline, secrets, tokens };
   }
 }


### PR DESCRIPTION
## Context
Refactors the new v2 pipeline secrets route to not use ember data.  Also moves the logic for checking if the user is a guest to the `beforeModel` method since it does not require any model data.

## Objective
The new v2 UI needs to move off of using ember data due to performance reasons for the events route.  The secrets route is currently using ember data to resolve various pieces of data which will not be available as the parent routes will not be using the resolved ember data model for those objects.  As such, the data that is needed for this route will now be directly fetched from the API endpoints.  The controller was intentionally not updated in this PR as it appears that it currently non-functional anyway.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
