### PR TITLE
fix: Fetch cache, subscribe, stages, workflowGraph for pipeline template detail page

### DIFF
--- a/app/templates/pipeline/detail/controller.js
+++ b/app/templates/pipeline/detail/controller.js
@@ -53,6 +53,30 @@ export default class TemplatesPipelineDetailController extends Controller {
     return config.annotations || {};
   }
 
+  get cache() {
+    const { config } = this.selectedVersionTemplate;
+
+    return config.cache || {};
+  }
+
+  get subscribe() {
+    const { config } = this.selectedVersionTemplate;
+
+    return config.subscribe || {};
+  }
+
+  get stages() {
+    const { config } = this.selectedVersionTemplate;
+
+    return config.stages || {};
+  }
+
+  get workflowGraph() {
+    const { config } = this.selectedVersionTemplate;
+
+    return config.workflowGraph || {};
+  }
+
   get jobs() {
     const { config } = this.selectedVersionTemplate;
     const configJobs = get(config, 'jobs') || {};


### PR DESCRIPTION
## Context

Would be nice to show cache, subscribe, stages, workflowGraph for pipeline template detail page.

## Objective

This PR fetches missing info so it can be displayed on pipeline template detail page.

## References
NA

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
