### PR TITLE
fix: Workflow graph component supports updating

### DIFF
--- a/app/components/pipeline/workflow/graph/template.hbs
+++ b/app/components/pipeline/workflow/graph/template.hbs
@@ -1,1 +1,4 @@
-<div id="workflow-graph" {{did-insert this.draw}} />
+<div id="workflow-graph"
+  {{did-insert this.draw}}
+  {{did-update this.redraw @workflowGraph @builds}}
+/>


### PR DESCRIPTION
## Context
The glimmer component for the workflow graph used in the v2 redesign is missing support for updating when its arguments change.

## Objective
Adds in the functionality for the component to update when the arguments change.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
