### PR TITLE
feat: New workflow graph component

### DIFF
--- a/app/components/pipeline/workflow/graph/component.js
+++ b/app/components/pipeline/workflow/graph/component.js
@@ -1,0 +1,95 @@
+/* global d3 */
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { isSkipped } from 'screwdriver-ui/utils/pipeline/event';
+import { decorateGraph } from 'screwdriver-ui/utils/graph-tools';
+import {
+  addEdges,
+  addJobIcons,
+  addJobNames,
+  addStages,
+  getElementSizes,
+  getGraphSvg,
+  getMaximumJobNameLength,
+  getNodeWidth
+} from 'screwdriver-ui/utils/pipeline/graph/d3-graph-util';
+import { nodeCanShowTooltip } from 'screwdriver-ui/utils/pipeline/graph/tooltip';
+
+export default class PipelineWorkflowGraphComponent extends Component {
+  @action
+  draw(element) {
+    const data = decorateGraph({
+      inputGraph: this.args.workflowGraph,
+      builds: this.args.builds,
+      jobs: this.args.jobs.map(job => {
+        return { ...job, isDisabled: job.state === 'DISABLED' };
+      }),
+      start: this.args.event.startFrom,
+      chainPR: this.args.chainPr,
+      prNum: this.args.event.prNum,
+      stages: this.args.stages
+    });
+
+    const isSkippedEvent = isSkipped(this.args.event, this.args.builds);
+    const elementSizes = getElementSizes();
+    const maximumJobNameLength = getMaximumJobNameLength(
+      data,
+      this.args.displayJobNameLength
+    );
+    const nodeWidth = getNodeWidth(elementSizes, maximumJobNameLength);
+
+    const onClickGraph = () => {
+      this.args.setShowTooltip(false);
+    };
+
+    const onClickNode = node => {
+      if (nodeCanShowTooltip(node)) {
+        this.args.setShowTooltip(true, node, d3.event, elementSizes);
+      }
+    };
+
+    // Add the SVG element
+    const svg = getGraphSvg(
+      element,
+      data,
+      elementSizes,
+      maximumJobNameLength,
+      onClickGraph
+    );
+
+    // stages
+    const verticalDisplacements =
+      this.args.stages.length > 0
+        ? addStages(svg, data, elementSizes, nodeWidth)
+        : {};
+
+    // edges
+    addEdges(
+      svg,
+      data,
+      elementSizes,
+      nodeWidth,
+      isSkippedEvent,
+      verticalDisplacements
+    );
+
+    // Jobs Icons
+    addJobIcons(
+      svg,
+      data,
+      elementSizes,
+      nodeWidth,
+      verticalDisplacements,
+      isSkippedEvent,
+      onClickNode
+    );
+
+    addJobNames(
+      svg,
+      data,
+      elementSizes,
+      maximumJobNameLength,
+      verticalDisplacements
+    );
+  }
+}

--- a/app/components/pipeline/workflow/graph/styles.scss
+++ b/app/components/pipeline/workflow/graph/styles.scss
@@ -1,0 +1,83 @@
+@use 'screwdriver-colors' as colors;
+
+@font-face {
+  font-family: 'screwdriver';
+  src: url('/assets/screwdriver.eot?anwrf#iefix') format('embedded-opentype'),
+    url('/assets/screwdriver.ttf?anwrf') format('truetype'),
+    url('/assets/screwdriver.woff?anwrf') format('woff'),
+    url('/assets/screwdriver.svg?anwrf#screwdriver') format('svg');
+  font-style: normal;
+}
+
+@mixin styles {
+  #workflow-graph {
+    .graph-node {
+      font-family: 'screwdriver';
+      fill: colors.$sd-text-light;
+      cursor: pointer;
+
+      &.build-success,
+      &.build-started_from {
+        fill: colors.$sd-success;
+
+        &:hover {
+          fill: darken(colors.$sd-success, 10%);
+        }
+      }
+
+      &.build-failure,
+      &.build-aborted {
+        fill: colors.$sd-failure;
+
+        &:hover {
+          fill: darken(colors.$sd-failure, 10%);
+        }
+      }
+
+      &.build-unstable,
+      &.build-warning {
+        fill: colors.$sd-unstable;
+
+        &:hover {
+          fill: darken(colors.$sd-unstable, 10%);
+        }
+      }
+
+      &.build-running,
+      &.build-queued,
+      &.build-blocked,
+      &.build-skipped {
+        fill: colors.$sd-queued;
+
+        &:hover {
+          fill: darken(colors.$sd-queued, 10%);
+        }
+      }
+    }
+    .graph-edge {
+      stroke: colors.$sd-text-light;
+      fill: transparent;
+
+      &.build-success,
+      &.build-started_from {
+        stroke: colors.$sd-success;
+      }
+    }
+
+    .stage-info {
+      padding: 10px;
+
+      .stage-name {
+        font-weight: bold;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+
+      .stage-description {
+        color: colors.$sd-text-med;
+        margin-top: 5px;
+      }
+    }
+  }
+}

--- a/app/components/pipeline/workflow/graph/template.hbs
+++ b/app/components/pipeline/workflow/graph/template.hbs
@@ -1,0 +1,1 @@
+<div id="workflow-graph" {{did-insert this.draw}} />

--- a/app/components/pipeline/workflow/styles.scss
+++ b/app/components/pipeline/workflow/styles.scss
@@ -1,5 +1,7 @@
+@use 'graph/styles' as graph;
 @use 'tooltip/styles' as tooltip;
 
 @mixin styles {
+  @include graph.styles;
   @include tooltip.styles;
 }

--- a/tests/integration/components/pipeline/workflow/graph/component-test.js
+++ b/tests/integration/components/pipeline/workflow/graph/component-test.js
@@ -1,0 +1,255 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | pipeline/workflow/graph', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders base graph', async function (assert) {
+    const workflowGraph = {
+      nodes: [{ name: '~commit' }, { name: 'main' }],
+      edges: [{ src: '~commit', dest: 'main' }]
+    };
+    const event = { startFrom: '~commit' };
+    const jobs = [{ id: 1 }];
+    const builds = [{ id: 1, jobId: 1, status: 'SUCCESS' }];
+    const stages = [];
+    const displayJobNameLength = 20;
+
+    this.setProperties({
+      workflowGraph,
+      event,
+      jobs,
+      builds,
+      stages,
+      displayJobNameLength
+    });
+    await render(
+      hbs`<Pipeline::Workflow::Graph
+            @workflowGraph={{this.workflowGraph}}
+            @event={{this.event}}
+            @jobs={{this.jobs}}
+            @builds={{this.builds}}
+            @stages={{this.stages}}
+            @chainPr={{false}}
+            @displayJobNameLength={{this.displayJobNameLength}}
+      />`
+    );
+
+    assert.dom('svg').exists({ count: 1 });
+
+    assert.equal(this.element.querySelector('svg').children.length, 5);
+  });
+
+  test('it renders with correct job display name length', async function (assert) {
+    const nodeNames = ['~commit', 'abcdefghijklmnopqrstuvwxyz'];
+    const workflowGraph = {
+      nodes: [{ name: nodeNames[0] }, { name: nodeNames[1] }],
+      edges: [{ src: nodeNames[0], dest: nodeNames[1] }]
+    };
+    const event = { startFrom: nodeNames[0] };
+    const jobs = [{ id: 1 }];
+    const builds = [{ id: 1, jobId: 1, status: 'SUCCESS' }];
+    const stages = [];
+    const displayJobNameLength = 25;
+
+    this.setProperties({
+      workflowGraph,
+      event,
+      jobs,
+      builds,
+      stages,
+      displayJobNameLength
+    });
+    await render(
+      hbs`<Pipeline::Workflow::Graph
+            @workflowGraph={{this.workflowGraph}}
+            @event={{this.event}}
+            @jobs={{this.jobs}}
+            @builds={{this.builds}}
+            @stages={{this.stages}}
+            @chainPr={{false}}
+            @displayJobNameLength={{this.displayJobNameLength}}
+      />`
+    );
+
+    const labels = this.element.querySelectorAll('.graph-label');
+
+    assert.equal(labels.length, 2);
+    assert.equal(labels[0].textContent.trim(), nodeNames[0] + nodeNames[0]);
+    assert.equal(
+      labels[1].textContent.trim(),
+      `${nodeNames[1].substring(0, 8)}...${nodeNames[1].slice(-8)}${
+        nodeNames[1]
+      }`
+    );
+  });
+
+  test('it renders virtual stage', async function (assert) {
+    const workflowGraph = {
+      nodes: [
+        { name: '~commit' },
+        {
+          id: 11,
+          name: 'stage@test:setup',
+          stageName: 'test',
+          virtual: true
+        },
+        { id: 1, name: 'main', stageName: 'test' },
+        {
+          id: 12,
+          name: 'stage@test:teardown',
+          stageName: 'test',
+          virtual: true
+        }
+      ],
+      edges: [
+        { src: '~commit', dest: 'stage@test:setup' },
+        { src: 'stage@test:setup', dest: 'main' },
+        { src: 'main', dest: 'stage@test:teardown' }
+      ]
+    };
+    const event = { startFrom: '~commit' };
+    const jobs = [
+      { id: 1, name: 'main' },
+      { id: 11, name: 'stage@test:setup' },
+      { id: 12, name: 'stage@test:teardown' }
+    ];
+    const builds = [
+      { id: 1, jobId: 11, status: 'SUCCESS' },
+      { id: 2, jobId: 1, status: 'SUCCESS' },
+      { id: 3, jobId: 12, status: 'SUCCESS' }
+    ];
+    const stages = [
+      { id: 10, name: 'test', jobIds: [1], setup: 11, teardown: 12 }
+    ];
+    const displayJobNameLength = 20;
+
+    this.setProperties({
+      workflowGraph,
+      event,
+      jobs,
+      builds,
+      stages,
+      displayJobNameLength
+    });
+    await render(
+      hbs`<Pipeline::Workflow::Graph
+            @workflowGraph={{this.workflowGraph}}
+            @event={{this.event}}
+            @jobs={{this.jobs}}
+            @builds={{this.builds}}
+            @stages={{this.stages}}
+            @chainPr={{false}}
+            @displayJobNameLength={{this.displayJobNameLength}}
+      />`
+    );
+
+    assert.dom('svg').exists({ count: 1 });
+
+    assert.equal(this.element.querySelector('svg').children.length, 7);
+  });
+
+  test('it renders stage', async function (assert) {
+    const workflowGraph = {
+      nodes: [
+        { name: '~commit' },
+        {
+          id: 11,
+          name: 'stage@test:setup',
+          stageName: 'test'
+        },
+        { id: 1, name: 'main', stageName: 'test' },
+        {
+          id: 12,
+          name: 'stage@test:teardown',
+          stageName: 'test'
+        }
+      ],
+      edges: [
+        { src: '~commit', dest: 'stage@test:setup' },
+        { src: 'stage@test:setup', dest: 'main' },
+        { src: 'main', dest: 'stage@test:teardown' }
+      ]
+    };
+    const event = { startFrom: '~commit' };
+    const jobs = [
+      { id: 1, name: 'main' },
+      { id: 11, name: 'stage@test:setup' },
+      { id: 12, name: 'stage@test:teardown' }
+    ];
+    const builds = [
+      { id: 1, jobId: 11, status: 'SUCCESS' },
+      { id: 2, jobId: 1, status: 'SUCCESS' },
+      { id: 3, jobId: 12, status: 'SUCCESS' }
+    ];
+    const stages = [
+      { id: 10, name: 'test', jobIds: [1], setup: 11, teardown: 12 }
+    ];
+    const displayJobNameLength = 20;
+
+    this.setProperties({
+      workflowGraph,
+      event,
+      jobs,
+      builds,
+      stages,
+      displayJobNameLength
+    });
+    await render(
+      hbs`<Pipeline::Workflow::Graph
+            @workflowGraph={{this.workflowGraph}}
+            @event={{this.event}}
+            @jobs={{this.jobs}}
+            @builds={{this.builds}}
+            @stages={{this.stages}}
+            @chainPr={{false}}
+            @displayJobNameLength={{this.displayJobNameLength}}
+      />`
+    );
+
+    assert.dom('svg').exists({ count: 1 });
+
+    assert.equal(this.element.querySelector('svg').children.length, 13);
+  });
+
+  test('it renders with chained PRs', async function (assert) {
+    const workflowGraph = {
+      nodes: [{ name: '~pr' }, { name: 'first' }, { name: 'second' }],
+      edges: [
+        { src: '~pr', dest: 'first' },
+        { src: 'first', dest: 'second' }
+      ]
+    };
+    const event = { startFrom: '~pr' };
+    const jobs = [{ id: 1 }];
+    const builds = [{ id: 1, jobId: 1, status: 'SUCCESS' }];
+    const stages = [];
+    const displayJobNameLength = 20;
+
+    this.setProperties({
+      workflowGraph,
+      event,
+      jobs,
+      builds,
+      stages,
+      displayJobNameLength
+    });
+    await render(
+      hbs`<Pipeline::Workflow::Graph
+            @workflowGraph={{this.workflowGraph}}
+            @event={{this.event}}
+            @jobs={{this.jobs}}
+            @builds={{this.builds}}
+            @stages={{this.stages}}
+            @chainPr={{true}}
+            @displayJobNameLength={{this.displayJobNameLength}}
+      />`
+    );
+
+    assert.dom('svg').exists({ count: 1 });
+
+    assert.equal(this.element.querySelector('svg').children.length, 8);
+  });
+});


### PR DESCRIPTION
## Context
New glimmer component for the V2 workflow graph

## Objective
Creates a new glimmer component and associated stylesheet for the workflow graph.  The primary difference between the new component and the existing component is that any logic around creating and massaging data related to the workflow graph is moved up a layer and the new component is effectively a dumb display layer.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
