### PR TITLE
feat: Make abort event button configurable

### DIFF
--- a/app/components/pipeline/event/card/template.hbs
+++ b/app/components/pipeline/event/card/template.hbs
@@ -23,25 +23,27 @@
       </a>
     </div>
     {{#if (eq this.status "RUNNING")}}
-      <BsButton
-        class="abort-event-button"
-        @type="danger"
-        @outline={{true}}
-        @onClick={{fn this.openAbortBuildModal}}
-        title="Abort event"
-      >
-        <FaIcon
-          @icon="stop-circle"
-          @fixedWidth="true"
-          @prefix="far"
-        />
-        {{#if this.showAbortBuildModal}}
-          <Pipeline::Modal::StopBuild
-            @eventId={{@event.id}}
-            @closeModal={{this.closeAbortBuildModal}}
+      {{#if @showAbort}}
+        <BsButton
+          class="abort-event-button"
+          @type="danger"
+          @outline={{true}}
+          @onClick={{fn this.openAbortBuildModal}}
+          title="Abort event"
+        >
+          <FaIcon
+            @icon="stop-circle"
+            @fixedWidth="true"
+            @prefix="far"
           />
-        {{/if}}
-      </BsButton>
+          {{#if this.showAbortBuildModal}}
+            <Pipeline::Modal::StopBuild
+              @eventId={{@event.id}}
+              @closeModal={{this.closeAbortBuildModal}}
+            />
+          {{/if}}
+        </BsButton>
+      {{/if}}
     {{/if}}
   </div>
 

--- a/tests/integration/components/pipeline/event/card/component-test.js
+++ b/tests/integration/components/pipeline/event/card/component-test.js
@@ -278,6 +278,7 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
         @event={{this.event}}
         @pipeline={{this.pipeline}}
         @userSettings={{this.userSettings}}
+        @showAbort={{true}}
       />`
     );
 


### PR DESCRIPTION
## Context
The event card for a running event has a button to abort the event.  With the event card being used in multiple different locations within the UI, the abort event button should be configurable to which instances actually allow the abort event action to be performed.

## Objective
Make the abort event button configurable.  By default the button is not displayed, so UI components that allow the action need to explicitly set the argument.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
