### PR TITLE
fix: show long parameter names as title

### DIFF
--- a/app/components/pipeline-parameterized-build/styles.scss
+++ b/app/components/pipeline-parameterized-build/styles.scss
@@ -32,6 +32,13 @@ button.start-with-parameters-button {
       display: none;
     }
   }
+
+  .parameter-name {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    max-width: 20em;
+  }
 }
 
 .notice-default-values-icon {

--- a/app/components/pipeline-parameterized-build/template.hbs
+++ b/app/components/pipeline-parameterized-build/template.hbs
@@ -29,7 +29,9 @@
                       @title={{parameter.description}}
                     />
                   {{/if}}
-                  {{parameter.name}}
+                  <div title={{parameter.name}} class="parameter-name">
+                    {{parameter.name}}
+                  </div>
                 </label>
                 <div class="col-8">
                   {{#if (is-array parameter.value)}}


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Long parameter names are overflow and they are under parameters form.
As result, we can't see them.

<img width="859" alt="before" src="https://github.com/user-attachments/assets/36a7f1a9-e4ac-47e0-b48d-f60026415e5d">

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Set `max-width` and omit parameter names if they are very long.
Show full names when hovering label.

<img width="420" alt="after" src="https://github.com/user-attachments/assets/338ca6dd-27de-4ab4-b8ad-8ab5bfd37b99">

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
