### PR TITLE
fix: Workflow data updates

### DIFF
--- a/app/workflow-data-reload/service.js
+++ b/app/workflow-data-reload/service.js
@@ -11,6 +11,8 @@ export default class WorkflowDataReloadService extends Service {
 
   latestCommitResponse;
 
+  latestCommitCallback;
+
   buildsCache;
 
   callbacks;
@@ -56,6 +58,7 @@ export default class WorkflowDataReloadService extends Service {
       this.queueNames.clear();
       this.eventIdSet.clear();
       this.eventIdCounts.clear();
+      this.removeLatestCommitCallback();
     }
   }
 
@@ -64,7 +67,17 @@ export default class WorkflowDataReloadService extends Service {
       .fetchFromApi('get', `/pipelines/${this.pipelineId}/latestCommitEvent`)
       .then(latestCommitEvent => {
         this.latestCommitResponse = latestCommitEvent;
+
+        if (this.latestCommitCallback) {
+          this.latestCommitCallback(latestCommitEvent);
+        }
+
         this.fetchBuilds();
+      })
+      .catch(() => {
+        if (this.latestCommitCallback) {
+          this.latestCommitCallback(null);
+        }
       });
   }
 
@@ -137,5 +150,13 @@ export default class WorkflowDataReloadService extends Service {
         }
       }
     }
+  }
+
+  registerLatestCommitCallback(callback) {
+    this.latestCommitCallback = callback;
+  }
+
+  removeLatestCommitCallback() {
+    this.latestCommitCallback = null;
   }
 }

--- a/app/workflow-data-reload/service.js
+++ b/app/workflow-data-reload/service.js
@@ -109,6 +109,10 @@ export default class WorkflowDataReloadService extends Service {
     return this.latestCommitResponse?.id;
   }
 
+  getBuildsForEvent(eventId) {
+    return this.buildsCache.get(eventId);
+  }
+
   registerCallback(queueName, eventId, callback) {
     if (!this.callbacks.has(queueName)) {
       this.callbacks.set(queueName, new Map());

--- a/app/workflow-data-reload/service.js
+++ b/app/workflow-data-reload/service.js
@@ -132,7 +132,6 @@ export default class WorkflowDataReloadService extends Service {
         if (this.eventIdCounts.get(eventId) === 1) {
           this.eventIdCounts.delete(eventId);
           this.eventIdSet.delete(eventId);
-          this.buildsCache.delete(eventId);
         } else {
           this.eventIdCounts.set(eventId, this.eventIdCounts.get(eventId) - 1);
         }

--- a/app/workflow-data-reload/service.js
+++ b/app/workflow-data-reload/service.js
@@ -113,7 +113,7 @@ export default class WorkflowDataReloadService extends Service {
     }
 
     if (this.buildsCache.has(eventId)) {
-      callback(this.buildsCache.get(eventId));
+      callback(this.buildsCache.get(eventId), this.latestCommitResponse);
     } else {
       this.fetchBuildDataForEvent(eventId).then(() => {});
     }

--- a/tests/unit/workflow-data-reload/service-test.js
+++ b/tests/unit/workflow-data-reload/service-test.js
@@ -96,6 +96,41 @@ module('Unit | Service | workflowDataReload', function (hooks) {
     assert.equal(fakeCallback.calledWith(fakeBuilds, fakeLatestCommit), true);
   });
 
+  test('fetchData calls callback for latest commit event', async function (assert) {
+    const service = this.owner.lookup('service:workflow-data-reload');
+    const shuttle = this.owner.lookup('service:shuttle');
+    const fakeBuilds = [{ id: 999 }];
+    const fakeLatestCommit = { id: 987 };
+    const fakeCallback = sinon.spy();
+
+    service.registerLatestCommitCallback(fakeCallback);
+    sinon
+      .stub(shuttle, 'fetchFromApi')
+      .onFirstCall()
+      .resolves(fakeLatestCommit)
+      .onSecondCall()
+      .resolves(fakeBuilds);
+
+    await service.fetchData();
+
+    assert.equal(fakeCallback.calledOnce, true);
+    assert.equal(fakeCallback.calledWith(fakeLatestCommit), true);
+  });
+
+  test('fetchData calls callback when there is no latest commit event', async function (assert) {
+    const service = this.owner.lookup('service:workflow-data-reload');
+    const shuttle = this.owner.lookup('service:shuttle');
+    const fakeCallback = sinon.spy();
+
+    service.registerLatestCommitCallback(fakeCallback);
+    sinon.stub(shuttle, 'fetchFromApi').rejects();
+
+    await service.fetchData();
+
+    assert.equal(fakeCallback.calledOnce, true);
+    assert.equal(fakeCallback.calledWith(null), true);
+  });
+
   test('registerCallback creates a new queue and adds event', function (assert) {
     const service = this.owner.lookup('service:workflow-data-reload');
     const shuttle = this.owner.lookup('service:shuttle');

--- a/tests/unit/workflow-data-reload/service-test.js
+++ b/tests/unit/workflow-data-reload/service-test.js
@@ -151,12 +151,14 @@ module('Unit | Service | workflowDataReload', function (hooks) {
     const callback = sinon.spy();
     const eventId = 123;
     const fakeBuilds = [{ id: 999 }];
+    const fakeLatestCommit = { id: 987, sha: 'abc123' };
 
     service.buildsCache.set(eventId, fakeBuilds);
+    service.latestCommitResponse = fakeLatestCommit;
 
     service.registerCallback('test', eventId, callback);
     assert.equal(callback.calledOnce, true);
-    assert.equal(callback.calledWith(fakeBuilds), true);
+    assert.equal(callback.calledWith(fakeBuilds, fakeLatestCommit), true);
   });
 
   test('registerCallback fetches data if cached response does not exist', async function (assert) {
@@ -165,15 +167,18 @@ module('Unit | Service | workflowDataReload', function (hooks) {
     const callback = sinon.spy();
     const eventId = 123;
     const fakeBuilds = [{ id: 999 }];
+    const fakeLatestCommit = { id: 987, sha: 'abc123' };
 
     const stubShuttle = sinon
       .stub(shuttle, 'fetchFromApi')
       .resolves(fakeBuilds);
 
+    service.latestCommitResponse = fakeLatestCommit;
+
     await service.registerCallback('test', eventId, callback);
     assert.equal(stubShuttle.calledOnce, true);
     assert.equal(callback.calledOnce, true);
-    assert.equal(callback.calledWith(fakeBuilds), true);
+    assert.equal(callback.calledWith(fakeBuilds, fakeLatestCommit), true);
   });
 
   test('removeCallback removes event from queue', function (assert) {

--- a/tests/unit/workflow-data-reload/service-test.js
+++ b/tests/unit/workflow-data-reload/service-test.js
@@ -282,7 +282,7 @@ module('Unit | Service | workflowDataReload', function (hooks) {
     assert.equal(service.eventIdCounts.get(987), 2);
   });
 
-  test('removeCallback removes builds cache value correctly', function (assert) {
+  test('removeCallback does not remove builds cache value', function (assert) {
     const service = this.owner.lookup('service:workflow-data-reload');
     const shuttle = this.owner.lookup('service:shuttle');
     const queueName = 'test';
@@ -298,6 +298,6 @@ module('Unit | Service | workflowDataReload', function (hooks) {
     assert.equal(service.queueNames.size, 0);
     assert.equal(service.eventIdSet.size, 0);
     assert.equal(service.eventIdCounts.size, 0);
-    assert.equal(service.buildsCache.size, 0);
+    assert.equal(service.buildsCache.size, 1);
   });
 });


### PR DESCRIPTION
## Context
The workflow data service can use some updates to better support the new UI.

## Objective
1. Fixes the event callback to always return the latest commit event as well (https://github.com/screwdriver-cd/ui/commit/dbf93fc814ee747d000054fcb08e2944d87b91bf)
2. Removes the builds cache clearing when the last callback for an event is removed.  This seems a bit counter-intuitive, but the event callback is only required when an event has not completed.  When an event is completed, the fetched builds should remain in the cache as the UI allows navigation between events and those events may have their build fetched already. (https://github.com/screwdriver-cd/ui/commit/b3419d1c5fbf021c03600f79776c68e5f7d14fbc)
3. Add a callback registration for `latest commit event`.  This is needed because a pipeline may not have created any events.  This callback allows the UI to continually monitor for the first pipeline event (https://github.com/screwdriver-cd/ui/commit/c5a49ea411c8b9f6ab8ee42654c093b555f728f1)
4. Due to point 2, exposing a getter for the cached builds of an event is required (https://github.com/screwdriver-cd/ui/commit/93785d6299269b45684327575a3cc7ae675ca798)

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
