### PR TITLE
feat: Table cell for build duration

### DIFF
--- a/app/components/pipeline/jobs/table/cell/duration/component.js
+++ b/app/components/pipeline/jobs/table/cell/duration/component.js
@@ -1,0 +1,100 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import humanizeDuration from 'humanize-duration';
+import { unfinishedStatuses } from 'screwdriver-ui/utils/build';
+
+export default class PipelineJobsTableCellDurationComponent extends Component {
+  @tracked duration;
+
+  latestBuild;
+
+  buildDuration;
+
+  intervalId;
+
+  humanizeConfig = {
+    round: true,
+    delimiter: ' ',
+    spacer: '',
+    units: ['h', 'm', 's'],
+    language: 'shortEn',
+    languages: {
+      shortEn: { h: () => 'h', m: () => 'm', s: () => 's' }
+    }
+  };
+
+  constructor() {
+    super(...arguments);
+
+    const { job } = this.args.record;
+
+    this.args.record.onCreate(job, builds => {
+      if (builds.length > 0) {
+        this.latestBuild = builds[builds.length - 1];
+        this.initializeBuildDuration();
+      }
+    });
+  }
+
+  willDestroy() {
+    super.willDestroy();
+
+    if (this.intervalId) {
+      clearInterval(this.intervalId);
+      this.intervalId = null;
+    }
+
+    this.args.record.onDestroy(this.args.record.job);
+  }
+
+  stopInterval() {
+    if (this.intervalId) {
+      clearInterval(this.intervalId);
+      this.intervalId = null;
+    }
+  }
+
+  startInterval() {
+    this.stopInterval();
+
+    this.intervalId = setInterval(() => {
+      this.buildDuration += 1000;
+      this.duration = this.getRunningDurationText();
+    }, 1000);
+  }
+
+  initializeBuildDuration() {
+    const startTime = Date.parse(this.latestBuild.startTime);
+
+    if (this.latestBuild.endTime) {
+      this.duration = humanizeDuration(
+        Date.parse(this.latestBuild.endTime) - startTime,
+        this.humanizeConfig
+      );
+
+      this.stopInterval();
+    } else if (unfinishedStatuses.includes(this.latestBuild.status))
+      if (this.latestBuild.status === 'RUNNING') {
+        this.buildDuration = new Date() - startTime;
+        this.duration = this.getRunningDurationText();
+
+        if (!this.intervalId) {
+          this.startInterval();
+        }
+      } else {
+        this.duration = '';
+      }
+    else {
+      this.duration = 'N/A';
+
+      this.stopInterval();
+    }
+  }
+
+  getRunningDurationText() {
+    return `Running for ${humanizeDuration(
+      this.buildDuration,
+      this.humanizeConfig
+    )}`;
+  }
+}

--- a/app/components/pipeline/jobs/table/cell/duration/template.hbs
+++ b/app/components/pipeline/jobs/table/cell/duration/template.hbs
@@ -1,0 +1,3 @@
+<div class="duration-cell">
+  {{this.duration}}
+</div>

--- a/tests/integration/components/pipeline/jobs/table/cell/duration/component-test.js
+++ b/tests/integration/components/pipeline/jobs/table/cell/duration/component-test.js
@@ -1,0 +1,201 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
+import { clearRender, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+
+module(
+  'Integration | Component | pipeline/jobs/table/cell/duration',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test('it renders', async function (assert) {
+      const job = { id: 123, name: 'main' };
+
+      this.setProperties({
+        record: {
+          job,
+          onCreate: () => {},
+          onDestroy: () => {}
+        }
+      });
+
+      await render(
+        hbs`<Pipeline::Jobs::Table::Cell::Duration
+            @record={{this.record}}
+        />`
+      );
+
+      assert.dom(this.element).hasText('');
+    });
+
+    test('it calls onCreate', async function (assert) {
+      const onCreate = sinon.spy();
+      const job = { id: 123, name: 'main' };
+
+      this.setProperties({
+        record: {
+          job,
+          onCreate,
+          onDestroy: () => {}
+        }
+      });
+
+      await render(
+        hbs`<Pipeline::Jobs::Table::Cell::Duration
+            @record={{this.record}}
+        />`
+      );
+
+      assert.equal(onCreate.calledOnce, true);
+      assert.equal(onCreate.calledWith(job), true);
+    });
+
+    test('it calls onDestroy', async function (assert) {
+      const onDestroy = sinon.spy();
+      const job = { id: 123, name: 'main' };
+
+      this.setProperties({
+        record: {
+          job,
+          onCreate: () => {},
+          onDestroy
+        }
+      });
+
+      await render(
+        hbs`<Pipeline::Jobs::Table::Cell::Duration
+            @record={{this.record}}
+        />`
+      );
+      await clearRender();
+
+      assert.equal(onDestroy.calledOnce, true);
+      assert.equal(onDestroy.calledWith(job), true);
+    });
+
+    test('it renders duration for completed build', async function (assert) {
+      const job = { id: 123, name: 'main' };
+      const builds = [
+        {
+          id: 999,
+          startTime: '2024-07-14T17:25:57.671Z',
+          endTime: '2024-07-14T17:26:55.202Z'
+        }
+      ];
+
+      this.setProperties({
+        record: {
+          job,
+          onCreate: (j, cb) => {
+            return cb(builds);
+          },
+          onDestroy: () => {}
+        }
+      });
+
+      await render(
+        hbs`<Pipeline::Jobs::Table::Cell::Duration
+            @record={{this.record}}
+        />`
+      );
+
+      assert.dom(this.element).hasText('58s');
+    });
+
+    test('it renders duration for queued build', async function (assert) {
+      const job = { id: 123, name: 'main' };
+      const now = new Date();
+      const builds = [
+        {
+          id: 999,
+          startTime: new Date(now - 1000 * 60 * 5 + 15 * 1000).toISOString(),
+          status: 'QUEUED'
+        }
+      ];
+
+      this.setProperties({
+        record: {
+          job,
+          onCreate: (j, cb) => {
+            return cb(builds);
+          },
+          onDestroy: () => {}
+        }
+      });
+
+      await render(
+        hbs`<Pipeline::Jobs::Table::Cell::Duration
+            @record={{this.record}}
+        />`
+      );
+
+      assert.dom(this.element).hasText('');
+
+      await clearRender();
+    });
+
+    test('it renders duration for running build', async function (assert) {
+      const job = { id: 123, name: 'main' };
+      const now = new Date();
+      const builds = [
+        {
+          id: 999,
+          startTime: new Date(now - 1000 * 60 * 5 + 15 * 1000).toISOString(),
+          status: 'RUNNING'
+        }
+      ];
+
+      this.setProperties({
+        record: {
+          job,
+          onCreate: (j, cb) => {
+            return cb(builds);
+          },
+          onDestroy: () => {}
+        }
+      });
+
+      await render(
+        hbs`<Pipeline::Jobs::Table::Cell::Duration
+            @record={{this.record}}
+        />`
+      );
+
+      assert.dom(this.element).hasText('Running for 4m 45s');
+
+      await clearRender();
+    });
+
+    test('it renders duration for a build that completed without an end time', async function (assert) {
+      const job = { id: 123, name: 'main' };
+      const now = new Date();
+      const builds = [
+        {
+          id: 999,
+          startTime: new Date(now - 1000 * 60 * 5 + 15 * 1000).toISOString()
+        }
+      ];
+
+      this.setProperties({
+        record: {
+          job,
+          onCreate: (j, cb) => {
+            return cb(builds);
+          },
+          onDestroy: () => {}
+        }
+      });
+
+      await render(
+        hbs`<Pipeline::Jobs::Table::Cell::Duration
+            @record={{this.record}}
+        />`
+      );
+
+      assert.dom(this.element).hasText('N/A');
+
+      await clearRender();
+    });
+  }
+);


### PR DESCRIPTION
## Context
The new jobs UI makes use of custom components for each cell in the table. This creates a new component for handling the build duration.  If a build is running, the component will automatically increment the build duration every second for additional user feedback that there is a build in progress.

## Objective
Create a glimmer component for the jobs. Screenshot will be captured in the linked PR

## References
#1171 for screenshot 
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
