### PR TITLE
fix: Parameter bug for pipelines where only job level parameters exist

### DIFF
--- a/app/components/pipeline/modal/confirm-action/component.js
+++ b/app/components/pipeline/modal/confirm-action/component.js
@@ -2,12 +2,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
-import {
-  buildPostBody,
-  capitalizeFirstLetter,
-  initializeParameters,
-  truncateMessage
-} from './util';
+import { buildPostBody, capitalizeFirstLetter, truncateMessage } from './util';
 
 export default class PipelineModalConfirmActionComponent extends Component {
   @service shuttle;
@@ -25,12 +20,6 @@ export default class PipelineModalConfirmActionComponent extends Component {
   @tracked reason = '';
 
   parameters;
-
-  constructor() {
-    super(...arguments);
-
-    this.parameters = initializeParameters(this.args.event);
-  }
 
   get action() {
     return this.args.job.status ? 'restart' : 'start';

--- a/app/components/pipeline/modal/confirm-action/component.js
+++ b/app/components/pipeline/modal/confirm-action/component.js
@@ -50,11 +50,13 @@ export default class PipelineModalConfirmActionComponent extends Component {
   }
 
   get isParameterized() {
-    if (this.args.pipeline.parameters) {
-      return Object.keys(this.args.pipeline.parameters).length > 0;
-    }
+    const pipelineParameters = this.args.pipeline.parameters || {};
+    const eventParameters = this.args.event.meta?.parameters || {};
 
-    return false;
+    return (
+      Object.keys(pipelineParameters).length > 0 ||
+      Object.keys(eventParameters).length > 0
+    );
   }
 
   get isSubmitButtonDisabled() {

--- a/app/components/pipeline/modal/confirm-action/util.js
+++ b/app/components/pipeline/modal/confirm-action/util.js
@@ -1,18 +1,3 @@
-import { flattenParameters } from 'screwdriver-ui/utils/pipeline/parameters';
-
-/**
- * Initialize parameters from an event API response object
- * @param event
- * @returns {undefined|*}
- */
-export function initializeParameters(event) {
-  if (event.meta?.parameters && event.meta.parameters.length > 0) {
-    return flattenParameters(event.meta.parameters);
-  }
-
-  return undefined;
-}
-
 /**
  * Truncate commit message to 150 characters
  * @param commitMessage

--- a/tests/unit/components/pipeline/modal/confirm-action/util-test.js
+++ b/tests/unit/components/pipeline/modal/confirm-action/util-test.js
@@ -2,22 +2,10 @@ import { module, test } from 'qunit';
 import {
   buildPostBody,
   capitalizeFirstLetter,
-  initializeParameters,
   truncateMessage
 } from 'screwdriver-ui/components/pipeline/modal/confirm-action/util';
 
 module('Unit | Component | pipeline/modal/confirm-action/util', function () {
-  test('initializeParameters initializes correctly', function (assert) {
-    assert.deepEqual(initializeParameters({ id: 123 }, undefined));
-    assert.deepEqual(initializeParameters({ id: 123, meta: {} }, undefined));
-    assert.deepEqual(
-      initializeParameters(
-        { id: 123, meta: { parameters: { foo: 'bar' } } },
-        { foo: 'bar' }
-      )
-    );
-  });
-
   test('truncateMessage truncates string', function (assert) {
     const shortMessage = 'short message';
 


### PR DESCRIPTION
## Context
In the new UI, there is a bug where the modal to restart a job does not correctly display the parameters when only job level parameters exist.

## Objective
Fixes the aforementioned bug.  Additionally cleans up the constructor to remove an unnecessary function call that was not providing any actual benefit.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
