### PR TITLE
fix: Add border around event cards

### DIFF
--- a/app/components/pipeline/event/card/styles.scss
+++ b/app/components/pipeline/event/card/styles.scss
@@ -6,7 +6,10 @@
   .event-card {
     display: flex;
     flex-direction: column;
-    padding: 1rem;
+    margin: 1rem;
+    padding: 0.5rem;
+    border-radius: 3px;
+    border: 1px solid colors.$sd-light-gray;
     cursor: pointer;
 
     &:hover {
@@ -165,9 +168,9 @@
       &.btn {
         display: flex;
 
-         svg {
-           margin: auto;
-         }
+        svg {
+          margin: auto;
+        }
       }
     }
   }


### PR DESCRIPTION
## Context
Event cards could use some help with visual separation as noted in https://github.com/screwdriver-cd/ui/pull/1205
  
## Objective
Adds a card border to help visually separate cards when stacked in a list

![Screenshot 2024-11-01 at 18-14-49 New Pipeline Events](https://github.com/user-attachments/assets/4cd93f8d-ea2f-4ce4-9706-b5fd567a2dc6)


## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
