### PR TITLE
fix(3227): Download directory should use feature flag

### DIFF
--- a/app/components/artifact-preview/component.js
+++ b/app/components/artifact-preview/component.js
@@ -50,7 +50,7 @@ export default Component.extend({
 
       const filePath = this.router.currentRoute.params.file_path;
 
-      if (filePath.endsWith('/')) {
+      if (filePath.endsWith('/') && ENV.APP.DOWNLOAD_ARTIFACT_DIR) {
         const curPath = filePath.replace(/\/$/, '');
 
         downloadLink = `${ENV.APP.SDAPI_HOSTNAME}/${ENV.APP.SDAPI_NAMESPACE}/builds/${this.buildId}/artifacts/${curPath}?type=download&dir=true`;

--- a/app/components/artifact-tree/component.js
+++ b/app/components/artifact-tree/component.js
@@ -101,6 +101,7 @@ export default Component.extend({
           this.setProperties({
             href,
             iframeUrl: `${href}?type=preview`,
+            isModalOpen: true
           });
         }
         this.router.transitionTo(


### PR DESCRIPTION
## Context

Looks like a line was accidentally removed in previous PR: https://github.com/screwdriver-cd/ui/pull/1195/files#diff-394984a29f42868adf35cce2c06778edd92bbd617a870edf4cfcf178c0d65ebdL104

## Objective

This PR fixes mistake and puts directory download behind feature flag.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/3227, https://github.com/screwdriver-cd/ui/pull/1195

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
