### PR TITLE
fix: Clean up styles and templates

### DIFF
--- a/app/v2/pipeline/controller.js
+++ b/app/v2/pipeline/controller.js
@@ -20,10 +20,10 @@ export default class NewPipelineController extends Controller {
 
   get routeClasses() {
     if (this.isEventsPullsRoute()) {
-      return 'grid events-pulls';
+      return 'events-pulls';
     }
     if (this.isJobsRoute()) {
-      return 'grid jobs';
+      return 'jobs';
     }
 
     return null;

--- a/app/v2/pipeline/styles.scss
+++ b/app/v2/pipeline/styles.scss
@@ -2,7 +2,7 @@
 @use 'jobs/styles' as jobs;
 
 @mixin styles {
-  .pipeline-page-contents {
+  #pipeline-page-contents {
     display: grid;
     height: 100%;
 
@@ -20,18 +20,16 @@
       grid-area: pipeline-header;
     }
 
-    .pipeline-main-content {
+    #pipeline-main {
       grid-area: pipeline-main;
       overflow: scroll;
 
-      &.grid {
-        &.events-pulls {
-          @include events.styles;
-        }
+      &.events-pulls {
+        @include events.styles;
+      }
 
-        &.jobs {
-          @include jobs.styles;
-        }
+      &.jobs {
+        @include jobs.styles;
       }
     }
   }

--- a/app/v2/pipeline/template.hbs
+++ b/app/v2/pipeline/template.hbs
@@ -1,5 +1,5 @@
 {{page-title "Pipeline"}}
-<div class="pipeline-page-contents">
+<div id="pipeline-page-contents">
   <Pipeline::Nav />
 
   <Pipeline::Header
@@ -7,7 +7,10 @@
     @collections={{this.model.collections}}
   />
 
-  <div class="pipeline-main-content {{this.routeClasses}}">
+  <div
+    id="pipeline-main"
+    class="{{this.routeClasses}}"
+  >
     {{outlet}}
   </div>
 </div>


### PR DESCRIPTION
## Context
The v2 pipeline route template can be updated to be updated to be a bit less verbose

## Objective
Uses ids on elements that should only exist once to provide more clear CSS targeting.  Also removes the `grid` class as it is not needed.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
