### PR TITLE
feat: Screwdriver style mixin for Bootstrap buttons

### DIFF
--- a/app/styles/screwdriver-button.scss
+++ b/app/styles/screwdriver-button.scss
@@ -1,0 +1,23 @@
+@use 'screwdriver-colors' as colors;
+
+@mixin styles {
+  .btn-primary {
+    color: colors.$sd-white;
+    background-color: colors.$sd-running;
+    border-color: colors.$sd-running;
+
+    &:hover {
+      background-color: rgba(colors.$sd-running, 0.75);
+      border-color: transparent;
+    }
+  }
+
+  .btn-outline-primary {
+    color: colors.$sd-running;
+    border-color: colors.$sd-running;
+
+    &:hover {
+      background-color: rgba(colors.$sd-running, 0.1);
+    }
+  }
+}


### PR DESCRIPTION
## Context
Create a style mixin for bootstrap buttons so that we can incrementally adopt a consistent standard on button styles on the new UI.
 
## Objective
Setting the primary and outline button styles based on bootstrap ember buttons (i.e., `BsButton` components).

Primary button:
![Screenshot 2024-07-03 at 17-06-53 New Pipeline Events Show](https://github.com/screwdriver-cd/ui/assets/157658916/a62391de-d6fe-4593-95c7-05902d41eddd)
Primary button hover state:
![Screenshot 2024-07-03 at 17-07-07 New Pipeline Events Show](https://github.com/screwdriver-cd/ui/assets/157658916/8425deb0-aa55-49a1-932a-395c58790954)
Primary button as outline style (note that the button background color is actually transparent hence the slight grey color in the attached screenshot):
![Screenshot 2024-07-03 at 17-08-15 New Pipeline Events Show](https://github.com/screwdriver-cd/ui/assets/157658916/85f4f400-4a98-4c63-b5fa-125a1bd6d910)
Primary button as outline hover state:
![Screenshot 2024-07-03 at 17-08-24 New Pipeline Events Show](https://github.com/screwdriver-cd/ui/assets/157658916/856a9199-b6f6-4132-bffa-26ef9e8ca44a)

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
