### PR TITLE
feat(3211): Build detail view - Hide steps and logs for virtual builds

### DIFF
--- a/app/build/model.js
+++ b/app/build/model.js
@@ -65,6 +65,7 @@ export default Model.extend({
   status: attr('string'),
   stats: attr(),
   statusMessage: attr('string', { defaultValue: null }),
+  statusMessageType: attr('string', { defaultValue: null }),
   steps: attr(),
   templateId: attr('number'),
   startTimeWords: computed('startTime', {

--- a/app/pipeline/build/controller.js
+++ b/app/pipeline/build/controller.js
@@ -44,6 +44,56 @@ export default Controller.extend({
     }
   ),
 
+  statusMessageAlertType: computed('model.build.statusMessageType', {
+    get() {
+      const statusMessageType = this.get('model.build.statusMessageType');
+
+      switch (statusMessageType) {
+        case 'ERROR':
+          return 'danger';
+        case 'INFO':
+          return 'info';
+        case 'WARN':
+        default:
+          return 'warning';
+      }
+    }
+  }),
+
+  statusMessageAlertIcon: computed('model.build.statusMessageType', {
+    get() {
+      const statusMessageType = this.get('model.build.statusMessageType');
+
+      switch (statusMessageType) {
+        case 'INFO':
+          return 'info-circle';
+        case 'ERROR':
+        case 'WARN':
+        default:
+          return 'exclamation-triangle';
+      }
+    }
+  }),
+
+  isVirtualBuild: computed(
+    'model.build.jobId',
+    'model.event.workflowGraph.nodes',
+    {
+      get() {
+        const jobId = parseInt(this.get('model.build.jobId'), 10);
+        const nodes = this.get('model.event.workflowGraph.nodes');
+
+        return nodes.find(node => node.id === jobId).virtual;
+      }
+    }
+  ),
+
+  showStepCollection: computed('isVirtualBuild', 'stepList', {
+    get() {
+      return !this.get('isVirtualBuild') && this.get('stepList');
+    }
+  }),
+
   prEvents: computed(
     'job.id',
     'model.event.pr.url',

--- a/app/pipeline/build/template.hbs
+++ b/app/pipeline/build/template.hbs
@@ -50,8 +50,8 @@
   {{#if this.build.statusMessage}}
     <InfoMessage
       @message={{this.build.statusMessage}}
-      @type="warning"
-      @icon="exclamation-triangle"
+      @type={{this.statusMessageAlertType}}
+      @icon={{this.statusMessageAlertIcon}}
     />
   {{/if}}
   {{#if this.build.meta.build.warning}}
@@ -66,7 +66,7 @@
 </div>
 
 
-{{#if this.stepList}}
+{{#if this.showStepCollection}}
   <BuildStepCollection
     @preselectedStepName={{this.preselectedStepName}}
     @selectedArtifact={{this.selectedArtifact}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,7 +95,7 @@
         "qunit": "^2.19.1",
         "qunit-dom": "^2.0.0",
         "sass-embedded": "^1.77.0",
-        "screwdriver-data-schema": "^24.0.0",
+        "screwdriver-data-schema": "^24.1.0",
         "sinon": "^18.0.0",
         "webpack": "^5.76.2"
       },
@@ -34556,9 +34556,9 @@
       }
     },
     "node_modules/screwdriver-data-schema": {
-      "version": "24.0.2",
-      "resolved": "https://registry.npmjs.org/screwdriver-data-schema/-/screwdriver-data-schema-24.0.2.tgz",
-      "integrity": "sha512-wtFkEPeG7WxBDg42dFbi3CHM5V1VlfJ023M0u3loMfQOrau4ukc1cAxGFnhR4mRvAI1ZgZBDjo5S7EpPdO/dDw==",
+      "version": "24.1.0",
+      "resolved": "https://registry.npmjs.org/screwdriver-data-schema/-/screwdriver-data-schema-24.1.0.tgz",
+      "integrity": "sha512-QLegs7AzvLrXui+pyhvj3pQjAr5cwx/Tl/c5DdHexYDgBoR5b7jM+SCi5nI9UeH1N4WQXkos/YzplOiIcqlNSw==",
       "dev": true,
       "dependencies": {
         "cron-parser": "^4.7.0",
@@ -65973,9 +65973,9 @@
       }
     },
     "screwdriver-data-schema": {
-      "version": "24.0.2",
-      "resolved": "https://registry.npmjs.org/screwdriver-data-schema/-/screwdriver-data-schema-24.0.2.tgz",
-      "integrity": "sha512-wtFkEPeG7WxBDg42dFbi3CHM5V1VlfJ023M0u3loMfQOrau4ukc1cAxGFnhR4mRvAI1ZgZBDjo5S7EpPdO/dDw==",
+      "version": "24.1.0",
+      "resolved": "https://registry.npmjs.org/screwdriver-data-schema/-/screwdriver-data-schema-24.1.0.tgz",
+      "integrity": "sha512-QLegs7AzvLrXui+pyhvj3pQjAr5cwx/Tl/c5DdHexYDgBoR5b7jM+SCi5nI9UeH1N4WQXkos/YzplOiIcqlNSw==",
       "dev": true,
       "requires": {
         "cron-parser": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "qunit": "^2.19.1",
     "qunit-dom": "^2.0.0",
     "sass-embedded": "^1.77.0",
-    "screwdriver-data-schema": "^24.0.0",
+    "screwdriver-data-schema": "^24.1.0",
     "sinon": "^18.0.0",
     "webpack": "^5.76.2"
   }

--- a/tests/acceptance/pipeline-builds-test.js
+++ b/tests/acceptance/pipeline-builds-test.js
@@ -106,6 +106,7 @@ module('Acceptance | pipeline build', function (hooks) {
       const build = makeBuilds(1000000)[0];
 
       build.id = 1000000;
+      build.jobId = 12345;
       build.status = 'FAILURE';
 
       return [

--- a/tests/mock/workflow-graph.js
+++ b/tests/mock/workflow-graph.js
@@ -7,7 +7,7 @@ export default () =>
         { name: '~pr' },
         { name: '~commit' },
         { id: 12345, name: 'main' },
-        { is: 123456, name: 'publish' }
+        { id: 123456, name: 'publish' }
       ],
       edges: [
         { src: '~pr', dest: 'main' },


### PR DESCRIPTION
## Context

For virtual jobs, builds are created but never executed. API marks status of such builds as "SUCCESS" when those are eligible for execution.
API also sets "Skipped execution of the virtual job" and "INFO" as `statusMessage` and `statusMessageType` respectively. 

In the UI, the build detail view shows that the was a failure in `sd-setup-init` step. This gives a false impression that the build got executed and the step failed.

**Before**
![image](https://github.com/user-attachments/assets/447f32a0-320b-49d3-b9a6-acfd48b63d43)


## Objective

We need to make below changes in the build details view

1. Hide steps and logs section
2. All the status messages are displayed as a warning in the banner. Style the message based on the `statusMessageType`. In the case of virtual jobs, the message "Skipped execution of the virtual job" should be displayed as information.

**After**
![image](https://github.com/user-attachments/assets/b1ae8de9-bca8-40d9-ba4c-0e11fb4a15c2)


## References

https://github.com/screwdriver-cd/screwdriver/issues/3211

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
