### PR TITLE
download all should be available only at the root

### DIFF
--- a/app/components/artifact-preview/component.js
+++ b/app/components/artifact-preview/component.js
@@ -49,10 +49,9 @@ export default Component.extend({
       window.open(downloadLink, '_blank');
     },
     downloadAll() {
-      const downloadLink = this.iframeUrl.replace(
-        /\/artifacts\/.*$/,
-        '/artifacts'
-      );
+      // https://api.screwdriver.cd/v4/documentation#/v4/getV4BuildsIdArtifacts
+      // Reconstruct the downloadLink from the env var since iframeUrl is not available for directory-level access.
+      const downloadLink = `${ENV.APP.SDAPI_HOSTNAME}/${ENV.APP.SDAPI_NAMESPACE}/builds/${this.buildId}/artifacts`;
 
       window.open(downloadLink, '_blank');
     }

--- a/app/components/artifact-preview/template.hbs
+++ b/app/components/artifact-preview/template.hbs
@@ -1,20 +1,23 @@
 <div>
-  <BsButton
-    @type="primary"
-    @icon="glyphicon glyphicon-download"
-    @onClick={{action "download"}}
-    title="Download current artifact"
-  >
-    Download
-  </BsButton>
-  <BsButton
-    @type="primary"
-    @icon="glyphicon glyphicon-download"
-    @onClick={{action "downloadAll"}}
-    title="Download all artifacts as ZIP file"
-  >
-    Download All
-  </BsButton>
+  {{#if (eq this.selectedArtifact "/")}}
+    <BsButton
+      @type="primary"
+      @icon="glyphicon glyphicon-download"
+      @onClick={{action "downloadAll"}}
+      title="Download all artifacts as ZIP file"
+    >
+      Download All
+    </BsButton>
+  {{else}}
+    <BsButton
+      @type="primary"
+      @icon="glyphicon glyphicon-download"
+      @onClick={{action "download"}}
+      title="Download current artifact"
+    >
+      Download
+    </BsButton>
+  {{/if}}
   {{#if this.iframeUrl}}
     <iframe id={{this.iframeId}} src={{this.iframeUrl}}>
       <h4>

--- a/app/components/build-step-collection/template.hbs
+++ b/app/components/build-step-collection/template.hbs
@@ -105,7 +105,11 @@
   </div>
   <div class="col-9 partial-view">
     {{#if this.isArtifacts}}
-      <ArtifactPreview @iframeUrl={{this.iframeUrl}} />
+      <ArtifactPreview 
+        @iframeUrl={{this.iframeUrl}}
+        @selectedArtifact={{this.selectedArtifact}}
+        @buildId={{this.buildId}}
+      />
     {{else}}
       <BuildLog
         @stepName={{this.selectedStep}}


### PR DESCRIPTION
## Context

The presence of two buttons on the artifact preview creates a cluttered user interface and can lead to confusion for users. This design choice is not visually appealing and detracts from the overall user experience.
![Screenshot 2024-10-07 at 11 39 15 PM](https://github.com/user-attachments/assets/f242c946-b936-49e7-896f-77506025671f)

## Objective

The "Download All" button should be displayed only at the root directory level.
<img width="1878" alt="Screenshot 2024-10-08 at 1 57 59 PM" src="https://github.com/user-attachments/assets/d10bfbfd-ac31-45d8-9ee6-c6921c0c36b4">

The "Download" button should be at the file level access.  
<img width="1891" alt="Screenshot 2024-10-08 at 1 58 07 PM" src="https://github.com/user-attachments/assets/ad026d65-57cf-496f-9bef-6bd287f679eb">

## References

https://github.com/screwdriver-cd/screwdriver/issues/1749

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
