### PR TITLE
fix: Update start modal to allow for optional messaging

### DIFF
--- a/app/components/pipeline/modal/start-event/styles.scss
+++ b/app/components/pipeline/modal/start-event/styles.scss
@@ -8,5 +8,13 @@
       font-weight: variables.$weight-bold;
       color: colors.$sd-light-gray;
     }
+
+    #user-notice {
+      display: flex;
+
+      svg {
+        padding-right: 0.75rem;
+      }
+    }
   }
 }

--- a/app/components/pipeline/modal/start-event/template.hbs
+++ b/app/components/pipeline/modal/start-event/template.hbs
@@ -25,6 +25,16 @@
       />
     {{/if}}
 
+    {{#if @notice}}
+      <div
+        id="user-notice"
+        class="alert alert-warning"
+      >
+        <FaIcon @icon="exclamation-triangle" />
+        {{@notice}}
+      </div>
+    {{/if}}
+
     {{#if this.isParameterized}}
       <Pipeline::Parameters
         @action="start"

--- a/tests/integration/components/pipeline/modal/start-event/component-test.js
+++ b/tests/integration/components/pipeline/modal/start-event/component-test.js
@@ -47,5 +47,23 @@ module(
       assert.dom('.no-parameters-title').doesNotExist();
       assert.dom('.parameter-group').exists({ count: 2 });
     });
+
+    test('it renders optional notice', async function (assert) {
+      this.setProperties({
+        pipeline: {},
+        jobs: [],
+        closeModal: () => {}
+      });
+      await render(
+        hbs`<Pipeline::Modal::StartEvent
+            @pipeline={{this.pipeline}}
+            @jobs={{this.jobs}}
+            @closeModal={{this.closeModal}}
+            @notice="This is a notice to the user"
+        />`
+      );
+
+      assert.dom('#user-notice').exists({ count: 1 });
+    });
   }
 );


### PR DESCRIPTION
## Context
The start event modal is used in multiple places.  There may be some additional messaging that needs to happen to better alert the user to pay attention to certain specifics of their pipeline configuration.

## Objective
Update the start event modal to allow for optional messaging.
![Optional notice](https://github.com/user-attachments/assets/0966b624-5df9-4292-8d92-2b343f250135)

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
