### PR TITLE
fix(3171): workflow graph is not rendering in pipeline template detail page

### DIFF
--- a/app/templates/pipeline/detail/controller.js
+++ b/app/templates/pipeline/detail/controller.js
@@ -67,14 +67,14 @@ export default class TemplatesPipelineDetailController extends Controller {
   }
 
   get workflowGraph() {
-    const { config } = this.selectedVersionTemplate;
+    const { workflowGraph } = this.selectedVersionTemplate;
 
     const defaultWorkflowGraph = {
       nodes: [],
       edges: []
     };
 
-    return config.workflowGraph || defaultWorkflowGraph;
+    return workflowGraph || defaultWorkflowGraph;
   }
 
   get jobs() {


### PR DESCRIPTION
## Context

Workflow graph has been moved out of pipeline template `config`. Workflow graph is no longer getting rendered in the pipeline template detail view.

## Objective

Look up for workflow directly on the pipeline template

## References

https://github.com/screwdriver-cd/screwdriver/issues/3171

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
