### PR TITLE
feat: Table cell for build start time

### DIFF
--- a/app/components/pipeline/jobs/table/cell/start-time/component.js
+++ b/app/components/pipeline/jobs/table/cell/start-time/component.js
@@ -1,0 +1,42 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { toCustomLocaleString } from 'screwdriver-ui/utils/time-range';
+
+export default class PipelineJobsTableCellStartTimeComponent extends Component {
+  @tracked latestBuild;
+
+  constructor() {
+    super(...arguments);
+
+    const { job } = this.args.record;
+
+    this.args.record.onCreate(job, builds => {
+      if (builds.length > 0) {
+        this.latestBuild = builds[builds.length - 1];
+      }
+    });
+  }
+
+  willDestroy() {
+    super.willDestroy();
+
+    this.args.record.onDestroy(this.args.record.job);
+  }
+
+  get startTime() {
+    if (!this.latestBuild) {
+      return null;
+    }
+    if (!this.latestBuild.startTime) {
+      return 'Not started';
+    }
+
+    if (this.args.record.timestampFormat === 'UTC') {
+      return toCustomLocaleString(new Date(this.latestBuild.startTime), {
+        timeZone: 'UTC'
+      });
+    }
+
+    return toCustomLocaleString(new Date(this.latestBuild.startTime));
+  }
+}

--- a/app/components/pipeline/jobs/table/cell/start-time/template.hbs
+++ b/app/components/pipeline/jobs/table/cell/start-time/template.hbs
@@ -1,0 +1,5 @@
+<div class="start-time-cell">
+  {{#if this.startTime}}
+    {{this.startTime}}
+  {{/if}}
+</div>

--- a/tests/integration/components/pipeline/jobs/table/cell/start-time/component-test.js
+++ b/tests/integration/components/pipeline/jobs/table/cell/start-time/component-test.js
@@ -1,0 +1,130 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
+import { clearRender, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+
+module(
+  'Integration | Component | pipeline/jobs/table/cell/start-time',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test('it renders', async function (assert) {
+      const job = { id: 123, name: 'main' };
+
+      this.setProperties({
+        record: {
+          job,
+          onCreate: () => {},
+          onDestroy: () => {}
+        }
+      });
+
+      await render(
+        hbs`<Pipeline::Jobs::Table::Cell::StartTime
+            @record={{this.record}}
+        />`
+      );
+
+      assert.dom(this.element).hasText('');
+    });
+
+    test('it calls onCreate', async function (assert) {
+      const onCreate = sinon.spy();
+      const job = { id: 123, name: 'main' };
+
+      this.setProperties({
+        record: {
+          job,
+          onCreate,
+          onDestroy: () => {}
+        }
+      });
+
+      await render(
+        hbs`<Pipeline::Jobs::Table::Cell::StartTime
+            @record={{this.record}}
+        />`
+      );
+
+      assert.equal(onCreate.calledOnce, true);
+      assert.equal(onCreate.calledWith(job), true);
+    });
+
+    test('it calls onDestroy', async function (assert) {
+      const onDestroy = sinon.spy();
+      const job = { id: 123, name: 'main' };
+
+      this.setProperties({
+        record: {
+          job,
+          onCreate: () => {},
+          onDestroy
+        }
+      });
+
+      await render(
+        hbs`<Pipeline::Jobs::Table::Cell::StartTime
+            @record={{this.record}}
+        />`
+      );
+      await clearRender();
+
+      assert.equal(onDestroy.calledOnce, true);
+      assert.equal(onDestroy.calledWith(job), true);
+    });
+
+    test('it renders start time', async function (assert) {
+      const job = { id: 123, name: 'main' };
+      const builds = [
+        {
+          id: 1,
+          startTime: '2021-01-01T20:30:00.000Z'
+        }
+      ];
+
+      this.setProperties({
+        record: {
+          job,
+          timestampFormat: 'UTC',
+          onCreate: (j, cb) => {
+            cb(builds);
+          },
+          onDestroy: () => {}
+        }
+      });
+
+      await render(
+        hbs`<Pipeline::Jobs::Table::Cell::StartTime
+            @record={{this.record}}
+        />`
+      );
+
+      assert.dom(this.element).hasText('01/01/2021, 08:30 PM UTC');
+    });
+
+    test('it renders text when start time is not available', async function (assert) {
+      const job = { id: 123, name: 'main' };
+      const builds = [{ id: 1 }];
+
+      this.setProperties({
+        record: {
+          job,
+          timestampFormat: 'UTC',
+          onCreate: (j, cb) => {
+            cb(builds);
+          },
+          onDestroy: () => {}
+        }
+      });
+
+      await render(
+        hbs`<Pipeline::Jobs::Table::Cell::StartTime
+            @record={{this.record}}
+        />`
+      );
+
+      assert.dom(this.element).hasText('Not started');
+    });
+  }
+);


### PR DESCRIPTION
## Context
The new jobs UI makes use of custom components for each cell in the table. This creates a new component for handling the start time of the latest build for a job.

## Objective
Create a glimmer component for the jobs. Screenshot will be captured in the linked PR

## References
#1171 for screenshot 
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
