### PR TITLE
fix: Non-dismissible modal messages

### DIFF
--- a/app/components/pipeline/modal/confirm-action/template.hbs
+++ b/app/components/pipeline/modal/confirm-action/template.hbs
@@ -13,6 +13,7 @@
         @message={{this.errorMessage}}
         @type="warning"
         @icon="exclamation-triangle"
+        @dismissible={{false}}
       />
     {{/if}}
     {{#if this.successMessage}}
@@ -20,6 +21,7 @@
         @message={{this.successMessage}}
         @type="success"
         @icon="check-circle"
+        @dismissible={{false}}
       />
     {{/if}}
     <div id="confirm-action-job">Job: <code>{{@job.name}}</code></div>

--- a/app/components/pipeline/modal/stop-build/template.hbs
+++ b/app/components/pipeline/modal/stop-build/template.hbs
@@ -15,6 +15,7 @@
         @message={{this.errorMessage}}
         @type="warning"
         @icon="exclamation-triangle"
+        @dismissible={{false}}
       />
     {{/if}}
     {{#if this.successMessage}}
@@ -22,6 +23,7 @@
         @message={{this.successMessage}}
         @type="success"
         @icon="check-circle"
+        @dismissible={{false}}
       />
     {{/if}}
     Are you sure you want to stop the build?

--- a/app/components/pipeline/modal/toggle-job/template.hbs
+++ b/app/components/pipeline/modal/toggle-job/template.hbs
@@ -15,6 +15,7 @@
         @message={{this.errorMessage}}
         @type="warning"
         @icon="exclamation-triangle"
+        @dismissible={{false}}
       />
     {{/if}}
     {{#if this.successMessage}}
@@ -22,6 +23,7 @@
         @message={{this.successMessage}}
         @type="success"
         @icon="check-circle"
+        @dismissible={{false}}
       />
     {{/if}}
     <label>


### PR DESCRIPTION
## Context
The new UI uses modals and the `InfoMessage` component, but having the `InfoMessage` component be dismissible is a little awkward.

## Objective
Make the `InfoMessage` component that appears in the new UI modals to be non-dismissible.

## References
Requires #1104

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
