### PR TITLE
fix: Request body utility to handle arbitrary events

### DIFF
--- a/app/utils/pipeline/modal/request.js
+++ b/app/utils/pipeline/modal/request.js
@@ -23,10 +23,12 @@ export function buildPostBody( // eslint-disable-line import/prefer-default-expo
     causeMessage: `Manually started by ${username}`
   };
 
-  if (job && job.status) {
+  if (job?.status) {
     data.startFrom = job.name;
     data.groupEventId = event.groupEventId;
     data.parentEventId = event.id;
+  } else if (job?.name) {
+    data.startFrom = job.name;
   } else {
     data.startFrom = '~commit';
   }

--- a/tests/unit/utils/pipeline/modal/request-test.js
+++ b/tests/unit/utils/pipeline/modal/request-test.js
@@ -13,6 +13,28 @@ module('Unit | Utility | pipeline/modal/request', function () {
     );
   });
 
+  test('buildPostBody sets correct values for new event', function (assert) {
+    assert.deepEqual(
+      buildPostBody('foobar', 123, null, null, null, false, null),
+      {
+        pipelineId: 123,
+        causeMessage: 'Manually started by foobar',
+        startFrom: '~commit'
+      }
+    );
+  });
+
+  test('buildPostBody sets correct values for new event starting from job', function (assert) {
+    assert.deepEqual(
+      buildPostBody('foobar', 123, { name: 'main' }, null, null, false, null),
+      {
+        pipelineId: 123,
+        causeMessage: 'Manually started by foobar',
+        startFrom: 'main'
+      }
+    );
+  });
+
   test('buildPostBody sets correct values for restart', function (assert) {
     assert.deepEqual(
       buildPostBody(


### PR DESCRIPTION
## Context
The utility that is used to generate POST body data for starting a job needs to better handle arbitrary events.  Users are allowed to create a new event from any job in the pipeline and this utility needs to be modified to allow for such instances.

## Objective
Update the request body utility to allow for events to be started from any job, not just `~commit`

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
