### PR TITLE
fix: Simplify pipeline controller

### DIFF
--- a/app/v2/pipeline/controller.js
+++ b/app/v2/pipeline/controller.js
@@ -6,14 +6,6 @@ export default class NewPipelineController extends Controller {
 
   @service router;
 
-  get collections() {
-    return this.model.collections;
-  }
-
-  get pipeline() {
-    return this.model.pipeline;
-  }
-
   get isEventsPullsJobsRoute() {
     const { currentRouteName } = this.router;
 

--- a/app/v2/pipeline/template.hbs
+++ b/app/v2/pipeline/template.hbs
@@ -3,8 +3,8 @@
   <Pipeline::Nav />
 
   <Pipeline::Header
-    @pipeline={{this.pipeline}}
-    @collections={{this.collections}}
+    @pipeline={{this.model.pipeline}}
+    @collections={{this.model.collections}}
   />
 
   <div class="pipeline-main-content {{if this.isEventsPullsJobsRoute "grid"}}">


### PR DESCRIPTION
## Context
The controller for the v2 pipeline route does not need a getter for the collections and pipeline since they are already part of the model and the template can reference those values directly.

## Objective
Remove unnecessary getters in the controller and update the template to use the values directly.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
