### PR TITLE
feat: Glimmer component for pipeline workflow

### DIFF
--- a/app/components/pipeline/workflow/component.js
+++ b/app/components/pipeline/workflow/component.js
@@ -1,0 +1,193 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import { isComplete, isSkipped } from 'screwdriver-ui/utils/pipeline/event';
+import { getDisplayJobNameLength, getWorkflowGraph } from './util';
+
+const BUILD_QUEUE_NAME = 'graph';
+
+export default class PipelineWorkflowComponent extends Component {
+  @service router;
+
+  @service shuttle;
+
+  @service workflowDataReload;
+
+  @tracked showDownstreamTriggers = false;
+
+  @tracked showTooltip = false;
+
+  @tracked showStageTooltip = false;
+
+  @tracked d3Data = null;
+
+  pipeline;
+
+  userSettings;
+
+  @tracked event;
+
+  @tracked selectedEvent;
+
+  @tracked latestCommitEvent;
+
+  @tracked builds;
+
+  @tracked jobs;
+
+  @tracked stages;
+
+  @tracked triggers;
+
+  @tracked workflowGraphToDisplay;
+
+  workflowGraph;
+
+  workflowGraphWithDownstreamTriggers;
+
+  constructor() {
+    super(...arguments);
+
+    const { pipeline } = this.args;
+
+    this.pipeline = pipeline;
+    this.userSettings = this.args.userSettings;
+
+    if (this.args.noEvents) {
+      this.workflowDataReload.registerLatestCommitCallback(
+        latestCommitEvent => {
+          if (latestCommitEvent) {
+            this.workflowDataReload.removeLatestCommitCallback();
+
+            const pipelineId = pipeline.id;
+
+            Promise.all([
+              this.shuttle.fetchFromApi('get', `/pipelines/${pipelineId}/jobs`),
+              this.shuttle.fetchFromApi(
+                'get',
+                `/pipelines/${pipelineId}/stages`
+              ),
+              this.shuttle.fetchFromApi(
+                'get',
+                `/pipelines/${pipelineId}/triggers`
+              )
+            ]).then(([jobs, stages, triggers]) => {
+              this.router.replaceWith('v2.pipeline.events.show', {
+                ...this.args,
+                noEvents: false,
+                event: latestCommitEvent,
+                jobs,
+                stages,
+                triggers,
+                id: latestCommitEvent.id
+              });
+            });
+          }
+        }
+      );
+    } else {
+      this.jobs = this.args.jobs;
+      this.stages = this.args.stages;
+      this.triggers = this.args.triggers;
+      this.latestCommitEvent = this.args.latestCommitEvent;
+
+      if (this.args.event) {
+        this.event = this.args.event;
+
+        this.workflowDataReload.registerCallback(
+          BUILD_QUEUE_NAME,
+          this.event.id,
+          this.buildsCallback
+        );
+        this.setWorkflowGraphFromEvent();
+      }
+    }
+
+    this.workflowDataReload.start(this.args.pipeline.id);
+  }
+
+  willDestroy() {
+    super.willDestroy();
+
+    this.workflowDataReload.stop();
+  }
+
+  @action
+  update(element, [event]) {
+    const builds = this.workflowDataReload.getBuildsForEvent(event.id);
+
+    this.event = event;
+    this.builds = builds;
+
+    this.setWorkflowGraphFromEvent();
+  }
+
+  @action
+  setWorkflowGraphFromEvent() {
+    const { workflowGraph } = this.event;
+
+    this.workflowGraph = getWorkflowGraph(workflowGraph, null);
+    this.workflowGraphWithDownstreamTriggers = getWorkflowGraph(
+      workflowGraph,
+      this.triggers
+    );
+    this.workflowGraphToDisplay = this.workflowGraph;
+  }
+
+  @action
+  buildsCallback(builds, latestCommitEvent) {
+    this.builds = builds;
+    this.latestCommitEvent = latestCommitEvent;
+
+    if (isSkipped(this.event, builds) || isComplete(builds)) {
+      this.workflowDataReload.removeCallback(BUILD_QUEUE_NAME, this.event.id);
+    }
+  }
+
+  get eventRailAnchor() {
+    return this.args.invalidEvent ? this.latestCommitEvent : this.event;
+  }
+
+  get displayJobNameLength() {
+    return getDisplayJobNameLength(this.userSettings);
+  }
+
+  get disableDownstreamTriggers() {
+    return (
+      this.workflowGraph.nodes.length ===
+      this.workflowGraphWithDownstreamTriggers.nodes.length
+    );
+  }
+
+  @action
+  toggleShowDownstreamTriggers() {
+    this.showDownstreamTriggers = !this.showDownstreamTriggers;
+
+    this.workflowGraphToDisplay = this.showDownstreamTriggers
+      ? this.workflowGraphWithDownstreamTriggers
+      : this.workflowGraph;
+  }
+
+  @action
+  setShowTooltip(showTooltip, node, d3Event) {
+    this.showTooltip = showTooltip;
+
+    if (showTooltip) {
+      this.d3Data = { node, d3Event };
+    } else {
+      this.d3Data = null;
+    }
+  }
+
+  @action
+  setShowStageTooltip(showStageTooltip, stage, d3Event) {
+    this.showStageTooltip = showStageTooltip;
+
+    if (showStageTooltip) {
+      this.d3Data = { stage, d3Event };
+    } else {
+      this.d3Data = null;
+    }
+  }
+}

--- a/app/components/pipeline/workflow/styles.scss
+++ b/app/components/pipeline/workflow/styles.scss
@@ -1,7 +1,77 @@
+@use 'variables';
+
+@use 'event-rail/styles' as event-rail;
 @use 'graph/styles' as graph;
 @use 'tooltip/styles' as tooltip;
 
 @mixin styles {
-  @include graph.styles;
-  @include tooltip.styles;
+  #pipeline-workflow-container {
+    display: grid;
+    $events-rail-width: 26rem;
+
+    grid-template-areas: 'events workflow';
+    grid-template-columns: $events-rail-width calc(100% - $events-rail-width);
+    grid-template-rows: 100%;
+
+    @include event-rail.styles;
+
+    #event-card-rail {
+      grid-area: events;
+    }
+
+    #workflow-graph-container {
+      grid-area: workflow;
+      $graph-controls-height: 2.5rem;
+
+      #workflow-graph-controls {
+        display: flex;
+        align-content: center;
+        padding-left: 1rem;
+        height: $graph-controls-height;
+
+        .button-container {
+          .x-toggle-component {
+            label {
+              margin-bottom: 0;
+
+              &.off-label {
+                padding-right: 0;
+              }
+
+              &.on-label {
+                padding-left: 0.85rem;
+              }
+            }
+          }
+        }
+      }
+
+      #graph-container {
+        position: relative;
+        height: calc(100% - $graph-controls-height);
+        overflow: auto;
+
+        #workflow-graph {
+          height: 100%;
+
+          svg {
+            min-width: 100%;
+            min-height: 100%;
+          }
+        }
+
+        @include graph.styles;
+        @include tooltip.styles;
+      }
+    }
+
+    #no-events,
+    #invalid-event {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      font-size: 2.5rem;
+      font-weight: variables.$weight-bold;
+    }
+  }
 }

--- a/app/components/pipeline/workflow/template.hbs
+++ b/app/components/pipeline/workflow/template.hbs
@@ -1,0 +1,84 @@
+<div
+  id="pipeline-workflow-container"
+  {{did-update this.update @event}}
+>
+  <Pipeline::Workflow::EventRail
+    @pipeline={{this.pipeline}}
+    @userSettings={{this.userSettings}}
+    @event={{this.eventRailAnchor}}
+    @jobs={{this.jobs}}
+    @reloadEvents={{@reloadEventRail}}
+  />
+
+  {{#if this.event}}
+    <div id="workflow-graph-container">
+      <div id="workflow-graph-controls">
+        <div
+          class="button-container"
+          title="Toggle to {{if this.showDownstreamTriggers "hide" "show"}} the downstream trigger nodes."
+        >
+          <XToggle
+            @size="medium"
+            @theme="material"
+            @showLabels={{true}}
+            @value={{this.showDownstreamTriggers}}
+            @offLabel="Hide triggers"
+            @onLabel="Show triggers"
+            @onToggle={{fn this.toggleShowDownstreamTriggers}}
+            @disabled={{this.disableDownstreamTriggers}}
+          />
+        </div>
+      </div>
+
+      <div id="graph-container">
+        <Pipeline::Workflow::Graph
+          @workflowGraph={{this.workflowGraphToDisplay}}
+          @event={{this.event}}
+          @jobs={{this.jobs}}
+          @builds={{this.builds}}
+          @stages={{this.stages}}
+          @chainPr={{this.pipeline.prChain}}
+          @displayJobNameLength={{this.displayJobNameLength}}
+          @setShowTooltip={{this.setShowTooltip}}
+          @displayStageTooltip={{true}}
+          @setShowStageTooltip={{this.setShowStageTooltip}}
+        />
+
+        {{#if this.showTooltip}}
+          <Pipeline::Workflow::Tooltip
+            @d3Data={{this.d3Data}}
+            @event={{this.event}}
+            @jobs={{this.jobs}}
+            @builds={{this.builds}}
+            @workflowGraph={{this.workflowGraphToDisplay}}
+            @pipeline={{this.pipeline}}
+            @latestCommitEvent={{this.latestCommitEvent}}
+          />
+        {{/if}}
+        {{#if this.showStageTooltip}}
+          <Pipeline::Workflow::Tooltip::Stage
+            @d3Data={{this.d3Data}}
+            @event={{this.event}}
+            @jobs={{this.jobs}}
+            @builds={{this.builds}}
+            @workflowGraph={{this.workflowGraphToDisplay}}
+            @pipeline={{this.pipeline}}
+            @latestCommitEvent={{this.latestCommitEvent}}
+          />
+        {{/if}}
+      </div>
+    </div>
+  {{/if}}
+
+  {{#if @noEvents}}
+    <div id="no-events">
+      This pipeline has no events yet
+    </div>
+  {{/if}}
+
+  {{#if @invalidEvent}}
+    <div id="invalid-event">
+      Event does not exist for this pipeline
+    </div>
+  {{/if}}
+</div>

--- a/tests/integration/components/pipeline/workflow/component-test.js
+++ b/tests/integration/components/pipeline/workflow/component-test.js
@@ -1,0 +1,136 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+
+module('Integration | Component | pipeline/workflow', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders for pipeline with no events', async function (assert) {
+    const router = this.owner.lookup('service:router');
+    const workflowDataReload = this.owner.lookup(
+      'service:workflow-data-reload'
+    );
+
+    sinon.stub(router, 'currentRouteName').value('events');
+    sinon.stub(workflowDataReload, 'start').callsFake(() => {});
+
+    this.setProperties({
+      pipeline: {},
+      userSettings: {}
+    });
+
+    await render(
+      hbs`<Pipeline::Workflow
+        @pipeline={{this.pipeline}}
+        @userSettings={{this.userSettings}}
+        @noEvents={{true}}
+      />`
+    );
+
+    assert.dom('#event-rail').exists({ count: 1 });
+    assert.dom('#workflow-graph-container').doesNotExist();
+    assert.dom('#no-events').exists({ count: 1 });
+    assert.dom('#invalid-event').doesNotExist();
+  });
+
+  test('it renders for pipeline with invalid event', async function (assert) {
+    const router = this.owner.lookup('service:router');
+    const shuttle = this.owner.lookup('service:shuttle');
+    const workflowDataReload = this.owner.lookup(
+      'service:workflow-data-reload'
+    );
+
+    sinon.stub(router, 'currentRouteName').value('events');
+    sinon.stub(router, 'currentURL').value('/v2/pipelines/1/events/11');
+    sinon.stub(shuttle, 'fetchFromApi').resolves([]);
+    sinon.stub(workflowDataReload, 'start').callsFake(() => {});
+
+    this.setProperties({
+      pipeline: {},
+      userSettings: {},
+      jobs: [],
+      stages: [],
+      triggers: [],
+      latestCommitEvent: {
+        id: 123,
+        sha: 'abc123def456',
+        commit: { author: { name: 'batman' }, message: 'Some amazing changes' },
+        creator: { name: 'batman' },
+        meta: {}
+      }
+    });
+
+    await render(
+      hbs`<Pipeline::Workflow
+        @pipeline={{this.pipeline}}
+        @userSettings={{this.userSettings}}
+        @jobs={{this.jobs}}
+        @stages={{this.stages}}
+        @triggers={{this.triggers}}
+        @latestCommitEvent={{this.latestCommitEvent}}
+        @invalidEvent={{true}}
+      />`
+    );
+
+    assert.dom('#event-rail').exists({ count: 1 });
+    assert.dom('#workflow-graph-container').doesNotExist();
+    assert.dom('#no-events').doesNotExist();
+    assert.dom('#invalid-event').exists({ count: 1 });
+  });
+
+  test('it renders for pipeline with event', async function (assert) {
+    const router = this.owner.lookup('service:router');
+    const shuttle = this.owner.lookup('service:shuttle');
+    const workflowDataReload = this.owner.lookup(
+      'service:workflow-data-reload'
+    );
+    const eventId = 123;
+
+    sinon.stub(router, 'currentRouteName').value('events');
+    sinon.stub(router, 'currentURL').value(`/v2/pipelines/1/events/${eventId}`);
+    sinon.stub(shuttle, 'fetchFromApi').resolves([]);
+    sinon.stub(workflowDataReload, 'registerCallback').callsFake(() => {});
+    sinon.stub(workflowDataReload, 'start').callsFake(() => {});
+
+    const event = {
+      id: eventId,
+      sha: 'abc123def456',
+      commit: { author: { name: 'batman' }, message: 'Some amazing changes' },
+      creator: { name: 'batman' },
+      meta: {},
+      workflowGraph: {
+        nodes: [{ name: '~commit' }, { name: 'main' }],
+        edges: [{ src: '~commit', dest: 'main' }]
+      }
+    };
+
+    this.setProperties({
+      pipeline: {},
+      userSettings: {},
+      jobs: [],
+      stages: [],
+      triggers: [],
+      latestCommitEvent: event,
+      event
+    });
+
+    await render(
+      hbs`<Pipeline::Workflow
+        @pipeline={{this.pipeline}}
+        @userSettings={{this.userSettings}}
+        @jobs={{this.jobs}}
+        @stages={{this.stages}}
+        @triggers={{this.triggers}}
+        @latestCommitEvent={{this.latestCommitEvent}}
+        @event={{this.event}}
+      />`
+    );
+
+    assert.dom('#event-rail').exists({ count: 1 });
+    assert.dom('#workflow-graph-container').exists({ count: 1 });
+    assert.dom('#no-events').doesNotExist();
+    assert.dom('#invalid-event').doesNotExist();
+  });
+});


### PR DESCRIPTION
## Context
Having a glimmer component for the pipeline UI allows for more dynamic updates of the page, as well the ability to update the component as different arguments change.

## Objective
Create a new component to handle the pipeline UI.  This component will provide better messaging to users with the state of the pipeline

**For a normal event:**
![Screenshot 2024-11-01 at 17-56-45 New Pipeline Events](https://github.com/user-attachments/assets/14faa5f1-8da5-4619-9cf4-b10870b86b6f)

**For pipelines with no events:**
![Screenshot 2024-11-01 at 17-58-00 New Pipeline Events](https://github.com/user-attachments/assets/56b0abfd-2365-41c6-b216-17f665eb67ea)

**For landing on an invalid event within the pipeline:**
![Screenshot 2024-11-01 at 17-57-21 New Pipeline Events](https://github.com/user-attachments/assets/ae47299e-0268-4d0e-a791-a403d1cfb691)


## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
