### PR TITLE
fix: job name is omitted on the workflow graph when its displayName is shorter than its name

### DIFF
--- a/app/utils/graph-tools.js
+++ b/app/utils/graph-tools.js
@@ -535,10 +535,16 @@ const decorateGraph = ({
   const virtualTeardownNodes = [];
   const nodes = [];
 
-  // Remove setup and teardown nodes
   originalNodes.forEach(n => {
     const { name: jobName, virtual } = n;
 
+    // displayName may be Numeric
+    // e.g. screwdriver.cd/displayName: 12345 (NOT "12345")
+    if (n.displayName) {
+      n.displayName = String(n.displayName);
+    }
+
+    // Remove setup and teardown nodes
     if (virtual && isStageSetupJob(jobName)) {
       virtualSetupNodes.push(n);
     } else if (virtual && isStageTeardownJob(jobName)) {

--- a/app/utils/pipeline/graph/d3-graph-util.js
+++ b/app/utils/pipeline/graph/d3-graph-util.js
@@ -53,7 +53,10 @@ export function getElementSizes(isMinified = false) {
  */
 export function getMaximumJobNameLength(data, displayJobNameLength) {
   return Math.min(
-    data.nodes.reduce((max, cur) => Math.max(cur.name.length, max), 0),
+    data.nodes.reduce(
+      (max, cur) => Math.max((cur.displayName || cur.name).length, max),
+      0
+    ),
     displayJobNameLength
   );
 }

--- a/tests/unit/utils/graph-tools-test.js
+++ b/tests/unit/utils/graph-tools-test.js
@@ -17,6 +17,19 @@ const SIMPLE_GRAPH = {
   ]
 };
 
+const SIMPLE_GRAPH_WITH_DISPLAY_NAME = {
+  nodes: [
+    { name: '~pr' },
+    { name: '~commit' },
+    { name: 'main', displayName: 'abc' },
+    { name: 'detached', displayName: 123 }
+  ],
+  edges: [
+    { src: '~pr', dest: 'main' },
+    { src: '~commit', dest: 'main' }
+  ]
+};
+
 const COMPLEX_GRAPH = {
   nodes: [
     { name: '~pr' },
@@ -95,6 +108,36 @@ module('Unit | Utility | graph tools', function () {
       }
     };
     const result = decorateGraph({ inputGraph: SIMPLE_GRAPH });
+
+    assert.deepEqual(result, expectedOutput);
+  });
+
+  test('it processes a simple graph with displayName', function (assert) {
+    const expectedOutput = {
+      nodes: [
+        { name: '~pr', pos: { x: 0, y: 0 } },
+        { name: '~commit', pos: { x: 0, y: 1 } },
+        { name: 'main', displayName: 'abc', pos: { x: 1, y: 0 } },
+        { name: 'detached', displayName: '123', pos: { x: 0, y: 2 } }
+      ],
+      edges: [
+        { src: '~pr', dest: 'main', from: { x: 0, y: 0 }, to: { x: 1, y: 0 } },
+        {
+          src: '~commit',
+          dest: 'main',
+          from: { x: 0, y: 1 },
+          to: { x: 1, y: 0 }
+        }
+      ],
+      stages: [],
+      meta: {
+        height: 3,
+        width: 2
+      }
+    };
+    const result = decorateGraph({
+      inputGraph: SIMPLE_GRAPH_WITH_DISPLAY_NAME
+    });
 
     assert.deepEqual(result, expectedOutput);
   });

--- a/tests/unit/utils/pipeline/graph/d3-graph-util-test.js
+++ b/tests/unit/utils/pipeline/graph/d3-graph-util-test.js
@@ -47,6 +47,19 @@ module('Unit | Utility | pipeline-graph | d3-graph-util', function () {
     assert.equal(getMaximumJobNameLength(data, 5), 5);
   });
 
+  test('getMaximumJobNameLength returns maximum job name length when job has displayName', function (assert) {
+    const data = {
+      nodes: [
+        { name: 'job1' },
+        { name: 'job2', displayName: '0123456789' },
+        { name: 'job3' }
+      ]
+    };
+
+    assert.equal(getMaximumJobNameLength(data, 20), 10);
+    assert.equal(getMaximumJobNameLength(data, 5), 5);
+  });
+
   test('getNodeWidth returns correct node width', function (assert) {
     assert.equal(getNodeWidth({ ICON_SIZE: 10, TITLE_SIZE: 5 }, 10), 70);
     assert.equal(getNodeWidth({ ICON_SIZE: 10, TITLE_SIZE: 5 }, 2), 20);


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

When the job has longer `displayName` than its name, the job name is omitted on the workflow graph even `Display Name Length` has enough value.

![omit](https://github.com/user-attachments/assets/0e49b7ed-f81a-429a-941b-98ae815660ab)

```yaml
jobs:
  test:
    image: node:18
    requires: [ ~commit, ~pr ]
    steps:
      - test: echo "foo"
    annotations:
      screwdriver.cd/displayName: "very-long-long-long-long-name"
```

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Calculate the maximum job name length correctly including `displayName`.

![tobe](https://github.com/user-attachments/assets/bcdc7ca2-9920-4e51-9371-e85640472718)

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
