### PR TITLE
fix(3227): Show download button when the flag is false

### DIFF
--- a/app/components/artifact-preview/template.hbs
+++ b/app/components/artifact-preview/template.hbs
@@ -19,6 +19,15 @@
         Download
       </BsButton>
     {{/if}}
+  {{else}}
+    <BsButton
+      @type="primary"
+      @icon="glyphicon glyphicon-download"
+      @onClick={{action "download"}}
+      title="Download current artifact"
+    >
+      Download
+    </BsButton>
   {{/if}}
   {{#if this.iframeUrl}}
     <iframe id={{this.iframeId}} src={{this.iframeUrl}}>

--- a/tests/integration/components/artifact-preview/component-test.js
+++ b/tests/integration/components/artifact-preview/component-test.js
@@ -17,4 +17,18 @@ module('Integration | Component | artifact-preview', function (hooks) {
         'Alternative content for browsers which do not support iframe'
       );
   });
+
+  test('it renders download all button if DOWNLOAD_ARTIFACT_DIR is true', async function (assert) {
+    this.set('allowDownloadDir', true);
+
+    await render(hbs`<ArtifactPreview @selectedArtifact="/"/>`);
+    assert.dom('button').includesText('Download All');
+  });
+
+  test('it renders download button if DOWNLOAD_ARTIFACT_DIR is false', async function (assert) {
+    this.set('allowDownloadDir', false);
+
+    await render(hbs`<ArtifactPreview @selectedArtifact="/"/>`);
+    assert.dom('button').includesText('Download');
+  });
 });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
#1206 has a minor bug with the if-else conditions in the template which causes the download button to go missing when feature flag is false.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Fixes the missing download button when feature flag is false.


## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/3227

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
