### PR TITLE
fix: Refactor to no use ember data for pipeline data

### DIFF
--- a/app/v2/pipeline/template.hbs
+++ b/app/v2/pipeline/template.hbs
@@ -3,11 +3,7 @@
   <Pipeline::Nav />
 
   <div class="pipeline-header">
-    <PipelineHeader
-      @pipeline={{this.pipeline}}
-      @collections={{this.collections}}
-      @addToCollection={{action "addToCollection"}}
-    />
+    <!-- TODO: need a new pipeline header component that does not rely on ember data -->
   </div>
 
   <div class="pipeline-main-content {{if this.isEventsPullsJobsRoute "grid"}}">


### PR DESCRIPTION
## Context
The new UI needs to not rely on ember data model for pipeline data.

## Objective
Refactors the route to not use ember data to resolve the pipeline model; instead, the API object returned is used.  The existing pipeline header component expects to use the ember data model for pipeline, as such it is temporarily removed and will be replaced with a new glimmer component in a follow up pull request.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
