### PR TITLE
fix: Refactor graph updating

### DIFF
--- a/app/components/pipeline/workflow/graph/component.js
+++ b/app/components/pipeline/workflow/graph/component.js
@@ -12,12 +12,15 @@ import {
   getGraphSvg,
   getMaximumJobNameLength,
   getNodeWidth,
-  icon
+  updateEdgeStatuses,
+  updateJobStatuses
 } from 'screwdriver-ui/utils/pipeline/graph/d3-graph-util';
 import { nodeCanShowTooltip } from 'screwdriver-ui/utils/pipeline/graph/tooltip';
 
 export default class PipelineWorkflowGraphComponent extends Component {
   decoratedGraph;
+
+  graphSvg;
 
   constructor() {
     super(...arguments);
@@ -65,7 +68,7 @@ export default class PipelineWorkflowGraphComponent extends Component {
     };
 
     // Add the SVG element
-    const svg = getGraphSvg(
+    this.graphSvg = getGraphSvg(
       element,
       this.decoratedGraph,
       elementSizes,
@@ -77,7 +80,7 @@ export default class PipelineWorkflowGraphComponent extends Component {
     const verticalDisplacements =
       this.args.stages.length > 0
         ? addStages(
-            svg,
+            this.graphSvg,
             this.decoratedGraph,
             elementSizes,
             nodeWidth,
@@ -88,7 +91,7 @@ export default class PipelineWorkflowGraphComponent extends Component {
 
     // edges
     addEdges(
-      svg,
+      this.graphSvg,
       this.decoratedGraph,
       elementSizes,
       nodeWidth,
@@ -98,7 +101,7 @@ export default class PipelineWorkflowGraphComponent extends Component {
 
     // Jobs Icons
     addJobIcons(
-      svg,
+      this.graphSvg,
       this.decoratedGraph,
       elementSizes,
       nodeWidth,
@@ -108,7 +111,7 @@ export default class PipelineWorkflowGraphComponent extends Component {
     );
 
     addJobNames(
-      svg,
+      this.graphSvg,
       this.decoratedGraph,
       elementSizes,
       maximumJobNameLength,
@@ -129,20 +132,7 @@ export default class PipelineWorkflowGraphComponent extends Component {
     }
 
     this.getDecoratedGraph();
-    this.decoratedGraph.nodes.forEach(node => {
-      const n = element.querySelector(`g.graph-node[data-job="${node.name}"]`);
-
-      if (n) {
-        const txt = n.querySelector('text');
-
-        txt.firstChild.textContent = icon(node.status);
-        n.setAttribute(
-          'class',
-          `graph-node${
-            node.status ? ` build-${node.status.toLowerCase()}` : ''
-          }`
-        );
-      }
-    });
+    updateEdgeStatuses(this.graphSvg, this.decoratedGraph);
+    updateJobStatuses(this.graphSvg, this.decoratedGraph);
   }
 }

--- a/app/utils/pipeline/graph/d3-graph-util.js
+++ b/app/utils/pipeline/graph/d3-graph-util.js
@@ -487,7 +487,7 @@ export function addJobIcons( // eslint-disable-line max-params
 ) {
   const { ICON_SIZE } = sizes;
 
-  svg
+  const nodeGroups = svg
     .selectAll('jobs')
     .data(data.nodes)
     .enter()
@@ -502,8 +502,13 @@ export function addJobIcons( // eslint-disable-line max-params
       return `graph-node${d.status ? ` build-${d.status.toLowerCase()}` : ''}`;
     })
     .attr('data-job', d => d.name)
-    // create the icon graphic
-    .insert('text')
+    .on('click', node => {
+      onClick(node);
+    });
+
+  // create the icon graphic
+  nodeGroups
+    .append('text')
     .text(d => {
       if (isSkipped && d.status === 'STARTED_FROM') {
         return icon('SKIPPED');
@@ -520,18 +525,15 @@ export function addJobIcons( // eslint-disable-line max-params
         (d.pos.y + 1) * ICON_SIZE +
         d.pos.y * ICON_SIZE +
         getVerticalDisplacementByRowPosition(d.pos.y, verticalDisplacements)
-    )
-    .on('click', node => {
-      onClick(node);
-    })
-    .insert('title')
-    .text(d => {
-      if (/sd@/.test(d.name) && d.displayName !== undefined) {
-        return d.displayName;
-      }
+    );
 
-      return d.status ? `${d.name} - ${d.status}` : d.name;
-    });
+  nodeGroups.append('title').text(d => {
+    if (/sd@/.test(d.name) && d.displayName !== undefined) {
+      return d.displayName;
+    }
+
+    return d.status ? `${d.name} - ${d.status}` : d.name;
+  });
 }
 
 /**
@@ -597,6 +599,47 @@ export function addJobNames(
       }
 
       return d.name;
+    });
+}
+
+/**
+ * Updates the job statuses in the existing graph SVG
+ * @param svg
+ * @param data
+ */
+export function updateJobStatuses(svg, data) {
+  svg
+    .selectAll('.graph-node')
+    .data(data.nodes)
+    .join()
+    .attr('class', node => {
+      return `graph-node${
+        node.status ? ` build-${node.status.toLowerCase()}` : ''
+      }`;
+    })
+    .select('text')
+    .html(node => {
+      return icon(node.status);
+    });
+}
+
+/**
+ * Updates the edge statuses in the existing graph SVG
+ * @param svg
+ * @param data
+ */
+export function updateEdgeStatuses(svg, data) {
+  svg
+    .selectAll('.graph-edge')
+    .data(data.edges)
+    .join()
+    .attr('class', edge => {
+      return `graph-edge ${
+        edge.status ? `build-${edge.status.toLowerCase()}` : ''
+      }`;
+    })
+    .attr('stroke-dasharray', edge => {
+      return !edge.status ? 5 : 0;
     });
 }
 


### PR DESCRIPTION
## Context
Updating an existing graph should be only need to consist of updating the metadata on the build status of nodes and edges and then updating the classes on the existing SVG.

## Objective
1. Refactor the job node in the graph so that the event handler is on the SVG `<g>` element
2. Refactor the child element of the SVG `<g>` element so that the text and title are siblings for easier targeting and updating
3. Add in a utility function that can update the graph edge on an existing SVG graph
4. Add in a utility function that can update the graph node on an existing SVG graph
5. Refactor the V2 graph component to properly update the existing SVG graph as necessary

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
