### PR TITLE
fix: Update stop modal text

### DIFF
--- a/app/components/pipeline/modal/stop-build/component.js
+++ b/app/components/pipeline/modal/stop-build/component.js
@@ -18,7 +18,7 @@ export default class PipelineModalStopBuildComponent extends Component {
       await this.shuttle
         .fetchFromApi('put', `/events/${this.args.eventId}/stop`)
         .then(() => {
-          this.successMessage = 'Build stopped successfully';
+          this.successMessage = 'All builds for the event stopped successfully';
           this.isDisabled = true;
         })
         .catch(err => {


### PR DESCRIPTION
## Context
The existing text  doesn't fully capture the fact that multiple builds may have been stopped.

## Objective
Update the modal text to better indicate to the user that all builds in a particular event have stopped.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
