### PR TITLE
feat: New modal component to stop a running build

### DIFF
--- a/app/components/pipeline/modal/stop-build/component.js
+++ b/app/components/pipeline/modal/stop-build/component.js
@@ -1,0 +1,29 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+
+export default class PipelineModalStopBuildComponent extends Component {
+  @service shuttle;
+
+  @tracked isDisabled = false;
+
+  @tracked errorMessage = null;
+
+  @tracked successMessage = null;
+
+  @action
+  async stopBuild() {
+    await this.shuttle
+      .fetchFromApi('put', `/builds/${this.args.buildId}`, {
+        status: 'ABORTED'
+      })
+      .then(() => {
+        this.successMessage = 'Build stopped successfully';
+        this.isDisabled = true;
+      })
+      .catch(err => {
+        this.errorMessage = err.message;
+      });
+  }
+}

--- a/app/components/pipeline/modal/stop-build/template.hbs
+++ b/app/components/pipeline/modal/stop-build/template.hbs
@@ -1,0 +1,39 @@
+<BsModal
+  id="stop-build-modal"
+  @onHide={{fn @closeModal}}
+  @onSubmit={{fn this.stopBuild}}
+  as |modal|
+>
+  <modal.header>
+    <div class="modal-title">
+      Stop the build
+    </div>
+  </modal.header>
+  <modal.body>
+    {{#if this.errorMessage}}
+      <InfoMessage
+        @message={{this.errorMessage}}
+        @type="warning"
+        @icon="exclamation-triangle"
+      />
+    {{/if}}
+    {{#if this.successMessage}}
+      <InfoMessage
+        @message={{this.successMessage}}
+        @type="success"
+        @icon="check-circle"
+      />
+    {{/if}}
+    Are you sure you want to stop the build?
+  </modal.body>
+  <modal.footer>
+    <BsButton
+      id="stop-build"
+      @type="primary"
+      @onClick={{modal.submit}}
+      disabled={{this.isDisabled}}
+    >
+      Yes
+    </BsButton>
+  </modal.footer>
+</BsModal>

--- a/tests/integration/components/pipeline/modal/stop-build/component-test.js
+++ b/tests/integration/components/pipeline/modal/stop-build/component-test.js
@@ -1,0 +1,77 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
+import { click, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+
+module('Integration | Component | pipeline/modal/stop-build', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    this.setProperties({
+      buildId: 1,
+      closeModal: () => {}
+    });
+
+    await render(
+      hbs`<Pipeline::Modal::StopBuild
+        @buildId={{this.buildId}}
+        @closeModal={{this.closeModal}}
+      />`
+    );
+
+    assert.dom('.alert').doesNotExist();
+    assert.dom('#stop-build').exists({ count: 1 });
+    assert.dom('#stop-build').isEnabled();
+  });
+
+  test('it displays error message when stop fails', async function (assert) {
+    const shuttle = this.owner.lookup('service:shuttle');
+    const errorMessage = 'Failed to stop build';
+    const shuttleStub = sinon
+      .stub(shuttle, 'fetchFromApi')
+      .rejects({ message: errorMessage });
+
+    this.setProperties({
+      buildId: 1,
+      closeModal: () => {}
+    });
+
+    await render(
+      hbs`<Pipeline::Modal::StopBuild
+        @buildId={{this.buildId}}
+        @closeModal={{this.closeModal}}
+      />`
+    );
+
+    await click('#stop-build');
+
+    assert.equal(shuttleStub.calledOnce, true);
+    assert.dom('.alert').exists({ count: 1 });
+    assert.dom('.alert > span').hasText(errorMessage);
+  });
+
+  test('it displays success message when stop succeeds', async function (assert) {
+    const shuttle = this.owner.lookup('service:shuttle');
+    const shuttleStub = sinon.stub(shuttle, 'fetchFromApi').resolves();
+
+    this.setProperties({
+      buildId: 1,
+      closeModal: () => {}
+    });
+
+    await render(
+      hbs`<Pipeline::Modal::StopBuild
+        @buildId={{this.buildId}}
+        @closeModal={{this.closeModal}}
+      />`
+    );
+
+    await click('#stop-build');
+
+    assert.equal(shuttleStub.calledOnce, true);
+    assert.dom('.alert').exists({ count: 1 });
+    assert.dom('.alert > span').hasText('Build stopped successfully');
+    assert.dom('#stop-build').isDisabled();
+  });
+});


### PR DESCRIPTION
## Context
The new UI for tooltips needs to allow users to abort a running build.

## Objective
Adds a new UI modal component to stop a running build.

New modal:
![Screenshot 2024-07-15 at 14-23-47 New Pipeline Events Show](https://github.com/user-attachments/assets/8e15c2b7-f264-45bb-aecd-0633f4dc36b9)

Showing notification that the action was successful:
![Screenshot 2024-07-15 at 14-24-50 New Pipeline Events Show](https://github.com/user-attachments/assets/54874592-7197-4142-affe-39a21500537f)

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
