### PR TITLE
fix(3227): Add feature flag for download all artifacts

### DIFF
--- a/app/components/artifact-preview/component.js
+++ b/app/components/artifact-preview/component.js
@@ -3,8 +3,8 @@ import ENV from 'screwdriver-ui/config/environment';
 
 export default Component.extend({
   iframeUrl: '',
-
   iframeId: '',
+  allowDownloadDir: ENV.APP.DOWNLOAD_ARTIFACT_DIR,
 
   init() {
     this._super(...arguments);

--- a/app/components/artifact-preview/template.hbs
+++ b/app/components/artifact-preview/template.hbs
@@ -1,13 +1,15 @@
 <div>
-  {{#if (eq this.selectedArtifact "/")}}
-    <BsButton
-      @type="primary"
-      @icon="glyphicon glyphicon-download"
-      @onClick={{action "downloadAll"}}
-      title="Download all artifacts as ZIP file"
-    >
-      Download All
-    </BsButton>
+  {{#if this.allowDownloadDir}}
+    {{#if (eq this.selectedArtifact "/")}}
+      <BsButton
+        @type="primary"
+        @icon="glyphicon glyphicon-download"
+        @onClick={{action "downloadAll"}}
+        title="Download all artifacts as ZIP file"
+      >
+        Download All
+      </BsButton>
+    {{/if}}
   {{else}}
     <BsButton
       @type="primary"

--- a/config/environment.js
+++ b/config/environment.js
@@ -70,6 +70,7 @@ module.exports = environment => {
       RELEASE_VERSION: 'stable',
       DOWNTIME_JOBS: true,
       SHOW_AVATAR: true,
+      DOWNLOAD_ARTIFACT_DIR: true,
       FEEDBACK_HOSTNAME: '',
       FEEDBACK_SCRIPT: '',
       FEEDBACK_CONFIG: ''


### PR DESCRIPTION
## Context

It might be good to put the artifact directory download behind a feature flag.

## Objective

This PR adds a feature flag for downloading artifact directories.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/3227

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
