### PR TITLE
fix: case where there are no parameter groups to expand

### DIFF
--- a/app/utils/pipeline/parameters.js
+++ b/app/utils/pipeline/parameters.js
@@ -174,7 +174,9 @@ export function getNormalizedParameterGroups(
     });
   }
 
-  normalizedParameterGroups[0].isOpen = true;
+  if (normalizedParameterGroups.length > 0) {
+    normalizedParameterGroups[0].isOpen = true;
+  }
 
   return normalizedParameterGroups.concat(normalizedJobParameterGroups);
 }

--- a/tests/unit/utils/pipeline/parameters-test.js
+++ b/tests/unit/utils/pipeline/parameters-test.js
@@ -230,6 +230,35 @@ module('Unit | Utility | Pipeline | parameters', function () {
     });
   });
 
+  test('getNormalizedParameterGroups returns normalized parameter groups with no expanded items', function (assert) {
+    const parameterGroups = getNormalizedParameterGroups(
+      {},
+      {},
+      { job1: { a: true, b: { value: 'xyz' } }, job2: { j2: 123 } },
+      { job1: { b: '123xyz' }, job2: { j2: 999 } },
+      null
+    );
+
+    assert.equal(parameterGroups.length, 2);
+    assert.deepEqual(parameterGroups[0], {
+      jobName: 'job1',
+      parameters: [
+        { name: 'a', value: true, defaultValues: true, description: '' },
+        { name: 'b', value: 'xyz', defaultValues: '123xyz', description: '' }
+      ],
+      isOpen: false,
+      paramGroupTitle: 'Job: job1'
+    });
+    assert.deepEqual(parameterGroups[1], {
+      jobName: 'job2',
+      parameters: [
+        { name: 'j2', value: 123, defaultValues: 999, description: '' }
+      ],
+      isOpen: false,
+      paramGroupTitle: 'Job: job2'
+    });
+  });
+
   test('flattenParameterGroup flattens correctly', function (assert) {
     assert.deepEqual(flattenParameterGroup({ param: { value: 123 } }), {
       param: 123


### PR DESCRIPTION
## Context
Fixes dereference issue where there are no parameter groups to expand.

## Objective
#1066 refactored the parameter logic into a utility class, but there was an issue with cases around situations without a parameter group to expand (i.e., there is no job node provided to start the pipeline from and there are also no pipeline parameters configured).  This fix re-introduces the original length check to ensure that the `isOpen` field is properly set when there is a parameter group that needs to be expanded.
 
## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
