### PR TITLE
fix: Update restart modal to better handle stages

### DIFF
--- a/app/components/pipeline/modal/confirm-action/template.hbs
+++ b/app/components/pipeline/modal/confirm-action/template.hbs
@@ -24,7 +24,11 @@
         @dismissible={{false}}
       />
     {{/if}}
-    <div id="confirm-action-job">Job: <code>{{@job.name}}</code></div>
+    {{#if @stage}}
+      <div id="confirm-action-stage">Stage: <code>{{@stage.name}}</code></div>
+    {{else}}
+      <div id="confirm-action-job">Job: <code>{{@job.name}}</code></div>
+    {{/if}}
     <div id="confirm-action-commit">
       Commit: <code>{{this.truncatedMessage}}</code>
       <a

--- a/app/components/pipeline/workflow/tooltip/stage/template.hbs
+++ b/app/components/pipeline/workflow/tooltip/stage/template.hbs
@@ -21,6 +21,7 @@
     @jobs={{@jobs}}
     @latestCommitEvent={{@latestCommitEvent}}
     @job={{this.job}}
+    @stage={{@d3Data.stage}}
     @closeModal={{this.closeConfirmActionModal}}
   />
 {{/if}}

--- a/tests/integration/components/pipeline/modal/confirm-action/component-test.js
+++ b/tests/integration/components/pipeline/modal/confirm-action/component-test.js
@@ -68,6 +68,36 @@ module(
       assert.dom('.modal-title').hasText('Are you sure you want to restart?');
     });
 
+    test('it renders stage name if set', async function (assert) {
+      this.setProperties({
+        pipeline: { parameters: {} },
+        event: {
+          commit: { message: 'commit message', url: 'http://foo.com' },
+          sha: 'deadbeef0123456789'
+        },
+        jobs: [],
+        latestCommitEvent: { sha: 'deadbeef0123456789' },
+        job: { name: 'main' },
+        stage: { name: 'stage' },
+        closeModal: () => {}
+      });
+      await render(
+        hbs`<Pipeline::Modal::ConfirmAction
+            @pipeline={{this.pipeline}}
+            @event={{this.event}}
+            @jobs={{this.jobs}}
+            @latestCommitEvent={{this.latestCommitEvent}}
+            @job={{this.job}}
+            @stage={{this.stage}}
+            @closeModal={{this.closeModal}}
+        />`
+      );
+
+      assert.dom('#confirm-action-stage').exists({ count: 1 });
+      assert.dom('#confirm-action-stage').hasText('Stage: stage');
+      assert.dom('#confirm-action-job').doesNotExist();
+    });
+
     test('it renders warning message for non-latest commit event', async function (assert) {
       this.setProperties({
         pipeline: { parameters: {} },


### PR DESCRIPTION
## Context
The modal that handles restarting a job does not handle stages particularly well at the moment.  When a start needs to be restarted, the stage name should be displayed to the user instead of the job name.

## Objective
Update the modal to display the stage name instead of the job name when the user wants to restart from a stage.
![Screenshot 2024-09-18 at 15-57-46 New Pipeline Events Show](https://github.com/user-attachments/assets/436c890f-0efd-4fa8-8b3e-174ce7764b4e)

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
