### PR TITLE
feat: download all artifacts is available when hover of the artifact root dir tree

### DIFF
--- a/app/components/artifact-preview/component.js
+++ b/app/components/artifact-preview/component.js
@@ -47,14 +47,6 @@ export default Component.extend({
       );
 
       window.open(downloadLink, '_blank');
-    },
-    downloadAll() {
-      const downloadLink = this.iframeUrl.replace(
-        /\/artifacts\/.*$/,
-        '/artifacts'
-      );
-
-      window.open(downloadLink, '_blank');
     }
   }
 });

--- a/app/components/artifact-preview/template.hbs
+++ b/app/components/artifact-preview/template.hbs
@@ -7,29 +7,6 @@
   >
     Download
   </BsButton>
-  {{!-- <BsButton
-    @type="primary"
-    @icon="glyphicon glyphicon-download"
-    @onClick={{action "downloadAll"}}
-    title="Download all artifacts as ZIP file"
-  >
-    Download All
-  </BsButton> --}}
-  {{!-- <BsDropdown as |dd|>
-    <dd.button>Download <span class="caret"></span></dd.button>
-    <dd.menu as |ddm|>
-      <ddm.item>
-        <a href onclick={{action "changeItems" item dd.closeDropdown}}>
-          Something
-        </a>
-      </ddm.item>
-      <ddm.item>
-        <a href onclick={{action "changeItems" item dd.closeDropdown}}>
-          Something different
-        </a>
-      </ddm.item>
-    </dd.menu>
-  </BsDropdown> --}}
   {{#if this.iframeUrl}}
     <iframe id={{this.iframeId}} src={{this.iframeUrl}}>
       <h4>

--- a/app/components/artifact-preview/template.hbs
+++ b/app/components/artifact-preview/template.hbs
@@ -7,14 +7,29 @@
   >
     Download
   </BsButton>
-  <BsButton
+  {{!-- <BsButton
     @type="primary"
     @icon="glyphicon glyphicon-download"
     @onClick={{action "downloadAll"}}
     title="Download all artifacts as ZIP file"
   >
     Download All
-  </BsButton>
+  </BsButton> --}}
+  {{!-- <BsDropdown as |dd|>
+    <dd.button>Download <span class="caret"></span></dd.button>
+    <dd.menu as |ddm|>
+      <ddm.item>
+        <a href onclick={{action "changeItems" item dd.closeDropdown}}>
+          Something
+        </a>
+      </ddm.item>
+      <ddm.item>
+        <a href onclick={{action "changeItems" item dd.closeDropdown}}>
+          Something different
+        </a>
+      </ddm.item>
+    </dd.menu>
+  </BsDropdown> --}}
   {{#if this.iframeUrl}}
     <iframe id={{this.iframeId}} src={{this.iframeUrl}}>
       <h4>

--- a/app/components/artifact-tree-content/component.js
+++ b/app/components/artifact-tree-content/component.js
@@ -37,13 +37,32 @@ export default Component.extend({
     }
   }),
 
+  isHovered: false,
+
   actions: {
+    setHoverState(state) {
+      this.set('isHovered', state);
+    },
+
     toggle() {
       this.node.actions.toggle();
       this.router.transitionTo(
         'pipeline.build.artifacts.detail',
         this.artifactPath
       );
+    },
+
+    // todo: the downloadLink should not depend on the iframeUrl alone
+    // this works for now because downloadLink to download all artifacts is very predictable
+    // $url/v4/builds/$id/artifacts
+    // but this will not work for downloading a directory that is not the root directory
+    downloadAll() {
+      const downloadLink = this.iframeUrl.replace(
+        /\/artifacts\/.*$/,
+        '/artifacts'
+      );
+
+      window.open(downloadLink, '_blank');
     }
   }
 });

--- a/app/components/artifact-tree-content/style.scss
+++ b/app/components/artifact-tree-content/style.scss
@@ -8,3 +8,23 @@ a:visited {
   color: inherit;
   text-decoration: none;
 }
+
+.artifact-folder-container {
+  display: flex;
+  align-items: center;
+
+  &:hover {
+    background-color: #f0f0f0; // Background color on hover
+    color: $sd-text-med;
+  }
+}
+
+.artifact-folder-span {
+  cursor: pointer;
+  padding-right: 8px; /* Space between the folder name and download icon */
+}
+
+.artifact-download-icon {
+  margin-left: 8px;
+  cursor: pointer;
+}

--- a/app/components/artifact-tree-content/template.hbs
+++ b/app/components/artifact-tree-content/template.hbs
@@ -6,8 +6,23 @@
     {{@node.file.text}}
   </LinkTo>
 {{else}}
-  <span onclick={{action "toggle"}}>
-    <FaIcon @icon="folder{{if @node.isExpanded "-open"}}" @fixedWidth={{true}}/>
-    {{@node.fileName}}
-  </span>
+  <div class="artifact-folder-container"
+    onmouseenter={{action "setHoverState" true}}
+    onmouseleave={{action "setHoverState" false}}
+  >
+    <span onclick={{action "toggle"}} class="artifact-folder-span">
+      <FaIcon @icon="folder{{if @node.isExpanded "-open"}}" @fixedWidth={{true}}/>
+      {{@node.fileName}}
+    </span>
+    {{!-- only show download all on the root folder --}}
+    {{#if (and this.isHovered (eq @node.fileName undefined))}}
+      <span
+        class="artifact-download-icon"
+        onclick={{action "downloadAll"}}
+      >
+        <FaIcon @icon="download" @fixedWidth={{true}} title="Download All"/>
+        <BsTooltip @title="Download all artifacts as ZIP file" @placement="top"/>
+      </span>
+    {{/if}}
+  </div>
 {{/if}}

--- a/app/components/artifact-tree/template.hbs
+++ b/app/components/artifact-tree/template.hbs
@@ -1,10 +1,9 @@
 <h4>
   Artifacts
 </h4>
-
 {{#if this.treedata.content.length}}
   <BasicTree
-    @contentComponent={{component "artifact-tree-content"}}
+    @contentComponent={{component "artifact-tree-content" iframeUrl=this.iframeUrl}}
     @childrenComponent={{component "artifact-tree-children"}} as |tree|
   >
     <tree.Node


### PR DESCRIPTION
## Context

The presence of two buttons on the artifact preview creates a cluttered user interface and can lead to confusion for users. This design choice is not visually appealing and detracts from the overall user experience.

![Screenshot 2024-10-07 at 11 39 15 PM](https://github.com/user-attachments/assets/fb5c2f0e-e0a5-4197-b4cf-45d0f5a8ec5f)

## Objective

The download all icon is only visible when hovering over the artifact root tree, as shown below. This design helps to maintain a clean interface and more intuitive. 

![Screenshot 2024-10-07 at 11 36 29 PM](https://github.com/user-attachments/assets/767d06d5-7975-498d-8ce8-2596f25d38b7)

## References

https://github.com/screwdriver-cd/screwdriver/issues/1749

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
