### PR TITLE
feat: Display admins on the pipeline page

### DIFF
--- a/app/components/pipeline-options/component.js
+++ b/app/components/pipeline-options/component.js
@@ -52,6 +52,7 @@ export default Component.extend({
   aliasName: '',
   pipelineName: '',
   expandedState: {},
+  isAdminsExpanded: false,
   sortedJobs: computed('jobs', function filterThenSortJobs() {
     const prRegex = /PR-\d+:.*/;
 
@@ -80,6 +81,34 @@ export default Component.extend({
       }
     }
   ),
+  adminsCount: computed('pipeline.admins', {
+    get() {
+      const admins =
+        this.get('pipeline.admins') === undefined ? {} : this.pipeline.admins;
+
+      return Object.keys(admins).filter(key => admins[key]).length;
+    }
+  }),
+  displayAdmins: computed('pipeline.admins', 'isAdminsExpanded', {
+    get() {
+      const admins =
+        this.get('pipeline.admins') === undefined ? {} : this.pipeline.admins;
+
+      const enabledAdmins = Object.keys(admins).filter(key => admins[key]);
+
+      if (!enabledAdmins) {
+        return '';
+      }
+
+      let displayAdmins = enabledAdmins;
+
+      if (displayAdmins.length > 5 && !this.isAdminsExpanded) {
+        displayAdmins = displayAdmins.slice(0, 5);
+      }
+
+      return displayAdmins.join(', ');
+    }
+  }),
   // Updating a pipeline
   async init() {
     this._super(...arguments);
@@ -270,6 +299,9 @@ export default Component.extend({
       }
 
       this.onUpdatePipeline(pipelineConfig);
+    },
+    toggleExpand() {
+      this.toggleProperty('isAdminsExpanded');
     },
     toggleJob(jobId, user, name, stillActive) {
       const status = stillActive ? 'ENABLED' : 'DISABLED';

--- a/app/components/pipeline-options/styles.scss
+++ b/app/components/pipeline-options/styles.scss
@@ -179,6 +179,21 @@
       padding-left: 3px;
     }
   }
+
+  .admins-list {
+    font-weight: bold;
+    margin-top: 10px;
+  }
+
+  .no-admin-message {
+    font-weight: bold;
+    color: $sd-failure;
+    margin-top: 10px;
+  }
+
+  .inline-link {
+    display: inline;
+  }
 }
 
 .text-input {

--- a/app/components/pipeline-options/template.hbs
+++ b/app/components/pipeline-options/template.hbs
@@ -167,6 +167,32 @@
                 </div>
               </div>
             </li>
+            <li>
+              <div class="row">
+                <div class="col-12">
+                  <h4>Admins</h4>
+                  <p>
+                    Users with write access to the repository are added to the pipeline admins
+                    by starting or stopping builds, or by <a href="#sync-pipeline" class="inline-link">executing a pipeline sync</a>.
+                  </p>
+                  {{#if this.displayAdmins}}
+                    <p class="admins-list">
+                      {{this.displayAdmins}}
+                      {{#if (and (gt this.adminsCount 5) (not this.isAdminsExpanded))}}
+                        ... <a href="#" onclick={{action "toggleExpand"}}>more</a>
+                      {{/if}}
+                      {{#if this.isAdminsExpanded}}
+                        <a href="#" onclick={{action "toggleExpand"}}>collapse</a>
+                      {{/if}}
+                    </p>
+                  {{else}}
+                    <p class="no-admin-message">
+                      This pipeline has no admins.
+                    </p>
+                  {{/if}}
+                </div>
+              </div>
+            </li>
           {{/if}}
         </ul>
       </section>
@@ -291,7 +317,7 @@
         <li>
           <div class="row">
             <div class="col-10">
-              <h4>
+              <h4 id="sync-pipeline">
                 Pipeline
               </h4>
               <p>

--- a/tests/acceptance/pipeline-options-test.js
+++ b/tests/acceptance/pipeline-options-test.js
@@ -60,7 +60,7 @@ module('Acceptance | pipeline/options', function (hooks) {
     await visit('/pipelines/1/options');
 
     assert.equal(currentURL(), '/pipelines/1/options');
-    assert.dom('section.pipeline li').exists({ count: 5 });
+    assert.dom('section.pipeline li').exists({ count: 6 });
     assert.dom('section.jobs li').exists({ count: 3 });
     assert.dom('section.danger li').exists({ count: 1 });
   });

--- a/tests/integration/components/pipeline-options/component-test.js
+++ b/tests/integration/components/pipeline-options/component-test.js
@@ -42,7 +42,15 @@ module('Integration | Component | pipeline options', function (hooks) {
       EmberObject.create({
         appId: 'foo/bar',
         scmUri: 'github.com:84604643:master',
-        id: 'abc1234'
+        id: 'abc1234',
+        admins: {
+          admin1: true,
+          admin2: true,
+          admin3: true,
+          admin4: true,
+          admin5: true,
+          admin6: true
+        }
       })
     );
 
@@ -78,7 +86,7 @@ module('Integration | Component | pipeline options', function (hooks) {
 
     // Pipeline
     assert.dom('section.pipeline h3').hasText('Pipeline');
-    assert.dom('section.pipeline li').exists({ count: 5 });
+    assert.dom('section.pipeline li').exists({ count: 6 });
     assert
       .dom('section.pipeline h4')
       .hasText('Checkout URL and Source Directory');
@@ -96,6 +104,20 @@ module('Integration | Component | pipeline options', function (hooks) {
       $('section > ul > li:nth-child(5) input').attr('placeholder'),
       'Select Jobs...'
     );
+    assert.dom('section.pipeline li:nth-child(6) h4').hasText('Admins');
+    assert
+      .dom('section.pipeline li:nth-child(6) p')
+      .hasText(
+        'Users with write access to the repository are added to the pipeline admins by starting or stopping builds, or by executing a pipeline sync.'
+      );
+    assert
+      .dom('section.pipeline li:nth-child(6) .admins-list')
+      .hasText('admin1, admin2, admin3, admin4, admin5 ... more');
+
+    await click('section.pipeline li:nth-child(6) .admins-list a');
+    assert
+      .dom('section.pipeline li:nth-child(6) .admins-list')
+      .hasText('admin1, admin2, admin3, admin4, admin5, admin6 collapse');
 
     // Jobs
     assert.dom('section.jobs h3').hasText('Jobs');


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Allows users to easily view pipeline admins.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
- Display Admins in the Pipeline on the Options page.
![image](https://github.com/user-attachments/assets/a0885e2c-a504-4efa-8793-3bd497153bc6)

- Click `more` to expand.
![image](https://github.com/user-attachments/assets/e1750705-8bee-43b1-8ef7-2833cbb0281f)

- If there is no enabled admin.
![image](https://github.com/user-attachments/assets/9f688f19-d241-4df4-a816-3aa5fcacf209)


## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
