### PR TITLE
feat: v2 jobs table glimmer component

### DIFF
--- a/app/components/pipeline/jobs/styles.scss
+++ b/app/components/pipeline/jobs/styles.scss
@@ -1,0 +1,5 @@
+@use 'table/styles' as table;
+
+@mixin styles {
+  @include table.styles;
+}

--- a/app/components/pipeline/jobs/table/component.js
+++ b/app/components/pipeline/jobs/table/component.js
@@ -1,0 +1,121 @@
+import Component from '@glimmer/component';
+import { service } from '@ember/service';
+import { action } from '@ember/object';
+import DataReloader from './dataReloader';
+
+const INITIAL_PAGE_SIZE = 10;
+
+export default class PipelineJobsTableComponent extends Component {
+  @service shuttle;
+
+  @service('emt-themes/ember-bootstrap-v5') emberModelTableBootstrapTheme;
+
+  dataReloader;
+
+  data = [];
+
+  columns = [
+    {
+      title: 'JOB',
+      propertyName: 'jobName',
+      className: 'job-column',
+      component: 'jobCell'
+    },
+    {
+      title: 'HISTORY',
+      className: 'history-column',
+      component: 'historyCell'
+    },
+    {
+      title: 'DURATION',
+      className: 'duration-column',
+      component: 'durationCell'
+    },
+    {
+      title: 'START TIME',
+      className: 'start-time-column',
+      component: 'startTimeCell'
+    },
+    {
+      title: 'COVERAGE',
+      className: 'coverage-column',
+      component: 'coverageCell'
+    },
+    {
+      title: 'METRICS',
+      className: 'metrics-column',
+      component: 'metricsCell'
+    },
+    {
+      title: 'ACTIONS',
+      className: 'actions-column',
+      component: 'actionsCell'
+    }
+  ];
+
+  constructor() {
+    super(...arguments);
+
+    const jobIds = this.args.jobs.map(job => job.id);
+
+    this.dataReloader = new DataReloader(
+      this.shuttle,
+      jobIds,
+      INITIAL_PAGE_SIZE
+    );
+    const initialJobIds = this.dataReloader.newJobIds();
+
+    this.args.jobs.forEach(job => {
+      this.data.push({
+        job,
+        jobName: job.name,
+        pipeline: this.args.pipeline,
+        jobs: this.args.jobs,
+        timestampFormat: this.args.userSettings.timestampFormat,
+        onCreate: (jobToMonitor, buildsCallback) => {
+          this.dataReloader.addCallbackForJobId(
+            jobToMonitor.id,
+            buildsCallback
+          );
+        },
+        onDestroy: jobToMonitor => {
+          this.dataReloader.removeCallbacksForJobId(jobToMonitor.id);
+        }
+      });
+    });
+
+    this.dataReloader.fetchBuildsForJobs(initialJobIds).then(() => {
+      this.dataReloader.start();
+    });
+  }
+
+  willDestroy() {
+    super.willDestroy();
+
+    this.dataReloader.destroy();
+  }
+
+  get theme() {
+    const theme = this.emberModelTableBootstrapTheme;
+
+    theme.searchPlaceholderMsg = 'Search for job by name';
+    theme.table = 'table table-condensed table-hover table-sm';
+
+    return theme;
+  }
+
+  @action
+  onDisplayDataChanged(data) {
+    const jobIds = data.filteredContent.map(record => record.job.id);
+
+    this.dataReloader.updateJobsMatchingFilter(
+      jobIds,
+      data.pageSize,
+      data.currentPageNumber
+    );
+
+    this.dataReloader
+      .fetchBuildsForJobs(this.dataReloader.newJobIds())
+      .then(() => {});
+  }
+}

--- a/app/components/pipeline/jobs/table/styles.scss
+++ b/app/components/pipeline/jobs/table/styles.scss
@@ -1,0 +1,155 @@
+@use 'screwdriver-colors' as colors;
+
+@use 'cell/actions/styles' as actions;
+@use 'cell/history/styles' as history;
+@use 'cell/job/styles' as job;
+@use 'cell/metrics/styles' as metrics;
+
+@mixin styles {
+  #jobs-table {
+    padding: 1rem;
+
+    #jobs-table-search {
+      width: 100%;
+      margin-bottom: 1rem;
+    }
+
+    table {
+      thead {
+        color: colors.$sd-text-med;
+
+        th {
+          &.history-column {
+            width: 15rem;
+          }
+
+          &.duration-column,
+          &.start-time-column {
+            width: 20rem;
+          }
+
+          &.coverage-column,
+          &.metrics-column,
+          &.actions-column {
+            width: 10rem;
+          }
+        }
+      }
+
+      tbody {
+        @include actions.styles;
+        @include history.styles;
+        @include job.styles;
+        @include metrics.styles;
+
+        tr {
+          color: colors.$sd-text;
+
+          &:hover {
+            color: colors.$sd-text;
+            background-color: rgba(colors.$sd-running, 0.1);
+          }
+        }
+
+        td {
+          vertical-align: middle;
+        }
+
+        svg {
+          &.SUCCESS {
+            color: colors.$sd-success;
+          }
+
+          &.WARNING,
+          &.UNSTABLE {
+            color: colors.$sd-unstable;
+          }
+
+          &.FAILURE,
+          &.ABORTED {
+            color: colors.$sd-failure;
+          }
+
+          &.RUNNING,
+          &.QUEUED,
+          &.BLOCKED,
+          &.CREATED,
+          &.SKIPPED {
+            color: colors.$sd-running;
+          }
+
+          &.COLLAPSED,
+          &.FROZEN {
+            color: colors.$sd-text-light;
+          }
+        }
+      }
+    }
+
+    #jobs-table-footer {
+      display: flex;
+      color: colors.$sd-text-med;
+      margin: 5rem 0;
+
+      .table-summary {
+        display: flex;
+        margin: auto;
+      }
+
+      #select-pagination-size {
+        label {
+          background-color: transparent;
+          border: none;
+          color: colors.$sd-text-med;
+        }
+
+        select {
+          border-radius: 0.25rem;
+        }
+      }
+
+      #page-navigation {
+        display: flex;
+
+        button {
+          background-color: transparent;
+          border: none;
+
+          svg {
+            color: colors.$sd-text;
+          }
+
+          &:disabled {
+            svg {
+              color: rgba(colors.$sd-text, 0.5);
+            }
+          }
+        }
+      }
+
+      #pagination-controls {
+        display: flex;
+        justify-content: flex-end;
+
+        #page-select {
+          display: flex;
+          width: 10rem;
+          margin-right: 2.5rem;
+
+          label {
+            background-color: transparent;
+            border: none;
+            color: colors.$sd-text-med;
+          }
+
+          select {
+            display: flex;
+            align-items: center;
+            padding: 0.375rem 0.75rem;
+            margin-bottom: 0;
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/components/pipeline/jobs/table/template.hbs
+++ b/app/components/pipeline/jobs/table/template.hbs
@@ -1,0 +1,73 @@
+<div id="jobs-table">
+  <ModelsTable
+    @data={{this.data}}
+    @columns={{this.columns}}
+    @columnComponents={{hash
+      jobCell=(component "pipeline/jobs/table/cell/job")
+      historyCell=(component "pipeline/jobs/table/cell/history")
+      durationCell=(component "pipeline/jobs/table/cell/duration")
+      startTimeCell=(component "pipeline/jobs/table/cell/start-time")
+      coverageCell=(component "pipeline/jobs/table/cell/coverage")
+      metricsCell=(component "pipeline/jobs/table/cell/metrics")
+      actionsCell=(component "pipeline/jobs/table/cell/actions")
+    }}
+    @themeInstance={{this.theme}}
+    @useFilteringByColumns={{false}}
+    @onDisplayDataChanged={{this.onDisplayDataChanged}}
+    as |MT|
+  >
+    <MT.GlobalFilter>
+      <Input
+        id="jobs-table-search"
+        @value={{MT.globalFilter}}
+        @type="text"
+        placeholder="Search for job by name..."
+      />
+    </MT.GlobalFilter>
+
+    <MT.Table />
+
+    <div id="jobs-table-footer">
+      <MT.Summary as |Summary|>
+        {{Summary.summary}}
+      </MT.Summary>
+
+      <MT.PageSizeSelect id="select-pagination-size"/>
+
+      <MT.PaginationSimple id="pagination-controls"as |PS|>
+        <div id="page-navigation">
+          <BsButton
+            disabled={{if PS.goToBackEnabled false true}}
+            @onClick={{fn PS.goToFirst}}
+          >
+            <FaIcon @icon="angle-double-left"/>
+          </BsButton>
+          <BsButton
+            disabled={{if PS.goToBackEnabled false true}}
+            @onClick={{fn PS.goToPrev}}
+          >
+            <FaIcon @icon="angle-left"/>
+          </BsButton>
+          <BsButton
+            disabled={{if PS.goToForwardEnabled false true}}
+            @onClick={{fn PS.goToNext}}
+          >
+            <FaIcon @icon="angle-right"/>
+          </BsButton>
+          <BsButton
+            disabled={{if PS.goToForwardEnabled false true}}
+            @onClick={{fn PS.goToLast}}
+          >
+            <FaIcon @icon="angle-double-right"/>
+          </BsButton>
+
+        </div>
+
+        <div id="page-select">
+          <label class="input-group-text">Page:</label>
+          <PS.PageNumberSelect/>
+        </div>
+      </MT.PaginationSimple>
+    </div>
+  </ModelsTable>
+</div>

--- a/app/components/pipeline/styles.scss
+++ b/app/components/pipeline/styles.scss
@@ -1,15 +1,17 @@
-@use 'nav/styles' as nav;
 @use 'event/styles' as event;
 @use 'header/styles' as header;
+@use 'jobs/styles' as jobs;
 @use 'modal/styles' as modal;
+@use 'nav/styles' as nav;
 @use 'parameters/styles' as parameters;
 @use 'workflow/styles' as workflow;
 
 @mixin styles {
-  @include nav.styles;
   @include event.styles;
   @include header.styles;
+  @include jobs.styles;
   @include modal.styles;
+  @include nav.styles;
   @include parameters.styles;
   @include workflow.styles;
 }


### PR DESCRIPTION
## Context
The new v2 UI for the jobs route.

## Objective
Creates the new v2 UI glimmer component which is a customized table using `ember-models-table` as the base.  This table also incorporates automatic data refreshing to keep all the table data up to date.
![Screenshot 2024-09-18 at 14-15-53 New Pipeline Jobs](https://github.com/user-attachments/assets/fccdfe33-1154-4d53-8e29-637942dcb00c)

## References
Incorporates the glimmer components for each cell:
#1161 for the cells in the `JOB` column
#1162 for the cells in the `HISTORY` column 
#1163 for the cells in the `DURATION` column
#1164 for the cells in the `START TIME` column
#1165 for the cells in the `COVERAGE` column
#1166 for the cells in the `METRICS` column
#1169 for the cells in the `ACTIONS` column

The background refresh logic is from #1170

https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
