### PR TITLE
feat: Event card supports dynamic updating

### DIFF
--- a/app/components/pipeline/event/card/template.hbs
+++ b/app/components/pipeline/event/card/template.hbs
@@ -1,6 +1,8 @@
 <div
   class="event-card{{if this.isHighlighted " highlighted"}}"
   title={{this.title}}
+  {{did-insert this.initialize}}
+  {{did-update this.update @event}}
 >
   <div class="event-card-title">
     <div class="event-status {{this.status}}">
@@ -20,7 +22,7 @@
         {{this.truncatedSha}}
       </a>
     </div>
-    {{#if this.isRunning}}
+    {{#if (eq this.status "RUNNING")}}
       <BsButton
         class="abort-event-button"
         @type="danger"

--- a/tests/integration/components/pipeline/event/card/component-test.js
+++ b/tests/integration/components/pipeline/event/card/component-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
-import { render } from '@ember/test-helpers';
+import { render, rerender } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 
@@ -9,8 +9,10 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
 
   test('it renders title when event is first in group', async function (assert) {
     const router = this.owner.lookup('service:router');
+    const shuttle = this.owner.lookup('service:shuttle');
 
     sinon.stub(router, 'currentURL').value('/v2/pipelines/1/events/11');
+    sinon.stub(shuttle, 'fetchFromApi').resolves([]);
 
     this.setProperties({
       event: {
@@ -22,9 +24,7 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
         meta: {}
       },
       pipeline: {},
-      userSettings: {},
-      builds: [],
-      latestCommitEvent: { sha: 'abc123def456' }
+      userSettings: {}
     });
 
     await render(
@@ -32,8 +32,6 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
         @event={{this.event}}
         @pipeline={{this.pipeline}}
         @userSettings={{this.userSettings}}
-        @builds={{this.builds}}
-        @latestCommitEvent={{this.latestCommitEvent}}
       />`
     );
 
@@ -42,8 +40,10 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
 
   test('it renders title when event is first in group', async function (assert) {
     const router = this.owner.lookup('service:router');
+    const shuttle = this.owner.lookup('service:shuttle');
 
     sinon.stub(router, 'currentURL').value('/v2/pipelines/1/events/11');
+    sinon.stub(shuttle, 'fetchFromApi').resolves([]);
 
     this.setProperties({
       event: {
@@ -55,9 +55,7 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
         meta: {}
       },
       pipeline: {},
-      userSettings: {},
-      builds: [],
-      latestCommitEvent: { sha: 'abc123def456' }
+      userSettings: {}
     });
 
     await render(
@@ -65,8 +63,6 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
         @event={{this.event}}
         @pipeline={{this.pipeline}}
         @userSettings={{this.userSettings}}
-        @builds={{this.builds}}
-        @latestCommitEvent={{this.latestCommitEvent}}
       />`
     );
 
@@ -75,8 +71,10 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
 
   test('it renders core elements', async function (assert) {
     const router = this.owner.lookup('service:router');
+    const shuttle = this.owner.lookup('service:shuttle');
 
     sinon.stub(router, 'currentURL').value('/v2/pipelines/1/events/11');
+    sinon.stub(shuttle, 'fetchFromApi').resolves([{ status: 'SUCCESS' }]);
 
     this.setProperties({
       event: {
@@ -86,18 +84,14 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
         creator: { name: 'batman' },
         meta: {}
       },
-      builds: [{ status: 'SUCCESS' }],
       pipeline: {},
-      latestCommitEvent: { sha: 'abc123def456' },
       userSettings: {}
     });
 
     await render(
       hbs`<Pipeline::Event::Card
         @event={{this.event}}
-        @builds={{this.builds}}
         @pipeline={{this.pipeline}}
-        @latestCommitEvent={{this.latestCommitEvent}}
         @userSettings={{this.userSettings}}
       />`
     );
@@ -123,8 +117,10 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
 
   test('it does not render highlight', async function (assert) {
     const router = this.owner.lookup('service:router');
+    const shuttle = this.owner.lookup('service:shuttle');
 
     sinon.stub(router, 'currentURL').value('/v2/pipelines/1/events/99');
+    sinon.stub(shuttle, 'fetchFromApi').resolves([{ status: 'SUCCESS' }]);
 
     this.setProperties({
       event: {
@@ -134,9 +130,7 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
         creator: { name: 'batman' },
         meta: {}
       },
-      builds: [{ status: 'SUCCESS' }],
       pipeline: {},
-      latestCommitEvent: { sha: 'abc123def456' },
       userSettings: {}
     });
 
@@ -155,8 +149,10 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
 
   test('it renders event label', async function (assert) {
     const router = this.owner.lookup('service:router');
+    const shuttle = this.owner.lookup('service:shuttle');
 
     sinon.stub(router, 'currentURL').value('/v2/pipelines/1/events/11');
+    sinon.stub(shuttle, 'fetchFromApi').resolves([{ status: 'SUCCESS' }]);
 
     this.setProperties({
       event: {
@@ -166,18 +162,14 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
         creator: { name: 'batman' },
         meta: { label: 'Testing 123' }
       },
-      builds: [{ status: 'SUCCESS' }],
       pipeline: {},
-      latestCommitEvent: { sha: 'abc123def456' },
       userSettings: {}
     });
 
     await render(
       hbs`<Pipeline::Event::Card
         @event={{this.event}}
-        @builds={{this.builds}}
         @pipeline={{this.pipeline}}
-        @latestCommitEvent={{this.latestCommitEvent}}
         @userSettings={{this.userSettings}}
       />`
     );
@@ -187,8 +179,10 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
 
   test('it renders button for parameters', async function (assert) {
     const router = this.owner.lookup('service:router');
+    const shuttle = this.owner.lookup('service:shuttle');
 
     sinon.stub(router, 'currentURL').value('/v2/pipelines/1/events/11');
+    sinon.stub(shuttle, 'fetchFromApi').resolves([{ status: 'SUCCESS' }]);
 
     this.setProperties({
       event: {
@@ -202,18 +196,14 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
           }
         }
       },
-      builds: [{ status: 'SUCCESS' }],
       pipeline: {},
-      latestCommitEvent: { sha: 'abc123def456' },
       userSettings: {}
     });
 
     await render(
       hbs`<Pipeline::Event::Card
         @event={{this.event}}
-        @builds={{this.builds}}
         @pipeline={{this.pipeline}}
-        @latestCommitEvent={{this.latestCommitEvent}}
         @userSettings={{this.userSettings}}
         @showParameters={{true}}
       />`
@@ -226,8 +216,10 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
 
   test('it renders abort button for running event', async function (assert) {
     const router = this.owner.lookup('service:router');
+    const shuttle = this.owner.lookup('service:shuttle');
 
     sinon.stub(router, 'currentURL').value('/v2/pipelines/1/events/11');
+    sinon.stub(shuttle, 'fetchFromApi').resolves([{ status: 'RUNNING' }]);
 
     this.setProperties({
       event: {
@@ -237,22 +229,330 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
         creator: { name: 'batman' },
         meta: {}
       },
-      builds: [{ status: 'RUNNING' }],
       pipeline: {},
-      latestCommitEvent: { sha: 'abc123def456' },
       userSettings: {}
     });
 
     await render(
       hbs`<Pipeline::Event::Card
         @event={{this.event}}
-        @builds={{this.builds}}
         @pipeline={{this.pipeline}}
-        @latestCommitEvent={{this.latestCommitEvent}}
         @userSettings={{this.userSettings}}
       />`
     );
 
     assert.dom('.event-card-title .abort-event-button').exists({ count: 1 });
+  });
+
+  test('it renders latest commit badge', async function (assert) {
+    const router = this.owner.lookup('service:router');
+    const shuttle = this.owner.lookup('service:shuttle');
+    const workflowDataReloadService = this.owner.lookup(
+      'service:workflow-data-reload'
+    );
+    const latestCommitSha = 'abc123def456';
+
+    sinon.stub(router, 'currentURL').value('/v2/pipelines/1/events/11');
+    sinon.stub(shuttle, 'fetchFromApi').resolves([{ status: 'SUCCESS' }]);
+    workflowDataReloadService.latestCommitResponse = { sha: latestCommitSha };
+
+    this.setProperties({
+      event: {
+        id: 11,
+        sha: latestCommitSha,
+        commit: { author: { name: 'batman' }, message: 'Some amazing changes' },
+        creator: { name: 'batman' },
+        meta: {}
+      },
+      pipeline: {},
+      userSettings: {}
+    });
+
+    await render(
+      hbs`<Pipeline::Event::Card
+        @event={{this.event}}
+        @pipeline={{this.pipeline}}
+        @userSettings={{this.userSettings}}
+      />`
+    );
+
+    assert.dom('.event-card-title .sha .latest-commit').exists({ count: 1 });
+    assert.dom('.event-card-title .sha .latest-commit').hasText('#abc123d');
+  });
+
+  test('it does not render counts for collapsed event', async function (assert) {
+    const router = this.owner.lookup('service:router');
+    const shuttle = this.owner.lookup('service:shuttle');
+
+    sinon.stub(router, 'currentURL').value('/v2/pipelines/1/events/11');
+    sinon.stub(shuttle, 'fetchFromApi').resolves([{ status: 'COLLAPSED' }]);
+
+    this.setProperties({
+      event: {
+        id: 11,
+        sha: 'abc123def456',
+        commit: { author: { name: 'batman' }, message: 'Some amazing changes' },
+        creator: { name: 'batman' },
+        meta: {}
+      },
+      pipeline: {},
+      userSettings: {}
+    });
+
+    await render(
+      hbs`<Pipeline::Event::Card
+        @event={{this.event}}
+        @pipeline={{this.pipeline}}
+        @userSettings={{this.userSettings}}
+      />`
+    );
+
+    assert.dom('.event-card-footer .counts .count').doesNotExist();
+  });
+
+  test('it renders count values', async function (assert) {
+    const router = this.owner.lookup('service:router');
+    const shuttle = this.owner.lookup('service:shuttle');
+
+    sinon.stub(router, 'currentURL').value('/v2/pipelines/1/events/11');
+    sinon
+      .stub(shuttle, 'fetchFromApi')
+      .resolves([
+        { status: 'SUCCESS' },
+        { status: 'UNSTABLE' },
+        { status: 'SUCCESS' },
+        { status: 'FAILURE' }
+      ]);
+
+    this.setProperties({
+      event: {
+        id: 11,
+        sha: 'abc123def456',
+        commit: { author: { name: 'batman' }, message: 'Some amazing changes' },
+        creator: { name: 'batman' },
+        meta: {}
+      },
+      pipeline: {},
+      userSettings: {}
+    });
+
+    await render(
+      hbs`<Pipeline::Event::Card
+        @event={{this.event}}
+        @pipeline={{this.pipeline}}
+        @userSettings={{this.userSettings}}
+      />`
+    );
+
+    assert.dom('.event-card-footer .counts .failures').exists({ count: 1 });
+    assert.dom('.event-card-footer .counts .warnings').exists({ count: 1 });
+    assert.dom('.event-card-footer .counts .successes').exists({ count: 1 });
+  });
+
+  test('it re-renders correctly when event changes', async function (assert) {
+    const router = this.owner.lookup('service:router');
+    const shuttle = this.owner.lookup('service:shuttle');
+
+    sinon.stub(router, 'currentURL').value('/v2/pipelines/1/events/11');
+    sinon
+      .stub(shuttle, 'fetchFromApi')
+      .onCall(0)
+      .resolves([{ status: 'SUCCESS' }])
+      .onCall(1)
+      .resolves([{ status: 'FAILURE' }]);
+
+    this.setProperties({
+      event: {
+        id: 11,
+        sha: 'abc123def456',
+        commit: { author: { name: 'batman' }, message: 'Some amazing changes' },
+        creator: { name: 'batman' },
+        meta: {}
+      },
+      pipeline: {},
+      userSettings: {}
+    });
+
+    await render(
+      hbs`<Pipeline::Event::Card
+        @event={{this.event}}
+        @pipeline={{this.pipeline}}
+        @userSettings={{this.userSettings}}
+      />`
+    );
+
+    assert.dom('.event-card-title .event-status').hasClass('SUCCESS');
+    assert.dom('.event-card-title .sha').hasText('#abc123d');
+
+    this.setProperties({
+      event: {
+        id: 12,
+        sha: 'deadbeef123',
+        commit: { author: { name: 'robin' }, message: 'New change' },
+        creator: { name: 'robin' },
+        meta: {}
+      }
+    });
+
+    await rerender();
+
+    assert.dom('.event-card-title .event-status').hasClass('FAILURE');
+    assert.dom('.event-card-title .sha').hasText('#deadbee');
+  });
+
+  test('it renders latest commit badge', async function (assert) {
+    const router = this.owner.lookup('service:router');
+    const shuttle = this.owner.lookup('service:shuttle');
+    const workflowDataReloadService = this.owner.lookup(
+      'service:workflow-data-reload'
+    );
+    const latestCommitSha = 'abc123def456';
+
+    sinon.stub(router, 'currentURL').value('/v2/pipelines/1/events/11');
+    sinon.stub(shuttle, 'fetchFromApi').resolves([{ status: 'SUCCESS' }]);
+    workflowDataReloadService.latestCommitResponse = { sha: latestCommitSha };
+
+    this.setProperties({
+      event: {
+        id: 11,
+        sha: latestCommitSha,
+        commit: { author: { name: 'batman' }, message: 'Some amazing changes' },
+        creator: { name: 'batman' },
+        meta: {}
+      },
+      pipeline: {},
+      userSettings: {}
+    });
+
+    await render(
+      hbs`<Pipeline::Event::Card
+        @event={{this.event}}
+        @pipeline={{this.pipeline}}
+        @userSettings={{this.userSettings}}
+      />`
+    );
+
+    assert.dom('.event-card-title .sha .latest-commit').exists({ count: 1 });
+    assert.dom('.event-card-title .sha .latest-commit').hasText('#abc123d');
+  });
+
+  test('it does not render counts for collapsed event', async function (assert) {
+    const router = this.owner.lookup('service:router');
+    const shuttle = this.owner.lookup('service:shuttle');
+
+    sinon.stub(router, 'currentURL').value('/v2/pipelines/1/events/11');
+    sinon.stub(shuttle, 'fetchFromApi').resolves([{ status: 'COLLAPSED' }]);
+
+    this.setProperties({
+      event: {
+        id: 11,
+        sha: 'abc123def456',
+        commit: { author: { name: 'batman' }, message: 'Some amazing changes' },
+        creator: { name: 'batman' },
+        meta: {}
+      },
+      pipeline: {},
+      userSettings: {}
+    });
+
+    await render(
+      hbs`<Pipeline::Event::Card
+        @event={{this.event}}
+        @pipeline={{this.pipeline}}
+        @userSettings={{this.userSettings}}
+      />`
+    );
+
+    assert.dom('.event-card-footer .counts .count').doesNotExist();
+  });
+
+  test('it renders count values', async function (assert) {
+    const router = this.owner.lookup('service:router');
+    const shuttle = this.owner.lookup('service:shuttle');
+
+    sinon.stub(router, 'currentURL').value('/v2/pipelines/1/events/11');
+    sinon
+      .stub(shuttle, 'fetchFromApi')
+      .resolves([
+        { status: 'SUCCESS' },
+        { status: 'UNSTABLE' },
+        { status: 'SUCCESS' },
+        { status: 'FAILURE' }
+      ]);
+
+    this.setProperties({
+      event: {
+        id: 11,
+        sha: 'abc123def456',
+        commit: { author: { name: 'batman' }, message: 'Some amazing changes' },
+        creator: { name: 'batman' },
+        meta: {}
+      },
+      pipeline: {},
+      userSettings: {}
+    });
+
+    await render(
+      hbs`<Pipeline::Event::Card
+        @event={{this.event}}
+        @pipeline={{this.pipeline}}
+        @userSettings={{this.userSettings}}
+      />`
+    );
+
+    assert.dom('.event-card-footer .counts .failures').exists({ count: 1 });
+    assert.dom('.event-card-footer .counts .warnings').exists({ count: 1 });
+    assert.dom('.event-card-footer .counts .successes').exists({ count: 1 });
+  });
+
+  test('it re-renders correctly when event changes', async function (assert) {
+    const router = this.owner.lookup('service:router');
+    const shuttle = this.owner.lookup('service:shuttle');
+
+    sinon.stub(router, 'currentURL').value('/v2/pipelines/1/events/11');
+    sinon
+      .stub(shuttle, 'fetchFromApi')
+      .onCall(0)
+      .resolves([{ status: 'SUCCESS' }])
+      .onCall(1)
+      .resolves([{ status: 'FAILURE' }]);
+
+    this.setProperties({
+      event: {
+        id: 11,
+        sha: 'abc123def456',
+        commit: { author: { name: 'batman' }, message: 'Some amazing changes' },
+        creator: { name: 'batman' },
+        meta: {}
+      },
+      pipeline: {},
+      userSettings: {}
+    });
+
+    await render(
+      hbs`<Pipeline::Event::Card
+        @event={{this.event}}
+        @pipeline={{this.pipeline}}
+        @userSettings={{this.userSettings}}
+      />`
+    );
+
+    assert.dom('.event-card-title .event-status').hasClass('SUCCESS');
+    assert.dom('.event-card-title .sha').hasText('#abc123d');
+
+    this.setProperties({
+      event: {
+        id: 12,
+        sha: 'deadbeef123',
+        commit: { author: { name: 'robin' }, message: 'New change' },
+        creator: { name: 'robin' },
+        meta: {}
+      }
+    });
+
+    await rerender();
+
+    assert.dom('.event-card-title .event-status').hasClass('FAILURE');
+    assert.dom('.event-card-title .sha').hasText('#deadbee');
   });
 });


### PR DESCRIPTION
## Context
Event cards need the ability to dynamically update.  The `WorkflowDataReloadService` handles background data fetches for the latest commit event and builds for events.  The event card injects the `WorkflowDataReloadService` and registers the event with the `WorkflowDataReloadService` for handling data refreshes.  Additionally, if an event is still running, the event card updates the build time so that users can see how long the event has been running.

## Objective
Adds in the ability for event cards to dynamically update data that it is displaying.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
