### PR TITLE
fix: Fix button styles

### DIFF
--- a/app/styles/screwdriver-button.scss
+++ b/app/styles/screwdriver-button.scss
@@ -30,14 +30,14 @@
       background-color: rgba(colors.$sd-warn-bg, 0.75);
       border-color: transparent;
     }
+  }
 
-    .btn-outline-danger {
-      color: colors.$sd-warn-bg;
-      border-color: colors.$sd-warn-bg;
+  .btn-outline-danger {
+    color: colors.$sd-warn-bg;
+    border-color: colors.$sd-warn-bg;
 
-      &:hover {
-        background-color: rgba(colors.$sd-warn-bg, 0.1);
-      }
+    &:hover {
+      background-color: rgba(colors.$sd-warn-bg, 0.1);
     }
   }
 }


### PR DESCRIPTION
## Context
The styling for the `btn-outline-danger` got messed up previously and the style sheet needs to have the braces fixed to properly target the class.

## Objective
Fix the style sheet so that the `btn-outline-danger` class is at the correct level.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
