### PR TITLE
fix: Add option to download all artifacts as zip file

### DIFF
--- a/app/components/artifact-preview/component.js
+++ b/app/components/artifact-preview/component.js
@@ -47,6 +47,14 @@ export default Component.extend({
       );
 
       window.open(downloadLink, '_blank');
+    },
+    downloadAll() {
+      const downloadLink = this.iframeUrl.replace(
+        /\/artifacts\/.*$/,
+        '/artifacts'
+      );
+
+      window.open(downloadLink, '_blank');
     }
   }
 });

--- a/app/components/artifact-preview/template.hbs
+++ b/app/components/artifact-preview/template.hbs
@@ -3,8 +3,17 @@
     @type="primary"
     @icon="glyphicon glyphicon-download"
     @onClick={{action "download"}}
+    @label="Download current artifact"
   >
     Download
+  </BsButton>
+  <BsButton
+    @type="primary"
+    @icon="glyphicon glyphicon-download"
+    @onClick={{action "downloadAll"}}
+    @label="Download all artifacts as ZIP file"
+  >
+    Download All
   </BsButton>
   {{#if this.iframeUrl}}
     <iframe id={{this.iframeId}} src={{this.iframeUrl}}>


### PR DESCRIPTION
## Context

Would be nice if users could download all artifacts as zip file.

## Objective

This PR adds button to access new endpoint `GET /builds/{id}/artifacts`.

## References
Related to https://github.com/screwdriver-cd/screwdriver/pull/3199

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
