### PR TITLE
fix: Add missing test for v2 pipeline nav component

### DIFF
--- a/tests/integration/components/pipeline/nav/component-test.js
+++ b/tests/integration/components/pipeline/nav/component-test.js
@@ -1,0 +1,14 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | pipeline/nav', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    await render(hbs`<Pipeline::Nav />`);
+
+    assert.dom('#pipeline-nav a').exists({ count: 4 });
+  });
+});


### PR DESCRIPTION
## Context
The v2 glimmer component for the pipeline nav is missing a test.  Although the component itself is about as simple as possible, it should still have a test file in the event that it gets more complicated in the future.

## Objective
Add in missing test for the pipeline nav component.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
