### PR TITLE
feat: Add danger style for buttons

### DIFF
--- a/app/styles/screwdriver-button.scss
+++ b/app/styles/screwdriver-button.scss
@@ -20,4 +20,24 @@
       background-color: rgba(colors.$sd-running, 0.1);
     }
   }
+
+  .btn-danger {
+    color: colors.$sd-white;
+    background-color: colors.$sd-warn-bg;
+    border-color: colors.$sd-warn-bg;
+
+    &:hover {
+      background-color: rgba(colors.$sd-warn-bg, 0.75);
+      border-color: transparent;
+    }
+
+    .btn-outline-danger {
+      color: colors.$sd-warn-bg;
+      border-color: colors.$sd-warn-bg;
+
+      &:hover {
+        background-color: rgba(colors.$sd-warn-bg, 0.1);
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Context
Bootstrap buttons have a danger style that has no custom styling using the screwdriver color theme.

## Objective
Adds in the danger styling for solid and outline buttons using screwdriver color theme.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
