### PR TITLE
fix: Add warning color to graph arrow

### DIFF
--- a/app/components/pipeline/workflow/graph/styles.scss
+++ b/app/components/pipeline/workflow/graph/styles.scss
@@ -63,6 +63,10 @@
       &.build-started_from {
         stroke: colors.$sd-success;
       }
+
+      &.build-warning {
+        stroke: colors.$sd-warning;
+      }
     }
 
     .stage-info {


### PR DESCRIPTION
## Context
A job with a build that completed with a warning does not have a colored arrow pointing to the next job in the pipeline.

## Objective
Add a color to the graph arrow to further differentiate the graph node from other nodes in the workflow

Currently:
![Screenshot 2024-08-29 at 12-44-48 New Pipeline Events Show](https://github.com/user-attachments/assets/2ea97e52-52ad-4805-8002-f333642e4164)

Updated:
![Screenshot 2024-08-29 at 12-45-14 New Pipeline Events Show](https://github.com/user-attachments/assets/3c43a772-2bd1-481a-968f-36d09f86a5c0)

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
