### PR TITLE
fix: Update colors to use color template

### DIFF
--- a/app/components/pipeline/nav/styles.scss
+++ b/app/components/pipeline/nav/styles.scss
@@ -8,12 +8,12 @@
     padding-top: 0.75rem;
 
     a {
-      color: #6b7280;
+      color: rgba(colors.$sd-text, 0.75);
       margin: 0 auto;
       padding: 0.75rem;
 
       &.active {
-        color: #1c64f2;
+        color: colors.$sd-running;
       }
     }
   }


### PR DESCRIPTION
## Context
Consolidate colors to use the defined Screwdriver colors rather than have lots of one-off color values scattered throughout the styles.

## Objective
Limit the use of arbitrary colors and leverage the Screwdriver colors template as much as possible.  There's some minor changes in the actual colors, but it still maintains the grey and blue colors for the different class states on the anchor tag.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
