### PR TITLE
fix: Fix logic for determining parameter types

### DIFF
--- a/app/components/pipeline-event-row/component.js
+++ b/app/components/pipeline-event-row/component.js
@@ -4,6 +4,7 @@ import { computed, get, getProperties } from '@ember/object';
 import { statusIcon } from 'screwdriver-ui/utils/build';
 import { inject as service } from '@ember/service';
 import MAX_NUM_OF_PARAMETERS_ALLOWED from 'screwdriver-ui/utils/constants';
+import { isPipelineParameter } from 'screwdriver-ui/utils/pipeline/parameters';
 import { getTimestamp } from '../../utils/timestamp-format';
 
 export default Component.extend({
@@ -47,9 +48,7 @@ export default Component.extend({
         ? {}
         : this.get('event.meta.parameters')
     ).forEach(([propertyName, propertyVal]) => {
-      const keys = Object.keys(propertyVal);
-
-      if (keys.length === 2 && keys[0] === 'value') {
+      if (isPipelineParameter(propertyVal)) {
         pipelineParameters[propertyName] = propertyVal;
       } else {
         jobParameters[propertyName] = propertyVal;

--- a/app/components/pipeline-workflow/component.js
+++ b/app/components/pipeline-workflow/component.js
@@ -9,6 +9,7 @@ import {
   canJobStart,
   canStageStart
 } from 'screwdriver-ui/utils/pipeline-workflow';
+import { isPipelineParameter } from 'screwdriver-ui/utils/pipeline/parameters';
 import { copy } from 'ember-copy';
 
 export default Component.extend({
@@ -247,9 +248,7 @@ export default Component.extend({
         // Segregate pipeline level and job level parameters
         Object.entries(eventParameters).forEach(
           ([propertyName, propertyVal]) => {
-            const keys = Object.keys(propertyVal);
-
-            if (keys.length === 1 && keys[0] === 'value') {
+            if (isPipelineParameter(propertyVal)) {
               pipelineParameters[propertyName] = propertyVal;
             } else {
               jobParameters[propertyName] = propertyVal;
@@ -365,9 +364,7 @@ export default Component.extend({
 
       // Segregate pipeline level and job level parameters
       Object.entries(eventParameters).forEach(([propertyName, propertyVal]) => {
-        const keys = Object.keys(propertyVal);
-
-        if (keys.length === 1 && keys[0] === 'value') {
+        if (isPipelineParameter(propertyVal)) {
           pipelineParameters[propertyName] = propertyVal;
         } else {
           jobParameters[propertyName] = propertyVal;

--- a/app/utils/pipeline/parameters.js
+++ b/app/utils/pipeline/parameters.js
@@ -1,4 +1,13 @@
 /**
+ * Determines if a parameter is a pipeline parameter
+ * @param parameter {{object}} The parameter object
+ * @returns {boolean}
+ */
+export function isPipelineParameter(parameter) {
+  return parameter.value !== undefined;
+}
+
+/**
  * Extracts parameters from the API response object of an event
  * @param event
  * @returns {{pipelineParameters: {}, jobParameters: {}}}
@@ -10,9 +19,7 @@ export function extractEventParameters(event) {
 
   // Extract pipeline level and job level parameters
   Object.entries(eventParameters).forEach(([propertyName, propertyVal]) => {
-    const keys = Object.keys(propertyVal);
-
-    if (keys.length === 1 && keys[0] === 'value') {
+    if (isPipelineParameter(propertyVal)) {
       pipelineParameters[propertyName] = propertyVal;
     } else {
       jobParameters[propertyName] = propertyVal;

--- a/tests/unit/utils/pipeline/parameters-test.js
+++ b/tests/unit/utils/pipeline/parameters-test.js
@@ -7,11 +7,19 @@ import {
   flattenJobParameters,
   flattenParameters,
   flattenParameterGroup,
-  normalizeParameters,
-  getNormalizedParameterGroups
+  getNormalizedParameterGroups,
+  isPipelineParameter,
+  normalizeParameters
 } from 'screwdriver-ui/utils/pipeline/parameters';
 
 module('Unit | Utility | Pipeline | parameters', function () {
+  test('isPipelineParameter', function (assert) {
+    assert.equal(isPipelineParameter({}), false);
+    assert.equal(isPipelineParameter({ value: 'abc' }), true);
+    assert.equal(isPipelineParameter({ value: 'abc', default: false }), true);
+    assert.equal(isPipelineParameter({ p1: { value: 'abc' } }), false);
+  });
+
   test('extractEventParameters extracts parameters from event object', function (assert) {
     const parameters = extractEventParameters({
       meta: {


### PR DESCRIPTION
## Context
https://github.com/screwdriver-cd/models/pull/630 modified the API response to always return a default field. This broke the previous assumption that minimum number of keys in the response object is 1.  

#1189 added in a fix for the change in the API object, however there are a few other places in the UI code that used the same logic and needs to be updated.

## Objective
Add a new utility function that is less fragile to determine whether a parameter is a pipeline level parameter.  Updates all instances where determining if a parameter is a pipeline parameter is manually done.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
