### PR TITLE
Fix: parameters UI bug

### DIFF
--- a/app/components/pipeline-event-row/component.js
+++ b/app/components/pipeline-event-row/component.js
@@ -49,7 +49,7 @@ export default Component.extend({
     ).forEach(([propertyName, propertyVal]) => {
       const keys = Object.keys(propertyVal);
 
-      if (keys.length === 1 && keys[0] === 'value') {
+      if (keys.length === 2 && keys[0] === 'value') {
         pipelineParameters[propertyName] = propertyVal;
       } else {
         jobParameters[propertyName] = propertyVal;

--- a/app/components/pipeline-event-row/template.hbs
+++ b/app/components/pipeline-event-row/template.hbs
@@ -155,10 +155,10 @@
                   {{#each-in this.pipelineParameters as |pName pVal|}}
                     <li>
                       <span class="parameter-name badge">
-                        {{pName}}
+                        {{pName}}:
                       </span>
                       <span class="parameter-value">
-                        :{{pVal.value}}
+                        {{pVal.value}}
                       </span>
                     </li>
                   {{/each-in}}
@@ -175,10 +175,10 @@
                     {{#each-in parameters as |pName pVal|}}
                       <li>
                         <span class="parameter-name badge">
-                          {{pName}}
+                          {{pName}}:
                         </span>
                         <span class="parameter-value">
-                          :{{pVal.value}}
+                          {{pVal.value}}
                         </span>
                       </li>
                     {{/each-in}}


### PR DESCRIPTION
## Context
https://github.com/screwdriver-cd/models/pull/630 modified the API response to always return a default field.  This broke the previous assumption that minimum number of keys in the response object is 1.

## Objective
Updates the minimum key length to match the updated API response so that the parameter parsing can be handled properly.  Also adjusts the spacing on the parameter colon.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
