### PR TITLE
feat: Disable search when no events are available

### DIFF
--- a/app/components/pipeline/workflow/event-rail/component.js
+++ b/app/components/pipeline/workflow/event-rail/component.js
@@ -102,6 +102,10 @@ export default class PipelineWorkflowEventRailComponent extends Component {
     });
   }
 
+  get isSearchDisabled() {
+    return !this.events;
+  }
+
   @action
   openSearchEventModal() {
     this.showSearchEventModal = true;

--- a/app/components/pipeline/workflow/event-rail/template.hbs
+++ b/app/components/pipeline/workflow/event-rail/template.hbs
@@ -8,6 +8,7 @@
       @type="primary"
       @outline={{true}}
       @onClick={{this.openSearchEventModal}}
+      disabled={{this.isSearchDisabled}}
       title="Search for an event by SHA"
     >
       <FaIcon @icon="search" />

--- a/tests/integration/components/pipeline/workflow/event/rail/component-test.js
+++ b/tests/integration/components/pipeline/workflow/event/rail/component-test.js
@@ -14,13 +14,11 @@ module(
 
       sinon.stub(router, 'currentRouteName').value('events');
 
-      await render(
-        hbs`<Pipeline::Workflow::EventRail
-        />`
-      );
+      await render(hbs`<Pipeline::Workflow::EventRail/>`);
 
       assert.dom('#event-rail-actions').exists({ count: 1 });
       assert.dom('#search-for-event-button').exists({ count: 1 });
+      assert.dom('#search-for-event-button').isDisabled();
       assert.dom('#start-event-button').exists({ count: 1 });
       assert.dom('#event-cards-container').exists({ count: 1 });
     });


### PR DESCRIPTION
## Context
When there are no events to display in the event rail, the search button can be disabled.

## Objective
Disable search button when there are no events in the event rail.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
