### PR TITLE
fix: make long build parameters confirmable

### DIFF
--- a/app/components/pipeline-parameterized-build/styles.scss
+++ b/app/components/pipeline-parameterized-build/styles.scss
@@ -60,3 +60,9 @@ button.start-with-parameters-button {
     content: 'Start pipeline with parameters';
   }
 }
+
+.ember-basic-dropdown-content {
+  li.ember-power-select-option {
+    width: fit-content;
+  }
+}

--- a/app/components/pipeline-parameterized-build/template.hbs
+++ b/app/components/pipeline-parameterized-build/template.hbs
@@ -58,6 +58,7 @@
                         @renderInPlace={{true}}
                         @searchEnabled={{true}}
                         @selected={{value}}
+                        @title={{value}}
                         @onOpen={{ action
                             "onOpen"
                         }}


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

We can't check what build parameter is filled when long value selected.

Long build parameters are
- invisible when mouse over
- omitted at the select box

![hide](https://github.com/user-attachments/assets/1416012e-53e4-4a28-8f97-3a169bfb1957)
![omit](https://github.com/user-attachments/assets/c18f2dfb-8009-408d-882a-5adf8871e7ea)

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Stretch the width of blue background color to show white letters.
Show the selected value when hovering select box.

![stretch](https://github.com/user-attachments/assets/4d9bae2b-9982-42a6-80f1-a852a0129857)
![title](https://github.com/user-attachments/assets/127b8da2-d8db-4b4e-ac08-c4a77874ec49)

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
