### PR TITLE
feat: Add stub route for v2 builds

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -142,6 +142,11 @@ Router.map(function route() {
           this.route('index', { path: '/' });
         });
         this.route('pulls');
+        this.route(
+          'build',
+          { path: 'builds/:build_id' },
+          function buildRoute() {}
+        );
       }
     );
   });

--- a/app/v2/pipeline/build/route.js
+++ b/app/v2/pipeline/build/route.js
@@ -1,0 +1,3 @@
+import Route from '@ember/routing/route';
+
+export default class V2PipelineBuildRoute extends Route {}

--- a/app/v2/pipeline/build/template.hbs
+++ b/app/v2/pipeline/build/template.hbs
@@ -1,0 +1,2 @@
+{{page-title "Build"}}
+{{outlet}}

--- a/tests/unit/v2/pipeline/build/route-test.js
+++ b/tests/unit/v2/pipeline/build/route-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
+
+module('Unit | Route | v2/pipeline/build', function (hooks) {
+  setupTest(hooks);
+
+  test('it exists', function (assert) {
+    let route = this.owner.lookup('route:v2/pipeline/build');
+
+    assert.ok(route);
+  });
+});


### PR DESCRIPTION
## Context
The new v2 UI for tooltips of the workflow graph needs to provide a link to a build.

## Objective
Adds in a stub route so that the graph tooltip component can reference the build route.

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
