### PR TITLE
fix: Simplify and update route implementation

### DIFF
--- a/app/v2/pipeline/index/route.js
+++ b/app/v2/pipeline/index/route.js
@@ -2,22 +2,15 @@ import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 
 export default class NewPipelineIndexRoute extends Route {
-  @service
-  router;
+  @service router;
 
   beforeModel() {
     const { pipeline } = this.modelFor('v2.pipeline');
 
     if (pipeline.childPipelines) {
-      this.router.transitionTo('pipeline.child-pipelines');
+      this.router.replaceWith('pipeline.child-pipelines');
     } else {
-      this.router.transitionTo('v2.pipeline.events');
+      this.router.replaceWith('v2.pipeline.events');
     }
   }
-
-  /* eslint-disable camelcase */
-  model(/* { pipeline_id } */) {
-    return this;
-  }
-  /* eslint-enable camelcase */
 }


### PR DESCRIPTION
## Context
The v2 pipeline index route (`/v2/pipeline/`) is an intermediary route that effectively resolve to either the pipeline event route or the child pipeline route.  The route should not provide any model information.

## Objective
Update and simplify the route so that it only processes the pipeline modal information to determine which landing page to direct the user to based on the pipeline model.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
