### PR TITLE
fix: Integrates the workflow graph into the v2 route

### DIFF
--- a/app/components/pipeline/nav/styles.scss
+++ b/app/components/pipeline/nav/styles.scss
@@ -1,11 +1,10 @@
 @use 'screwdriver-colors' as colors;
 
 @mixin styles {
-  .pipeline-nav {
+  #pipeline-nav {
     border-right: 1px solid colors.$sd-separator;
     display: flex;
     flex-direction: column;
-    grid-area: pipeline-nav;
     padding-top: 0.75rem;
 
     a {

--- a/app/components/pipeline/nav/template.hbs
+++ b/app/components/pipeline/nav/template.hbs
@@ -1,4 +1,4 @@
-<div class="pipeline-nav">
+<div id="pipeline-nav">
   <LinkTo @route="v2.pipeline.events" title="Events">
     <FaIcon @icon="cubes" @size="16x" />
   </LinkTo>

--- a/app/components/pipeline/styles.scss
+++ b/app/components/pipeline/styles.scss
@@ -2,10 +2,12 @@
 @use 'header/styles' as header;
 @use 'modal/styles' as modal;
 @use 'parameters/styles' as parameters;
+@use 'workflow/styles' as workflow;
 
 @mixin styles {
   @include nav.styles;
   @include header.styles;
   @include modal.styles;
   @include parameters.styles;
+  @include workflow.styles;
 }

--- a/app/components/pipeline/workflow/tooltip/component.js
+++ b/app/components/pipeline/workflow/tooltip/component.js
@@ -4,12 +4,10 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import { isActivePipeline } from 'screwdriver-ui/utils/pipeline';
 import { getTooltipData } from 'screwdriver-ui/utils/pipeline/graph/tooltip';
-import canJobStart from 'screwdriver-ui/utils/pipeline-workflow';
+import { canJobStart } from 'screwdriver-ui/utils/pipeline-workflow';
 
 export default class PipelineWorkflowTooltipComponent extends Component {
   @service router;
-
-  @service shuttle;
 
   @service session;
 
@@ -20,8 +18,6 @@ export default class PipelineWorkflowTooltipComponent extends Component {
   @tracked isDescriptionClicked = false;
 
   @tracked showConfirmActionModal = false;
-
-  @tracked confirmActionMeta;
 
   @tracked showStopBuildModal = false;
 
@@ -85,17 +81,13 @@ export default class PipelineWorkflowTooltipComponent extends Component {
     return description;
   }
 
-  get job() {
-    return this.tooltipData.job;
-  }
-
   @action
   setTooltipPosition(element) {
     const { d3Event } = this.args.d3Data;
     const { ICON_SIZE } = this.args.d3Data.sizes;
 
-    element.style.top = `${d3Event.clientY + ICON_SIZE}px`;
-    element.style.left = `${d3Event.clientX - 30}px`;
+    element.style.top = `${d3Event.layerY + ICON_SIZE}px`;
+    element.style.left = `${d3Event.layerX - 30}px`;
   }
 
   @action

--- a/app/components/pipeline/workflow/tooltip/styles.scss
+++ b/app/components/pipeline/workflow/tooltip/styles.scss
@@ -35,10 +35,10 @@
     span {
       margin: 0;
       padding-bottom: 1rem;
-    }
 
-    &:last-child {
-      padding-bottom: 0;
+      &:last-child {
+        padding-bottom: 0;
+      }
     }
 
     hr {

--- a/app/components/pipeline/workflow/tooltip/template.hbs
+++ b/app/components/pipeline/workflow/tooltip/template.hbs
@@ -57,7 +57,7 @@
         {{else}}
           {{#if this.canJobStartFromView}}
               <a
-                id="toggle-job-link"
+                id="start-job-link"
                  href="#"
                 {{on "click" (fn this.openConfirmActionModal)}}
               >

--- a/app/v2/pipeline/events/show/controller.js
+++ b/app/v2/pipeline/events/show/controller.js
@@ -1,0 +1,65 @@
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import ENV from 'screwdriver-ui/config/environment';
+import { getFilteredGraph } from './util';
+
+export default class V2PipelineEventsShowController extends Controller {
+  @service session;
+
+  @tracked showDownstreamTriggers = false;
+
+  @tracked showTooltip = false;
+
+  @tracked d3Data = null;
+
+  get workflowGraph() {
+    return getFilteredGraph(this.model.event.workflowGraph);
+  }
+
+  get workflowGraphWithDownstreamTriggers() {
+    const workflowGraph = structuredClone(
+      getFilteredGraph(this.model.event.workflowGraph)
+    );
+    const { triggers } = this.model;
+
+    triggers.forEach(trigger => {
+      if (trigger.triggers.length > 0) {
+        workflowGraph.nodes.push({
+          name: `~sd-${trigger.jobName}-triggers`,
+          triggers: trigger.triggers,
+          status: 'DOWNSTREAM_TRIGGER'
+        });
+        workflowGraph.edges.push({
+          src: trigger.jobName,
+          dest: `~sd-${trigger.jobName}-triggers`
+        });
+      }
+    });
+
+    return workflowGraph;
+  }
+
+  get displayJobNameLength() {
+    return this.model.userSettings.displayJobNameLength
+      ? this.model.userSettings.displayJobNameLength
+      : ENV.APP.MINIMUM_JOBNAME_LENGTH;
+  }
+
+  @action
+  toggleShowDownstreamTriggers() {
+    this.showDownstreamTriggers = !this.showDownstreamTriggers;
+  }
+
+  @action
+  setShowTooltip(showTooltip, node, d3Event, sizes) {
+    this.showTooltip = showTooltip;
+
+    if (showTooltip) {
+      this.d3Data = { node, d3Event, sizes };
+    } else {
+      this.d3Data = null;
+    }
+  }
+}

--- a/app/v2/pipeline/events/show/template.hbs
+++ b/app/v2/pipeline/events/show/template.hbs
@@ -23,6 +23,63 @@
   </div>
 </div>
 
-
 <div class="pipeline-workflow-graph">
+  <div id="pipeline-workflow-graph-controls">
+    <div
+      class="button-container"
+      title="Toggle to {{if this.showDownstreamTriggers "hide" "show"}} the downstream trigger nodes."
+    >
+      <XToggle
+        @size="medium"
+        @theme="material"
+        @showLabels={{true}}
+        @value={{this.showDownstreamTriggers}}
+        @offLabel="Hide triggers"
+        @onLabel="Show triggers"
+        @onToggle={{fn this.toggleShowDownstreamTriggers}}
+      />
+    </div>
+  </div>
+
+  <div id="workflow-graph-container">
+    {{#if this.showDownstreamTriggers}}
+      <Pipeline::Workflow::Graph
+        @workflowGraph={{this.workflowGraphWithDownstreamTriggers}}
+        @event={{this.model.event}}
+        @jobs={{this.model.jobs}}
+        @builds={{this.model.builds}}
+        @stages={{this.model.stages}}
+        @chainPr={{this.model.pipeline.prChain}}
+        @displayJobNameLength={{this.displayJobNameLength}}
+        @setShowTooltip={{this.setShowTooltip}}
+        @displayStageTooltip={{true}}
+        @setShowStageTooltip={{this.setShowStageTooltip}}
+      />
+    {{else}}
+      <Pipeline::Workflow::Graph
+        @workflowGraph={{this.workflowGraph}}
+        @event={{this.model.event}}
+        @jobs={{this.model.jobs}}
+        @builds={{this.model.builds}}
+        @stages={{this.model.stages}}
+        @chainPr={{this.model.pipeline.prChain}}
+        @displayJobNameLength={{this.displayJobNameLength}}
+        @setShowTooltip={{this.setShowTooltip}}
+        @displayStageTooltip={{true}}
+        @setShowStageTooltip={{this.setShowStageTooltip}}
+      />
+    {{/if}}
+
+    {{#if this.showTooltip}}
+      <Pipeline::Workflow::Tooltip
+        @d3Data={{this.d3Data}}
+        @event={{this.model.event}}
+        @jobs={{this.model.jobs}}
+        @builds={{this.model.builds}}
+        @workflowGraph={{this.workflowGraph}}
+        @pipeline={{this.model.pipeline}}
+        @latestCommitEvent={{this.model.latestCommitEvent}}
+      />
+    {{/if}}
+  </div>
 </div>

--- a/app/v2/pipeline/events/show/util.js
+++ b/app/v2/pipeline/events/show/util.js
@@ -1,0 +1,16 @@
+/**
+ * Filters the workflow graph by removing nodes that start with 'sd@' (i.e., triggers external pipelines)
+ * @param event
+ */
+// eslint-disable-next-line import/prefer-default-export
+export const getFilteredGraph = workflowGraph => {
+  const nodes = workflowGraph.nodes.filter(node => {
+    return !node.name.startsWith('sd@');
+  });
+
+  const edges = workflowGraph.edges.filter(edge => {
+    return !edge.dest.startsWith('sd@');
+  });
+
+  return { nodes, edges };
+};

--- a/app/v2/pipeline/events/styles.scss
+++ b/app/v2/pipeline/events/styles.scss
@@ -6,9 +6,8 @@
   grid-template-areas:
     'pipeline-tab pipeline-tab'
     'pipeline-events pipeline-event-main-content';
-
-  grid-template-rows: 3.75rem;
-  grid-template-columns: 26rem;
+  grid-template-rows: 3.75rem calc(100% - 3.75rem);
+  grid-template-columns: 26rem calc(100% - 26rem);
 
   .pipeline-tab {
     grid-area: pipeline-tab;
@@ -128,5 +127,27 @@
 
   .pipeline-workflow-graph {
     grid-area: pipeline-event-main-content;
+
+    #pipeline-workflow-graph-controls {
+      display: flex;
+      align-content: center;
+      padding-left: 1rem;
+      height: 2.5rem;
+    }
+
+    #workflow-graph-container {
+      position: relative;
+      height: calc(100% - 2.5rem);
+      overflow: auto;
+
+      #workflow-graph {
+        height: 100%;
+
+        svg {
+          min-width: 100%;
+          min-height: 100%;
+        }
+      }
+    }
   }
 }

--- a/app/v2/pipeline/styles.scss
+++ b/app/v2/pipeline/styles.scss
@@ -5,12 +5,15 @@
     display: grid;
     height: 100%;
 
-    grid-template-columns: 4rem;
-    grid-auto-rows: min-content auto;
-
     grid-template-areas:
       'pipeline-nav pipeline-header'
       'pipeline-nav pipeline-main';
+    grid-template-columns: 4rem calc(100% - 4rem);
+    grid-template-rows: 4.5rem calc(100% - 4.5rem);
+
+    #pipeline-nav {
+      grid-area: pipeline-nav;
+    }
 
     #pipeline-header {
       grid-area: pipeline-header;

--- a/tests/unit/v2/pipeline/events/show/controller-test.js
+++ b/tests/unit/v2/pipeline/events/show/controller-test.js
@@ -1,0 +1,56 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
+
+module('Unit | Controller | v2/pipeline/events/show', function (hooks) {
+  setupTest(hooks);
+
+  test('it exists', function (assert) {
+    const controller = this.owner.lookup('controller:v2/pipeline/events/show');
+
+    assert.ok(controller);
+  });
+
+  test('it gets workflow graph-tooltip', function (assert) {
+    const controller = this.owner.lookup('controller:v2/pipeline/events/show');
+    const workflowGraph = {
+      nodes: [{ name: '~pr' }, { name: '~commit' }, { name: 'main' }],
+      edges: [{ src: '~commit', dest: 'main' }]
+    };
+
+    controller.model = { event: { workflowGraph } };
+
+    assert.deepEqual(controller.workflowGraph, workflowGraph);
+  });
+
+  test('it gets workflow graph-tooltip with external triggers', function (assert) {
+    const controller = this.owner.lookup('controller:v2/pipeline/events/show');
+    const workflowGraph = {
+      nodes: [{ name: '~pr' }, { name: '~commit' }, { name: 'main' }],
+      edges: [{ src: '~commit', dest: 'main' }]
+    };
+    const triggers = [{ jobName: 'main', triggers: ['~sd@123:main'] }];
+
+    controller.model = { event: { workflowGraph }, triggers };
+
+    const graph = controller.workflowGraphWithDownstreamTriggers;
+
+    assert.equal(graph.nodes.length, workflowGraph.nodes.length + 1);
+    assert.equal(graph.edges.length, workflowGraph.edges.length + 1);
+  });
+
+  test('it gets display job name length', function (assert) {
+    const controller = this.owner.lookup('controller:v2/pipeline/events/show');
+
+    controller.model = { userSettings: { displayJobNameLength: 32 } };
+
+    assert.equal(controller.displayJobNameLength, 32);
+  });
+
+  test('it gets default display job name length', function (assert) {
+    const controller = this.owner.lookup('controller:v2/pipeline/events/show');
+
+    controller.model = { userSettings: {} };
+
+    assert.equal(controller.displayJobNameLength, 20);
+  });
+});

--- a/tests/unit/v2/pipeline/events/show/util-test.js
+++ b/tests/unit/v2/pipeline/events/show/util-test.js
@@ -1,0 +1,20 @@
+import { module, test } from 'qunit';
+import { getFilteredGraph } from 'screwdriver-ui/v2/pipeline/events/show/util';
+
+module('Unit | Utility | v2/pipeline/events/show', function () {
+  test('getFilteredGraph removes nodes that trigger external pipelines', function (assert) {
+    assert.deepEqual(
+      getFilteredGraph({
+        nodes: [{ name: 'sd@123' }, { name: 'main' }, { name: 'build' }],
+        edges: [
+          { src: 'main', dest: 'build' },
+          { src: 'build', dest: 'sd@123' }
+        ]
+      }),
+      {
+        nodes: [{ name: 'main' }, { name: 'build' }],
+        edges: [{ src: 'main', dest: 'build' }]
+      }
+    );
+  });
+});


### PR DESCRIPTION
## Context
Integrates the new workflow graph glimmer component into the v2 event route.

## Objective
Wraps up the piping for allowing the workflow graph to be displayed on the page.  Some additional clean up around the CSS has been done as well as removing some unused code. 

![Screenshot 2024-08-05 at 16-37-21 New Pipeline Events Show](https://github.com/user-attachments/assets/c318f694-2594-42bf-bc3a-80030a7ebf2e)

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
