### PR TITLE
fix: Refactor routes to not use ember data

### DIFF
--- a/app/v2/pipeline/events/show/route.js
+++ b/app/v2/pipeline/events/show/route.js
@@ -12,7 +12,6 @@ export default class NewPipelineEventsShowRoute extends Route {
     let event = latestCommitEvent;
 
     if (eventId !== latestCommitEvent.id) {
-      console.log('Not the latest commit event');
       event = await this.shuttle.fetchFromApi('get', `/events/${eventId}`);
     }
 

--- a/app/v2/pipeline/events/show/route.js
+++ b/app/v2/pipeline/events/show/route.js
@@ -2,13 +2,53 @@ import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 
 export default class NewPipelineEventsShowRoute extends Route {
-  @service
-  store;
+  @service shuttle;
 
-  setupController() {
-    const { event_id: eventId } = this.paramsFor('v2.pipeline.events.show');
-    const eventsController = this.controllerFor('v2.pipeline.events');
+  async model() {
+    const eventId = this.paramsFor('v2.pipeline.events.show').event_id;
+    const model = this.modelFor('v2.pipeline.events');
+    const { latestCommitEvent } = model;
 
-    eventsController.set('selectedEventId', eventId);
+    let event = latestCommitEvent;
+
+    if (eventId !== latestCommitEvent.id) {
+      console.log('Not the latest commit event');
+      event = await this.shuttle.fetchFromApi('get', `/events/${eventId}`);
+    }
+
+    const events = await this.shuttle.fetchFromApi(
+      'get',
+      `/pipelines/${model.pipeline.id}/events?page=1&count=20`
+    );
+
+    const builds = await this.shuttle.fetchFromApi(
+      'get',
+      `/events/${eventId}/builds?fetchSteps=false`
+    );
+
+    const jobs = await this.shuttle.fetchFromApi(
+      'get',
+      `/pipelines/${model.pipeline.id}/jobs`
+    );
+
+    const stages = await this.shuttle.fetchFromApi(
+      'get',
+      `/pipelines/${model.pipeline.id}/stages`
+    );
+
+    const triggers = await this.shuttle.fetchFromApi(
+      'get',
+      `/pipelines/${model.pipeline.id}/triggers`
+    );
+
+    return {
+      ...model,
+      event,
+      events,
+      builds,
+      jobs,
+      stages,
+      triggers
+    };
   }
 }

--- a/app/v2/pipeline/events/show/template.hbs
+++ b/app/v2/pipeline/events/show/template.hbs
@@ -1,2 +1,28 @@
 {{page-title "Show"}}
-{{outlet}}
+
+<!-- TODO: if there are no events, then we don't need to display the below -->
+<div class="pipeline-events">
+  <div class="search-filter-bar">
+
+    <span class="search-filter">
+      <span class="search">
+        {{svg-jar "search" class="img"}}
+      </span>
+      <span class="filter">
+        <FaIcon @icon="filter" />
+      </span>
+    </span>
+
+    <span class="new-event">
+      <span>Start a new event</span>
+      <FaIcon @icon="plus" />
+    </span>
+  </div>
+
+  <div class="event-cards">
+  </div>
+</div>
+
+
+<div class="pipeline-workflow-graph">
+</div>

--- a/app/v2/pipeline/events/template.hbs
+++ b/app/v2/pipeline/events/template.hbs
@@ -14,48 +14,4 @@
   </BsNav>
 </div>
 
-<div class="pipeline-events">
-  <div class="search-filter-bar">
-
-    <span class="search-filter">
-      <span class="search">
-        {{svg-jar "search" class="img"}}
-      </span>
-      <span class="filter">
-        <FaIcon @icon="filter" />
-      </span>
-    </span>
-
-    <span class="new-event">
-      <span>Start a new event</span>
-      <FaIcon @icon="plus" />
-    </span>
-  </div>
-
-  <div class="event-cards">
-  {{#if this.isGroupedEvents}}
-    {{#each this.groupedEvents as |eventGroup| }}
-      <Newui::EventCardGroup
-       @selectedEventId={{this.selectedEventId}}
-       @pipelineId={{this.pipelineId}}
-       @lastSuccessful={{this.lastSuccessful}}
-       @latestCommit={{this.latestCommit}}
-       @events={{eventGroup}}
-      />
-    {{/each}}
-  {{else}}
-    {{#each this.events as |event|}}
-      <Newui::EventCard @event={{event}}
-       @selectedEventId={{this.selectedEventId}}
-       @pipelineId={{this.pipelineId}}
-       @lastSuccessful={{this.lastSuccessful}}
-       @latestCommit={{this.latestCommit}}
-      />
-    {{/each}}
-  {{/if}}
-  </div>
-</div>
-
-<div class="pipeline-workflow-graph" />
-
 {{outlet}}

--- a/app/v2/pipeline/route.js
+++ b/app/v2/pipeline/route.js
@@ -6,17 +6,12 @@ export default class NewPipelineRoute extends Route {
 
   @service shuttle;
 
-  @service store;
-
   async model(params) {
-    const collections = this.store.findAll('collection').catch(() => []);
-
     const pipeline = await this.shuttle
       .fetchFromApi('get', `/pipelines/${params.pipeline_id}`)
       .catch(() => null);
 
     return {
-      collections,
       pipeline
     };
   }


### PR DESCRIPTION
## Context
The API performance improvements that we want to do is currently hinged on not using ember data and using the APIs directly, as such we need to refactor the new v2 pipeline event routes to not rely on the ember data models.

## Objective
Refactors the v2 pipeline events routes to not rely on ember data models.  There are components for the event cards that still need to be refactored, so in the interim those components have been removed from the template.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
