### PR TITLE
fix: Refactor graph tooltips location

### DIFF
--- a/app/components/pipeline/workflow/util.js
+++ b/app/components/pipeline/workflow/util.js
@@ -1,6 +1,6 @@
 /**
  * Filters the workflow graph by removing nodes that start with 'sd@' (i.e., triggers external pipelines)
- * @param event
+ * @param workflowGraph {{nodes: Array, edges: Array}} The workflow graph to filter
  */
 // eslint-disable-next-line import/prefer-default-export
 export const getFilteredGraph = workflowGraph => {

--- a/app/v2/pipeline/events/show/controller.js
+++ b/app/v2/pipeline/events/show/controller.js
@@ -3,7 +3,7 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import ENV from 'screwdriver-ui/config/environment';
-import { getFilteredGraph } from './util';
+import { getFilteredGraph } from 'screwdriver-ui/components/pipeline/workflow/util';
 
 export default class V2PipelineEventsShowController extends Controller {
   @service session;

--- a/tests/unit/components/pipeline/workflow/util-test.js
+++ b/tests/unit/components/pipeline/workflow/util-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
-import { getFilteredGraph } from 'screwdriver-ui/v2/pipeline/events/show/util';
+import { getFilteredGraph } from 'screwdriver-ui/components/pipeline/workflow/util';
 
-module('Unit | Utility | v2/pipeline/events/show', function () {
+module('Unit | Component | pipeline/workflow/util', function () {
   test('getFilteredGraph removes nodes that trigger external pipelines', function (assert) {
     assert.deepEqual(
       getFilteredGraph({


### PR DESCRIPTION
## Context
Starting some refactoring work around the main v2 event landing page so that the page can support background data fetching.  This utility should therefore get moved to the workflow component directory as a new component will be created to replace what exists on the controller for the route.

## Objective
Moves the utility to the workflow component directory.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
