### PR TITLE
fix: build parameter tooltip style when a value is short or a description is defined

### DIFF
--- a/app/components/pipeline-parameterized-build/styles.scss
+++ b/app/components/pipeline-parameterized-build/styles.scss
@@ -71,5 +71,6 @@ button.start-with-parameters-button {
 .ember-basic-dropdown-content {
   li.ember-power-select-option {
     width: fit-content;
+    min-width: 100%;
   }
 }

--- a/app/components/pipeline-parameterized-build/styles.scss
+++ b/app/components/pipeline-parameterized-build/styles.scss
@@ -33,7 +33,7 @@ button.start-with-parameters-button {
     }
   }
 
-  .parameter-name {
+  .control-label {
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;

--- a/app/components/pipeline-parameterized-build/template.hbs
+++ b/app/components/pipeline-parameterized-build/template.hbs
@@ -29,9 +29,9 @@
                       @title={{parameter.description}}
                     />
                   {{/if}}
-                  <div title={{parameter.name}} class="parameter-name">
+                  <span title={{parameter.name}}>
                     {{parameter.name}}
-                  </div>
+                  </span>
                 </label>
                 <div class="col-8">
                   {{#if (is-array parameter.value)}}


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Follow up https://github.com/screwdriver-cd/ui/pull/1116 and https://github.com/screwdriver-cd/ui/pull/1123 .

- It renders 2 rows when a pipeline description is defined
- Select box option value is short then its width is also short

![bad](https://github.com/user-attachments/assets/2e776781-133e-4f59-a08c-e73d1d84ce1e)

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

- Put parameter description icon and parameter name into one line
- Spread the width of short parameter selector option

![tobe](https://github.com/user-attachments/assets/193e4570-c20c-4ff4-b455-4a231579f0df)


## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
