### PR TITLE
fix: bug where pipeline id gets cleared

### DIFF
--- a/app/workflow-data-reload/service.js
+++ b/app/workflow-data-reload/service.js
@@ -35,9 +35,8 @@ export default class WorkflowDataReloadService extends Service {
   }
 
   start(pipelineId) {
-    this.pipelineId = pipelineId;
-
     this.stop();
+    this.pipelineId = pipelineId;
     this.fetchData().then(() => {});
 
     this.intervalId = setInterval(


### PR DESCRIPTION
## Context
Before starting the data reloader for a given pipeline, the stop method is called to clear any stored state.  Part of the information cleared in the stop method is the pipeline id.

## Objective
Set the pipeline id after `stop` returns

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
