### PR TITLE
fix(3112): Start/restart an event from a stage

### DIFF
--- a/app/components/pipeline-events/component.js
+++ b/app/components/pipeline-events/component.js
@@ -51,7 +51,7 @@ export async function stopBuild(givenEvent, job) {
 }
 
 // eslint-disable-next-line require-jsdoc
-export async function startDetachedBuild(job, options = {}) {
+export async function startDetachedBuild(job, options = {}, stage) {
   this.set('isShowingModal', true);
 
   let event = this.selectedEventObj;
@@ -81,7 +81,7 @@ export async function startDetachedBuild(job, options = {}) {
   let causeMessage = `Manually started by ${user}`;
   const { prNum } = event;
 
-  let startFrom = job.name;
+  let startFrom = stage ? `stage@${stage.name}` : job.name;
 
   if (reason) {
     causeMessage = `[force start]${reason}`;

--- a/app/components/pipeline-workflow/template.hbs
+++ b/app/components/pipeline-workflow/template.hbs
@@ -14,9 +14,11 @@
     @startFrom={{this.selectedEventObj.startFrom}}
     @causeMessage={{this.selectedEventObj.causeMessage}}
     @graphClicked={{action "graphClicked"}}
+    @onShowStageActionsMenu={{action "onShowStageActionsMenu"}}
     @isSkipped={{this.selectedEventObj.isSkipped}}
     @prChainEnabled={{this.prChainEnabled}}
     @stages={{this.stages}}
+    @displayStageMenuHandle={{this.displayStageMenuHandle}}
   >
     <WorkflowTooltip
       @pipeline={{this.pipeline}}
@@ -30,6 +32,14 @@
       @setJobState={{this.setJobState}}
       @confirmStartBuild={{action "confirmStartBuild"}}
     />
+
+    <WorkflowStageActionsMenu
+      @showMenu={{this.showStageActionsMenu}}
+      @canRestartPipeline={{this.canRestartPipeline}}
+      @canStageStartFromView={{this.canStageStartFromView}}
+      @menuData={{this.stageMenuData}}
+      @confirmStartBuild={{action "confirmStartBuild"}}
+    />
   </WorkflowGraphD3>
   {{#if this.isShowingModal}}
     <ModalDialog
@@ -41,10 +51,17 @@
         Are you sure to start?
       </h3>
       <p>
-        Job:
-        <code>
-          {{this.tooltipData.job.name}}
-        </code>
+        {{#if (eq this.newEventStartFromType 'STAGE')}}
+          Stage:
+          <code>
+            {{this.menuData.stage.name}}
+          </code>
+        {{else}}
+          Job:
+          <code>
+            {{this.tooltipData.job.name}}
+          </code>
+        {{/if}}
         <br />
         Commit:
         <code>

--- a/app/components/workflow-graph-d3/component.js
+++ b/app/components/workflow-graph-d3/component.js
@@ -185,6 +185,14 @@ export default Component.extend({
       if (!this.minified && typeof fn === 'function') {
         fn(job, d3.event, this.elementSizes);
       }
+    },
+
+    stageMenuHandleClicked(stage) {
+      const fn = this.onShowStageActionsMenu;
+
+      if (!this.minified && typeof fn === 'function') {
+        fn(stage, d3.event);
+      }
     }
   },
   redraw(data) {
@@ -227,6 +235,10 @@ export default Component.extend({
       this.send('buildClicked', e);
     };
 
+    const onStageMenuHandleClick = stage => {
+      this.send('stageMenuHandleClicked', stage);
+    };
+
     // Add the SVG element
     const svg = getGraphSvg(
       this.element,
@@ -240,7 +252,14 @@ export default Component.extend({
 
     // stages
     const verticalDisplacements = this.showStages
-      ? addStages(svg, data, this.elementSizes, nodeWidth)
+      ? addStages(
+          svg,
+          data,
+          this.elementSizes,
+          nodeWidth,
+          onStageMenuHandleClick,
+          this.displayStageMenuHandle
+        )
       : {};
 
     // edges

--- a/app/components/workflow-graph-d3/styles.scss
+++ b/app/components/workflow-graph-d3/styles.scss
@@ -112,16 +112,33 @@ g {
 
 .stage-info {
   padding: 10px;
-}
 
-.stage-name {
-  font-weight: bold;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
+  .stage-title {
+    display: flex;
+    flex-overflow: wrap;
 
-.stage-description {
-  color: $sd-text-med;
-  margin-top: 5px;
+    .stage-name {
+      font-weight: bold;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .stage-actions {
+      margin-left: auto;
+
+      .stage-menu-handle {
+        font-weight: bold;
+        font-size: 20px;
+        height: 20px;
+        line-height: 10px;
+        cursor: pointer;
+      }
+    }
+  }
+
+  .stage-description {
+    color: $sd-text-med;
+    margin-top: 5px;
+  }
 }

--- a/app/components/workflow-stage-actions-menu/component.js
+++ b/app/components/workflow-stage-actions-menu/component.js
@@ -36,8 +36,6 @@ export default Component.extend({
           pipelineWorkflowElement.scrollLeft) -
         20;
 
-      // const left = event.layerX + stageInfoWrapperElement.left - 20;
-
       el.style.top = `${top}px`;
       el.style.left = `${left}px`;
     }

--- a/app/components/workflow-stage-actions-menu/component.js
+++ b/app/components/workflow-stage-actions-menu/component.js
@@ -1,0 +1,45 @@
+import Component from '@ember/component';
+import { get } from '@ember/object';
+
+export default Component.extend({
+  classNames: 'workflow-stage-actions-menu',
+  classNameBindings: ['showMenu'],
+  showMenu: false,
+
+  didUpdateAttrs() {
+    this._super(...arguments);
+
+    const event = get(this, 'menuData.mouseevent');
+    const stage = get(this, 'menuData.stage');
+    const el = this.element;
+
+    // setting menu position
+    if (el && event) {
+      const pipelineWorkflowElement =
+        document.getElementsByClassName('pipelineWorkflow')[0];
+      const pipelineWorkflowElementClientRect =
+        pipelineWorkflowElement.getBoundingClientRect();
+      const stageInfoWrapperElementClientRect = document
+        .getElementsByClassName(`stage-info-wrapper _stage_${stage.name}`)[0]
+        .getBoundingClientRect();
+
+      const top =
+        event.layerY +
+        (stageInfoWrapperElementClientRect.y -
+          pipelineWorkflowElementClientRect.y +
+          pipelineWorkflowElement.scrollTop) +
+        10;
+      const left =
+        event.layerX +
+        (stageInfoWrapperElementClientRect.x -
+          pipelineWorkflowElementClientRect.x +
+          pipelineWorkflowElement.scrollLeft) -
+        20;
+
+      // const left = event.layerX + stageInfoWrapperElement.left - 20;
+
+      el.style.top = `${top}px`;
+      el.style.left = `${left}px`;
+    }
+  }
+});

--- a/app/components/workflow-stage-actions-menu/styles.scss
+++ b/app/components/workflow-stage-actions-menu/styles.scss
@@ -1,0 +1,69 @@
+& {
+  visibility: hidden;
+  position: absolute;
+  text-align: left;
+  opacity: 0;
+  transition: opacity 0.3s 0.1s;
+
+  &.show-menu {
+    opacity: 1;
+    visibility: visible;
+  }
+
+  .content {
+    position: relative;
+    font-size: 16px;
+    background-color: $sd-white;
+    border: 2px solid $grey-400;
+    border-radius: 2px;
+    box-shadow: 0 4px 16px 0 $box-shadow;
+    padding: 16px 18px;
+
+    a,
+    p {
+      display: block;
+      margin-bottom: 10px;
+    }
+
+    &::before,
+    &::after {
+      bottom: 100%;
+      left: 20px;
+      border: solid transparent;
+      content: ' ';
+      height: 0;
+      width: 0;
+      position: absolute;
+      pointer-events: none;
+      box-sizing: border-box;
+    }
+
+    &::before {
+      border-color: transparent;
+      border-bottom-color: $grey-400;
+      border-width: 13px;
+      margin-left: -13px;
+    }
+
+    &::after {
+      border-color: transparent;
+      border-bottom-color: $sd-white;
+      border-width: 10px;
+      margin-left: -10px;
+    }
+
+    svg {
+      min-width: initial;
+    }
+  }
+  .content :last-child {
+    margin-bottom: 0;
+  }
+
+  &.left .content {
+    &::before,
+    &::after {
+      left: 20px;
+    }
+  }
+}

--- a/app/components/workflow-stage-actions-menu/template.hbs
+++ b/app/components/workflow-stage-actions-menu/template.hbs
@@ -1,0 +1,10 @@
+<div class="content">
+  {{#if this.canRestartPipeline}}
+    {{#if (eq this.canStageStartFromView true)}}
+      <a href="#" {{action this.confirmStartBuild 'STAGE'}}>
+        {{if this.menuData.stage.setup.status "Restart" "Start"}} pipeline from this stage
+      </a>
+    {{/if}}
+  {{/if}}
+  {{yield}}
+</div>

--- a/app/utils/graph-tools.js
+++ b/app/utils/graph-tools.js
@@ -102,14 +102,12 @@ const extractEventStages = (graph, pipelineStages) => {
         stageNameToEventStageMap[stageName] = eventStage;
       }
 
-      const jobInfo = { id: n.id, name: n.name };
-
       if (isStageSetupJob(n.name)) {
-        eventStage.setup = jobInfo;
+        eventStage.setup = n;
       } else if (isStageTeardownJob(n.name)) {
-        eventStage.teardown = jobInfo;
+        eventStage.teardown = n;
       } else {
-        eventStage.jobs.push(jobInfo);
+        eventStage.jobs.push(n);
       }
     }
   });

--- a/app/utils/pipeline-workflow.js
+++ b/app/utils/pipeline-workflow.js
@@ -7,7 +7,7 @@ import { isRoot, reverseGraph, subgraphFilter } from './graph-tools';
  * @param jobName{string}   Job name of the node in question
  * @returns {boolean}       True if the node can be started from the given view, false otherwise
  */
-export default function canJobStart(activeTab, pipelineGraph, jobName) {
+export function canJobStart(activeTab, pipelineGraph, jobName) {
   const reversedGraph = reverseGraph(pipelineGraph);
   const subgraph = subgraphFilter(reversedGraph, jobName);
 
@@ -36,4 +36,19 @@ export default function canJobStart(activeTab, pipelineGraph, jobName) {
   }
 
   return true;
+}
+
+/**
+ * Determines if a stage can be triggered from the view indicated by the activeTab
+ * @param activeTab{string} The active tab that is selected
+ * @param pipelineGraph     Pipeline graph as {nodes, edges}
+ * @param jobName{string}   Stage in question
+ * @returns {boolean}       True if the stage can be started from the given view, false otherwise
+ */
+export function canStageStart(activeTab, pipelineGraph, stage) {
+  if (activeTab === 'pulls') {
+    return false;
+  }
+
+  return canJobStart(activeTab, pipelineGraph, stage.setup.name);
 }

--- a/app/utils/pipeline/graph/d3-graph-util.js
+++ b/app/utils/pipeline/graph/d3-graph-util.js
@@ -265,9 +265,18 @@ export function getVerticalDisplacements(
  * @param data
  * @param sizes
  * @param nodeWidth
+ * @param onStageMenuHandleClick
+ * @param displayStageMenuHandle
  * @returns {{}}
  */
-export function addStages(svg, data, sizes, nodeWidth) {
+export function addStages(
+  svg,
+  data,
+  sizes,
+  nodeWidth,
+  onStageMenuHandleClick,
+  displayStageMenuHandle
+) {
   const { ICON_SIZE, TITLE_SIZE } = sizes;
 
   const stageNameDisplacementMap = {};
@@ -292,17 +301,39 @@ export function addStages(svg, data, sizes, nodeWidth) {
       .attr('height', 0) // Actual height will be computed and set later
       .attr('x', calcStageX(stage, nodeWidth, sizes))
       .attr('y', calcStageY(stage, sizes))
-      .attr('class', 'stage-info-wrapper');
+      .attr('class', `stage-info-wrapper _stage_${stage.name}`);
 
     const stageInfo = fo.append('xhtml:div').attr('class', 'stage-info');
 
     // stage info - name
-    stageInfo
+    const stageTitle = stageInfo
       .append('div')
+      .attr('class', 'stage-title')
+      .style('font-size', `${TITLE_SIZE}px`);
+
+    // stage info - name
+    stageTitle
+      .append('span')
       .html(stage.name)
       .attr('title', stage.name)
       .attr('class', 'stage-name')
       .style('font-size', `${TITLE_SIZE}px`);
+
+    if (displayStageMenuHandle) {
+      const stageActions = stageTitle
+        .append('div')
+        .attr('title', 'Stage actions')
+        .attr('class', 'stage-actions');
+
+      stageActions
+        .append('div')
+        .html('...')
+        .attr('title', 'Stage menu')
+        .attr('class', 'stage-menu-handle')
+        .on('click', () => {
+          onStageMenuHandleClick(stage);
+        });
+    }
 
     // stage info - description
     if (stage.description && stage.description.length > 0) {

--- a/tests/integration/components/pipeline-workflow/component-test.js
+++ b/tests/integration/components/pipeline-workflow/component-test.js
@@ -67,6 +67,7 @@ module('Integration | Component | pipeline workflow', function (hooks) {
 
     assert.dom('.graph-node').exists({ count: 8 });
     assert.dom('.workflow-tooltip').exists({ count: 1 });
+    assert.dom('.workflow-stage-actions-menu').exists({ count: 1 });
   });
 
   test('it renders an event without pr job', async function (assert) {
@@ -87,6 +88,7 @@ module('Integration | Component | pipeline workflow', function (hooks) {
 
     assert.dom('.graph-node').exists({ count: 7 });
     assert.dom('.workflow-tooltip').exists({ count: 1 });
+    assert.dom('.workflow-stage-actions-menu').exists({ count: 1 });
   });
 
   test('it renders with frozen window', async function (assert) {
@@ -162,6 +164,7 @@ module('Integration | Component | pipeline workflow', function (hooks) {
       .exists({ count: 1 });
     assert.dom('.graph-node.build-frozen').exists({ count: 1 });
     assert.dom('.workflow-tooltip').exists({ count: 1 });
+    assert.dom('.workflow-stage-actions-menu').exists({ count: 1 });
   });
 
   test('it renders with latest-commit', async function (assert) {
@@ -256,6 +259,7 @@ module('Integration | Component | pipeline workflow', function (hooks) {
 
     assert.dom('.graph-node').exists({ count: 4 });
     assert.dom('.workflow-tooltip').exists({ count: 1 });
+    assert.dom('.workflow-stage-actions-menu').exists({ count: 1 });
     assert.dom('.pipelineWorkflow g:nth-of-type(1)').hasClass('graph-node');
     assert
       .dom('.pipelineWorkflow g:nth-of-type(2)')

--- a/tests/integration/components/workflow-graph-d3/component-test.js
+++ b/tests/integration/components/workflow-graph-d3/component-test.js
@@ -311,7 +311,7 @@ module('Integration | Component | workflow graph d3', function (hooks) {
     ]);
 
     await render(
-      hbs`<WorkflowGraphD3 @workflowGraph={{this.workflowGraph}} @stages={{this.stages}}/>`
+      hbs`<WorkflowGraphD3 @workflowGraph={{this.workflowGraph}} @stages={{this.stages}} @displayStageMenuHandle={{true}}/>`
     );
 
     assert.equal(this.element.querySelectorAll('svg').length, 1);
@@ -329,6 +329,7 @@ module('Integration | Component | workflow graph d3', function (hooks) {
       2
     );
 
+    // stage name
     assert.equal(
       this.element.querySelectorAll(
         'svg > .stage-info-wrapper .stage-info .stage-name'
@@ -342,6 +343,15 @@ module('Integration | Component | workflow graph d3', function (hooks) {
       .dom('svg > .stage-info-wrapper:nth-of-type(2) .stage-info .stage-name')
       .hasText('production');
 
+    // stage actions menu handle
+    assert.equal(
+      this.element.querySelectorAll(
+        'svg > .stage-info-wrapper .stage-info .stage-actions .stage-menu-handle'
+      ).length,
+      2
+    );
+
+    // stage description
     assert.equal(
       this.element.querySelectorAll(
         'svg > .stage-info-wrapper .stage-info .stage-description'

--- a/tests/integration/components/workflow-stage-actions-menu/component-test.js
+++ b/tests/integration/components/workflow-stage-actions-menu/component-test.js
@@ -1,0 +1,148 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
+import { render, click, findAll } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module(
+  'Integration | Component | workflow stage actions menu',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test('it renders', async function (assert) {
+      await render(hbs`<WorkflowStageActionsMenu/>`);
+
+      assert.dom('.content').exists({ count: 1 });
+
+      // Template block usage:
+      await render(hbs`
+        <WorkflowStageActionsMenu/>
+        "template block text"
+      `);
+
+      assert.dom(this.element).includesText('template block text');
+    });
+
+    test('it renders start link', async function (assert) {
+      const data = {
+        stage: {
+          id: 1234,
+          name: 'integration',
+          setup: {
+            id: 777,
+            name: 'stage@integration:setup'
+          }
+        }
+      };
+
+      this.set('menuData', data);
+      this.set('canRestartPipeline', true);
+      this.set('canStageStartFromView', true);
+      this.set('confirmStartBuild', () => {
+        assert.ok(true);
+      });
+
+      await render(hbs`<WorkflowStageActionsMenu
+        @menuData={{this.menuData}}
+        @showMenu={{this.showMenu}}
+        @canRestartPipeline={{this.canRestartPipeline}}
+        @canStageStartFromView={{this.canStageStartFromView}}
+        @confirmStartBuild={{this.confirmStartBuild}}
+      />`);
+
+      assert.dom('.content a').exists({ count: 1 });
+      assert.dom('a:nth-of-type(1)').hasText('Start pipeline from this stage');
+      await click('a:nth-of-type(1)');
+    });
+
+    test('it renders restart link', async function (assert) {
+      const data = {
+        stage: {
+          id: 1234,
+          name: 'integration',
+          setup: {
+            id: 777,
+            name: 'stage@integration:setup',
+            status: 'RUNNING'
+          }
+        }
+      };
+
+      this.set('menuData', data);
+      this.set('canRestartPipeline', true);
+      this.set('canStageStartFromView', true);
+      this.set('confirmStartBuild', () => {
+        assert.ok(true);
+      });
+
+      await render(hbs`<WorkflowStageActionsMenu
+        @menuData={{this.menuData}}
+        @showMenu={{this.showMenu}}
+        @canRestartPipeline={{this.canRestartPipeline}}
+        @canStageStartFromView={{this.canStageStartFromView}}
+        @confirmStartBuild={{this.confirmStartBuild}}
+      />`);
+
+      assert.dom('.content a').exists({ count: 1 });
+      assert
+        .dom('a:nth-of-type(1)')
+        .hasText('Restart pipeline from this stage');
+      await click(findAll('.content a')[0]);
+    });
+
+    test('it hides start link when the user does not have permission', async function (assert) {
+      const data = {
+        stage: {
+          id: 1234,
+          name: 'integration',
+          setup: {
+            id: 777,
+            name: 'stage@integration:setup'
+          }
+        }
+      };
+
+      this.set('menuData', data);
+      this.set('canRestartPipeline', false);
+      this.set('canStageStartFromView', true);
+      this.set('confirmStartBuild', () => {});
+
+      await render(hbs`<WorkflowStageActionsMenu
+        @menuData={{this.menuData}}
+        @showMenu={{this.showMenu}}
+        @canRestartPipeline={{this.canRestartPipeline}}
+        @canStageStartFromView={{this.canStageStartFromView}}
+        @confirmStartBuild={{this.confirmStartBuild}}
+      />`);
+
+      assert.dom('.content a').doesNotExist();
+    });
+
+    test('it hides start link for PR event', async function (assert) {
+      const data = {
+        stage: {
+          id: 1234,
+          name: 'integration',
+          setup: {
+            id: 777,
+            name: 'stage@integration:setup'
+          }
+        }
+      };
+
+      this.set('menuData', data);
+      this.set('canRestartPipeline', true);
+      this.set('canStageStartFromView', false);
+      this.set('confirmStartBuild', () => {});
+
+      await render(hbs`<WorkflowStageActionsMenu
+        @menuData={{this.menuData}}
+        @showMenu={{this.showMenu}}
+        @canRestartPipeline={{this.canRestartPipeline}}
+        @canStageStartFromView={{this.canStageStartFromView}}
+        @confirmStartBuild={{this.confirmStartBuild}}
+      />`);
+
+      assert.dom('.content a').doesNotExist();
+    });
+  }
+);

--- a/tests/unit/utils/graph-tools-test.js
+++ b/tests/unit/utils/graph-tools-test.js
@@ -929,17 +929,27 @@ module('Unit | Utility | graph tools', function () {
         },
         id: 7,
         jobs: [
-          { id: 21, name: 'ci-deploy' },
-          { id: 22, name: 'ci-test' },
-          { id: 23, name: 'ci-certify' }
+          { id: 21, name: 'ci-deploy', stageName: 'integration' },
+          { id: 22, name: 'ci-test', stageName: 'integration' },
+          { id: 23, name: 'ci-certify', stageName: 'integration' }
         ],
         name: 'integration',
         pos: {
           x: 3,
           y: 0
         },
-        setup: { id: 28, name: 'stage@integration:setup' },
-        teardown: { id: 29, name: 'stage@integration:teardown' }
+        setup: {
+          id: 28,
+          name: 'stage@integration:setup',
+          stageName: 'integration',
+          virtual: true
+        },
+        teardown: {
+          id: 29,
+          name: 'stage@integration:teardown',
+          stageName: 'integration',
+          virtual: true
+        }
       },
       {
         description: undefined,
@@ -964,17 +974,25 @@ module('Unit | Utility | graph tools', function () {
         },
         id: 8,
         jobs: [
-          { id: 31, name: 'prod-deploy' },
-          { id: 32, name: 'prod-test' },
-          { id: 33, name: 'prod-certify' }
+          { id: 31, name: 'prod-deploy', stageName: 'production' },
+          { id: 32, name: 'prod-test', stageName: 'production' },
+          { id: 33, name: 'prod-certify', stageName: 'production' }
         ],
         name: 'production',
         pos: {
           x: 6,
           y: 0
         },
-        setup: { id: 38, name: 'stage@production:setup' },
-        teardown: { id: 39, name: 'stage@production:teardown' }
+        setup: {
+          id: 38,
+          name: 'stage@production:setup',
+          stageName: 'production'
+        },
+        teardown: {
+          id: 39,
+          name: 'stage@production:teardown',
+          stageName: 'production'
+        }
       }
     ];
 

--- a/tests/unit/utils/pipeline-workflow-test.js
+++ b/tests/unit/utils/pipeline-workflow-test.js
@@ -1,4 +1,7 @@
-import canJobStart from 'screwdriver-ui/utils/pipeline-workflow';
+import {
+  canJobStart,
+  canStageStart
+} from 'screwdriver-ui/utils/pipeline-workflow';
 import { module, test } from 'qunit';
 
 module('Unit | Components | pipeline-workflow', function () {
@@ -15,21 +18,89 @@ module('Unit | Components | pipeline-workflow', function () {
       { name: 'pc1' },
       { name: 'pc2' },
       { name: 'pd1' },
-      { name: 'pd2' }
+      { name: 'pd2' },
+      // stage triggered by ~pr
+      { name: 'stage@alpha:setup', stageName: 'alpha' },
+      { name: 'alpha-deploy', stageName: 'alpha' },
+      { name: 'alpha-test', stageName: 'alpha' },
+      { name: 'alpha-deploy', stageName: 'alpha' },
+      { name: 'stage@alpha:teardown', stageName: 'alpha' },
+      // stage triggered by ~commit
+      { name: 'stage@beta:setup', stageName: 'beta' },
+      { name: 'beta-deploy', stageName: 'beta' },
+      { name: 'beta-test', stageName: 'beta' },
+      { name: 'beta-deploy', stageName: 'beta' },
+      { name: 'stage@beta:teardown', stageName: 'beta' },
+      // detached stage
+      { name: 'stage@gamma:setup', stageName: 'gamma' },
+      { name: 'gamma-deploy', stageName: 'gamma' },
+      { name: 'gamma-test', stageName: 'gamma' },
+      { name: 'gamma-deploy', stageName: 'gamma' },
+      { name: 'stage@gamma:teardown', stageName: 'gamma' }
     ],
     edges: [
       { src: '~pr', dest: 'p1' },
       { src: '~pr', dest: 'pc1' },
       { src: '~pr', dest: 'pd1' },
+      { src: '~pr', dest: 'stage@alpha:setup' },
       { src: 'p1', dest: 'p2' },
       { src: '~commit', dest: 'c1' },
       { src: '~commit', dest: 'pc1' },
+      { src: '~commit', dest: 'stage@beta:setup' },
       { src: 'c1', dest: 'c2' },
       { src: 'd1', dest: 'd2' },
       { src: 'd1', dest: 'pd1' },
       { src: 'pc1', dest: 'pc2' },
-      { src: 'pd1', dest: 'pd2' }
+      { src: 'pd1', dest: 'pd2' },
+      // stage alpha
+      { src: 'stage@alpha:setup', dest: 'alpha-deploy' },
+      { src: 'alpha-deploy', dest: 'alpha-test' },
+      { src: 'alpha-test', dest: 'alpha-certify' },
+      { src: 'alpha-certify', dest: 'stage@alpha:teardown' },
+      // stage beta
+      { src: 'stage@beta:setup', dest: 'beta-deploy' },
+      { src: 'beta-deploy', dest: 'beta-test' },
+      { src: 'beta-test', dest: 'beta-certify' },
+      { src: 'beta-certify', dest: 'stage@beta:teardown' },
+      // stage gamma
+      { src: 'stage@gamma:setup', dest: 'gamma-deploy' },
+      { src: 'gamma-deploy', dest: 'gamma-test' },
+      { src: 'gamma-test', dest: 'gamma-certify' },
+      { src: 'gamma-certify', dest: 'stage@gamma:teardown' }
     ]
+  };
+
+  const stageAlpha = {
+    name: 'alpha',
+    jobs: [
+      { name: 'alpha-deploy' },
+      { name: 'alpha-test' },
+      { name: 'alpha-certify' }
+    ],
+    setup: { name: 'stage@alpha:setup' },
+    teardown: { name: 'stage@alpha:teardown' }
+  };
+
+  const stageBeta = {
+    name: 'beta',
+    jobs: [
+      { name: 'beta-deploy' },
+      { name: 'beta-test' },
+      { name: 'beta-certify' }
+    ],
+    setup: { name: 'stage@beta:setup' },
+    teardown: { name: 'stage@beta:teardown' }
+  };
+
+  const stageGamma = {
+    name: 'gamma',
+    jobs: [
+      { name: 'gamma-deploy' },
+      { name: 'gamma-test' },
+      { name: 'gamma-certify' }
+    ],
+    setup: { name: 'stage@gamma:setup' },
+    teardown: { name: 'stage@gamma:teardown' }
   };
 
   test('can start a ~pr triggered job from pr view', assert => {
@@ -58,5 +129,23 @@ module('Unit | Components | pipeline-workflow', function () {
 
     assert.equal(canJobStart('events', workflowGraph, 'p1'), false);
     assert.equal(canJobStart('events', workflowGraph, 'p2'), false);
+  });
+
+  test('cannot start any stage from pr view', assert => {
+    [stageAlpha, stageBeta, stageGamma].forEach(stage => {
+      assert.equal(canStageStart('pulls', workflowGraph, stage), false);
+    });
+  });
+
+  test('can start non ~pr triggered stages from events view', assert => {
+    [stageBeta, stageGamma].forEach(stage => {
+      assert.equal(canStageStart('events', workflowGraph, stage), true);
+    });
+  });
+
+  test('cannot start ~pr triggered stages from events view', assert => {
+    [stageAlpha].forEach(stage => {
+      assert.equal(canStageStart('events', workflowGraph, stage), false);
+    });
   });
 });


### PR DESCRIPTION
## Context
When a stage is detached, there is no option in the UI to start execution of that stage.

## Objective

Add a menu at stage level in the workflow, which shows an action to start the event from that stage.

<img width="1295" alt="image" src="https://github.com/user-attachments/assets/c769bab4-f591-4503-b468-6f6409e02878">


## References

https://github.com/screwdriver-cd/screwdriver/issues/3112

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
