### PR TITLE
feat: V2 pipeline tab component

### DIFF
--- a/app/components/pipeline/styles.scss
+++ b/app/components/pipeline/styles.scss
@@ -3,6 +3,7 @@
 @use 'header/styles' as header;
 @use 'modal/styles' as modal;
 @use 'parameters/styles' as parameters;
+@use 'tab/styles' as tab;
 @use 'workflow/styles' as workflow;
 
 @mixin styles {
@@ -11,5 +12,6 @@
   @include header.styles;
   @include modal.styles;
   @include parameters.styles;
+  @include tab.styles;
   @include workflow.styles;
 }

--- a/app/components/pipeline/tab/styles.scss
+++ b/app/components/pipeline/tab/styles.scss
@@ -1,0 +1,35 @@
+@use 'screwdriver-colors' as colors;
+@use 'variables';
+
+@mixin styles {
+  #pipeline-tab {
+    padding-top: 0.5rem;
+    height: variables.$pipeline-tab-height;
+
+    ul.nav-tabs.nav {
+      border: none;
+
+      li {
+        border-bottom: 0.2rem solid colors.$sd-white;
+        padding-left: 1rem;
+        padding-right: 1rem;
+        text-align: center;
+
+        &.active {
+          border-bottom-color: colors.$sd-link;
+        }
+
+        a {
+          color: colors.$sd-text-med;
+          border: none;
+          background-color: transparent;
+
+          &.active {
+            color: colors.$sd-link;
+            font-weight: variables.$weight-bold;
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/components/pipeline/tab/template.hbs
+++ b/app/components/pipeline/tab/template.hbs
@@ -1,0 +1,13 @@
+<div id="pipeline-tab">
+  <BsNav @type="tabs" as |nav|>
+    <nav.item>
+      <nav.link-to @route="v2.pipeline.events">Events</nav.link-to>
+    </nav.item>
+    <nav.item>
+      <nav.link-to @route="v2.pipeline.pulls">Pull Requests</nav.link-to>
+    </nav.item>
+    <nav.item>
+      <nav.link-to @route="v2.pipeline.jobs">Jobs</nav.link-to>
+    </nav.item>
+  </BsNav>
+</div>

--- a/app/styles/variables.scss
+++ b/app/styles/variables.scss
@@ -4,3 +4,5 @@ $weight-bold: 600;
 
 $app-header-height: 4rem;
 $nav-banner-height: 3rem;
+
+$pipeline-tab-height: 3.75rem;

--- a/app/v2/pipeline/events/styles.scss
+++ b/app/v2/pipeline/events/styles.scss
@@ -10,37 +10,8 @@
   grid-template-rows: 3.75rem calc(100% - 3.75rem);
   grid-template-columns: 26rem calc(100% - 26rem);
 
-  .pipeline-tab {
+  #pipeline-tab {
     grid-area: pipeline-tab;
-
-    display: grid;
-    padding-top: 8px;
-    padding-bottom: 1px;
-
-    ul.nav-tabs.nav {
-      border: none;
-
-      li {
-        border-bottom: 0.2rem solid colors.$sd-white;
-        padding-left: 1rem;
-        padding-right: 1rem;
-        text-align: center;
-
-        &.active {
-          border-bottom-color: #1c64f2;
-        }
-
-        a {
-          &.active {
-            color: #1c64f2;
-          }
-
-          color: #6b7280;
-          border: none;
-          padding: 8px 16px 9px 16px;
-        }
-      }
-    }
   }
 
   .pipeline-events {

--- a/app/v2/pipeline/events/template.hbs
+++ b/app/v2/pipeline/events/template.hbs
@@ -1,17 +1,5 @@
 {{page-title "Events"}}
 
-<div class="pipeline-tab">
-  <BsNav @type="tabs" as |nav|>
-    <nav.item>
-      <nav.link-to @route="v2.pipeline.events">Events</nav.link-to>
-    </nav.item>
-    <nav.item>
-      <nav.link-to @route="v2.pipeline.pulls">Pull Requests</nav.link-to>
-    </nav.item>
-    <nav.item>
-      <nav.link-to @route="v2.pipeline.jobs">Jobs</nav.link-to>
-    </nav.item>
-  </BsNav>
-</div>
+<Pipeline::Tab />
 
 {{outlet}}

--- a/tests/integration/components/pipeline/tab/component-test.js
+++ b/tests/integration/components/pipeline/tab/component-test.js
@@ -1,0 +1,14 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | pipeline/tab', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    await render(hbs`<Pipeline::Tab />`);
+
+    assert.dom('a').exists({ count: 3 });
+  });
+});


### PR DESCRIPTION
## Context
The navigation tab for the v2 pipeline routes can should be extracted into a stand alone glimmer component.

## Objective
Refactor the pipeline navigation tabs into a glimmer component for better reusability and testing

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
