### PR TITLE
feat: Event group modal

### DIFF
--- a/app/components/pipeline/event/card/component.js
+++ b/app/components/pipeline/event/card/component.js
@@ -47,6 +47,8 @@ export default class PipelineEventCardComponent extends Component {
 
   @tracked showAbortBuildModal;
 
+  @tracked showEventHistoryModal;
+
   queueName;
 
   userSettings;
@@ -196,6 +198,14 @@ export default class PipelineEventCardComponent extends Component {
     return getExternalPipelineId(this.event);
   }
 
+  get groupHistoryButtonTitle() {
+    const groupId = this.event.parentEventId
+      ? this.event.parentEventId
+      : this.event.groupEventId;
+
+    return `View event history for ${groupId}`;
+  }
+
   @action
   openParametersModal() {
     this.showParametersModal = true;
@@ -214,5 +224,15 @@ export default class PipelineEventCardComponent extends Component {
   @action
   closeAbortBuildModal() {
     this.showAbortBuildModal = false;
+  }
+
+  @action
+  openEventHistoryModal() {
+    this.showEventHistoryModal = true;
+  }
+
+  @action
+  closeEventHistoryModal() {
+    this.showEventHistoryModal = false;
   }
 }

--- a/app/components/pipeline/event/card/styles.scss
+++ b/app/components/pipeline/event/card/styles.scss
@@ -153,7 +153,8 @@
       .event-buttons {
         display: flex;
 
-        .parameters-button {
+        .parameters-button,
+        .event-group-button {
           background: colors.$sd-white;
           margin: 0 0.25rem;
         }

--- a/app/components/pipeline/event/card/template.hbs
+++ b/app/components/pipeline/event/card/template.hbs
@@ -171,6 +171,31 @@
           </BsButton>
         {{/if}}
       {{/if}}
+
+      {{#if @showEventGroup}}
+        <BsButton
+          class="event-group-button"
+          @type="primary"
+          @outline={{true}}
+          @onClick={{fn this.openEventHistoryModal}}
+          title={{this.groupHistoryButtonTitle}}
+        >
+          <FaIcon
+            @icon="history"
+            @fixedWidth="true"
+            @prefix="fa"
+          />
+          {{#if this.showEventHistoryModal}}
+            <Pipeline::Modal::EventGroupHistory
+              @pipeline={{@pipeline}}
+              @event={{@event}}
+              @jobs={{@jobs}}
+              @userSettings={{@userSettings}}
+              @closeModal={{this.closeEventHistoryModal}}
+            />
+          {{/if}}
+        </BsButton>
+      {{/if}}
     </div>
   </div>
 </div>

--- a/app/components/pipeline/modal/event-group-history/component.js
+++ b/app/components/pipeline/modal/event-group-history/component.js
@@ -1,0 +1,45 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import ENV from 'screwdriver-ui/config/environment';
+
+export default class PipelineModalEventGroupHistoryComponent extends Component {
+  @service shuttle;
+
+  @tracked events = [];
+
+  intervalId;
+
+  constructor() {
+    super(...arguments);
+
+    this.fetchGroupEvents();
+    this.intervalId = setInterval(
+      () => this.fetchGroupEvents(),
+      ENV.APP.BUILD_RELOAD_TIMER
+    );
+  }
+
+  willDestroy() {
+    super.willDestroy();
+
+    if (this.intervalId) {
+      clearInterval(this.intervalId);
+    }
+  }
+
+  @action
+  fetchGroupEvents() {
+    this.shuttle
+      .fetchFromApi(
+        'get',
+        `/pipelines/${this.args.pipeline.id}/events?groupEventId=${this.args.event.groupEventId}`
+      )
+      .then(events => {
+        if (this.events.length < events.length) {
+          this.events = events;
+        }
+      });
+  }
+}

--- a/app/components/pipeline/modal/event-group-history/styles.scss
+++ b/app/components/pipeline/modal/event-group-history/styles.scss
@@ -1,0 +1,16 @@
+@use 'screwdriver-colors' as colors;
+
+@mixin styles {
+  #show-event-group-modal {
+    &.modal {
+      .modal-dialog {
+        max-width: 30rem;
+
+        .modal-body {
+          max-height: 35rem;
+          overflow: scroll;
+        }
+      }
+    }
+  }
+}

--- a/app/components/pipeline/modal/event-group-history/template.hbs
+++ b/app/components/pipeline/modal/event-group-history/template.hbs
@@ -1,0 +1,25 @@
+<BsModal
+  id="show-event-group-modal"
+  @onHide={{fn @closeModal}}
+  as |modal|
+>
+  <modal.header>
+    <div class="modal-title">Events in group: {{@event.groupEventId}}</div>
+  </modal.header>
+  <modal.body>
+    <VerticalCollection
+      @items={{this.events}}
+      @estimateHeight={{150}}
+      @idForFirstItem={{@event.id}}
+      as |event|
+    >
+      <Pipeline::Event::Card
+        @pipeline={{@pipeline}}
+        @event={{event}}
+        @jobs={{@jobs}}
+        @userSettings={{@userSettings}}
+        @queueName="eventGroupModal"
+      />
+    </VerticalCollection>
+  </modal.body>
+</BsModal>

--- a/app/components/pipeline/modal/styles.scss
+++ b/app/components/pipeline/modal/styles.scss
@@ -1,9 +1,11 @@
 @use 'confirm-action/styles' as confirmAction;
+@use 'event-group-history/styles' as eventGroup;
 @use 'start-event/styles' as startEvent;
 @use 'toggle-job/styles' as toggleJob;
 
 @mixin styles {
   @include confirmAction.styles;
+  @include eventGroup.styles;
   @include startEvent.styles;
   @include toggleJob.styles;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@fortawesome/free-solid-svg-icons": "^5.15.4",
         "@glimmer/component": "^1.1.2",
         "@glimmer/tracking": "^1.1.2",
+        "@html-next/vertical-collection": "^4.0.2",
         "ace-builds": "^1.8.0",
         "ansi_up": "^5.1.0",
         "babel-eslint": "^10.1.0",
@@ -4304,6 +4305,159 @@
       "dev": true,
       "dependencies": {
         "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@html-next/vertical-collection": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@html-next/vertical-collection/-/vertical-collection-4.0.2.tgz",
+      "integrity": "sha512-S8cgntEDdXrOwdylVGDh1BFe+nX5uuUzzb3teh1FE++/kbqsOfUpXOYRUsEzsqb0fRqcm6eLxvtNb282Zr67rQ==",
+      "dev": true,
+      "dependencies": {
+        "babel6-plugin-strip-class-callcheck": "^6.0.0",
+        "broccoli-funnel": "^3.0.8",
+        "broccoli-merge-trees": "^4.2.0",
+        "broccoli-rollup": "^5.0.0",
+        "ember-cli-babel": "^7.12.0",
+        "ember-cli-htmlbars": "^6.0.0",
+        "ember-cli-version-checker": "^5.1.2",
+        "ember-raf-scheduler": "^0.3.0"
+      },
+      "engines": {
+        "node": ">= 14.*"
+      }
+    },
+    "node_modules/@html-next/vertical-collection/node_modules/@types/broccoli-plugin": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/broccoli-plugin/-/broccoli-plugin-3.0.4.tgz",
+      "integrity": "sha512-VfG0WydDHFr6MGj75U16bKxOnrl8uP9bXvq7VD+NuvnAq5/22cQDrf8o7BnzBJQt+Xm9jkPt1hh2EHVWluGYIA==",
+      "deprecated": "This is a stub types definition. broccoli-plugin provides its own type definitions, so you do not need this installed.",
+      "dev": true,
+      "dependencies": {
+        "broccoli-plugin": "*"
+      }
+    },
+    "node_modules/@html-next/vertical-collection/node_modules/broccoli-funnel": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-3.0.8.tgz",
+      "integrity": "sha512-ng4eIhPYiXqMw6SyGoxPHR3YAwEd2lr9FgBI1CyTbspl4txZovOsmzFkMkGAlu88xyvYXJqHiM2crfLa65T1BQ==",
+      "dev": true,
+      "dependencies": {
+        "array-equal": "^1.0.0",
+        "broccoli-plugin": "^4.0.7",
+        "debug": "^4.1.1",
+        "fs-tree-diff": "^2.0.1",
+        "heimdalljs": "^0.2.0",
+        "minimatch": "^3.0.0",
+        "walk-sync": "^2.0.2"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      }
+    },
+    "node_modules/@html-next/vertical-collection/node_modules/broccoli-merge-trees": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-4.2.0.tgz",
+      "integrity": "sha512-nTrQe5AQtCrW4enLRvbD/vTLHqyW2tz+vsLXQe4IEaUhepuMGVKJJr+I8n34Vu6fPjmPLwTjzNC8izMIDMtHPw==",
+      "dev": true,
+      "dependencies": {
+        "broccoli-plugin": "^4.0.2",
+        "merge-trees": "^2.0.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      }
+    },
+    "node_modules/@html-next/vertical-collection/node_modules/broccoli-rollup": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/broccoli-rollup/-/broccoli-rollup-5.0.0.tgz",
+      "integrity": "sha512-QdMuXHwsdz/LOS8zu4HP91Sfi4ofimrOXoYP/lrPdRh7lJYD87Lfq4WzzUhGHsxMfzANIEvl/7qVHKD3cFJ4tA==",
+      "dev": true,
+      "dependencies": {
+        "@types/broccoli-plugin": "^3.0.0",
+        "broccoli-plugin": "^4.0.7",
+        "fs-tree-diff": "^2.0.1",
+        "heimdalljs": "^0.2.6",
+        "node-modules-path": "^1.0.1",
+        "rollup": "^2.50.0",
+        "rollup-pluginutils": "^2.8.1",
+        "symlink-or-copy": "^1.2.0",
+        "walk-sync": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
+    "node_modules/@html-next/vertical-collection/node_modules/ember-cli-version-checker": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-5.1.2.tgz",
+      "integrity": "sha512-rk7GY+FmLn/2e22HsZs0Ycrz8HQ1W3Fv+2TFOuEFW9optnDXDgkntPBIl6gact/LHsfBM5RKbM3dHsIIeLgl0Q==",
+      "dev": true,
+      "dependencies": {
+        "resolve-package-path": "^3.1.0",
+        "semver": "^7.3.4",
+        "silent-error": "^1.1.1"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      }
+    },
+    "node_modules/@html-next/vertical-collection/node_modules/fs-tree-diff": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
+      "integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
+      "dev": true,
+      "dependencies": {
+        "@types/symlink-or-copy": "^1.2.0",
+        "heimdalljs-logger": "^0.1.7",
+        "object-assign": "^4.1.0",
+        "path-posix": "^1.0.0",
+        "symlink-or-copy": "^1.1.8"
+      },
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/@html-next/vertical-collection/node_modules/resolve-package-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-3.1.0.tgz",
+      "integrity": "sha512-2oC2EjWbMJwvSN6Z7DbDfJMnD8MYEouaLn5eIX0j8XwPsYCVIyY9bbnX88YHVkbr8XHqvZrYbxaLPibfTYKZMA==",
+      "dev": true,
+      "dependencies": {
+        "path-root": "^0.1.1",
+        "resolve": "^1.17.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12"
+      }
+    },
+    "node_modules/@html-next/vertical-collection/node_modules/rollup": {
+      "version": "2.79.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz",
+      "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
+      "dev": true,
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/@html-next/vertical-collection/node_modules/walk-sync": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
+      "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
+      "dev": true,
+      "dependencies": {
+        "@types/minimatch": "^3.0.3",
+        "ensure-posix-path": "^1.1.0",
+        "matcher-collection": "^2.0.0",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": "8.* || >= 10.*"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -21674,6 +21828,18 @@
       "dependencies": {
         "errno": "^0.1.3",
         "readable-stream": "^2.0.1"
+      }
+    },
+    "node_modules/ember-raf-scheduler": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/ember-raf-scheduler/-/ember-raf-scheduler-0.3.0.tgz",
+      "integrity": "sha512-i8JWQidNCX7n5TOTIKRDR0bnsQN9aJh/GtOJKINz2Wr+I7L7sYVhli6MFqMYNGKC9j9e6iWsznfAIxddheyEow==",
+      "dev": true,
+      "dependencies": {
+        "ember-cli-babel": "^7.26.6"
+      },
+      "engines": {
+        "node": "12.* || 14.* || >= 16"
       }
     },
     "node_modules/ember-ref-bucket": {
@@ -41677,6 +41843,130 @@
         "@hapi/hoek": "^9.0.0"
       }
     },
+    "@html-next/vertical-collection": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@html-next/vertical-collection/-/vertical-collection-4.0.2.tgz",
+      "integrity": "sha512-S8cgntEDdXrOwdylVGDh1BFe+nX5uuUzzb3teh1FE++/kbqsOfUpXOYRUsEzsqb0fRqcm6eLxvtNb282Zr67rQ==",
+      "dev": true,
+      "requires": {
+        "babel6-plugin-strip-class-callcheck": "^6.0.0",
+        "broccoli-funnel": "^3.0.8",
+        "broccoli-merge-trees": "^4.2.0",
+        "broccoli-rollup": "^5.0.0",
+        "ember-cli-babel": "^7.12.0",
+        "ember-cli-htmlbars": "^6.0.0",
+        "ember-cli-version-checker": "^5.1.2",
+        "ember-raf-scheduler": "^0.3.0"
+      },
+      "dependencies": {
+        "@types/broccoli-plugin": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/@types/broccoli-plugin/-/broccoli-plugin-3.0.4.tgz",
+          "integrity": "sha512-VfG0WydDHFr6MGj75U16bKxOnrl8uP9bXvq7VD+NuvnAq5/22cQDrf8o7BnzBJQt+Xm9jkPt1hh2EHVWluGYIA==",
+          "dev": true,
+          "requires": {
+            "broccoli-plugin": "*"
+          }
+        },
+        "broccoli-funnel": {
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-3.0.8.tgz",
+          "integrity": "sha512-ng4eIhPYiXqMw6SyGoxPHR3YAwEd2lr9FgBI1CyTbspl4txZovOsmzFkMkGAlu88xyvYXJqHiM2crfLa65T1BQ==",
+          "dev": true,
+          "requires": {
+            "array-equal": "^1.0.0",
+            "broccoli-plugin": "^4.0.7",
+            "debug": "^4.1.1",
+            "fs-tree-diff": "^2.0.1",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "walk-sync": "^2.0.2"
+          }
+        },
+        "broccoli-merge-trees": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-4.2.0.tgz",
+          "integrity": "sha512-nTrQe5AQtCrW4enLRvbD/vTLHqyW2tz+vsLXQe4IEaUhepuMGVKJJr+I8n34Vu6fPjmPLwTjzNC8izMIDMtHPw==",
+          "dev": true,
+          "requires": {
+            "broccoli-plugin": "^4.0.2",
+            "merge-trees": "^2.0.0"
+          }
+        },
+        "broccoli-rollup": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/broccoli-rollup/-/broccoli-rollup-5.0.0.tgz",
+          "integrity": "sha512-QdMuXHwsdz/LOS8zu4HP91Sfi4ofimrOXoYP/lrPdRh7lJYD87Lfq4WzzUhGHsxMfzANIEvl/7qVHKD3cFJ4tA==",
+          "dev": true,
+          "requires": {
+            "@types/broccoli-plugin": "^3.0.0",
+            "broccoli-plugin": "^4.0.7",
+            "fs-tree-diff": "^2.0.1",
+            "heimdalljs": "^0.2.6",
+            "node-modules-path": "^1.0.1",
+            "rollup": "^2.50.0",
+            "rollup-pluginutils": "^2.8.1",
+            "symlink-or-copy": "^1.2.0",
+            "walk-sync": "^2.2.0"
+          }
+        },
+        "ember-cli-version-checker": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-5.1.2.tgz",
+          "integrity": "sha512-rk7GY+FmLn/2e22HsZs0Ycrz8HQ1W3Fv+2TFOuEFW9optnDXDgkntPBIl6gact/LHsfBM5RKbM3dHsIIeLgl0Q==",
+          "dev": true,
+          "requires": {
+            "resolve-package-path": "^3.1.0",
+            "semver": "^7.3.4",
+            "silent-error": "^1.1.1"
+          }
+        },
+        "fs-tree-diff": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
+          "integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
+          "dev": true,
+          "requires": {
+            "@types/symlink-or-copy": "^1.2.0",
+            "heimdalljs-logger": "^0.1.7",
+            "object-assign": "^4.1.0",
+            "path-posix": "^1.0.0",
+            "symlink-or-copy": "^1.1.8"
+          }
+        },
+        "resolve-package-path": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-3.1.0.tgz",
+          "integrity": "sha512-2oC2EjWbMJwvSN6Z7DbDfJMnD8MYEouaLn5eIX0j8XwPsYCVIyY9bbnX88YHVkbr8XHqvZrYbxaLPibfTYKZMA==",
+          "dev": true,
+          "requires": {
+            "path-root": "^0.1.1",
+            "resolve": "^1.17.0"
+          }
+        },
+        "rollup": {
+          "version": "2.79.2",
+          "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz",
+          "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
+          "dev": true,
+          "requires": {
+            "fsevents": "~2.3.2"
+          }
+        },
+        "walk-sync": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
+          "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
+          "dev": true,
+          "requires": {
+            "@types/minimatch": "^3.0.3",
+            "ensure-posix-path": "^1.1.0",
+            "matcher-collection": "^2.0.0",
+            "minimatch": "^3.0.4"
+          }
+        }
+      }
+    },
     "@humanwhocodes/config-array": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
@@ -55977,6 +56267,15 @@
             }
           }
         }
+      }
+    },
+    "ember-raf-scheduler": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/ember-raf-scheduler/-/ember-raf-scheduler-0.3.0.tgz",
+      "integrity": "sha512-i8JWQidNCX7n5TOTIKRDR0bnsQN9aJh/GtOJKINz2Wr+I7L7sYVhli6MFqMYNGKC9j9e6iWsznfAIxddheyEow==",
+      "dev": true,
+      "requires": {
+        "ember-cli-babel": "^7.26.6"
       }
     },
     "ember-ref-bucket": {

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.15.4",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
+    "@html-next/vertical-collection": "^4.0.2",
     "ace-builds": "^1.8.0",
     "ansi_up": "^5.1.0",
     "babel-eslint": "^10.1.0",

--- a/tests/integration/components/pipeline/event/card/component-test.js
+++ b/tests/integration/components/pipeline/event/card/component-test.js
@@ -113,6 +113,9 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
     assert
       .dom('.event-card-footer .event-buttons .parameters-button')
       .doesNotExist();
+    assert
+      .dom('.event-card-footer .event-buttons .event-group-button')
+      .doesNotExist();
   });
 
   test('it does not render highlight', async function (assert) {
@@ -211,6 +214,43 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
 
     assert
       .dom('.event-card-footer .event-buttons .parameters-button')
+      .exists({ count: 1 });
+  });
+
+  test('it renders button for event group', async function (assert) {
+    const router = this.owner.lookup('service:router');
+    const shuttle = this.owner.lookup('service:shuttle');
+
+    sinon.stub(router, 'currentURL').value('/v2/pipelines/1/events/11');
+    sinon.stub(shuttle, 'fetchFromApi').resolves([{ status: 'SUCCESS' }]);
+
+    this.setProperties({
+      event: {
+        id: 11,
+        sha: 'abc123def456',
+        commit: { author: { name: 'batman' }, message: 'Some amazing changes' },
+        creator: { name: 'batman' },
+        meta: {
+          parameters: {
+            foo: { value: 'bar' }
+          }
+        }
+      },
+      pipeline: {},
+      userSettings: {}
+    });
+
+    await render(
+      hbs`<Pipeline::Event::Card
+        @event={{this.event}}
+        @pipeline={{this.pipeline}}
+        @userSettings={{this.userSettings}}
+        @showEventGroup={{true}}
+      />`
+    );
+
+    assert
+      .dom('.event-card-footer .event-buttons .event-group-button')
       .exists({ count: 1 });
   });
 

--- a/tests/integration/components/pipeline/modal/event-group-history/component-test.js
+++ b/tests/integration/components/pipeline/modal/event-group-history/component-test.js
@@ -1,0 +1,61 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
+import { clearRender, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+
+module(
+  'Integration | Component | pipeline/modal/event-group-history',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test('it renders', async function (assert) {
+      const router = this.owner.lookup('service:router');
+      const workflowDataReload = this.owner.lookup(
+        'service:workflow-data-reload'
+      );
+      const shuttle = this.owner.lookup('service:shuttle');
+      const groupEventId = 1;
+      const mockEvent = {
+        sha: 'abc123def456',
+        commit: { author: { name: 'batman' }, message: 'Some amazing changes' },
+        creator: { name: 'batman' },
+        meta: {},
+        groupEventId
+      };
+
+      sinon.stub(router, 'currentURL').value('');
+      sinon.stub(workflowDataReload, 'registerCallback').returns();
+      sinon.stub(shuttle, 'fetchFromApi').resolves([
+        { ...mockEvent, id: 3 },
+        { ...mockEvent, id: 2 },
+        { ...mockEvent, id: 1 }
+      ]);
+
+      this.setProperties({
+        pipeline: {},
+        event: { ...mockEvent, id: 1 },
+        jobs: {},
+        userSettings: {},
+        closeModal: () => {}
+      });
+
+      await render(
+        hbs`<Pipeline::Modal::EventGroupHistory
+            @pipeline={{this.pipeline}}
+            @event={{this.event}}
+            @jobs={{this.jobs}}
+            @userSettings={{this.userSettings}}
+            @closeModal={{this.closeModal}}
+        />`
+      );
+
+      assert.dom('.modal-header').exists({ count: 1 });
+      assert.dom('.modal-header').hasText(`Events in group: ${groupEventId} ×`);
+      assert.dom('.modal-body').exists({ count: 1 });
+      assert.dom('.modal-footer').doesNotExist();
+
+      await clearRender();
+    });
+  }
+);


### PR DESCRIPTION
## Context
Users should be able to view all events that make up a group.  In the V1 interface, there is an expandable option for displaying events, however the drawback of the V1 interface is that older events in the group are completely removed from the view and in certain aspects makes it difficult to really understand the order of events that have happened for the pipeline.

The V2 interface will instead keep all events in the event rail as they occur and have a button in within the event card that will open up a modal to display all events that make up an event group.  This will hopefully make it easier for users to navigate the full event history of a pipeline while providing the additional grouping information if they want to dive into the event history of an event group. 

## Objective
Create a modal to display all events that make up an event group.  Also adds the button to display the event group modal into the event card itself.

Event group modal will display the event group in the modal title and the events that make up the event group:
![Screenshot 2024-10-21 at 12-27-17 New Pipeline Events](https://github.com/user-attachments/assets/72838ad8-cb00-45af-968c-b447d14f840a)

The modal will also overflow with a vertical scroll:
![Screenshot 2024-10-21 at 12-27-53 New Pipeline Events](https://github.com/user-attachments/assets/a9346671-c260-4df1-9a74-fba11413aed0)

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
