### PR TITLE
feat: Table cell for build metrics

### DIFF
--- a/app/components/pipeline/jobs/table/cell/metrics/component.js
+++ b/app/components/pipeline/jobs/table/cell/metrics/component.js
@@ -1,0 +1,24 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+export default class PipelineJobsTableCellMetricsComponent extends Component {
+  @tracked latestBuild;
+
+  constructor() {
+    super(...arguments);
+
+    const { job } = this.args.record;
+
+    this.args.record.onCreate(job, builds => {
+      if (builds.length > 0) {
+        this.latestBuild = builds[builds.length - 1];
+      }
+    });
+  }
+
+  willDestroy() {
+    super.willDestroy();
+
+    this.args.record.onDestroy(this.args.record.job);
+  }
+}

--- a/app/components/pipeline/jobs/table/cell/metrics/styles.scss
+++ b/app/components/pipeline/jobs/table/cell/metrics/styles.scss
@@ -1,0 +1,15 @@
+@use 'screwdriver-colors' as colors;
+
+@mixin styles {
+  .metrics-cell {
+    a {
+      display: flex;
+      font-size: 1.25rem;
+      color: colors.$sd-running;
+
+      &:hover {
+        color: colors.$sd-running;
+      }
+    }
+  }
+}

--- a/app/components/pipeline/jobs/table/cell/metrics/template.hbs
+++ b/app/components/pipeline/jobs/table/cell/metrics/template.hbs
@@ -1,0 +1,15 @@
+<div class="metrics-cell">
+  {{#if this.latestBuild}}
+    <LinkTo
+      @route="pipeline.metrics"
+      @model={{@record.job.pipelineId}}
+      @query={{hash jobId=@record.job.id}}
+    >
+      <FaIcon
+        @icon="chart-line"
+        @fixedWidth="true"
+        @title="Job metrics"
+      />
+    </LinkTo>
+  {{/if}}
+</div>

--- a/tests/integration/components/pipeline/jobs/table/cell/metrics/component-test.js
+++ b/tests/integration/components/pipeline/jobs/table/cell/metrics/component-test.js
@@ -1,0 +1,100 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
+import { clearRender, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+
+module(
+  'Integration | Component | pipeline/jobs/table/cell/metrics',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test('it renders', async function (assert) {
+      const job = { id: 123, name: 'main' };
+
+      this.setProperties({
+        record: {
+          job,
+          onCreate: () => {},
+          onDestroy: () => {}
+        }
+      });
+
+      await render(
+        hbs`<Pipeline::Jobs::Table::Cell::Metrics
+            @record={{this.record}}
+        />`
+      );
+
+      assert.dom('a').doesNotExist();
+    });
+
+    test('it calls onCreate', async function (assert) {
+      const onCreate = sinon.spy();
+      const job = { id: 123, name: 'main' };
+
+      this.setProperties({
+        record: {
+          job,
+          onCreate,
+          onDestroy: () => {}
+        }
+      });
+
+      await render(
+        hbs`<Pipeline::Jobs::Table::Cell::Metrics
+            @record={{this.record}}
+        />`
+      );
+
+      assert.equal(onCreate.calledOnce, true);
+      assert.equal(onCreate.calledWith(job), true);
+    });
+
+    test('it calls onDestroy', async function (assert) {
+      const onDestroy = sinon.spy();
+      const job = { id: 123, name: 'main' };
+
+      this.setProperties({
+        record: {
+          job,
+          onCreate: () => {},
+          onDestroy
+        }
+      });
+
+      await render(
+        hbs`<Pipeline::Jobs::Table::Cell::Metrics
+            @record={{this.record}}
+        />`
+      );
+      await clearRender();
+
+      assert.equal(onDestroy.calledOnce, true);
+      assert.equal(onDestroy.calledWith(job), true);
+    });
+
+    test('it renders metrics link', async function (assert) {
+      const job = { id: 123, name: 'main' };
+      const builds = [{ id: 999 }];
+
+      this.setProperties({
+        record: {
+          job,
+          onCreate: (j, cb) => {
+            cb(builds);
+          },
+          onDestroy: () => {}
+        }
+      });
+
+      await render(
+        hbs`<Pipeline::Jobs::Table::Cell::Metrics
+            @record={{this.record}}
+        />`
+      );
+
+      assert.dom('a').exists({ count: 1 });
+    });
+  }
+);


### PR DESCRIPTION
## Context
The new jobs UI makes use of custom components for each cell in the table. This creates a new component for handling the job metrics.  For now, the metrics link will take the user back to the v1 UI as there is no v2 UI available yet.

## Objective
Create a glimmer component for the jobs. Screenshot will be captured in the linked PR

## References
#1171 for screenshot 
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
