### PR TITLE
feat: Event card title

### DIFF
--- a/app/components/pipeline/event/card/component.js
+++ b/app/components/pipeline/event/card/component.js
@@ -23,6 +23,8 @@ export default class PipelineEventCardComponent extends Component {
 
   @tracked status;
 
+  @tracked event;
+
   @tracked isRunning;
 
   @tracked failureCount;
@@ -40,6 +42,8 @@ export default class PipelineEventCardComponent extends Component {
 
     const { builds } = this.args;
 
+    this.event = this.args.event;
+
     this.showParametersModal = false;
     this.showAbortBuildModal = false;
     this.status = getStatus(this.args.event, builds);
@@ -51,6 +55,16 @@ export default class PipelineEventCardComponent extends Component {
 
   get isHighlighted() {
     return this.router.currentURL.endsWith(this.args.event.id);
+  }
+
+  get title() {
+    const title = `Event: ${this.event.id}`;
+
+    if (this.event.id === this.event.groupEventId) {
+      return title;
+    }
+
+    return `${title}\nGroup: ${this.event.groupEventId}`;
   }
 
   get icon() {

--- a/app/components/pipeline/event/card/template.hbs
+++ b/app/components/pipeline/event/card/template.hbs
@@ -1,4 +1,7 @@
-<div class="event-card {{if this.isHighlighted "highlighted"}}">
+<div
+  class="event-card{{if this.isHighlighted " highlighted"}}"
+  title={{this.title}}
+>
   <div class="event-card-title">
     <div class="event-status {{this.status}}">
       <FaIcon

--- a/tests/integration/components/pipeline/event/card/component-test.js
+++ b/tests/integration/components/pipeline/event/card/component-test.js
@@ -7,6 +7,72 @@ import sinon from 'sinon';
 module('Integration | Component | pipeline/event/card', function (hooks) {
   setupRenderingTest(hooks);
 
+  test('it renders title when event is first in group', async function (assert) {
+    const router = this.owner.lookup('service:router');
+
+    sinon.stub(router, 'currentURL').value('/v2/pipelines/1/events/11');
+
+    this.setProperties({
+      event: {
+        id: 11,
+        groupEventId: 11,
+        sha: 'abc123def456',
+        commit: { author: { name: 'batman' }, message: 'Some amazing changes' },
+        creator: { name: 'batman' },
+        meta: {}
+      },
+      pipeline: {},
+      userSettings: {},
+      builds: [],
+      latestCommitEvent: { sha: 'abc123def456' }
+    });
+
+    await render(
+      hbs`<Pipeline::Event::Card
+        @event={{this.event}}
+        @pipeline={{this.pipeline}}
+        @userSettings={{this.userSettings}}
+        @builds={{this.builds}}
+        @latestCommitEvent={{this.latestCommitEvent}}
+      />`
+    );
+
+    assert.dom('.event-card').hasAttribute('title', 'Event: 11');
+  });
+
+  test('it renders title when event is first in group', async function (assert) {
+    const router = this.owner.lookup('service:router');
+
+    sinon.stub(router, 'currentURL').value('/v2/pipelines/1/events/11');
+
+    this.setProperties({
+      event: {
+        id: 11,
+        groupEventId: 3,
+        sha: 'abc123def456',
+        commit: { author: { name: 'batman' }, message: 'Some amazing changes' },
+        creator: { name: 'batman' },
+        meta: {}
+      },
+      pipeline: {},
+      userSettings: {},
+      builds: [],
+      latestCommitEvent: { sha: 'abc123def456' }
+    });
+
+    await render(
+      hbs`<Pipeline::Event::Card
+        @event={{this.event}}
+        @pipeline={{this.pipeline}}
+        @userSettings={{this.userSettings}}
+        @builds={{this.builds}}
+        @latestCommitEvent={{this.latestCommitEvent}}
+      />`
+    );
+
+    assert.dom('.event-card').hasAttribute('title', `Event: 11\nGroup: 3`);
+  });
+
   test('it renders core elements', async function (assert) {
     const router = this.owner.lookup('service:router');
 


### PR DESCRIPTION
## Context
It is hard to differentiate the different event cards as there is no additional information displayed in the UI

## Objective
Add a title attribute to the event card component.  This allows users to mouse over the event card and additional information about the event and event group are provided.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
