### PR TITLE
fix(3143): fix job list view to load jobs sequentially

### DIFF
--- a/app/components/pipeline-list-view/component.js
+++ b/app/components/pipeline-list-view/component.js
@@ -74,8 +74,11 @@ export default Component.extend({
 
   async init() {
     this._super(...arguments);
+    this.set('isLoading', true);
     const jobs = await this.updateListViewJobs();
     const rows = this.getRows(jobs);
+
+    this.set('isLoading', false);
     const customTheme = {
       table: 'table table-condensed table-sm',
       sortAscIcon: 'fa fa-fw fa-sort-up',

--- a/app/components/pipeline-list-view/component.js
+++ b/app/components/pipeline-list-view/component.js
@@ -1,5 +1,5 @@
 import Component from '@ember/component';
-import { get, set, observer } from '@ember/object';
+import { get, observer } from '@ember/object';
 import moment from 'moment';
 import { inject as service } from '@ember/service';
 import { toCustomLocaleString } from 'screwdriver-ui/utils/time-range';
@@ -20,6 +20,8 @@ export default Component.extend({
   isLoading: false,
   isShowingModal: false,
   data: [],
+  lastRows: [],
+  moreJobs: true,
   timestampPreference: null,
   columns: [
     {
@@ -72,8 +74,8 @@ export default Component.extend({
 
   async init() {
     this._super(...arguments);
-    const rows = this.getRows(this.jobsDetails);
-
+    const jobs = await this.updateListViewJobs();
+    const rows = this.getRows(jobs);
     const customTheme = {
       table: 'table table-condensed table-sm',
       sortAscIcon: 'fa fa-fw fa-sort-up',
@@ -296,20 +298,27 @@ export default Component.extend({
       );
 
       if (!isEqualRes) {
-        set(this, 'lastRows', lastRows);
+        this.set('lastRows', rows);
         this.set('data', rows);
       }
     }
   ),
 
   actions: {
-    async onScrolledToBottom() {
-      this.set('isLoading', true);
-      const jobs = await this.updateListViewJobs();
-      const rows = this.getRows(jobs);
+    async onScrolledToBottom({ currentTarget }) {
+      const { scrollTop, scrollHeight, clientHeight } = currentTarget;
 
-      this.set('data', rows);
-      this.set('isLoading', false);
+      if (scrollTop + clientHeight > scrollHeight - 300) {
+        if (this.moreJobs && !this.isLoading) {
+          this.set('isLoading', true);
+          const newJobs = await this.updateListViewJobs();
+
+          if (newJobs.length === 0) {
+            this.set('moreJobs', false);
+          }
+          this.set('isLoading', false);
+        }
+      }
     },
 
     closeModal() {

--- a/app/components/pipeline-list-view/template.hbs
+++ b/app/components/pipeline-list-view/template.hbs
@@ -27,8 +27,9 @@
   @showCurrentPageNumberSelect={{false}}
   @multipleColumnsSorting={{false}}
   @pageSize={{this.data.length}}
+  onScroll={{action "onScrolledToBottom"}}
 />
-<div class="loader" {{in-viewport onEnter=(action "onScrolledToBottom")}}>
+<div class="loader">
   {{#if this.isLoading}}
       Loading...
   {{/if}}


### PR DESCRIPTION
## Context
<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Continued from #1118, #1119

The upper limit on the number of drawings for a job has been practically removed with #1118.
However, the number of jobs that can be loaded at one time is limited to 200 by `ENV.APP.LIST_VIEW_PAGE_SIZE`
Moreover, scrolling on the job-list-view page should cause additional jobs to be loaded every 200, but this is not working properly.

## Objective
All jobs can be displayed on job-list-view page.
- Scrolling to the bottom of the job-list-view table will cause additional jobs to be loaded correctly. (Like pipeline event list)
- Stop acquisition when the number of additional acquisitions is 0, so that job loading does not occur endlessly.

Operation after change with 500 jobs

https://github.com/user-attachments/assets/792f4525-0139-4ecc-ae13-812419aaf2ed


<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
