### PR TITLE
fix: display parameter form when click start button just after rendering

### DIFF
--- a/app/components/pipeline-list-view/component.js
+++ b/app/components/pipeline-list-view/component.js
@@ -74,11 +74,15 @@ export default Component.extend({
 
   async init() {
     this._super(...arguments);
-    this.set('isLoading', true);
+    this.setProperties({
+      isLoading: true,
+      pipelineParameters: this.getDefaultPipelineParameters(),
+      jobParameters: this.getDefaultJobParameters()
+    });
+
     const jobs = await this.updateListViewJobs();
     const rows = this.getRows(jobs);
 
-    this.set('isLoading', false);
     const customTheme = {
       table: 'table table-condensed table-sm',
       sortAscIcon: 'fa fa-fw fa-sort-up',
@@ -98,8 +102,7 @@ export default Component.extend({
 
     this.setProperties({
       data: rows,
-      pipelineParameters: this.getDefaultPipelineParameters(),
-      jobParameters: this.getDefaultJobParameters()
+      isLoading: false
     });
   },
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

The build parameters form does not appear when users too quickly click start button on the job list view page.
But after wait for a moment, the form appears correctly.

https://github.com/user-attachments/assets/69bf6831-1f97-459f-af53-6c07cabb95c5

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Fix to show the parameter form even users start build quickly.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
