### PR TITLE
Feat: Glimmer component for events rail

### DIFF
--- a/app/components/pipeline/workflow/event-rail/component.js
+++ b/app/components/pipeline/workflow/event-rail/component.js
@@ -1,0 +1,124 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+
+const EVENT_BATCH_SIZE = 10;
+
+export default class PipelineWorkflowEventRailComponent extends Component {
+  @service shuttle;
+
+  @service router;
+
+  @service workflowDataReload;
+
+  @tracked showSearchEventModal = false;
+
+  @tracked showStartEventModal = false;
+
+  @tracked events;
+
+  @tracked firstItemId;
+
+  eventType;
+
+  oldestCommitEventId = null;
+
+  constructor() {
+    super(...arguments);
+
+    this.eventType = this.router.currentRouteName.includes('events')
+      ? 'pipeline'
+      : 'pr';
+
+    const { event } = this.args;
+
+    if (event) {
+      this.firstItemId = event.id;
+      this.events = [event];
+    }
+  }
+
+  @action
+  update(element, [event, reloadEvents]) {
+    if (reloadEvents) {
+      this.firstItemId = event.id;
+      this.events = [event];
+    }
+  }
+
+  async fetchEvents(eventId, direction) {
+    const sort = direction === 'gt' ? 'ascending' : 'descending';
+
+    return this.shuttle
+      .fetchFromApi(
+        'get',
+        `/pipelines/${this.args.pipeline.id}/events?count=${EVENT_BATCH_SIZE}&type=${this.eventType}&id=${direction}:${eventId}&sort=${sort}`
+      )
+      .then(events => {
+        return events;
+      });
+  }
+
+  @action
+  async fetchNewerEvents(event) {
+    return this.fetchEvents(event.id, 'gt').then(events => {
+      return events.reverse();
+    });
+  }
+
+  @action
+  async fetchOlderEvents(event) {
+    if (event.id === this.oldestCommitEventId) {
+      return [];
+    }
+
+    return this.fetchEvents(event.id, 'lt').then(events => {
+      if (events.length < EVENT_BATCH_SIZE) {
+        if (events.length === 0) {
+          this.oldestCommitEventId = event.id;
+        } else {
+          this.oldestCommitEventId = events[events.length - 1].id;
+        }
+      }
+
+      return events;
+    });
+  }
+
+  @action addNewerEvents(event) {
+    this.fetchNewerEvents(event).then(newerEvents => {
+      if (newerEvents.length > 0) {
+        this.events = newerEvents.concat(this.events);
+      }
+    });
+  }
+
+  @action addOlderEvents(event) {
+    this.fetchOlderEvents(event).then(olderEvents => {
+      if (olderEvents.length > 0) {
+        this.events = this.events.concat(olderEvents);
+      }
+    });
+  }
+
+  @action
+  openSearchEventModal() {
+    this.showSearchEventModal = true;
+  }
+
+  @action
+  closeSearchEventModal() {
+    this.showSearchEventModal = false;
+  }
+
+  @action
+  openStartEventModal() {
+    this.showStartEventModal = true;
+  }
+
+  @action
+  closeStartEventModal() {
+    this.showStartEventModal = false;
+  }
+}

--- a/app/components/pipeline/workflow/event-rail/styles.scss
+++ b/app/components/pipeline/workflow/event-rail/styles.scss
@@ -1,0 +1,38 @@
+@use 'screwdriver-colors' as colors;
+@use 'screwdriver-button' as button;
+
+@mixin styles {
+  #event-rail {
+    @include button.styles;
+
+    height: 100%;
+    border-top: 1px solid rgba(colors.$sd-text-med, 0.5);
+    border-right: 1px solid rgba(colors.$sd-text-med, 0.5);
+
+    $rail-actions-height: 4rem;
+
+    #event-rail-actions {
+      height: $rail-actions-height;
+      display: flex;
+      padding: 0.5rem 1rem 1rem;
+      gap: 1rem;
+
+      #search-for-event-button {
+        display: flex;
+
+        svg {
+          margin: auto;
+        }
+      }
+
+      #start-event-button {
+        margin-left: auto;
+      }
+    }
+
+    #event-cards-container {
+      height: calc(100% - $rail-actions-height);
+      overflow: scroll;
+    }
+  }
+}

--- a/app/components/pipeline/workflow/event-rail/template.hbs
+++ b/app/components/pipeline/workflow/event-rail/template.hbs
@@ -1,0 +1,61 @@
+<div
+  id="event-rail"
+  {{did-update this.update @event @reloadEvents}}
+>
+  <div id="event-rail-actions">
+    <BsButton
+      id="search-for-event-button"
+      @type="primary"
+      @outline={{true}}
+      @onClick={{this.openSearchEventModal}}
+      title="Search for an event by SHA"
+    >
+      <FaIcon @icon="search" />
+      {{#if this.showSearchEventModal}}
+        <Pipeline::Modal::SearchEvent
+          @pipeline={{@pipeline}}
+          @jobs={{@jobs}}
+          @userSettings={{@userSettings}}
+          @closeModal={{this.closeSearchEventModal}}
+        />
+      {{/if}}
+    </BsButton>
+    <BsButton
+      id="start-event-button"
+      @type="primary"
+      @outline={{true}}
+      @defaultText="Start a new event"
+      @onClick={{this.openStartEventModal}}
+      title="Start a new event"
+    />
+    {{#if this.showStartEventModal}}
+      <Pipeline::Modal::StartEvent
+        @pipeline={{@pipeline}}
+        @jobs={{@jobs}}
+        @closeModal={{this.closeStartEventModal}}
+      />
+    {{/if}}
+  </div>
+
+  <div id="event-cards-container">
+    <VerticalCollection
+      @items={{this.events}}
+      @estimateHeight={{150}}
+      @idForFirstItem={{this.firstItemId}}
+      @firstReached={{this.addNewerEvents}}
+      @lastReached={{this.addOlderEvents}}
+      as |event|
+    >
+      <Pipeline::Event::Card
+        @pipeline={{@pipeline}}
+        @event={{event}}
+        @jobs={{@jobs}}
+        @userSettings={{@userSettings}}
+        @queueName="eventRail"
+        @showAbort={{true}}
+        @showParameters={{true}}
+        @showEventGroup={{true}}
+      />
+    </VerticalCollection>
+  </div>
+</div>

--- a/tests/integration/components/pipeline/workflow/event/rail/component-test.js
+++ b/tests/integration/components/pipeline/workflow/event/rail/component-test.js
@@ -1,0 +1,28 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+
+module(
+  'Integration | Component | pipeline/workflow/event/rail',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test('it renders', async function (assert) {
+      const router = this.owner.lookup('service:router');
+
+      sinon.stub(router, 'currentRouteName').value('events');
+
+      await render(
+        hbs`<Pipeline::Workflow::EventRail
+        />`
+      );
+
+      assert.dom('#event-rail-actions').exists({ count: 1 });
+      assert.dom('#search-for-event-button').exists({ count: 1 });
+      assert.dom('#start-event-button').exists({ count: 1 });
+      assert.dom('#event-cards-container').exists({ count: 1 });
+    });
+  }
+);


### PR DESCRIPTION
## Context
Creating a new Glimmer component to house all of the events and provide buttons for event search and starting a new event.

## Objective
Creates a component for the event rail in the v2 UI

The screenshot below shows the first card being highlighted as the current event that has been selected and displayed on the UI.  Second card is a normal event card, while third event card shows the mouse over color.

![Screenshot 2024-10-31 at 10-14-45 New Pipeline Events](https://github.com/user-attachments/assets/2bb09e67-942a-49b2-bf00-4295fadf5883)

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
