### PR TITLE
fix: Update hover style for disabled buttons

### DIFF
--- a/app/styles/screwdriver-button.scss
+++ b/app/styles/screwdriver-button.scss
@@ -6,7 +6,7 @@
     background-color: colors.$sd-running;
     border-color: colors.$sd-running;
 
-    &:hover {
+    &:hover:not(:disabled) {
       background-color: rgba(colors.$sd-running, 0.75);
       border-color: transparent;
     }
@@ -16,7 +16,7 @@
     color: colors.$sd-running;
     border-color: colors.$sd-running;
 
-    &:hover {
+    &:hover:not(:disabled) {
       background-color: rgba(colors.$sd-running, 0.1);
     }
   }
@@ -26,7 +26,7 @@
     background-color: colors.$sd-warn-bg;
     border-color: colors.$sd-warn-bg;
 
-    &:hover {
+    &:hover:not(:disabled) {
       background-color: rgba(colors.$sd-warn-bg, 0.75);
       border-color: transparent;
     }
@@ -36,7 +36,7 @@
     color: colors.$sd-warn-bg;
     border-color: colors.$sd-warn-bg;
 
-    &:hover {
+    &:hover:not(:disabled) {
       background-color: rgba(colors.$sd-warn-bg, 0.1);
     }
   }


### PR DESCRIPTION
## Context
Hover states for the buttons that always present.  The disabled button state uses a lighter color and the hover state may be confusing as a result

## Objective
Remove the hover state from buttons that are disabled.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
