### PR TITLE
fix: pipeline options page

### DIFF
--- a/app/components/pipeline-options/styles.scss
+++ b/app/components/pipeline-options/styles.scss
@@ -183,6 +183,10 @@
   .admins-list {
     font-weight: bold;
     margin-top: 10px;
+    a {
+      color: $sd-link;
+      display: inline;
+    }
   }
 
   .no-admin-message {

--- a/app/components/pipeline-options/template.hbs
+++ b/app/components/pipeline-options/template.hbs
@@ -182,10 +182,10 @@
                     <p class="admins-list">
                       {{this.displayAdmins}}
                       {{#if (and (gt this.adminsCount 5) (not this.isAdminsExpanded))}}
-                        ... <a href="#" onclick={{action "toggleExpand"}}>more</a>
+                        ... <a class="admin-toggle" {{action "toggleExpand"}}>more</a>
                       {{/if}}
                       {{#if this.isAdminsExpanded}}
-                        <a href="#" onclick={{action "toggleExpand"}}>collapse</a>
+                        <a class="admin-toggle" {{action "toggleExpand"}}>collapse</a>
                       {{/if}}
                     </p>
                   {{else}}
@@ -607,7 +607,7 @@
           <li>
             {{#if this.showRemoveDangerButton}}
               <div class="row">
-                <div class="col-1 col-md-8">
+                <div class="col-10">
                   <h4>
                     Delete this pipeline
                   </h4>
@@ -615,7 +615,7 @@
                     Once you delete a pipeline, there is no going back.
                   </p>
                 </div>
-                <div class="col-1 col-md-4 right">
+                <div class="col-2 right">
                   <a
                     href="#"
                     class="trash"


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

- When click the more and collapse buttons on pipeline admins row, then force to move to page top.
- Pipeline delete row's layout is broken when the window width is small.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

- Don't jump to page top when click pipeline admins buttons.
- Fix the pipeline delete row's classes

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
