### PR TITLE
feat(3193): Show remote trigger's displayName as title [1]

### DIFF
--- a/app/utils/pipeline/graph/d3-graph-util.js
+++ b/app/utils/pipeline/graph/d3-graph-util.js
@@ -54,7 +54,14 @@ export function getElementSizes(isMinified = false) {
 export function getMaximumJobNameLength(data, displayJobNameLength) {
   return Math.min(
     data.nodes.reduce(
-      (max, cur) => Math.max((cur.displayName || cur.name).length, max),
+      (max, cur) =>
+        Math.max(
+          (!/sd@/.test(cur.name) && cur.displayName
+            ? cur.displayName
+            : cur.name
+          ).length,
+          max
+        ),
       0
     ),
     displayJobNameLength
@@ -518,7 +525,13 @@ export function addJobIcons( // eslint-disable-line max-params
       onClick(node);
     })
     .insert('title')
-    .text(d => (d.status ? `${d.name} - ${d.status}` : d.name));
+    .text(d => {
+      if (/sd@/.test(d.name) && d.displayName !== undefined) {
+        return d.displayName;
+      }
+
+      return d.status ? `${d.name} - ${d.status}` : d.name;
+    });
 }
 
 /**
@@ -546,7 +559,10 @@ export function addJobNames(
     .enter()
     .append('text')
     .text(d => {
-      const displayName = d.displayName !== undefined ? d.displayName : d.name;
+      const displayName =
+        !/sd@/.test(d.name) && d.displayName !== undefined
+          ? d.displayName
+          : d.name;
 
       return displayName.length > maximumJobNameLength
         ? `${displayName.substring(0, 8)}...${displayName.slice(-8)}`
@@ -575,7 +591,13 @@ export function addJobNames(
         getVerticalDisplacementByRowPosition(d.pos.y, verticalDisplacements)
     )
     .insert('title')
-    .text(d => d.name);
+    .text(d => {
+      if (/sd@/.test(d.name) && d.displayName !== undefined) {
+        return d.displayName;
+      }
+
+      return d.name;
+    });
 }
 
 /**

--- a/tests/integration/components/workflow-graph-d3/component-test.js
+++ b/tests/integration/components/workflow-graph-d3/component-test.js
@@ -87,6 +87,59 @@ module('Integration | Component | workflow graph d3', function (hooks) {
     assert.dom('svg text.graph-label:nth-of-type(4)').includesText('bar');
   });
 
+  test('it renders a upstream remote triggers', async function (assert) {
+    this.set('workflowGraph', {
+      nodes: [
+        { name: '~pr' },
+        { name: '~commit' },
+        { name: '~sd@123:main', displayName: 'foo/bar@main' },
+        { name: '~sd@456:main' },
+        { name: 'foo', displayName: 'bar' },
+        { name: 'baz' }
+      ],
+      edges: [
+        { src: '~pr', dest: 'foo' },
+        { src: '~commit', dest: 'foo' },
+        { src: '~sd@123:main', dest: 'foo' },
+        { src: '~sd@456:main', dest: 'baz' }
+      ]
+    });
+
+    await render(
+      hbs`<WorkflowGraphD3 @workflowGraph={{this.workflowGraph}} />`
+    );
+
+    assert.equal(this.element.querySelectorAll('svg').length, 1);
+    assert.equal(this.element.querySelectorAll('svg > g.graph-node').length, 6);
+    assert.equal(
+      this.element.querySelectorAll('svg > path.graph-edge').length,
+      4
+    );
+
+    assert
+      .dom('svg text.graph-label:nth-of-type(3)')
+      .includesText('~sd@123:main');
+    assert
+      .dom('svg text.graph-label:nth-of-type(4)')
+      .includesText('~sd@456:main');
+    assert.dom('svg text.graph-label:nth-of-type(5)').includesText('bar');
+    assert.dom('svg text.graph-label:nth-of-type(6)').includesText('baz');
+
+    assert
+      .dom('svg text.graph-label:nth-of-type(3) title')
+      .hasText('foo/bar@main');
+    assert
+      .dom('svg text.graph-label:nth-of-type(4) title')
+      .hasText('~sd@456:main');
+    assert.dom('svg text.graph-label:nth-of-type(5) title').hasText('foo');
+    assert.dom('svg text.graph-label:nth-of-type(6) title').hasText('baz');
+
+    assert.dom('svg g.graph-node:nth-of-type(3) title').hasText('foo/bar@main');
+    assert.dom('svg g.graph-node:nth-of-type(4) title').hasText('~sd@456:main');
+    assert.dom('svg g.graph-node:nth-of-type(5) title').hasText('foo');
+    assert.dom('svg g.graph-node:nth-of-type(6) title').hasText('baz');
+  });
+
   test('it renders statuses when build data is available', async function (assert) {
     this.set('workflowGraph', {
       nodes: [

--- a/tests/unit/utils/pipeline/graph/d3-graph-util-test.js
+++ b/tests/unit/utils/pipeline/graph/d3-graph-util-test.js
@@ -52,7 +52,8 @@ module('Unit | Utility | pipeline-graph | d3-graph-util', function () {
       nodes: [
         { name: 'job1' },
         { name: 'job2', displayName: '0123456789' },
-        { name: 'job3' }
+        { name: 'job3' },
+        { name: '~sd@1:foo', displayName: '0123456789/0123456789' }
       ]
     };
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Make it easier to know what pipeline is assign as upstream remote trigger.

https://github.com/screwdriver-cd/screwdriver/issues/3193

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Show the upstream remote trigger pipeline's name on workflow graph as title.
The format is `org/repo#branch:job` and this value is stored in remote trigger node's `displayName` property. (https://github.com/screwdriver-cd/models/pull/628)

<img width="306" alt="fix" src="https://github.com/user-attachments/assets/bd8e03ce-4cce-40c7-be19-5bf02ee05f41">

We can display pipeline name instead of `~sd@123:main` form, but it makes workflow graph longer because repository name can be too longer than job name.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

https://github.com/screwdriver-cd/screwdriver/issues/3193

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
