### PR TITLE
fix: long parameter is not nowrap

### DIFF
--- a/app/components/pipeline-parameterized-build/styles.scss
+++ b/app/components/pipeline-parameterized-build/styles.scss
@@ -68,6 +68,11 @@ button.start-with-parameters-button {
   }
 }
 
+.ember-basic-dropdown-trigger,
+.ember-power-select-option {
+  white-space: nowrap;
+}
+
 .ember-basic-dropdown-content {
   li.ember-power-select-option {
     width: fit-content;


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

The long build parameter is wrapped when its value contains line breakable characters (e.g. whitespace).

![break](https://github.com/user-attachments/assets/039efd78-f9cb-4f51-9ef6-53e4dca8c4ca)

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Add `nowrap` style to show as one line.

![nowrap](https://github.com/user-attachments/assets/1360aa75-8c29-4585-8286-d1ded33fd534)

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
