### PR TITLE
fix: Expand default modal styles

### DIFF
--- a/app/styles/bootstrap-modal.scss
+++ b/app/styles/bootstrap-modal.scss
@@ -1,4 +1,6 @@
+@use 'screwdriver-button' as screwdriverButton;
 @use 'screwdriver-colors' as colors;
+@use 'variables';
 
 @mixin styles {
   #ember-bootstrap-wormhole {
@@ -7,9 +9,28 @@
       opacity: 1;
     }
 
-    .modal-content {
-      border-radius: 8px;
-      box-shadow: 0 0 10px colors.$sd-black;
+    .modal {
+      .modal-dialog {
+        max-width: 50%;
+
+        .modal-content {
+          border-radius: 8px;
+          box-shadow: 0 0 10px colors.$sd-black;
+
+          @include screwdriverButton.styles;
+
+          .modal-header {
+            font-weight: variables.$weight-bold;
+            font-size: 1.5rem;
+          }
+
+          .modal-footer {
+            button {
+              width: 10rem;
+            }
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Context
The new UI is making more uses of modals, as such it would be nice to have a more expansive set of styles already pre-configured.

## Objective
Expands the set of styles already configured for a modal in the new UI.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
