### PR TITLE
fix: Updates confirm action modal to latest UI

### DIFF
--- a/app/components/pipeline/modal/confirm-action/component.js
+++ b/app/components/pipeline/modal/confirm-action/component.js
@@ -14,6 +14,10 @@ export default class PipelineModalConfirmActionComponent extends Component {
 
   @service session;
 
+  @tracked errorMessage = null;
+
+  @tracked successMessage = null;
+
   @tracked isAwaitingResponse = false;
 
   @tracked wasActionSuccessful = false;
@@ -105,20 +109,20 @@ export default class PipelineModalConfirmActionComponent extends Component {
       this.reason
     );
 
-    return new Promise((resolve, reject) => {
-      this.shuttle
-        .fetchFromApi('POST', '/events', data)
-        .then(() => {
-          this.wasActionSuccessful = true;
-          resolve();
-        })
-        .catch(err => {
-          this.wasActionSuccessful = false;
-          reject(err);
-        })
-        .finally(() => {
-          this.isAwaitingResponse = false;
-        });
-    });
+    await this.shuttle
+      .fetchFromApi('post', '/events', data)
+      .then(() => {
+        this.successMessage = `${capitalizeFirstLetter(
+          this.action
+        )}ed successfully`;
+        this.wasActionSuccessful = true;
+      })
+      .catch(err => {
+        this.wasActionSuccessful = false;
+        this.errorMessage = err.message;
+      })
+      .finally(() => {
+        this.isAwaitingResponse = false;
+      });
   }
 }

--- a/app/components/pipeline/modal/confirm-action/styles.scss
+++ b/app/components/pipeline/modal/confirm-action/styles.scss
@@ -1,72 +1,31 @@
 @use 'screwdriver-colors' as colors;
 
 @mixin styles {
-  #ember-bootstrap-wormhole {
-    .modal.confirm-action {
-      .modal-dialog {
-        max-width: 50%;
+  #confirm-action-modal {
+    .modal-body {
+      display: flex;
+      flex-direction: column;
 
-        .modal-body {
+      .frozen-reason {
+        label {
           display: flex;
-          flex-direction: column;
+          margin-bottom: 0;
 
-          .modal-title {
-            font-size: 1.75rem;
-            padding-bottom: 0.75rem;
+          > div {
+            margin: auto;
+            padding-right: 0.25rem;
           }
 
-          .alert {
-            margin-bottom: 0.5rem;
-          }
-
-          .frozen-reason {
-            display: flex;
-            justify-content: space-between;
-
-            label {
-              margin: auto;
-              padding-right: 0.25rem;
-            }
-
-            input {
-              flex: 1;
-              border-radius: 4px;
-              border: 1px solid colors.$sd-text-med;
-              padding-left: 8px;
-            }
-          }
-
-          .pipeline-parameters {
-            padding-top: 2.5rem;
+          input {
+            flex: 1;
+            border-radius: 4px;
+            border: 1px solid colors.$sd-text-med;
           }
         }
+      }
 
-        .modal-footer {
-          display: flex;
-          justify-content: space-between;
-
-          button {
-            width: 10rem;
-
-            color: colors.$sd-link;
-            border-color: colors.$sd-link;
-
-            &:hover {
-              background-color: colors.$sd-info-bg;
-            }
-
-            &.confirm {
-              color: colors.$sd-white;
-              background-color: colors.$sd-running;
-              border-color: colors.$sd-running;
-
-              &:hover {
-                background-color: colors.$sd-link;
-                border-color: colors.$sd-link;
-              }
-            }
-          }
-        }
+      .pipeline-parameters {
+        padding-top: 2.5rem;
       }
     }
   }

--- a/app/components/pipeline/modal/confirm-action/template.hbs
+++ b/app/components/pipeline/modal/confirm-action/template.hbs
@@ -1,10 +1,27 @@
 <BsModal
-  class="confirm-action"
+  id="confirm-action-modal"
   @onHide={{fn @closeModal}}
+  @onSubmit={{fn this.startBuild}}
   as |modal|
 >
-  <modal.body>
+  <modal.header>
     <div class="modal-title">Are you sure you want to {{this.action}}?</div>
+  </modal.header>
+  <modal.body>
+    {{#if this.errorMessage}}
+      <InfoMessage
+        @message={{this.errorMessage}}
+        @type="warning"
+        @icon="exclamation-triangle"
+      />
+    {{/if}}
+    {{#if this.successMessage}}
+      <InfoMessage
+        @message={{this.successMessage}}
+        @type="success"
+        @icon="check-circle"
+      />
+    {{/if}}
     <div id="confirm-action-job">Job: <code>{{@job.name}}</code></div>
     <div id="confirm-action-commit">
       Commit: <code>{{this.truncatedMessage}}</code>
@@ -26,9 +43,13 @@
     {{#if this.isFrozen}}
       <div class="frozen-reason">
         <label>
-          Reason:
+          <div>Reason:</div>
+          <Input
+            @type="text"
+            @value={{this.reason}}
+            placeholder="Please enter a reason"
+          />
         </label>
-        <Input @type="text" @value={{this.reason}} placeholder="Please enter a reason"/>
       </div>
     {{/if}}
 
@@ -45,22 +66,13 @@
   </modal.body>
   <modal.footer>
     <BsButton
-      class="confirm"
+      id="submit-action"
       disabled={{this.isSubmitButtonDisabled}}
+      @type="primary"
       @defaultText="Yes"
       @pendingText={{this.pendingAction}}
       @fulfilledText={{this.completedAction}}
-      @onClick={{this.startBuild}}
+      @onClick={{modal.submit}}
     />
-    <BsButton
-      @outline={{true}}
-      @onClick={{modal.close}}
-    >
-      {{#if this.wasActionSuccessful}}
-        Close
-      {{else}}
-        No
-      {{/if}}
-    </BsButton>
   </modal.footer>
 </BsModal>

--- a/app/components/pipeline/modal/styles.scss
+++ b/app/components/pipeline/modal/styles.scss
@@ -1,5 +1,7 @@
+@use 'confirm-action/styles' as confirmAction;
 @use 'toggle-job/styles' as toggleJob;
 
 @mixin styles {
+  @include confirmAction.styles;
   @include toggleJob.styles;
 }

--- a/app/components/pipeline/styles.scss
+++ b/app/components/pipeline/styles.scss
@@ -1,13 +1,11 @@
 @use 'nav/styles' as nav;
 @use 'header/styles' as header;
-@use 'modal/confirm-action/styles' as confirm-action-modal;
 @use 'modal/styles' as modal;
 @use 'parameters/styles' as parameters;
 
 @mixin styles {
   @include nav.styles;
   @include header.styles;
-  @include confirm-action-modal.styles;
   @include modal.styles;
   @include parameters.styles;
 }


### PR DESCRIPTION
## Context
The confirm action modal should be unified to the same style and structure introduced in #1088 

## Objective
Unifies the new confirm action modal to the new v2 UI.
 
## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
