### PR TITLE
fix(3143): show all jobs in the job list view

### DIFF
--- a/app/components/pipeline-list-view/template.hbs
+++ b/app/components/pipeline-list-view/template.hbs
@@ -26,7 +26,7 @@
   @showGlobalFilter={{false}}
   @showCurrentPageNumberSelect={{false}}
   @multipleColumnsSorting={{false}}
-  @pageSize={{100}}
+  @pageSize={{this.data.length}}
 />
 <div class="loader" {{in-viewport onEnter=(action "onScrolledToBottom")}}>
   {{#if this.isLoading}}

--- a/tests/integration/components/pipeline-list-view/component-test.js
+++ b/tests/integration/components/pipeline-list-view/component-test.js
@@ -101,7 +101,7 @@ module('Integration | Component | pipeline list view', function (hooks) {
     assert.dom('tbody tr').exists({ count: 2 });
   });
 
-  test.only('it renders with large number of jobs', async function (assert) {
+  test('it renders with large number of jobs', async function (assert) {
     const jobs = Array.from({ length: 1000 }, (_, i) => {
       return {
         jobId: i,

--- a/tests/integration/components/pipeline-list-view/component-test.js
+++ b/tests/integration/components/pipeline-list-view/component-test.js
@@ -101,6 +101,66 @@ module('Integration | Component | pipeline list view', function (hooks) {
     assert.dom('tbody tr').exists({ count: 2 });
   });
 
+  test.only('it renders with large number of jobs', async function (assert) {
+    const jobs = Array.from({ length: 1000 }, (_, i) => {
+      return {
+        jobId: i,
+        jobName: `job${i}`,
+        builds: [
+          {
+            id: i,
+            jobId: i,
+            status: 'SUCCESS',
+            startTime: '',
+            endTime: ''
+          }
+        ],
+        annotations: {
+          'screwdriver.cd/displayName': `job${i}`
+        }
+      };
+    });
+
+    set(this, 'pipeline', PIPELINE);
+    set(this, 'jobsDetails', jobs);
+    set(this, 'updateListViewJobs', () => Promise.resolve(jobs));
+    set(this, 'refreshListViewJobs', () => {
+      assert.ok(true);
+    });
+    set(this, 'startSingleBuild', () => {
+      assert.ok(true);
+    });
+    set(this, 'stopBuild', () => {
+      assert.ok(true);
+    });
+    set(this, 'buildParameters', []);
+    set(this, 'showListView', true);
+    set(this, 'setShowListView', () => {
+      assert.ok(true);
+    });
+
+    await render(hbs`<PipelineListView
+      @pipeline={{this.pipeline}}
+      @jobsDetails={{this.jobsDetails}}
+      @updateListViewJobs={{this.updateListViewJobs}}
+      @refreshListViewJobs={{this.refreshListViewJobs}}
+      @startSingleBuild={{this.startSingleBuild}}
+      @stopBuild={{this.stopBuild}}
+      @buildParameters={{this.buildParameters}}
+      @showListView={{this.showListView}}
+      @setShowListView={{this.setShowListView}}
+    />`);
+
+    assert.dom('table').exists({ count: 1 });
+    assert.dom('thead').exists({ count: 1 });
+    assert.dom('tbody').exists({ count: 1 });
+    assert.dom('th.table-header').exists({ count: 7 });
+    assert
+      .dom('thead')
+      .hasText('JOB HISTORY DURATION START TIME COVERAGE METRICS ACTIONS');
+    assert.dom('tbody tr').exists({ count: 1000 });
+  });
+
   test('it renders then resets jobDetails', async function (assert) {
     set(this, 'pipeline', PIPELINE);
     set(this, 'jobsDetails', [


### PR DESCRIPTION
## Context
The job list view only displays up to 100 jobs.
Because of this, some jobs will not be displayed in a pipeline with more than 100 jobs.

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
All jobs are displayed in the job list view even if the pipeline has more than 100 jobs.

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/3167

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
