### PR TITLE
fix(3211): Find workflow graph node for a virtual build by job name

### DIFF
--- a/app/job/model.js
+++ b/app/job/model.js
@@ -4,6 +4,7 @@ import { alias, match } from '@ember/object/computed';
 import ENV from 'screwdriver-ui/config/environment';
 import { toCustomLocaleString } from 'screwdriver-ui/utils/time-range';
 import { isActiveBuild } from 'screwdriver-ui/utils/build';
+import { PR_JOB_NAME } from 'screwdriver-data-schema/config/regex';
 import { SHOULD_RELOAD_NO, SHOULD_RELOAD_YES } from '../mixins/model-reloader';
 
 export default Model.extend({
@@ -61,6 +62,11 @@ export default Model.extend({
     }
   }),
   prParentJobId: attr('string'),
+  prParentJobName: computed('isPR', 'name', {
+    get() {
+      return this.isPR ? this.name.match(PR_JOB_NAME)[2] : null;
+    }
+  }),
   // } for pr job only
   permutations: attr(),
   annotations: computed('permutations.0.annotations', 'permutations.[]', {

--- a/app/pipeline/build/controller.js
+++ b/app/pipeline/build/controller.js
@@ -75,18 +75,15 @@ export default Controller.extend({
     }
   }),
 
-  isVirtualBuild: computed(
-    'model.build.jobId',
-    'model.event.workflowGraph.nodes',
-    {
-      get() {
-        const jobId = parseInt(this.get('model.build.jobId'), 10);
-        const nodes = this.get('model.event.workflowGraph.nodes');
+  isVirtualBuild: computed('model.job', 'model.event.workflowGraph.nodes', {
+    get() {
+      const job = this.get('model.job');
+      const jobName = job.isPR ? job.prParentJobName : job.name;
+      const nodes = this.get('model.event.workflowGraph.nodes');
 
-        return nodes.find(node => node.id === jobId).virtual;
-      }
+      return nodes.find(node => node.name === jobName).virtual;
     }
-  ),
+  }),
 
   showStepCollection: computed('isVirtualBuild', 'stepList', {
     get() {

--- a/app/pipeline/build/controller.js
+++ b/app/pipeline/build/controller.js
@@ -78,7 +78,7 @@ export default Controller.extend({
   isVirtualBuild: computed('model.job', 'model.event.workflowGraph.nodes', {
     get() {
       const job = this.get('model.job');
-      const jobName = job.isPR ? job.prParentJobName : job.name;
+      const jobName = job.prParentJobName || job.name;
       const nodes = this.get('model.event.workflowGraph.nodes');
 
       return nodes.find(node => node.name === jobName).virtual;

--- a/tests/unit/job/model-test.js
+++ b/tests/unit/job/model-test.js
@@ -13,4 +13,20 @@ module('Unit | Model | job', function (hooks) {
 
     assert.ok(!!model);
   });
+
+  test('it returns pr parent job name', function (assert) {
+    const model = run(() =>
+      this.owner.lookup('service:store').createRecord('job', {
+        name: 'PR-123:deploy'
+      })
+    );
+
+    run(() => {
+      // job is a PR job
+      assert.equal(model.get('prParentJobName'), 'deploy');
+      // job is not a PR job
+      model.set('name', 'publish');
+      assert.equal(model.get('prParentJobName'), null);
+    });
+  });
 });


### PR DESCRIPTION
## Context

Changes made in this PR https://github.com/screwdriver-cd/ui/pull/1201 relied on the `id` of workflow graph node to find a node corresponding to the job associated with the build.

But, it appears `id` for workflow graph nodes are not being set in case of PR event
![image](https://github.com/user-attachments/assets/68078b0e-31fb-4ca9-9fad-ef6c5efd6bfd)


## Objective

Update the logic to find the workflow graph node by `name` instead of `id`.

## References

https://github.com/screwdriver-cd/screwdriver/issues/3211

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
