### PR TITLE
feat(3143): Unhide start and restart buttons for all stage jobs

### DIFF
--- a/app/components/workflow-tooltip/component.js
+++ b/app/components/workflow-tooltip/component.js
@@ -58,17 +58,6 @@ export default Component.extend({
       return description;
     }
   ),
-  displayRestartButton: computed(
-    'canRestartPipeline',
-
-    'tooltipData.job.stageName',
-    function displayRestartButton() {
-      return (
-        get(this, 'canRestartPipeline') &&
-        !get(this, 'tooltipData.job.stageName')
-      );
-    }
-  ),
   actions: {
     toggleJob(toggleJobName) {
       const state = this.jobState;

--- a/app/components/workflow-tooltip/template.hbs
+++ b/app/components/workflow-tooltip/template.hbs
@@ -31,7 +31,7 @@
         Enable this job
       </a>
     {{else}}
-      {{#if this.displayRestartButton}}
+      {{#if this.canRestartPipeline}}
         {{#if this.tooltipData.job.manualStartDisabled}}
           <p>
             Disabled manually starting

--- a/tests/integration/components/workflow-tooltip/component-test.js
+++ b/tests/integration/components/workflow-tooltip/component-test.js
@@ -271,7 +271,7 @@ module('Integration | Component | workflow tooltip', function (hooks) {
 
     this.set('data', data);
     this.set('confirmStartBuild', () => {});
-    this.set('canJobStartFromView', true);
+    this.set('canJobStartFromView', false);
 
     await render(hbs`<WorkflowTooltip
         @tooltipData={{this.data}}
@@ -327,7 +327,7 @@ module('Integration | Component | workflow tooltip', function (hooks) {
 
     this.set('data', data);
     this.set('confirmStartBuild', () => {});
-    this.set('canJobStartFromView', false);
+    this.set('canJobStartFromView', true);
 
     await render(hbs`<WorkflowTooltip
         @tooltipData={{this.data}}

--- a/tests/integration/components/workflow-tooltip/component-test.js
+++ b/tests/integration/components/workflow-tooltip/component-test.js
@@ -271,7 +271,7 @@ module('Integration | Component | workflow tooltip', function (hooks) {
 
     this.set('data', data);
     this.set('confirmStartBuild', () => {});
-    this.set('canJobStartFromView', false);
+    this.set('canJobStartFromView', true);
 
     await render(hbs`<WorkflowTooltip
         @tooltipData={{this.data}}
@@ -298,7 +298,7 @@ module('Integration | Component | workflow tooltip', function (hooks) {
 
     this.set('data', data);
     this.set('confirmStartBuild', () => {});
-    this.set('canJobStartFromView', false);
+    this.set('canJobStartFromView', true);
 
     await render(hbs`<WorkflowTooltip
         @tooltipData={{this.data}}

--- a/tests/integration/components/workflow-tooltip/component-test.js
+++ b/tests/integration/components/workflow-tooltip/component-test.js
@@ -286,7 +286,7 @@ module('Integration | Component | workflow tooltip', function (hooks) {
     assert.dom('a:nth-of-type(3)').hasText('Disable this job');
   });
 
-  test('it hides start link for stage jobs', async function (assert) {
+  test('it renders start link for stage jobs', async function (assert) {
     const data = {
       job: {
         buildId: 1234,
@@ -307,13 +307,14 @@ module('Integration | Component | workflow tooltip', function (hooks) {
         @canJobStartFromView={{this.canJobStartFromView}}
       />`);
 
-    assert.dom('.content a').exists({ count: 3 });
+    assert.dom('.content a').exists({ count: 4 });
     assert.dom('a:nth-of-type(1)').hasText('Go to build details');
     assert.dom('a:nth-of-type(2)').hasText('Go to build metrics');
-    assert.dom('a:nth-of-type(3)').hasText('Disable this job');
+    assert.dom('a:nth-of-type(3)').hasText('Start pipeline from here');
+    assert.dom('a:nth-of-type(4)').hasText('Disable this job');
   });
 
-  test('it hides restart link for stage jobs', async function (assert) {
+  test('it renders restart link for stage jobs', async function (assert) {
     const data = {
       job: {
         buildId: 1234,
@@ -335,10 +336,11 @@ module('Integration | Component | workflow tooltip', function (hooks) {
         @canJobStartFromView={{this.canJobStartFromView}}
       />`);
 
-    assert.dom('.content a').exists({ count: 3 });
+    assert.dom('.content a').exists({ count: 4 });
     assert.dom('a:nth-of-type(1)').hasText('Go to build details');
     assert.dom('a:nth-of-type(2)').hasText('Go to build metrics');
-    assert.dom('a:nth-of-type(3)').hasText('Disable this job');
+    assert.dom('a:nth-of-type(3)').hasText('Restart pipeline from here');
+    assert.dom('a:nth-of-type(4)').hasText('Disable this job');
   });
 
   test('it renders stop frozen build link', async function (assert) {


### PR DESCRIPTION
## Context

Start and restart buttons are not shown for stage jobs

## Objective

Unhide start and restart buttons for stage jobs

## References

https://github.com/screwdriver-cd/screwdriver/issues/3143

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
