### PR TITLE
fix: bug determining if an event is skipped

### DIFF
--- a/app/components/pipeline/workflow/graph/component.js
+++ b/app/components/pipeline/workflow/graph/component.js
@@ -41,7 +41,7 @@ export default class PipelineWorkflowGraphComponent extends Component {
 
   @action
   draw(element) {
-    const isSkippedEvent = isSkipped(this.args.event);
+    const isSkippedEvent = isSkipped(this.args.event, this.args.builds);
     const elementSizes = getElementSizes();
     const maximumJobNameLength = getMaximumJobNameLength(
       this.decoratedGraph,

--- a/app/utils/pipeline/event.js
+++ b/app/utils/pipeline/event.js
@@ -4,14 +4,17 @@ import { hasWarning } from './build';
 /**
  * Determines if the event has been skipped
  * @param {Object} event Event object in the format returned by the API
+ * @param {Array} builds Array of builds in the format returned by the API
  * @returns {boolean} true if the event has been skipped
  */
-export const isSkipped = event => {
+export const isSkipped = (event, builds) => {
   if (event.type === 'pr') {
     return false;
   }
 
-  return !!event?.commit?.message.match(/\[(skip ci|ci skip)\]/);
+  return builds?.length > 0
+    ? false
+    : !!event?.commit?.message.match(/\[(skip ci|ci skip)\]/);
 };
 
 /**
@@ -42,7 +45,7 @@ export const isComplete = builds => {
  * @returns {*} The status of the event
  */
 export const getStatus = (event, builds) => {
-  if (isSkipped(event)) {
+  if (isSkipped(event, builds)) {
     return 'SKIPPED';
   }
 

--- a/tests/unit/utils/pipeline/event-test.js
+++ b/tests/unit/utils/pipeline/event-test.js
@@ -7,14 +7,14 @@ import {
 
 module('Unit | Utility | Pipeline | event', function () {
   test('isSkipped returns correct value', function (assert) {
+    const builds = [{ id: 123 }];
+
     assert.equal(isSkipped({ type: 'pr' }), false);
+    assert.equal(isSkipped({ type: 'pr' }, []), false);
+    assert.equal(isSkipped({ type: 'pr' }, builds), false);
+    assert.equal(isSkipped({ type: 'pipeline' }, builds), false);
     assert.equal(isSkipped({ type: 'pipeline' }), false);
-    assert.equal(
-      isSkipped({
-        type: 'pipeline'
-      }),
-      false
-    );
+    assert.equal(isSkipped({ type: 'pipeline' }, []), false);
     assert.equal(
       isSkipped({
         type: 'pipeline',


### PR DESCRIPTION
## Context
The `isSkipped` logic fails to account for events that share the same commit that was initially skipped.

## Objective
Fix `isSkipped` so that it correctly accounts for builds in an event.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
