### PR TITLE
fix: Fix class collision

### DIFF
--- a/app/v2/pipeline/styles.scss
+++ b/app/v2/pipeline/styles.scss
@@ -1,7 +1,7 @@
 @use 'events/styles' as events;
 
 @mixin styles {
-  .pipeline-page {
+  .pipeline-page-contents {
     display: grid;
     height: 100%;
 

--- a/app/v2/pipeline/template.hbs
+++ b/app/v2/pipeline/template.hbs
@@ -1,5 +1,5 @@
 {{page-title "Pipeline"}}
-<div class="pipeline-page">
+<div class="pipeline-page-contents">
   <Pipeline::Nav />
 
   <Pipeline::Header


### PR DESCRIPTION
## Context
The `pipeline-page` class is currently used at a higher level in the DOM tree.  While the `pipeline-page` class doesn't apply any particular styles at the moment, having it used further down the DOM tree may cause styling issues further down the road.

## Objective
Change the class being used to one that is more specific and contains the actual styles needed for the element.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
