### PR TITLE
fix: Fixes the tooltip position

### DIFF
--- a/app/components/pipeline/workflow/graph/component.js
+++ b/app/components/pipeline/workflow/graph/component.js
@@ -44,7 +44,7 @@ export default class PipelineWorkflowGraphComponent extends Component {
 
     const onClickNode = node => {
       if (nodeCanShowTooltip(node)) {
-        this.args.setShowTooltip(true, node, d3.event, elementSizes);
+        this.args.setShowTooltip(true, node, d3.event);
       }
     };
 

--- a/app/components/pipeline/workflow/tooltip/component.js
+++ b/app/components/pipeline/workflow/tooltip/component.js
@@ -84,10 +84,28 @@ export default class PipelineWorkflowTooltipComponent extends Component {
   @action
   setTooltipPosition(element) {
     const { d3Event } = this.args.d3Data;
-    const { ICON_SIZE } = this.args.d3Data.sizes;
 
-    element.style.top = `${d3Event.layerY + ICON_SIZE}px`;
-    element.style.left = `${d3Event.layerX - 30}px`;
+    const workflowGraphElement = document.getElementById('workflow-graph');
+
+    if (workflowGraphElement && d3Event.target) {
+      const workflowGraphRect = workflowGraphElement.getBoundingClientRect();
+      const nodeRect = d3Event.target.getBoundingClientRect();
+
+      const x = nodeRect.width / 2 + nodeRect.x;
+      const y = nodeRect.height + nodeRect.y;
+
+      // The constants below are from the CSS style sheet
+      const padding = 14;
+      const borderWidth = 2;
+      const triangleWidth = 13;
+
+      element.style.top = `${
+        y - workflowGraphRect.y + padding + triangleWidth
+      }px`;
+      element.style.left = `${
+        x - workflowGraphRect.x - padding - borderWidth - triangleWidth
+      }px`;
+    }
   }
 
   @action

--- a/app/v2/pipeline/events/show/controller.js
+++ b/app/v2/pipeline/events/show/controller.js
@@ -53,11 +53,11 @@ export default class V2PipelineEventsShowController extends Controller {
   }
 
   @action
-  setShowTooltip(showTooltip, node, d3Event, sizes) {
+  setShowTooltip(showTooltip, node, d3Event) {
     this.showTooltip = showTooltip;
 
     if (showTooltip) {
-      this.d3Data = { node, d3Event, sizes };
+      this.d3Data = { node, d3Event };
     } else {
       this.d3Data = null;
     }


### PR DESCRIPTION
## Context
Sets the tooltip position to always be anchored to the graph node's midpoint.

## Objective
The tooltip position is determined by the mouse position when the user clicks on a graph node.  To provide a more static and consistent position for the tooltip, the graph node's actual position is now used to determine the tooltip position rather than the mouse's coordinates.

![Screenshot 2024-08-07 at 17-42-26 New Pipeline Events Show](https://github.com/user-attachments/assets/8a7948f5-a224-44d5-aa48-559799eb54bd)


## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
