### PR TITLE
Fix: fixes the missing download button

### DIFF
--- a/app/components/artifact-preview/template.hbs
+++ b/app/components/artifact-preview/template.hbs
@@ -9,16 +9,16 @@
       >
         Download All
       </BsButton>
+    {{else}}
+      <BsButton
+        @type="primary"
+        @icon="glyphicon glyphicon-download"
+        @onClick={{action "download"}}
+        title="Download current artifact"
+      >
+        Download
+      </BsButton>
     {{/if}}
-  {{else}}
-    <BsButton
-      @type="primary"
-      @icon="glyphicon glyphicon-download"
-      @onClick={{action "download"}}
-      title="Download current artifact"
-    >
-      Download
-    </BsButton>
   {{/if}}
   {{#if this.iframeUrl}}
     <iframe id={{this.iframeId}} src={{this.iframeUrl}}>


### PR DESCRIPTION
## Context
https://github.com/screwdriver-cd/ui/pull/1202 has a minor bug with the if-else conditions in the template which causes the download button to go missing

## Objective
Fixes the missing download button

## References
https://github.com/screwdriver-cd/screwdriver/issues/3227

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
