### PR TITLE
fix: updates parameter component

### DIFF
--- a/app/components/pipeline/parameters/component.js
+++ b/app/components/pipeline/parameters/component.js
@@ -38,7 +38,9 @@ export default class PipelineParametersComponent extends Component {
   }
 
   get title() {
-    return `${this.args.action} pipeline with parameters`.toUpperCase();
+    return this.args.action
+      ? `${this.args.action} pipeline with parameters`.toUpperCase()
+      : null;
   }
 
   @action

--- a/app/components/pipeline/parameters/selectable/styles.scss
+++ b/app/components/pipeline/parameters/selectable/styles.scss
@@ -3,6 +3,11 @@
 @mixin styles {
   .ember-basic-dropdown {
     .parameter-selector {
+      &.ember-power-select-trigger[aria-disabled='true'] {
+        background: rgba(colors.$sd-disabled, 0.25);
+        color: colors.$sd-text;
+      }
+
       .ember-power-select-selected-item {
         display: block;
         overflow: scroll;

--- a/app/components/pipeline/parameters/selectable/styles.scss
+++ b/app/components/pipeline/parameters/selectable/styles.scss
@@ -1,0 +1,22 @@
+@use 'screwdriver-colors' as colors;
+
+@mixin styles {
+  .ember-basic-dropdown {
+    .parameter-selector {
+      .ember-power-select-selected-item {
+        display: block;
+        overflow: scroll;
+        text-overflow: ellipsis;
+      }
+    }
+
+    .ember-basic-dropdown-content-wormhole-origin {
+      .ember-power-select-options {
+        li {
+          overflow: scroll;
+          text-overflow: ellipsis;
+        }
+      }
+    }
+  }
+}

--- a/app/components/pipeline/parameters/selectable/template.hbs
+++ b/app/components/pipeline/parameters/selectable/template.hbs
@@ -1,5 +1,6 @@
 <PowerSelect
   class="parameter-selector"
+  @disabled={{@disabled}}
   @options={{@parameter.defaultValues}}
   @renderInPlace={{true}}
   @searchEnabled={{true}}

--- a/app/components/pipeline/parameters/styles.scss
+++ b/app/components/pipeline/parameters/styles.scss
@@ -1,5 +1,6 @@
 @use 'screwdriver-colors' as colors;
 @use 'variables';
+@use 'selectable/styles' as selectable;
 
 @mixin styles {
   .pipeline-parameters {
@@ -20,7 +21,18 @@
         padding: 0.5rem;
 
         .group-title {
+          display: flex;
           font-size: 1.5rem;
+
+          svg {
+            margin-top: 0.25rem;
+            margin-right: 0.25rem;
+          }
+
+          .title {
+            overflow: hidden;
+            text-overflow: ellipsis;
+          }
         }
 
         .parameter-list {
@@ -38,6 +50,12 @@
               margin-bottom: auto;
               padding-right: 0.5rem;
               flex-basis: 25%;
+              max-width: 50%;
+
+              .name {
+                overflow: hidden;
+                text-overflow: ellipsis;
+              }
 
               svg {
                 margin-top: auto;
@@ -52,6 +70,9 @@
 
             .dropdown-selection-container {
               flex: 1;
+              min-width: 50%;
+
+              @include selectable.styles;
             }
 
             > input {

--- a/app/components/pipeline/parameters/styles.scss
+++ b/app/components/pipeline/parameters/styles.scss
@@ -80,6 +80,11 @@
               border-radius: 4px;
               border: 1px solid colors.$sd-text-med;
               padding-left: 8px;
+
+              &:disabled {
+                background-color: rgba(colors.$sd-disabled, 0.25);
+                color: colors.$sd-text;
+              }
             }
           }
         }

--- a/app/components/pipeline/parameters/template.hbs
+++ b/app/components/pipeline/parameters/template.hbs
@@ -6,14 +6,27 @@
     {{#each this.parameters as |parameterGroup|}}
       <div class="parameter-group">
         <div class="group-title">
-          <FaIcon @icon={{if parameterGroup.isOpen "minus-square" "plus-square"}} {{on "click" (fn this.toggleParameterGroup parameterGroup.paramGroupTitle)}}></FaIcon>
-          {{parameterGroup.paramGroupTitle}}
+          <FaIcon
+            @icon={{if parameterGroup.isOpen "minus-square" "plus-square"}}
+            {{on "click" (fn this.toggleParameterGroup parameterGroup.paramGroupTitle)}}
+          />
+          <div
+            class="title"
+            title={{parameterGroup.paramGroupTitle}}
+          >
+            {{parameterGroup.paramGroupTitle}}
+          </div>
         </div>
         <div class="parameter-list {{if parameterGroup.isOpen "expanded" "collapsed"}}">
           {{#each parameterGroup.parameters as |parameter|}}
             <div class="parameter">
               <label>
-                {{parameter.name}}
+                <div
+                  class="name"
+                  title={{parameter.name}}
+                >
+                  {{parameter.name}}
+                </div>
                 {{#if parameter.description}}
                   <FaIcon @icon="question-circle" @title={{parameter.description}}></FaIcon>
                 {{/if}}

--- a/app/components/pipeline/parameters/template.hbs
+++ b/app/components/pipeline/parameters/template.hbs
@@ -1,7 +1,9 @@
 <div class="pipeline-parameters">
-  <div class="parameter-title">
-    {{this.title}}
-  </div>
+  {{#if @action}}
+    <div class="parameter-title">
+      {{this.title}}
+    </div>
+  {{/if}}
   <div class="parameters-container">
     {{#each this.parameters as |parameterGroup|}}
       <div class="parameter-group">
@@ -41,6 +43,7 @@
               {{#if (is-array parameter.defaultValues)}}
                 <div class="dropdown-selection-container">
                   <Pipeline::Parameters::Selectable
+                    @disabled={{if @action false true}}
                     @parameter={{parameter}}
                     @onOpen={{this.openSelect}}
                     @onSelectValue={{(fn this.updateParameter parameterGroup.jobName)}}
@@ -49,6 +52,7 @@
               {{else}}
                 <Input
                   @value={{parameter.value}}
+                  disabled={{if @action false true}}
                   defaultValue={{parameter.value}}
                   {{on "input" (fn this.onInput parameterGroup.jobName parameter)}}
                 />


### PR DESCRIPTION
## Context
The parameters of a pipeline may be long and cause text overflows in the UI.  Adds additional support for the UI to present a read only view.

## Objective
1.  Adds functionality to the parameters to be read-only
![Screenshot 2024-08-21 at 10-39-31 New Pipeline Events Show](https://github.com/user-attachments/assets/a6d9aaa5-37f9-4b9d-bb3a-ac66546b3127)

2. Truncates any long text that causes overflows and provides a mouse over that the user can activate to display the full text

For a parameter group title that overflows:
![title mouse over](https://github.com/user-attachments/assets/2c5c19b9-e186-4911-b8cb-4f47286e5c10)

For a parameter name that overflows:
![parameter mouse over](https://github.com/user-attachments/assets/007efaec-38a6-426a-a87f-ed48150d3ce7)

For a parameter name that overflows:
![Screenshot 2024-08-21 at 10-40-16 New Pipeline Events Show](https://github.com/user-attachments/assets/eb150003-1795-4b64-beba-87c079941819)


## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
