### PR TITLE
feat(3171): Move pipeline template workflowGraph out of config into a new field

### DIFF
--- a/app/components/validator-results/template.hbs
+++ b/app/components/validator-results/template.hbs
@@ -13,7 +13,7 @@
     @name={{this.templateName}}
     @template={{this.results.template}}
     @stages={{this.results.template.config.stages}}
-    @workflowGraph={{this.results.template.config.workflowGraph}}
+    @workflowGraph={{this.results.template.workflowGraph}}
     @annotations={{this.results.template.config.annotations}}
     @parameters={{this.results.template.config.parameters}}
     @cache={{this.results.template.config.cache}}


### PR DESCRIPTION
BREAKING CHANGE: Move workflowGraph out of config and keep it at the same level as config

## Context

Changes were made in https://github.com/screwdriver-cd/data-schema/pull/571 (and related PRs) and https://github.com/screwdriver-cd/ui/pull/1101 to store `workflowGraph` of pipeline template as part of the `config

## Objective

Move `workflowGraph` out of `config` and keep it at the same level as `config`

## References

https://github.com/screwdriver-cd/screwdriver/issues/3171

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
