### PR TITLE
fix: typo in test names

### DIFF
--- a/tests/unit/v2/pipeline/events/show/controller-test.js
+++ b/tests/unit/v2/pipeline/events/show/controller-test.js
@@ -10,7 +10,7 @@ module('Unit | Controller | v2/pipeline/events/show', function (hooks) {
     assert.ok(controller);
   });
 
-  test('it gets workflow graph-tooltip', function (assert) {
+  test('it gets workflow graph', function (assert) {
     const controller = this.owner.lookup('controller:v2/pipeline/events/show');
     const workflowGraph = {
       nodes: [{ name: '~pr' }, { name: '~commit' }, { name: 'main' }],
@@ -22,7 +22,7 @@ module('Unit | Controller | v2/pipeline/events/show', function (hooks) {
     assert.deepEqual(controller.workflowGraph, workflowGraph);
   });
 
-  test('it gets workflow graph-tooltip with external triggers', function (assert) {
+  test('it gets workflow graph with external triggers', function (assert) {
     const controller = this.owner.lookup('controller:v2/pipeline/events/show');
     const workflowGraph = {
       nodes: [{ name: '~pr' }, { name: '~commit' }, { name: 'main' }],


### PR DESCRIPTION
## Context
Found some typos in a couple of tests that don't clearly indicate what the test is attempting to check for.

## Objective
Update test name to properly reflect what the test is checking.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
