### PR TITLE
fix: Util to check if an event was skipped

### DIFF
--- a/app/utils/pipeline/event.js
+++ b/app/utils/pipeline/event.js
@@ -1,0 +1,14 @@
+/**
+ * Determines if the event has been skipped
+ * @param event
+ * @param builds
+ * @returns {boolean}
+ */
+// eslint-disable-next-line import/prefer-default-export
+export const isSkipped = (event, builds) => {
+  if (event.type === 'pr' || builds.length > 0) {
+    return false;
+  }
+
+  return !!event.commit.message.match(/\[(skip ci|ci skip)\]/);
+};

--- a/tests/unit/utils/pipeline/event-test.js
+++ b/tests/unit/utils/pipeline/event-test.js
@@ -1,0 +1,66 @@
+import { module, test } from 'qunit';
+import { isSkipped } from 'screwdriver-ui/utils/pipeline/event';
+
+module('Unit | Utility | Pipeline | event', function () {
+  test('pr events are not skipped', function (assert) {
+    assert.equal(isSkipped({ type: 'pr' }, []), false);
+  });
+
+  test('pipeline events with builds are not skipped', function (assert) {
+    assert.equal(
+      isSkipped(
+        {
+          type: 'pipeline'
+        },
+        [{ id: 1 }]
+      ),
+      false
+    );
+  });
+
+  test('pipeline events without skip trigger in commit messages are not skipped', function (assert) {
+    assert.equal(
+      isSkipped(
+        {
+          type: 'pipeline',
+          commit: { message: 'Made some changes' }
+        },
+        []
+      ),
+      false
+    );
+    assert.equal(
+      isSkipped(
+        {
+          type: 'pipeline',
+          commit: { message: 'skip ci Made some changes' }
+        },
+        []
+      ),
+      false
+    );
+  });
+
+  test('pipeline events with skip trigger in commit messages are skipped', function (assert) {
+    assert.equal(
+      isSkipped(
+        {
+          type: 'pipeline',
+          commit: { message: '[skip ci] Made some changes' }
+        },
+        []
+      ),
+      true
+    );
+    assert.equal(
+      isSkipped(
+        {
+          type: 'pipeline',
+          commit: { message: '[ci skip] Made some changes' }
+        },
+        []
+      ),
+      true
+    );
+  });
+});


### PR DESCRIPTION
## Context
Creates a new utility function that checks whether an event has was skipped due to having the `skip ci` or `ci skip` text in the commit.

## Objective
The new UI needs to determine if an event was skipped and this utility function extracts that logic out so that it can be used by the new workflow graph.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
