### PR TITLE
fix: moved default workflow graph for pipeline template

### DIFF
--- a/app/templates/pipeline/detail/controller.js
+++ b/app/templates/pipeline/detail/controller.js
@@ -20,11 +20,6 @@ export default class TemplatesPipelineDetailController extends Controller {
 
   pipelineTemplateTags = [];
 
-  workflowGraph = {
-    nodes: [],
-    edges: []
-  };
-
   @tracked startTime;
 
   @tracked endTime;
@@ -72,9 +67,15 @@ export default class TemplatesPipelineDetailController extends Controller {
   }
 
   get workflowGraph() {
+    console.log('selectedVersionTemplate', this.selectedVersionTemplate);
     const { config } = this.selectedVersionTemplate;
 
-    return config.workflowGraph || {};
+    const defaultWorkflowGraph = {
+      nodes: [],
+      edges: []
+    };
+
+    return config.workflowGraph || defaultWorkflowGraph;
   }
 
   get jobs() {

--- a/app/templates/pipeline/detail/controller.js
+++ b/app/templates/pipeline/detail/controller.js
@@ -67,7 +67,6 @@ export default class TemplatesPipelineDetailController extends Controller {
   }
 
   get workflowGraph() {
-    console.log('selectedVersionTemplate', this.selectedVersionTemplate);
     const { config } = this.selectedVersionTemplate;
 
     const defaultWorkflowGraph = {


### PR DESCRIPTION
## Context

The workflow graph value init [here](https://github.com/screwdriver-cd/ui/blob/6202078d8216a6c89dd8abd8f5377fe993f9a6e3/app/templates/pipeline/detail/controller.js#L23-L26) overwrites the value from [the config of selected version](https://github.com/screwdriver-cd/ui/blob/6202078d8216a6c89dd8abd8f5377fe993f9a6e3/app/templates/pipeline/detail/controller.js#L74-L78) 

## Objective

The default value of workflow graph which is 
```
  workflowGraph = {
    nodes: [],
    edges: []
  };
 ```
 should be used only when the selected version is missing the workflow graph config. 
 
## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
