### PR TITLE
fix: Use title instead of label for Download buttons

### DIFF
--- a/app/components/artifact-preview/template.hbs
+++ b/app/components/artifact-preview/template.hbs
@@ -3,7 +3,7 @@
     @type="primary"
     @icon="glyphicon glyphicon-download"
     @onClick={{action "download"}}
-    @label="Download current artifact"
+    title="Download current artifact"
   >
     Download
   </BsButton>
@@ -11,7 +11,7 @@
     @type="primary"
     @icon="glyphicon glyphicon-download"
     @onClick={{action "downloadAll"}}
-    @label="Download all artifacts as ZIP file"
+    title="Download all artifacts as ZIP file"
   >
     Download All
   </BsButton>


### PR DESCRIPTION
## Context

Would be nice if the title showed up when hovering on the download buttons.

## Objective

This PR uses `title` instead of `@label`.

## References

Related to https://github.com/screwdriver-cd/ui/pull/1179

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
