### PR TITLE
fix: Update tooltip route to v1 UI

### DIFF
--- a/app/components/pipeline/workflow/tooltip/template.hbs
+++ b/app/components/pipeline/workflow/tooltip/template.hbs
@@ -22,8 +22,8 @@
   {{else}}
     <LinkTo
       id="build-link"
-      @route="v2.pipeline.build"
-      @model={{this.tooltipData.job.buildId}}
+      @route="pipeline.build"
+      @models={{array @pipeline.id this.tooltipData.job.buildId}}
       @disabled={{not this.buildDetailsAvailable}}
     >
       Go to build details


### PR DESCRIPTION
## Context
The new v2 UI for the build details page isn't available yet.  The tooltip should instead point back to the v1 UI.

## Objective
Update the tooltip to link the user to the v1 UI.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
