### PR TITLE
feat: Data refreshing utility for jobs table

### DIFF
--- a/app/components/pipeline/jobs/table/dataReloader.js
+++ b/app/components/pipeline/jobs/table/dataReloader.js
@@ -1,0 +1,113 @@
+import ENV from 'screwdriver-ui/config/environment';
+import { setBuildStatus } from 'screwdriver-ui/utils/pipeline/build';
+
+export default class DataReloader {
+  shuttle;
+
+  pageSize;
+
+  jobIdsMatchingFilter = [];
+
+  jobCallbacks = {};
+
+  builds = {};
+
+  intervalId;
+
+  constructor(shuttle, jobIds, pageSize) {
+    this.shuttle = shuttle;
+    this.jobIdsMatchingFilter = jobIds.slice(0, pageSize);
+
+    jobIds.forEach(jobId => {
+      this.builds[jobId] = [];
+    });
+  }
+
+  setCorrectBuildStatus(builds) {
+    builds.forEach(build => {
+      setBuildStatus(build);
+
+      return build;
+    });
+  }
+
+  updateJobsMatchingFilter(jobIds, pageSize, currentPage) {
+    if (jobIds.length < pageSize) {
+      this.jobIdsMatchingFilter = jobIds;
+    } else {
+      const startIndex = (currentPage - 1) * pageSize;
+      const endIndex = startIndex + pageSize;
+
+      this.jobIdsMatchingFilter = jobIds.slice(startIndex, endIndex);
+    }
+  }
+
+  newJobIds() {
+    return this.jobIdsMatchingFilter.filter(
+      jobId => this.jobCallbacks[jobId] === undefined
+    );
+  }
+
+  removeCallbacksForJobId(jobId) {
+    delete this.jobCallbacks[jobId];
+  }
+
+  addCallbackForJobId(jobId, buildsCallback) {
+    if (this.builds[jobId]) {
+      buildsCallback(this.builds[jobId]);
+    }
+
+    if (!this.jobCallbacks[jobId]) {
+      this.jobCallbacks[jobId] = [];
+    }
+
+    this.jobCallbacks[jobId].push(buildsCallback);
+  }
+
+  async fetchBuildsForJobs(jobIds) {
+    if (jobIds.length === 0) {
+      return;
+    }
+
+    await this.shuttle
+      .fetchFromApi(
+        'get',
+        `/builds/statuses?jobIds=${jobIds.join('&jobIds=')}&numBuilds=${
+          ENV.APP.NUM_BUILDS_LISTED
+        }`
+      )
+      .then(response => {
+        response.forEach(buildsForJob => {
+          this.setCorrectBuildStatus(buildsForJob.builds);
+
+          const { jobId } = buildsForJob;
+
+          this.builds[jobId] = buildsForJob.builds;
+
+          if (this.jobCallbacks[jobId]) {
+            this.jobCallbacks[jobId].forEach(callback => {
+              callback(buildsForJob.builds);
+            });
+          }
+        });
+      });
+  }
+
+  start() {
+    this.intervalId = setInterval(() => {
+      if (Object.keys(this.jobCallbacks).length === 0) {
+        return;
+      }
+
+      this.fetchBuildsForJobs(this.jobIdsMatchingFilter).then(() => {});
+    }, ENV.APP.BUILD_RELOAD_TIMER);
+  }
+
+  destroy() {
+    if (this.intervalId) {
+      clearInterval(this.intervalId);
+    }
+
+    this.intervalId = null;
+  }
+}

--- a/tests/unit/components/pipeline/jobs/table/dataReloader-test.js
+++ b/tests/unit/components/pipeline/jobs/table/dataReloader-test.js
@@ -1,0 +1,126 @@
+import { module, test } from 'qunit';
+import DataReloader from 'screwdriver-ui/components/pipeline/jobs/table/dataReloader';
+import sinon from 'sinon';
+
+module('Unit | Component | pipeline/jobs/table/dataReloader', function () {
+  test('setCorrectBuildStatus sets correct values', function (assert) {
+    const builds = [
+      { status: 'SUCCESS' },
+      { status: 'SUCCESS', meta: { build: { warning: { message: 'Oops' } } } }
+    ];
+
+    new DataReloader(null, [], 0).setCorrectBuildStatus(builds);
+
+    assert.equal(builds[0].status, 'SUCCESS');
+    assert.equal(builds[1].status, 'WARNING');
+  });
+
+  test('updateJobsMatchingFilter updates', function (assert) {
+    const jobIds = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+    const dataReloader = new DataReloader(null, jobIds, 3);
+
+    assert.equal(dataReloader.jobIdsMatchingFilter.length, 3);
+    assert.equal(dataReloader.jobIdsMatchingFilter[0], 0);
+    assert.equal(dataReloader.jobIdsMatchingFilter[1], 1);
+    assert.equal(dataReloader.jobIdsMatchingFilter[2], 2);
+
+    dataReloader.updateJobsMatchingFilter(jobIds, 50, 1);
+    assert.equal(dataReloader.jobIdsMatchingFilter.length, jobIds.length);
+
+    dataReloader.updateJobsMatchingFilter(jobIds, 3, 2);
+    assert.equal(dataReloader.jobIdsMatchingFilter.length, 3);
+    assert.equal(dataReloader.jobIdsMatchingFilter[0], 3);
+    assert.equal(dataReloader.jobIdsMatchingFilter[1], 4);
+    assert.equal(dataReloader.jobIdsMatchingFilter[2], 5);
+
+    dataReloader.updateJobsMatchingFilter(jobIds, 5, 1);
+
+    assert.equal(dataReloader.jobIdsMatchingFilter.length, 5);
+    assert.equal(dataReloader.jobIdsMatchingFilter[0], 0);
+    assert.equal(dataReloader.jobIdsMatchingFilter[1], 1);
+    assert.equal(dataReloader.jobIdsMatchingFilter[2], 2);
+    assert.equal(dataReloader.jobIdsMatchingFilter[3], 3);
+    assert.equal(dataReloader.jobIdsMatchingFilter[4], 4);
+  });
+
+  test('newJobIds returns new job ids', function (assert) {
+    const dataReloader = new DataReloader(null, [1, 2, 3, 4, 5], 5);
+
+    dataReloader.jobIdsMatchingFilter = [1, 2, 6, 7, 8];
+    dataReloader.jobCallbacks = { 1: [], 2: [], 3: [], 4: [], 5: [] };
+    const newJobIds = dataReloader.newJobIds();
+
+    assert.equal(newJobIds.length, 3);
+    assert.equal(newJobIds[0], 6);
+    assert.equal(newJobIds[1], 7);
+    assert.equal(newJobIds[2], 8);
+  });
+
+  test('removeCallbacksForJobId removes entry', function (assert) {
+    const dataReloader = new DataReloader(null, [1, 2], 2);
+
+    dataReloader.jobCallbacks = { 1: [], 2: [] };
+    assert.equal(Object.entries(dataReloader.jobCallbacks).length, 2);
+
+    dataReloader.removeCallbacksForJobId(1);
+    assert.equal(Object.entries(dataReloader.jobCallbacks).length, 1);
+    assert.equal(dataReloader.jobCallbacks[1], undefined);
+  });
+
+  test('addCallbackForJobId adds callback', function (assert) {
+    const dataReloader = new DataReloader(null, [], 0);
+    const jobId = 1;
+    const callback = sinon.stub();
+
+    dataReloader.addCallbackForJobId(jobId, callback);
+
+    assert.equal(dataReloader.jobCallbacks[jobId].length, 1);
+    assert.equal(dataReloader.jobCallbacks[jobId][0], callback);
+    assert.equal(callback.callCount, 0);
+  });
+
+  test('addCallbackForJobId calls callback if builds exist', function (assert) {
+    const dataReloader = new DataReloader(null, [], 0);
+    const jobId = 1;
+    const builds = [{ id: 1 }];
+    const callback = sinon.stub();
+
+    dataReloader.builds[jobId] = builds;
+    dataReloader.addCallbackForJobId(jobId, callback);
+
+    assert.equal(dataReloader.jobCallbacks[jobId].length, 1);
+    assert.equal(dataReloader.jobCallbacks[jobId][0], callback);
+    assert.equal(callback.callCount, 1);
+    assert.equal(callback.calledWith(builds), true);
+  });
+
+  test('fetchBuildsForJobs fetches builds and calls callbacks', async function (assert) {
+    const jobId = 1;
+    const jobs = [jobId];
+    const builds = [
+      { id: 11, status: 'SUCCESS' },
+      {
+        id: 12,
+        status: 'SUCCESS',
+        meta: { build: { warning: { message: 'Oops' } } }
+      }
+    ];
+    const buildStatuses = [{ jobId, builds }];
+    const callback = sinon.stub();
+    const shuttle = { fetchFromApi: () => {} };
+
+    sinon.stub(shuttle, 'fetchFromApi').resolves(buildStatuses);
+
+    const dataReloader = new DataReloader(shuttle, [], 0);
+
+    dataReloader.addCallbackForJobId(jobId, callback);
+
+    await dataReloader.fetchBuildsForJobs(jobs);
+
+    assert.equal(dataReloader.builds[jobId].length, builds.length);
+    assert.equal(dataReloader.builds[jobId][0].status, 'SUCCESS');
+    assert.equal(dataReloader.builds[jobId][1].status, 'WARNING');
+    assert.equal(callback.callCount, 1);
+    assert.equal(callback.calledWith(builds), true);
+  });
+});


### PR DESCRIPTION
## Context
The new v2 jobs UI should automatically refresh data.  For pipelines with lots of jobs, it is possible that many jobs are not actively being displayed in the UI.  This utility provides the functionality to refresh the necessary data that is only being displayed in the UI.

## Objective
Creates a utility that automatically refreshes the necessary data to render the v2 jobs UI.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
