### PR TITLE
fix: Remove event card from display

### DIFF
--- a/app/v2/pipeline/events/show/template.hbs
+++ b/app/v2/pipeline/events/show/template.hbs
@@ -24,17 +24,6 @@
     </span>
   </div>
 
-  <div class="event-cards">
-    <Pipeline::Event::Card
-      @event={{this.model.event}}
-      @userSettings={{this.model.userSettings}}
-      @builds={{this.model.builds}}
-      @jobs={{this.model.jobs}}
-      @pipeline={{this.model.pipeline}}
-      @latestCommitEvent={{this.model.latestCommitEvent}}
-      @enableEventRefresh={{true}}
-    />
-  </div>
 </div>
 
 <div class="pipeline-workflow-graph">


### PR DESCRIPTION
## Context
The pipeline page is getting a huge overhaul in the structure of the components.  The event card will also undergo a number of changes.  By removing the event card from the UI, the overhaul is more easily accomplished in isolated PRs.

## Objective
Remove the existing event card component from the UI for ease of updating the entire UI structure for the pipeline event page.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
