### PR TITLE
feat: Updates modal to support stopping all builds

### DIFF
--- a/app/components/pipeline/modal/stop-build/component.js
+++ b/app/components/pipeline/modal/stop-build/component.js
@@ -14,16 +14,28 @@ export default class PipelineModalStopBuildComponent extends Component {
 
   @action
   async stopBuild() {
-    await this.shuttle
-      .fetchFromApi('put', `/builds/${this.args.buildId}`, {
-        status: 'ABORTED'
-      })
-      .then(() => {
-        this.successMessage = 'Build stopped successfully';
-        this.isDisabled = true;
-      })
-      .catch(err => {
-        this.errorMessage = err.message;
-      });
+    if (this.args.eventId) {
+      await this.shuttle
+        .fetchFromApi('put', `/events/${this.args.eventId}/stop`)
+        .then(() => {
+          this.successMessage = 'Build stopped successfully';
+          this.isDisabled = true;
+        })
+        .catch(err => {
+          this.errorMessage = err.message;
+        });
+    } else {
+      await this.shuttle
+        .fetchFromApi('put', `/builds/${this.args.buildId}`, {
+          status: 'ABORTED'
+        })
+        .then(() => {
+          this.successMessage = 'Build stopped successfully';
+          this.isDisabled = true;
+        })
+        .catch(err => {
+          this.errorMessage = err.message;
+        });
+    }
   }
 }

--- a/tests/integration/components/pipeline/modal/stop-build/component-test.js
+++ b/tests/integration/components/pipeline/modal/stop-build/component-test.js
@@ -74,4 +74,29 @@ module('Integration | Component | pipeline/modal/stop-build', function (hooks) {
     assert.dom('.alert > span').hasText('Build stopped successfully');
     assert.dom('#stop-build').isDisabled();
   });
+
+  test('it calls correct API when no builds are configured', async function (assert) {
+    const shuttle = this.owner.lookup('service:shuttle');
+    const shuttleStub = sinon.stub(shuttle, 'fetchFromApi').resolves();
+    const eventId = 1;
+
+    this.setProperties({
+      eventId,
+      closeModal: () => {}
+    });
+
+    await render(
+      hbs`<Pipeline::Modal::StopBuild
+        @eventId={{this.eventId}}
+        @closeModal={{this.closeModal}}
+      />`
+    );
+
+    await click('#stop-build');
+
+    assert.equal(
+      shuttleStub.calledWith('put', `/events/${eventId}/stop`),
+      true
+    );
+  });
 });


### PR DESCRIPTION
## Context
The stop build modal already allows users to stop an individual build.  The V2 UI uses modals to prevent unintended actions by the user.

## Objective
Add in the ability for the stop build modal to stop all builds for an event.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
