### PR TITLE
fix: Stage tooltip

### DIFF
--- a/app/components/pipeline/modal/confirm-action/util.js
+++ b/app/components/pipeline/modal/confirm-action/util.js
@@ -38,7 +38,7 @@ export function capitalizeFirstLetter(string) {
 /**
  * Build post body for starting a job
  * @param username
- * @param pipeline
+ * @param pipelineId
  * @param job
  * @param event
  * @param parameters

--- a/app/components/pipeline/workflow/graph/component.js
+++ b/app/components/pipeline/workflow/graph/component.js
@@ -40,12 +40,17 @@ export default class PipelineWorkflowGraphComponent extends Component {
 
     const onClickGraph = () => {
       this.args.setShowTooltip(false);
+      this.args.setShowStageTooltip(false);
     };
 
     const onClickNode = node => {
       if (nodeCanShowTooltip(node)) {
         this.args.setShowTooltip(true, node, d3.event, elementSizes);
       }
+    };
+
+    const onClickStageMenu = stage => {
+      this.args.setShowStageTooltip(true, stage, d3.event);
     };
 
     // Add the SVG element
@@ -60,7 +65,14 @@ export default class PipelineWorkflowGraphComponent extends Component {
     // stages
     const verticalDisplacements =
       this.args.stages.length > 0
-        ? addStages(svg, data, elementSizes, nodeWidth)
+        ? addStages(
+            svg,
+            data,
+            elementSizes,
+            nodeWidth,
+            onClickStageMenu,
+            this.args.displayStageTooltip
+          )
         : {};
 
     // edges

--- a/app/components/pipeline/workflow/graph/styles.scss
+++ b/app/components/pipeline/workflow/graph/styles.scss
@@ -1,4 +1,5 @@
 @use 'screwdriver-colors' as colors;
+@use 'variables';
 
 @font-face {
   font-family: 'screwdriver';
@@ -67,11 +68,26 @@
     .stage-info {
       padding: 10px;
 
-      .stage-name {
-        font-weight: bold;
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
+      .stage-title {
+        display: flex;
+        justify-content: space-between;
+
+        .stage-name {
+          font-weight: bold;
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
+        }
+
+        .stage-actions {
+          .stage-menu-handle {
+            font-size: 1.5rem;
+            font-weight: variables.$weight-bold;
+            cursor: pointer;
+            height: 1.5rem;
+            line-height: 0.75rem;
+          }
+        }
       }
 
       .stage-description {

--- a/app/components/pipeline/workflow/tooltip/stage/component.js
+++ b/app/components/pipeline/workflow/tooltip/stage/component.js
@@ -53,11 +53,15 @@ export default class PipelineWorkflowTooltipStageComponent extends Component {
       const x = stageMenuRect.width / 2 + stageMenuRect.x;
       const y = stageMenuRect.height + stageMenuRect.y;
 
-      element.style.top = `${y - workflowGraphRect.y + 2}px`;
-      // 14 is 1 rem (the padding of the tooltip)
-      // 2 is the border width
-      // 13 is the width of the tooltip triangle
-      element.style.left = `${x - workflowGraphRect.x - 14 - 2 - 13}px`;
+      // The constants below are from the CSS style sheet
+      const padding = 14;
+      const borderWidth = 2;
+      const triangleWidth = 13;
+
+      element.style.top = `${y - workflowGraphRect.y + borderWidth}px`;
+      element.style.left = `${
+        x - workflowGraphRect.x - padding - borderWidth - triangleWidth
+      }px`;
     }
   }
 

--- a/app/components/pipeline/workflow/tooltip/stage/component.js
+++ b/app/components/pipeline/workflow/tooltip/stage/component.js
@@ -1,0 +1,73 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import { canJobStart } from 'screwdriver-ui/utils/pipeline-workflow';
+
+export default class PipelineWorkflowTooltipStageComponent extends Component {
+  @service router;
+
+  @service session;
+
+  @tracked showConfirmActionModal = false;
+
+  get canStartStageFromView() {
+    const activeTab = this.router.currentRoute.name.includes('events')
+      ? 'events'
+      : 'pulls';
+
+    return canJobStart(
+      activeTab,
+      this.args.workflowGraph,
+      this.args.d3Data.stage.setup.name
+    );
+  }
+
+  get stageStatus() {
+    const build = this.args.builds.find(
+      b => b.jobId === this.args.d3Data.stage.setup.id
+    );
+
+    return build ? build.status : null;
+  }
+
+  get job() {
+    const setupJob = this.args.d3Data.stage.setup;
+
+    return {
+      ...setupJob,
+      status: this.stageStatus
+    };
+  }
+
+  @action
+  setTooltipPosition(element) {
+    const { d3Event } = this.args.d3Data;
+    const workflowGraphElement = document.getElementById('workflow-graph');
+    const stageMenu = d3Event.target;
+
+    if (workflowGraphElement && stageMenu) {
+      const workflowGraphRect = workflowGraphElement.getBoundingClientRect();
+      const stageMenuRect = stageMenu.getBoundingClientRect();
+
+      const x = stageMenuRect.width / 2 + stageMenuRect.x;
+      const y = stageMenuRect.height + stageMenuRect.y;
+
+      element.style.top = `${y - workflowGraphRect.y + 2}px`;
+      // 14 is 1 rem (the padding of the tooltip)
+      // 2 is the border width
+      // 13 is the width of the tooltip triangle
+      element.style.left = `${x - workflowGraphRect.x - 14 - 2 - 13}px`;
+    }
+  }
+
+  @action
+  openConfirmActionModal() {
+    this.showConfirmActionModal = true;
+  }
+
+  @action
+  closeConfirmActionModal() {
+    this.showConfirmActionModal = false;
+  }
+}

--- a/app/components/pipeline/workflow/tooltip/stage/template.hbs
+++ b/app/components/pipeline/workflow/tooltip/stage/template.hbs
@@ -1,0 +1,26 @@
+<div id="workflow-graph-tooltip" {{did-insert this.setTooltipPosition}}>
+  <div class="triangle" />
+
+  {{#if this.canStartStageFromView}}
+    <a
+      id="start-job-link"
+      href="#"
+      {{on "click" (fn this.openConfirmActionModal)}}
+    >
+      {{if this.stageStatus "Restart" "Start"}} pipeline from this stage
+    </a>
+  {{else}}
+    <div>Can not {{if this.stageStatus "restart" "start"}} stage</div>
+  {{/if}}
+</div>
+
+{{#if this.showConfirmActionModal}}
+  <Pipeline::Modal::ConfirmAction
+    @pipeline={{@pipeline}}
+    @event={{@event}}
+    @jobs={{@jobs}}
+    @latestCommitEvent={{@latestCommitEvent}}
+    @job={{this.job}}
+    @closeModal={{this.closeConfirmActionModal}}
+  />
+{{/if}}

--- a/app/utils/pipeline/graph/d3-graph-util.js
+++ b/app/utils/pipeline/graph/d3-graph-util.js
@@ -277,7 +277,7 @@ export function addStages(
   onStageMenuHandleClick,
   displayStageMenuHandle
 ) {
-  const { ICON_SIZE, TITLE_SIZE } = sizes;
+  const { TITLE_SIZE } = sizes;
 
   const stageNameDisplacementMap = {};
   const stageNameToStageElementsMap = {};
@@ -297,7 +297,7 @@ export function addStages(
     // stage info
     const fo = svg
       .append('foreignObject')
-      .attr('width', nodeWidth * stage.graph.meta.width - ICON_SIZE / 2)
+      .attr('width', calcStageWidth(stage, nodeWidth, sizes))
       .attr('height', 0) // Actual height will be computed and set later
       .attr('x', calcStageX(stage, nodeWidth, sizes))
       .attr('y', calcStageY(stage, sizes))

--- a/app/v2/pipeline/events/show/controller.js
+++ b/app/v2/pipeline/events/show/controller.js
@@ -12,6 +12,8 @@ export default class V2PipelineEventsShowController extends Controller {
 
   @tracked showTooltip = false;
 
+  @tracked showStageTooltip = false;
+
   @tracked d3Data = null;
 
   get workflowGraph() {
@@ -58,6 +60,17 @@ export default class V2PipelineEventsShowController extends Controller {
 
     if (showTooltip) {
       this.d3Data = { node, d3Event, sizes };
+    } else {
+      this.d3Data = null;
+    }
+  }
+
+  @action
+  setShowStageTooltip(showStageTooltip, stage, d3Event) {
+    this.showStageTooltip = showStageTooltip;
+
+    if (showStageTooltip) {
+      this.d3Data = { stage, d3Event };
     } else {
       this.d3Data = null;
     }

--- a/app/v2/pipeline/events/show/template.hbs
+++ b/app/v2/pipeline/events/show/template.hbs
@@ -81,5 +81,16 @@
         @latestCommitEvent={{this.model.latestCommitEvent}}
       />
     {{/if}}
+    {{#if this.showStageTooltip}}
+      <Pipeline::Workflow::Tooltip::Stage
+        @d3Data={{this.d3Data}}
+        @event={{this.model.event}}
+        @jobs={{this.model.jobs}}
+        @builds={{this.model.builds}}
+        @workflowGraph={{this.workflowGraph}}
+        @pipeline={{this.model.pipeline}}
+        @latestCommitEvent={{this.model.latestCommitEvent}}
+      />
+    {{/if}}
   </div>
 </div>

--- a/tests/integration/components/pipeline/workflow/tooltip/stage/component-test.js
+++ b/tests/integration/components/pipeline/workflow/tooltip/stage/component-test.js
@@ -1,0 +1,131 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+
+module(
+  'Integration | Component | pipeline/workflow/tooltip/stage',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test('it renders an empty stage tooltip', async function (assert) {
+      const router = this.owner.lookup('service:router');
+
+      sinon.stub(router, 'currentRoute').value({
+        name: 'pulls'
+      });
+
+      this.setProperties({
+        d3Data: {
+          d3Event: { target: null },
+          stage: {
+            setup: {
+              name: 'setup'
+            }
+          }
+        },
+        event: {},
+        jobs: [],
+        builds: [],
+        workflowGraph: {
+          nodes: [],
+          edges: []
+        }
+      });
+
+      await render(
+        hbs`<Pipeline::Workflow::Tooltip::Stage
+            @d3Data={{this.d3Data}}
+            @event={{this.event}}
+            @jobs={{this.jobs}}
+            @builds={{this.builds}}
+            @workflowGraph={{this.workflowGraph}}
+        />`
+      );
+
+      assert.dom('#start-job-link').doesNotExist();
+      assert.dom('#workflow-graph-tooltip').exists();
+      assert.dom('#workflow-graph-tooltip').hasText('Can not start stage');
+    });
+
+    test('it renders an stage tooltip to start', async function (assert) {
+      const router = this.owner.lookup('service:router');
+
+      sinon.stub(router, 'currentRoute').value({
+        name: 'events'
+      });
+
+      this.setProperties({
+        d3Data: {
+          d3Event: { target: null },
+          stage: {
+            setup: {
+              name: 'setup'
+            }
+          }
+        },
+        event: {},
+        jobs: [],
+        builds: [],
+        workflowGraph: {
+          nodes: [],
+          edges: []
+        }
+      });
+
+      await render(
+        hbs`<Pipeline::Workflow::Tooltip::Stage
+            @d3Data={{this.d3Data}}
+            @event={{this.event}}
+            @jobs={{this.jobs}}
+            @builds={{this.builds}}
+            @workflowGraph={{this.workflowGraph}}
+        />`
+      );
+
+      assert.dom('#start-job-link').exists();
+      assert.dom('#start-job-link').hasText('Start pipeline from this stage');
+    });
+
+    test('it renders an stage tooltip to start', async function (assert) {
+      const router = this.owner.lookup('service:router');
+
+      sinon.stub(router, 'currentRoute').value({
+        name: 'events'
+      });
+
+      this.setProperties({
+        d3Data: {
+          d3Event: { target: null },
+          stage: {
+            setup: {
+              id: 123,
+              name: 'setup'
+            }
+          }
+        },
+        event: {},
+        jobs: [],
+        builds: [{ jobId: 123, status: 'SUCCESS' }],
+        workflowGraph: {
+          nodes: [],
+          edges: []
+        }
+      });
+
+      await render(
+        hbs`<Pipeline::Workflow::Tooltip::Stage
+            @d3Data={{this.d3Data}}
+            @event={{this.event}}
+            @jobs={{this.jobs}}
+            @builds={{this.builds}}
+            @workflowGraph={{this.workflowGraph}}
+        />`
+      );
+
+      assert.dom('#start-job-link').exists();
+      assert.dom('#start-job-link').hasText('Restart pipeline from this stage');
+    });
+  }
+);


### PR DESCRIPTION
## Context
The new UI is missing the tooltip for starting/restarting a stage from the workflow graph.

## Objective
Adds in the tooltip for starting/restarting a stage from the workflow graph.  Additional logic has been added to ensure that stages that can not be triggered indicate that to the user.

A stage that can be restarted:
![Screenshot 2024-08-07 at 17-15-50 New Pipeline Events Show](https://github.com/user-attachments/assets/93a25a1e-2fbc-42ad-a6ff-df8ade89b403)

A stage that can not be started:
![Screenshot 2024-08-07 at 17-15-21 New Pipeline Events Show](https://github.com/user-attachments/assets/78d63314-e244-4c1d-a22a-b4e0a4ed69d1)


## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
