### PR TITLE
feat: Graph updates when event argument changes

### DIFF
--- a/app/components/pipeline/workflow/graph/template.hbs
+++ b/app/components/pipeline/workflow/graph/template.hbs
@@ -1,4 +1,4 @@
 <div id="workflow-graph"
   {{did-insert this.draw}}
-  {{did-update this.redraw @workflowGraph @builds}}
+  {{did-update this.redraw @workflowGraph @builds @event}}
 />

--- a/tests/integration/components/pipeline/workflow/graph/component-test.js
+++ b/tests/integration/components/pipeline/workflow/graph/component-test.js
@@ -253,7 +253,7 @@ module('Integration | Component | pipeline/workflow/graph', function (hooks) {
     assert.equal(this.element.querySelector('svg').children.length, 8);
   });
 
-  test('it rerenders graph when workflowGraph changes', async function (assert) {
+  test('it re-renders graph when workflowGraph changes', async function (assert) {
     const workflowGraph = {
       nodes: [{ name: '~commit' }, { name: 'main' }],
       edges: [{ src: '~commit', dest: 'main' }]
@@ -303,7 +303,7 @@ module('Integration | Component | pipeline/workflow/graph', function (hooks) {
     assert.equal(this.element.querySelector('svg').children.length, 8);
   });
 
-  test('it rerenders graph when builds update', async function (assert) {
+  test('it re-renders graph when builds update', async function (assert) {
     const workflowGraph = {
       nodes: [{ name: '~commit' }, { name: 'main', id: 123 }],
       edges: [{ src: '~commit', dest: 'main' }]

--- a/tests/integration/components/pipeline/workflow/graph/component-test.js
+++ b/tests/integration/components/pipeline/workflow/graph/component-test.js
@@ -337,12 +337,7 @@ module('Integration | Component | pipeline/workflow/graph', function (hooks) {
     assert.dom('svg [data-job=main]').hasClass('build-running');
 
     this.setProperties({
-      builds: [{ id: 1, jobId: 123, status: 'SUCCESS' }],
-      workflowGraph,
-      event,
-      jobs,
-      stages,
-      displayJobNameLength
+      builds: [{ id: 1, jobId: 123, status: 'SUCCESS' }]
     });
     await rerender();
 


### PR DESCRIPTION
## Context
When the event cards are integrated into the UI, users will be clicking on the event cards and navigating to a different event within the pipeline event history.  As the page template is not changing, the graph component is not re-created with the new data; rather, it is updated with new arguments.  In order for the graph component to properly update due to the changing event argument, the update handler needs to account for the change in event and update the underlying graph SVG accordingly.

## Objective
Updates the workflow graph component to properly update as arguments that necessitate a graph update change.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
