### PR TITLE
feat: Add navigation to event card

### DIFF
--- a/app/components/pipeline/event/card/component.js
+++ b/app/components/pipeline/event/card/component.js
@@ -148,6 +148,17 @@ export default class PipelineEventCardComponent extends Component {
     }
   }
 
+  @action
+  goToEvent() {
+    const { event } = this;
+
+    this.router.transitionTo('v2.pipeline.events.show', {
+      event,
+      reloadEventRail: this.queueName !== 'eventRail',
+      id: event.id
+    });
+  }
+
   get isHighlighted() {
     return this.router.currentURL.endsWith(this.event.id);
   }

--- a/app/components/pipeline/event/card/template.hbs
+++ b/app/components/pipeline/event/card/template.hbs
@@ -3,6 +3,7 @@
   title={{this.title}}
   {{did-insert this.initialize}}
   {{did-update this.update @event}}
+  {{on "click" this.goToEvent}}
 >
   <div class="event-card-title">
     <div class="event-status {{this.status}}">


### PR DESCRIPTION
## Context
Event cards need to allow users to click on them and the UI updated to display the details of that event.

## Objective
Add ability to navigate to different events of the pipeline by clicking on an event card.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
