### PR TITLE
fix: bump data-schema to 24.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "qunit": "^2.19.1",
     "qunit-dom": "^2.0.0",
     "sass-embedded": "^1.77.0",
-    "screwdriver-data-schema": "^23.5.1",
+    "screwdriver-data-schema": "^24.0.0",
     "sinon": "^18.0.0",
     "webpack": "^5.76.2"
   }


### PR DESCRIPTION
## Context

There is a major version upgrade of `screwdriver-data-schema` to [24.0.0](https://github.com/screwdriver-cd/data-schema/releases/tag/v24.0.0). 

## Objective

This PR is to bump the dependency to the latest version. 

## References

https://github.com/screwdriver-cd/screwdriver/issues/3171

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
