### PR TITLE
feat: Modal to search for an event

### DIFF
--- a/app/components/pipeline/modal/search-event/component.js
+++ b/app/components/pipeline/modal/search-event/component.js
@@ -1,0 +1,57 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+
+export default class PipelineModalSearchEventComponent extends Component {
+  @service shuttle;
+
+  @tracked sha;
+
+  @tracked searchResults;
+
+  @tracked inputClass;
+
+  constructor() {
+    super(...arguments);
+
+    this.searchResults = [];
+    this.inputClass = null;
+  }
+
+  @action
+  handleInput(inputEvent) {
+    const inputValue = inputEvent.target.value;
+
+    if (inputValue && inputValue.length > 0) {
+      if (!/^[0-9a-f]{1,40}$/.test(inputValue)) {
+        if (!this.inputClass) {
+          this.inputClass = 'invalid';
+        }
+      } else {
+        this.inputClass = null;
+        this.shuttle
+          .fetchFromApi(
+            'get',
+            `/pipelines/${this.args.pipeline.id}/events?sha=${inputValue}`
+          )
+          .then(events => {
+            this.searchResults = events;
+          });
+      }
+    } else {
+      this.inputClass = null;
+    }
+  }
+
+  @action
+  handleKeyPress(event) {
+    if (event.key === 'Escape') {
+      if (this.sha?.length > 0) {
+        event.stopImmediatePropagation();
+        this.sha = null;
+        this.searchResults = [];
+      }
+    }
+  }
+}

--- a/app/components/pipeline/modal/search-event/component.js
+++ b/app/components/pipeline/modal/search-event/component.js
@@ -10,13 +10,13 @@ export default class PipelineModalSearchEventComponent extends Component {
 
   @tracked searchResults;
 
-  @tracked inputClass;
+  @tracked invalidSha;
 
   constructor() {
     super(...arguments);
 
     this.searchResults = [];
-    this.inputClass = null;
+    this.invalidSha = false;
   }
 
   @action
@@ -24,12 +24,13 @@ export default class PipelineModalSearchEventComponent extends Component {
     const inputValue = inputEvent.target.value;
 
     if (inputValue && inputValue.length > 0) {
-      if (!/^[0-9a-f]{1,40}$/.test(inputValue)) {
-        if (!this.inputClass) {
-          this.inputClass = 'invalid';
-        }
+      const validHex = /^[0-9a-f]{1,40}$/;
+
+      if (!validHex.test(inputValue)) {
+        this.invalidSha = true;
       } else {
-        this.inputClass = null;
+        this.invalidSha = false;
+
         this.shuttle
           .fetchFromApi(
             'get',
@@ -39,8 +40,6 @@ export default class PipelineModalSearchEventComponent extends Component {
             this.searchResults = events;
           });
       }
-    } else {
-      this.inputClass = null;
     }
   }
 
@@ -51,6 +50,7 @@ export default class PipelineModalSearchEventComponent extends Component {
         event.stopImmediatePropagation();
         this.sha = null;
         this.searchResults = [];
+        this.invalidSha = false;
       }
     }
   }

--- a/app/components/pipeline/modal/search-event/styles.scss
+++ b/app/components/pipeline/modal/search-event/styles.scss
@@ -1,0 +1,31 @@
+@use 'screwdriver-colors' as colors;
+
+@mixin styles {
+  #search-event-modal {
+    &.modal {
+      .modal-dialog {
+        max-width: 30rem;
+
+        #search-input {
+          display: flex;
+          justify-content: space-between;
+          margin-bottom: 1rem;
+
+          input {
+            flex: 1;
+            margin-right: 1rem;
+
+            &.invalid {
+              color: colors.$sd-warn-bg;
+            }
+          }
+        }
+
+        #search-results {
+          max-height: 35rem;
+          overflow: scroll;
+        }
+      }
+    }
+  }
+}

--- a/app/components/pipeline/modal/search-event/styles.scss
+++ b/app/components/pipeline/modal/search-event/styles.scss
@@ -1,4 +1,5 @@
 @use 'screwdriver-colors' as colors;
+@use 'screwdriver-input' as input;
 
 @mixin styles {
   #search-event-modal {
@@ -8,16 +9,18 @@
 
         #search-input {
           display: flex;
+          flex-direction: column;
           justify-content: space-between;
           margin-bottom: 1rem;
 
           input {
             flex: 1;
-            margin-right: 1rem;
+          }
 
-            &.invalid {
-              color: colors.$sd-warn-bg;
-            }
+          @include input.styles;
+
+          .invalid-sha {
+            color: colors.$sd-warn-bg;
           }
         }
 

--- a/app/components/pipeline/modal/search-event/template.hbs
+++ b/app/components/pipeline/modal/search-event/template.hbs
@@ -1,0 +1,38 @@
+<BsModal
+  id="search-event-modal"
+  @onHide={{fn @closeModal}}
+  as |modal|
+>
+  <modal.header>
+    <div class="modal-title">Search for an event</div>
+  </modal.header>
+  <modal.body>
+    <div id="search-input">
+      <Input
+        @type="text"
+        @value={{this.sha}}
+        autofocus={{true}}
+        class={{this.inputClass}}
+        placeholder="Search for an event by SHA"
+        {{on "input" this.handleInput}}
+        {{on "keydown" this.handleKeyPress}}
+      />
+    </div>
+
+    <div id="search-results">
+      <VerticalCollection
+        @items={{this.searchResults}}
+        @estimateHeight={{150}}
+        as |event|
+      >
+        <Pipeline::Event::Card
+          @pipeline={{@pipeline}}
+          @event={{event}}
+          @jobs={{@jobs}}
+          @userSettings={{@userSettings}}
+          @queueName="searchResults"
+        />
+      </VerticalCollection>
+    </div>
+  </modal.body>
+</BsModal>

--- a/app/components/pipeline/modal/search-event/template.hbs
+++ b/app/components/pipeline/modal/search-event/template.hbs
@@ -9,14 +9,18 @@
   <modal.body>
     <div id="search-input">
       <Input
-        @type="text"
+        @type="search"
         @value={{this.sha}}
         autofocus={{true}}
-        class={{this.inputClass}}
+        maxlength="40"
+        pattern="^[0-9a-fA-F]{1,40}$"
         placeholder="Search for an event by SHA"
         {{on "input" this.handleInput}}
         {{on "keydown" this.handleKeyPress}}
       />
+      {{#if this.invalidSha}}
+        <div class="invalid-sha">Invalid SHA.  SHA can only contain hex values.</div>
+      {{/if}}
     </div>
 
     <div id="search-results">

--- a/app/components/pipeline/modal/styles.scss
+++ b/app/components/pipeline/modal/styles.scss
@@ -1,11 +1,13 @@
 @use 'confirm-action/styles' as confirmAction;
 @use 'event-group-history/styles' as eventGroup;
+@use 'search-event/styles' as searchEvent;
 @use 'start-event/styles' as startEvent;
 @use 'toggle-job/styles' as toggleJob;
 
 @mixin styles {
   @include confirmAction.styles;
   @include eventGroup.styles;
+  @include searchEvent.styles;
   @include startEvent.styles;
   @include toggleJob.styles;
 }

--- a/app/styles/screwdriver-input.scss
+++ b/app/styles/screwdriver-input.scss
@@ -1,0 +1,15 @@
+@use 'screwdriver-colors' as colors;
+
+@mixin styles {
+  input[type='search'] {
+    color: colors.$sd-text;
+    border-radius: 5px;
+    border: 2px solid colors.$sd-separator;
+    padding: 0 0.25rem;
+
+    &:invalid {
+      color: colors.$sd-warn-bg;
+      border-color: colors.$sd-warn-bg;
+    }
+  }
+}

--- a/tests/integration/components/pipeline/modal/search-event/component-test.js
+++ b/tests/integration/components/pipeline/modal/search-event/component-test.js
@@ -29,6 +29,7 @@ module(
       assert.dom('.modal-title').exists({ count: 1 });
       assert.dom('#search-input').exists({ count: 1 });
       assert.dom('#search-input input').exists({ count: 1 });
+      assert.dom('#search-input .invalid-sha').doesNotExist();
       assert.dom('#search-results').exists({ count: 1 });
     });
 
@@ -82,55 +83,8 @@ module(
       await fillIn('input', 'xyz');
 
       assert.equal(shuttle.fetchFromApi.callCount, 0);
-      assert.dom('#search-input input').hasClass('invalid');
-    });
-
-    test('it does not change input class when input is continuously invalid', async function (assert) {
-      this.setProperties({
-        pipeline: {},
-        jobs: [],
-        userSettings: {},
-        closeModal: () => {}
-      });
-
-      await render(
-        hbs`<Pipeline::Modal::SearchEvent
-            @pipeline={{this.pipeline}}
-            @jobs={{this.jobs}}
-            @userSettings={{this.userSettings}}
-            @closeModal={{this.closeModal}}
-        />`
-      );
-
-      await fillIn('input', 'xyz');
-      assert.dom('#search-input input').hasClass('invalid');
-
-      await fillIn('input', 'xyzK');
-      assert.dom('#search-input input').hasClass('invalid');
-    });
-
-    test('it resets input class when input is empty', async function (assert) {
-      this.setProperties({
-        pipeline: {},
-        jobs: [],
-        userSettings: {},
-        closeModal: () => {}
-      });
-
-      await render(
-        hbs`<Pipeline::Modal::SearchEvent
-            @pipeline={{this.pipeline}}
-            @jobs={{this.jobs}}
-            @userSettings={{this.userSettings}}
-            @closeModal={{this.closeModal}}
-        />`
-      );
-
-      await fillIn('input', 'xyz');
-      assert.dom('#search-input input').hasClass('invalid');
-
-      await fillIn('input', '');
-      assert.dom('#search-input input').doesNotHaveClass('invalid');
+      assert.dom('#search-input input').isNotValid();
+      assert.dom('#search-input .invalid-sha').exists({ count: 1 });
     });
 
     test('it clears input and search results when escape key is pressed', async function (assert) {

--- a/tests/integration/components/pipeline/modal/search-event/component-test.js
+++ b/tests/integration/components/pipeline/modal/search-event/component-test.js
@@ -1,0 +1,166 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
+import { fillIn, render, triggerKeyEvent } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+
+module(
+  'Integration | Component | pipeline/modal/search-event',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test('it renders', async function (assert) {
+      this.setProperties({
+        pipeline: {},
+        jobs: [],
+        userSettings: {},
+        closeModal: () => {}
+      });
+
+      await render(
+        hbs`<Pipeline::Modal::SearchEvent
+            @pipeline={{this.pipeline}}
+            @jobs={{this.jobs}}
+            @userSettings={{this.userSettings}}
+            @closeModal={{this.closeModal}}
+        />`
+      );
+
+      assert.dom('.modal-title').exists({ count: 1 });
+      assert.dom('#search-input').exists({ count: 1 });
+      assert.dom('#search-input input').exists({ count: 1 });
+      assert.dom('#search-results').exists({ count: 1 });
+    });
+
+    test('it makes API call for valid input', async function (assert) {
+      const shuttle = this.owner.lookup('service:shuttle');
+
+      sinon.stub(shuttle, 'fetchFromApi').resolves([]);
+
+      this.setProperties({
+        pipeline: {},
+        jobs: [],
+        userSettings: {},
+        closeModal: () => {}
+      });
+
+      await render(
+        hbs`<Pipeline::Modal::SearchEvent
+            @pipeline={{this.pipeline}}
+            @jobs={{this.jobs}}
+            @userSettings={{this.userSettings}}
+            @closeModal={{this.closeModal}}
+        />`
+      );
+
+      await fillIn('input', 'abc123');
+
+      assert.equal(shuttle.fetchFromApi.callCount, 1);
+    });
+
+    test('it handles invalid input', async function (assert) {
+      const shuttle = this.owner.lookup('service:shuttle');
+
+      sinon.spy(shuttle);
+
+      this.setProperties({
+        pipeline: {},
+        jobs: [],
+        userSettings: {},
+        closeModal: () => {}
+      });
+
+      await render(
+        hbs`<Pipeline::Modal::SearchEvent
+            @pipeline={{this.pipeline}}
+            @jobs={{this.jobs}}
+            @userSettings={{this.userSettings}}
+            @closeModal={{this.closeModal}}
+        />`
+      );
+
+      await fillIn('input', 'xyz');
+
+      assert.equal(shuttle.fetchFromApi.callCount, 0);
+      assert.dom('#search-input input').hasClass('invalid');
+    });
+
+    test('it does not change input class when input is continuously invalid', async function (assert) {
+      this.setProperties({
+        pipeline: {},
+        jobs: [],
+        userSettings: {},
+        closeModal: () => {}
+      });
+
+      await render(
+        hbs`<Pipeline::Modal::SearchEvent
+            @pipeline={{this.pipeline}}
+            @jobs={{this.jobs}}
+            @userSettings={{this.userSettings}}
+            @closeModal={{this.closeModal}}
+        />`
+      );
+
+      await fillIn('input', 'xyz');
+      assert.dom('#search-input input').hasClass('invalid');
+
+      await fillIn('input', 'xyzK');
+      assert.dom('#search-input input').hasClass('invalid');
+    });
+
+    test('it resets input class when input is empty', async function (assert) {
+      this.setProperties({
+        pipeline: {},
+        jobs: [],
+        userSettings: {},
+        closeModal: () => {}
+      });
+
+      await render(
+        hbs`<Pipeline::Modal::SearchEvent
+            @pipeline={{this.pipeline}}
+            @jobs={{this.jobs}}
+            @userSettings={{this.userSettings}}
+            @closeModal={{this.closeModal}}
+        />`
+      );
+
+      await fillIn('input', 'xyz');
+      assert.dom('#search-input input').hasClass('invalid');
+
+      await fillIn('input', '');
+      assert.dom('#search-input input').doesNotHaveClass('invalid');
+    });
+
+    test('it clears input and search results when escape key is pressed', async function (assert) {
+      const shuttle = this.owner.lookup('service:shuttle');
+
+      sinon.stub(shuttle, 'fetchFromApi').resolves([]);
+
+      this.setProperties({
+        pipeline: {},
+        jobs: [],
+        userSettings: {},
+        closeModal: () => {}
+      });
+
+      await render(
+        hbs`<Pipeline::Modal::SearchEvent
+            @pipeline={{this.pipeline}}
+            @jobs={{this.jobs}}
+            @userSettings={{this.userSettings}}
+            @closeModal={{this.closeModal}}
+        />`
+      );
+
+      await fillIn('input', 'abc123');
+      assert.dom('#search-input input').hasValue('abc123');
+      assert.equal(shuttle.fetchFromApi.callCount, 1);
+
+      await triggerKeyEvent('input', 'keydown', 'Escape');
+      assert.dom('#search-input input').hasNoValue();
+      assert.equal(shuttle.fetchFromApi.callCount, 1);
+    });
+  }
+);


### PR DESCRIPTION
## Context
The v2 UI adds in a feature to search for an event by SHA.  To support the search feature, a new modal will be employed to provide the text input field and display of the results.  This modal will do dynamic searches so as valid characters are input into the text input field the results will be updated.  For invalid inputs, the text input field will change colors to provide immediate feedback.

The escape key is configured to allow clearing of the input field when an input has been provided.  If the input field is empty, the escape key will close the modal (which is the default behavior for all of the modals being used in the v2 UI).

## Objective
Create a new modal to support event searching.

Basic modal that is presented to the user:
![Screenshot 2024-10-29 at 17-54-03 New Pipeline Events](https://github.com/user-attachments/assets/a686518d-e8e6-4760-b12c-22e9684f7b3e)

Valid input with search results:
![Screenshot 2024-10-29 at 18-17-06 New Pipeline Events](https://github.com/user-attachments/assets/65eaf564-1564-4312-b786-70297e97d5cf)

Invalid input showing text color change and the search results not changing due to the invalid input:
![Screenshot 2024-10-29 at 18-17-33 New Pipeline Events](https://github.com/user-attachments/assets/7e8cfade-15d4-4efb-92a9-a429fc6dd800)

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
