### PR TITLE
feat: Table cell component for jobs

### DIFF
--- a/app/components/pipeline/jobs/table/cell/job/component.js
+++ b/app/components/pipeline/jobs/table/cell/job/component.js
@@ -1,0 +1,33 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { statusIcon } from 'screwdriver-ui/utils/build';
+import getDisplayName from './util';
+
+export default class PipelineJobsTableCellJobComponent extends Component {
+  @tracked latestBuild;
+
+  @tracked statusIcon;
+
+  constructor() {
+    super(...arguments);
+
+    const { job } = this.args.record;
+
+    this.args.record.onCreate(job, builds => {
+      if (builds.length > 0) {
+        this.latestBuild = builds[builds.length - 1];
+        this.statusIcon = statusIcon(this.latestBuild.status);
+      }
+    });
+  }
+
+  willDestroy() {
+    super.willDestroy();
+
+    this.args.record.onDestroy(this.args.record.job);
+  }
+
+  get jobName() {
+    return getDisplayName(this.args.record.job);
+  }
+}

--- a/app/components/pipeline/jobs/table/cell/job/styles.scss
+++ b/app/components/pipeline/jobs/table/cell/job/styles.scss
@@ -1,0 +1,25 @@
+@mixin styles {
+  .job-cell {
+    display: flex;
+    max-width: 50rem;
+    padding-right: 2.5rem;
+
+    .job-status {
+      display: flex;
+      height: 1.5rem;
+      width: 1.5rem;
+
+      a {
+        display: flex;
+
+        svg {
+          margin: auto;
+        }
+      }
+    }
+
+    .job-name {
+      overflow: scroll;
+    }
+  }
+}

--- a/app/components/pipeline/jobs/table/cell/job/template.hbs
+++ b/app/components/pipeline/jobs/table/cell/job/template.hbs
@@ -1,0 +1,26 @@
+<div class="job-cell">
+  <div class="job-status">
+    {{#if this.latestBuild}}
+      <LinkTo
+        @route="pipeline.build"
+        @models={{array @record.job.pipelineId this.latestBuild.id}}
+      >
+        <FaIcon
+          @icon={{this.statusIcon.name}}
+          @fixedWidth="true"
+          @prefix={{this.statusIcon.prefix}}
+          @spin={{this.statusIcon.spin}}
+          @flip={{this.statusIcon.flip}}
+          class={{this.latestBuild.status}}
+        />
+      </LinkTo>
+    {{/if}}
+  </div>
+
+  <div class="job-name">
+    <BsTooltip @placement="bottom">
+      {{@record.job.name}}
+    </BsTooltip>
+    {{this.jobName}}
+  </div>
+</div>

--- a/app/components/pipeline/jobs/table/cell/job/util.js
+++ b/app/components/pipeline/jobs/table/cell/job/util.js
@@ -8,9 +8,7 @@ export default function getDisplayName(job) {
   const { annotations } = job?.permutations?.[0] || {};
 
   if (annotations) {
-    return annotations['screwdriver.cd/displayName']
-      ? annotations['screwdriver.cd/displayName']
-      : jobName;
+    return annotations['screwdriver.cd/displayName'] || jobName;
   }
 
   return jobName;

--- a/app/components/pipeline/jobs/table/cell/job/util.js
+++ b/app/components/pipeline/jobs/table/cell/job/util.js
@@ -1,0 +1,17 @@
+/**
+ * Get the display name of the job.  Uses the display name configured in the annotation if available.
+ * @param job {Object} Job in the format returned by the API
+ * @returns {string}
+ */
+export default function getDisplayName(job) {
+  const jobName = job.name;
+  const { annotations } = job?.permutations?.[0] || {};
+
+  if (annotations) {
+    return annotations['screwdriver.cd/displayName']
+      ? annotations['screwdriver.cd/displayName']
+      : jobName;
+  }
+
+  return jobName;
+}

--- a/tests/integration/components/pipeline/jobs/table/cell/job/component-test.js
+++ b/tests/integration/components/pipeline/jobs/table/cell/job/component-test.js
@@ -1,0 +1,104 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
+import { clearRender, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+
+module(
+  'Integration | Component | pipeline/jobs/table/cell/job',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test('it renders', async function (assert) {
+      const job = { id: 123, name: 'main' };
+
+      this.setProperties({
+        record: {
+          job,
+          onCreate: () => {},
+          onDestroy: () => {}
+        }
+      });
+
+      await render(
+        hbs`<Pipeline::Jobs::Table::Cell::Job
+            @record={{this.record}}
+        />`
+      );
+
+      assert.dom('.job-name').hasText(job.name);
+    });
+
+    test('it calls onCreate', async function (assert) {
+      const onCreate = sinon.spy();
+      const job = { id: 123, name: 'main' };
+
+      this.setProperties({
+        record: {
+          job,
+          onCreate,
+          onDestroy: () => {}
+        }
+      });
+
+      await render(
+        hbs`<Pipeline::Jobs::Table::Cell::Job
+            @record={{this.record}}
+        />`
+      );
+
+      assert.equal(onCreate.calledOnce, true);
+      assert.equal(onCreate.calledWith(job), true);
+    });
+
+    test('it calls onDestroy', async function (assert) {
+      const onDestroy = sinon.spy();
+      const job = { id: 123, name: 'main' };
+
+      this.setProperties({
+        record: {
+          job,
+          onCreate: () => {},
+          onDestroy
+        }
+      });
+
+      await render(
+        hbs`<Pipeline::Jobs::Table::Cell::Job
+            @record={{this.record}}
+        />`
+      );
+      await clearRender();
+
+      assert.equal(onDestroy.calledOnce, true);
+      assert.equal(onDestroy.calledWith(job), true);
+    });
+
+    test('it uses display name if annotation is set', async function (assert) {
+      const displayName = 'Display me';
+      const job = {
+        id: 123,
+        name: 'main',
+        permutations: [
+          { annotations: { 'screwdriver.cd/displayName': displayName } }
+        ]
+      };
+
+      this.setProperties({
+        record: {
+          job,
+          onCreate: () => {},
+          onDestroy: () => {}
+        }
+      });
+
+      await render(
+        hbs`<Pipeline::Jobs::Table::Cell::Job
+            @record={{this.record}}
+        />`
+      );
+
+      assert.dom('.job-name').hasText(displayName);
+    });
+  }
+);

--- a/tests/unit/components/pipeline/jobs/table/cell/job/util-test.js
+++ b/tests/unit/components/pipeline/jobs/table/cell/job/util-test.js
@@ -1,0 +1,22 @@
+import { module, test } from 'qunit';
+import getDisplayName from 'screwdriver-ui/components/pipeline/jobs/table/cell/job/util';
+
+module('Unit | Component | pipeline/jobs/table/cell/job/util', function () {
+  test('getDisplayName uses job name', function (assert) {
+    const job = { name: 'abc123' };
+
+    assert.equal(getDisplayName(job), job.name);
+  });
+
+  test('getDisplayName uses configured annotation name', function (assert) {
+    const configuredName = 'configuredName';
+    const job = {
+      name: 'abc123',
+      permutations: [
+        { annotations: { 'screwdriver.cd/displayName': configuredName } }
+      ]
+    };
+
+    assert.equal(getDisplayName(job), configuredName);
+  });
+});


### PR DESCRIPTION
## Context
The new jobs UI makes use of custom components for each cell in the table.  This creates a new component for handling the job name and the build status.

## Objective
Create a glimmer component for the jobs.  Screenshot will be captured in the linked PR

## References
#1171 for screenshot 
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
