### PR TITLE
fix: Add dismissible configuration

### DIFF
--- a/app/components/info-message/component.js
+++ b/app/components/info-message/component.js
@@ -2,6 +2,7 @@ import Component from '@ember/component';
 
 export default Component.extend({
   type: 'info',
+  dismissible: true,
   actions: {
     clearMessage: function clearMessage() {
       this.set('message', null);

--- a/app/components/info-message/template.hbs
+++ b/app/components/info-message/template.hbs
@@ -1,5 +1,5 @@
 {{#if @message}}
-  <BsAlert @onDismissed={{action "clearMessage"}} @type={{this.type}}>
+  <BsAlert @onDismissed={{action "clearMessage"}} @type={{this.type}} @dismissible={{this.dismissible}}>
     {{#if
       (eq
         @message "This checkoutUrl is not supported for your current login host."


### PR DESCRIPTION
## Context
The `InfoMessage` component is a wrapper around the bootstrap alert component which has a configuration for allowing the alert to be dismissible.  The `InfoMessage` component doesn't expose this configuration; thus, all instances are by default dismissible.

## Objective
Expose the dismissible option so that the `InfoMessage` component can be configured to be dismissible or not.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
