### PR TITLE
feat: New modal to display parameters as readonly values

### DIFF
--- a/app/components/pipeline/modal/show-parameters/template.hbs
+++ b/app/components/pipeline/modal/show-parameters/template.hbs
@@ -1,0 +1,16 @@
+<BsModal
+  id="show-event-parameters-modal"
+  @onHide={{fn @closeModal}}
+  as |modal|
+>
+  <modal.header>
+    <div class="modal-title">Configured parameters for event</div>
+  </modal.header>
+  <modal.body>
+    <Pipeline::Parameters
+      @event={{@event}}
+      @pipeline={{@pipeline}}
+      @jobs={{@jobs}}
+    />
+  </modal.body>
+</BsModal>

--- a/tests/integration/components/pipeline/modal/show-parameters/component-test.js
+++ b/tests/integration/components/pipeline/modal/show-parameters/component-test.js
@@ -1,0 +1,31 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module(
+  'Integration | Component | pipeline/modal/show-parameters',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test('it renders', async function (assert) {
+      this.setProperties({
+        event: { meta: { parameters: { foo: { value: 'bar' } } } },
+        pipeline: { parameters: { foo: { value: 'foofoo' } } },
+        jobs: [],
+        closeModal: () => {}
+      });
+
+      await render(
+        hbs`<Pipeline::Modal::ShowParameters
+            @event={{this.event}}
+            @pipeline={{this.pipeline}}
+            @jobs={{this.jobs}}
+            @closeModal={{this.closeModal}}
+        />`
+      );
+
+      assert.dom('.modal-title').hasText('Configured parameters for event');
+    });
+  }
+);


### PR DESCRIPTION
## Context
Event cards need a way to display to the user the parameters that were configured for the event.  As the event has already been triggered, the parameters should also be displayed as read-only values

## Objective
New modal has updated title indicating that the parameters shown are the ones configured for the event:
![Screenshot 2024-08-27 at 16-49-22 New Pipeline Events Show](https://github.com/user-attachments/assets/dafe5d3c-2225-4f02-9470-7bdd99344d14)


## References
Builds on top of the changes from #1124

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
