### PR TITLE
feat: Table cell for job build history

### DIFF
--- a/app/components/pipeline/jobs/table/cell/history/component.js
+++ b/app/components/pipeline/jobs/table/cell/history/component.js
@@ -1,0 +1,24 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+export default class PipelineJobsTableCellHistoryComponent extends Component {
+  @tracked latestBuilds;
+
+  constructor() {
+    super(...arguments);
+
+    const { job } = this.args.record;
+
+    this.args.record.onCreate(job, builds => {
+      if (builds.length > 0) {
+        this.latestBuilds = builds;
+      }
+    });
+  }
+
+  willDestroy() {
+    super.willDestroy();
+
+    this.args.record.onDestroy(this.args.record.job);
+  }
+}

--- a/app/components/pipeline/jobs/table/cell/history/styles.scss
+++ b/app/components/pipeline/jobs/table/cell/history/styles.scss
@@ -1,0 +1,22 @@
+@mixin styles {
+  .history-cell {
+    display: flex;
+
+    .build-history-container {
+      a {
+        display: flex;
+
+        svg {
+          margin: auto;
+        }
+      }
+
+      .tooltip {
+        p {
+          text-align: left;
+          margin: 0;
+        }
+      }
+    }
+  }
+}

--- a/app/components/pipeline/jobs/table/cell/history/template.hbs
+++ b/app/components/pipeline/jobs/table/cell/history/template.hbs
@@ -1,0 +1,40 @@
+<div class="history-cell">
+  {{#if this.latestBuilds}}
+    {{#each this.latestBuilds as |build|}}
+      {{#if (not-eq build.status "CREATED")}}
+        <span class="build-history-container">
+          <LinkTo
+            @route="pipeline.build"
+            @models={{array @record.job.pipelineId build.id}}
+            @title={{build.id}}
+          >
+            <FaIcon
+              @icon="circle"
+              @fixedWidth="true"
+              class={{build.status}}
+            />
+          </LinkTo>
+          <BsTooltip
+            @placement="bottom"
+            @renderInPlace={{true}}
+            class="tooltip"
+          >
+            <p>Build# {{build.id}}</p>
+            {{#if build.startTime}}
+              <p>Start - {{moment-format build.startTime "MM/DD/YYYY HH:mmA"}}</p>
+            {{/if}}
+            {{#if build.endTime}}
+              <p>End - {{moment-format build.endTime "MM/DD/YYYY HH:mmA"}}</p>
+            {{/if}}
+          </BsTooltip>
+        </span>
+      {{else}}
+        <FaIcon
+          @icon="circle"
+          @fixedWidth="true"
+          class={{build.status}}
+        />
+      {{/if}}
+    {{/each}}
+  {{/if}}
+</div>

--- a/tests/integration/components/pipeline/jobs/table/cell/history/component-test.js
+++ b/tests/integration/components/pipeline/jobs/table/cell/history/component-test.js
@@ -1,0 +1,112 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
+import { clearRender, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+
+module(
+  'Integration | Component | pipeline/jobs/table/cell/history',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test('it renders', async function (assert) {
+      const job = { id: 123, name: 'main' };
+
+      this.setProperties({
+        record: {
+          job,
+          onCreate: () => {},
+          onDestroy: () => {}
+        }
+      });
+
+      await render(
+        hbs`<Pipeline::Jobs::Table::Cell::History
+            @record={{this.record}}
+        />`
+      );
+
+      assert.dom('a').doesNotExist();
+    });
+
+    test('it calls onCreate', async function (assert) {
+      const onCreate = sinon.spy();
+      const job = { id: 123, name: 'main' };
+
+      this.setProperties({
+        record: {
+          job,
+          onCreate,
+          onDestroy: () => {}
+        }
+      });
+
+      await render(
+        hbs`<Pipeline::Jobs::Table::Cell::History
+            @record={{this.record}}
+        />`
+      );
+
+      assert.equal(onCreate.calledOnce, true);
+      assert.equal(onCreate.calledWith(job), true);
+    });
+
+    test('it calls onDestroy', async function (assert) {
+      const onDestroy = sinon.spy();
+      const job = { id: 123, name: 'main' };
+
+      this.setProperties({
+        record: {
+          job,
+          onCreate: () => {},
+          onDestroy
+        }
+      });
+
+      await render(
+        hbs`<Pipeline::Jobs::Table::Cell::History
+            @record={{this.record}}
+        />`
+      );
+      await clearRender();
+
+      assert.equal(onDestroy.calledOnce, true);
+      assert.equal(onDestroy.calledWith(job), true);
+    });
+
+    test('it renders build history', async function (assert) {
+      const job = { id: 123, name: 'main' };
+      const builds = [
+        {
+          id: 111,
+          status: 'CREATED'
+        },
+        {
+          id: 999,
+          status: 'SUCCESS',
+          startTime: '2024-07-14T17:25:57.671Z',
+          endTime: '2024-07-14T17:26:55.202Z'
+        }
+      ];
+
+      this.setProperties({
+        record: {
+          job,
+          onCreate: (j, cb) => {
+            cb(builds);
+          },
+          onDestroy: () => {}
+        }
+      });
+
+      await render(
+        hbs`<Pipeline::Jobs::Table::Cell::History
+            @record={{this.record}}
+        />`
+      );
+
+      assert.dom('svg.CREATED').exists({ count: 1 });
+      assert.dom('.build-history-container a').exists({ count: 1 });
+    });
+  }
+);


### PR DESCRIPTION
## Context
The new jobs UI makes use of custom components for each cell in the table. This creates a new component for handling the  build history for a job.

## Objective
Create a glimmer component for the jobs. Screenshot will be captured in the linked PR

## References
#1171 for screenshot 
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
