### PR TITLE
feat: Isolate data reloading on an API level

### DIFF
--- a/app/workflow-data-reload/buildsDataReloader.js
+++ b/app/workflow-data-reload/buildsDataReloader.js
@@ -1,0 +1,20 @@
+import { setBuildStatus } from 'screwdriver-ui/utils/pipeline/build';
+import DataReloader from './dataReloader';
+
+export default class BuildsDataReloader extends DataReloader {
+  async fetchDataForId(eventId) {
+    return this.shuttle
+      .fetchFromApi('get', `/events/${eventId}/builds?fetchSteps=false`)
+      .then(builds => {
+        builds.forEach(build => {
+          setBuildStatus(build);
+        });
+
+        return builds;
+      });
+  }
+
+  getBuildsForEvent(eventId) {
+    return this.responseCache.get(eventId);
+  }
+}

--- a/app/workflow-data-reload/dataReloader.js
+++ b/app/workflow-data-reload/dataReloader.js
@@ -1,0 +1,121 @@
+import ENV from 'screwdriver-ui/config/environment';
+
+export default class DataReloader {
+  shuttle;
+
+  intervalId;
+
+  responseCache;
+
+  cacheKey;
+
+  callbacks;
+
+  queueNames;
+
+  idSet;
+
+  idCounts;
+
+  constructor(shuttle, cacheKey = null) {
+    this.shuttle = shuttle;
+    this.cacheKey = cacheKey;
+    this.responseCache = new Map();
+    this.callbacks = new Map();
+    this.queueNames = new Set();
+    this.idSet = new Set();
+    this.idCounts = new Map();
+  }
+
+  start() {
+    this.stop();
+
+    this.fetchData().then(() => {});
+
+    this.intervalId = setInterval(
+      () => this.fetchData().then(() => {}),
+      ENV.APP.BUILD_RELOAD_TIMER
+    );
+  }
+
+  stop() {
+    if (this.intervalId) {
+      clearInterval(this.intervalId);
+      this.intervalId = null;
+
+      this.cacheKey = null;
+      this.responseCache.clear();
+      this.callbacks.clear();
+      this.queueNames.clear();
+      this.idSet.clear();
+      this.idCounts.clear();
+    }
+  }
+
+  async fetchData() {
+    this.idSet.forEach(id => {
+      this.fetchDataForId(id).then(response => {
+        const key = this.cacheKey || id;
+
+        this.responseCache.set(key, response);
+
+        this.queueNames.forEach(queueName => {
+          if (this.callbacks.get(queueName).has(id)) {
+            this.callbacks.get(queueName).get(id)(response);
+          }
+        });
+      });
+    });
+  }
+
+  // eslint-disable-next-line no-empty-function, no-unused-vars
+  async fetchDataForId(id) {}
+
+  registerCallback(queueName, id, callback) {
+    if (!this.callbacks.has(queueName)) {
+      this.callbacks.set(queueName, new Map());
+      this.queueNames.add(queueName);
+    }
+
+    this.callbacks.get(queueName).set(id, callback);
+
+    this.idSet.add(id);
+
+    if (this.idCounts.has(id)) {
+      this.idCounts.set(id, this.idCounts.get(id) + 1);
+    } else {
+      this.idCounts.set(id, 1);
+    }
+
+    const key = this.cacheKey || id;
+
+    if (this.responseCache.has(key)) {
+      callback(this.responseCache.get(key));
+    } else {
+      this.fetchDataForId(id).then(response => {
+        this.responseCache.set(key, response);
+        callback(response);
+      });
+    }
+  }
+
+  removeCallback(queueName, id) {
+    if (this.callbacks.has(queueName)) {
+      const deleted = this.callbacks.get(queueName).delete(id);
+
+      if (deleted) {
+        if (this.callbacks.get(queueName).size === 0) {
+          this.callbacks.delete(queueName);
+          this.queueNames.delete(queueName);
+        }
+
+        if (this.idCounts.get(id) === 1) {
+          this.idCounts.delete(id);
+          this.idSet.delete(id);
+        } else {
+          this.idCounts.set(id, this.idCounts.get(id) - 1);
+        }
+      }
+    }
+  }
+}

--- a/app/workflow-data-reload/latestCommitEventReloader.js
+++ b/app/workflow-data-reload/latestCommitEventReloader.js
@@ -1,0 +1,20 @@
+import DataReloader from './dataReloader';
+
+export default class LatestCommitEventReloader extends DataReloader {
+  pipelineId;
+
+  setPipelineId(pipelineId) {
+    this.pipelineId = pipelineId;
+  }
+
+  async fetchDataForId() {
+    return this.shuttle
+      .fetchFromApi('get', `/pipelines/${this.pipelineId}/latestCommitEvent`)
+      .then(latestCommitEvent => {
+        return latestCommitEvent;
+      })
+      .catch(() => {
+        return null;
+      });
+  }
+}

--- a/tests/unit/workflow-data-reload/buildsDataReloader-test.js
+++ b/tests/unit/workflow-data-reload/buildsDataReloader-test.js
@@ -1,0 +1,45 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
+import BuildsDataReloader from 'screwdriver-ui/workflow-data-reload/buildsDataReloader';
+import sinon from 'sinon';
+
+module(
+  'Unit | Service | workflowDataReload | BuildsDataReloader',
+  function (hooks) {
+    setupTest(hooks);
+
+    test('fetchDataForId calls sets build status correctly', async function (assert) {
+      const shuttle = this.owner.lookup('service:shuttle');
+      const buildsDataReloader = new BuildsDataReloader(shuttle);
+
+      sinon.stub(shuttle, 'fetchFromApi').resolves([
+        {
+          id: 111,
+          status: 'SUCCESS'
+        },
+        {
+          id: 222,
+          status: 'SUCCESS',
+          meta: { build: { warning: { message: 'warning!' } } }
+        }
+      ]);
+
+      const builds = await buildsDataReloader.fetchDataForId(123);
+
+      assert.equal(builds.length, 2);
+      assert.equal(builds[0].status, 'SUCCESS');
+      assert.equal(builds[1].status, 'WARNING');
+    });
+
+    test('getBuildsForEvent returns correct value', async function (assert) {
+      const buildsDataReloader = new BuildsDataReloader(null);
+      const spyResponseCache = sinon.spy(new Map());
+
+      buildsDataReloader.responseCache = spyResponseCache;
+
+      buildsDataReloader.getBuildsForEvent(123);
+
+      assert.equal(spyResponseCache.get.calledOnce, true);
+    });
+  }
+);

--- a/tests/unit/workflow-data-reload/dataReloader-test.js
+++ b/tests/unit/workflow-data-reload/dataReloader-test.js
@@ -1,0 +1,294 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
+import DataReloader from 'screwdriver-ui/workflow-data-reload/dataReloader';
+import sinon from 'sinon';
+
+module('Unit | Service | workflowDataReload | DataReloader', function (hooks) {
+  setupTest(hooks);
+
+  test('fetchData calls callback with correct data', async function (assert) {
+    const dataReloader = new DataReloader(null);
+    const queueName = 'test';
+    const id = 123;
+    const fakeResponse = sinon.fake();
+    const fakeCallback = sinon.spy();
+
+    sinon.stub(dataReloader, 'fetchDataForId').resolves(fakeResponse);
+
+    dataReloader.queueNames.add(queueName);
+    dataReloader.callbacks.set(queueName, new Map());
+    dataReloader.callbacks.get(queueName).set(id, fakeCallback);
+    dataReloader.idSet.add(id);
+
+    await dataReloader.fetchData();
+
+    assert.equal(fakeCallback.calledOnce, true);
+    assert.equal(fakeCallback.calledWith(fakeResponse), true);
+  });
+
+  test('fetchData caches data correctly', async function (assert) {
+    const dataReloader = new DataReloader(null);
+    const id = 123;
+
+    sinon.stub(dataReloader, 'fetchDataForId').resolves(sinon.fake());
+
+    dataReloader.idSet.add(id);
+
+    await dataReloader.fetchData();
+
+    assert.equal(dataReloader.responseCache.size, 1);
+    assert.equal(dataReloader.responseCache.has(id), 1);
+  });
+
+  test('fetchData caches data correctly for single key cache', async function (assert) {
+    const cacheKey = 987;
+    const dataReloader = new DataReloader(null, cacheKey);
+    const id = 123;
+
+    sinon.stub(dataReloader, 'fetchDataForId').resolves(sinon.fake());
+
+    dataReloader.idSet.add(id);
+
+    await dataReloader.fetchData();
+
+    assert.equal(dataReloader.responseCache.size, 1);
+    assert.equal(dataReloader.responseCache.has(cacheKey), 1);
+  });
+
+  test('registerCallback creates a new queue and adds event', function (assert) {
+    const dataReloader = new DataReloader(null);
+    const queueName = 'test';
+    const id = 123;
+
+    dataReloader.registerCallback(queueName, id, () => {});
+
+    assert.equal(dataReloader.callbacks.has(queueName), true);
+    assert.equal(dataReloader.callbacks.get(queueName).size, 1);
+    assert.equal(dataReloader.queueNames.has(queueName), true);
+    assert.equal(dataReloader.idCounts.get(id), 1);
+    assert.equal(dataReloader.idSet.has(id), true);
+  });
+
+  test('registerCallback adds event to existing queue', function (assert) {
+    const dataReloader = new DataReloader(null);
+    const queueName = 'test';
+    const id1 = 123;
+    const id2 = 987;
+
+    dataReloader.registerCallback(queueName, id1, () => {});
+    dataReloader.registerCallback(queueName, id2, () => {});
+
+    assert.equal(dataReloader.callbacks.get(queueName).size, 2);
+    assert.equal(dataReloader.idCounts.get(id1), 1);
+    assert.equal(dataReloader.idCounts.get(id2), 1);
+    assert.equal(dataReloader.idSet.has(id1), true);
+    assert.equal(dataReloader.idSet.has(id2), true);
+  });
+
+  test('registerCallback increments event count', function (assert) {
+    const dataReloader = new DataReloader(null);
+    const queue1 = 'test';
+    const queue2 = 'abc';
+    const id1 = 123;
+    const id2 = 987;
+
+    dataReloader.registerCallback(queue1, id1, () => {});
+    dataReloader.registerCallback(queue2, id1, () => {});
+    dataReloader.registerCallback(queue2, id2, () => {});
+
+    assert.equal(dataReloader.callbacks.get(queue1).size, 1);
+    assert.equal(dataReloader.callbacks.get(queue2).size, 2);
+    assert.equal(dataReloader.idCounts.get(id1), 2);
+    assert.equal(dataReloader.idCounts.get(id2), 1);
+    assert.equal(dataReloader.idSet.has(id1), true);
+    assert.equal(dataReloader.idSet.has(id2), true);
+  });
+
+  test('registerCallback calls callback if response exists in cache', function (assert) {
+    const dataReloader = new DataReloader(null);
+    const callback = sinon.spy();
+    const id = 123;
+    const fakeResponse = sinon.fake();
+
+    dataReloader.responseCache.set(id, fakeResponse);
+
+    dataReloader.registerCallback('test', id, callback);
+    assert.equal(callback.calledOnce, true);
+    assert.equal(callback.calledWith(fakeResponse), true);
+  });
+
+  test('registerCallback calls callback if response exists in cache for single key cache', function (assert) {
+    const cacheKey = 987;
+    const dataReloader = new DataReloader(null, cacheKey);
+    const id = 123;
+    const callback = sinon.spy();
+    const fakeResponse = sinon.fake();
+
+    sinon.spy(dataReloader, 'fetchDataForId');
+    dataReloader.responseCache.set(cacheKey, fakeResponse);
+
+    dataReloader.registerCallback('test', id, callback);
+    assert.equal(callback.calledOnce, true);
+    assert.equal(callback.calledWith(fakeResponse), true);
+    assert.equal(dataReloader.fetchDataForId.notCalled, true);
+  });
+
+  test('registerCallback fetches data if cached response does not exist', async function (assert) {
+    const dataReloader = new DataReloader(null);
+    const id = 123;
+    const callback = sinon.spy();
+    const fakeResponse = sinon.fake();
+
+    const fetchDataForIdStub = sinon
+      .stub(dataReloader, 'fetchDataForId')
+      .resolves(fakeResponse);
+
+    await dataReloader.registerCallback('test', id, callback);
+    assert.equal(fetchDataForIdStub.calledOnce, true);
+    assert.equal(fetchDataForIdStub.calledWith(id), true);
+    assert.equal(callback.calledOnce, true);
+    assert.equal(callback.calledWith(fakeResponse), true);
+  });
+
+  test('registerCallback caches fetched data if cached response does not exist', async function (assert) {
+    const dataReloader = new DataReloader(null);
+    const id = 123;
+    const callback = sinon.spy();
+    const fakeResponse = sinon.fake();
+
+    const fetchDataForIdStub = sinon
+      .stub(dataReloader, 'fetchDataForId')
+      .resolves(fakeResponse);
+
+    await dataReloader.registerCallback('test', id, callback);
+    assert.equal(fetchDataForIdStub.calledOnce, true);
+    assert.equal(fetchDataForIdStub.calledWith(id), true);
+    assert.equal(callback.calledOnce, true);
+    assert.equal(callback.calledWith(fakeResponse), true);
+    assert.equal(dataReloader.responseCache.size, 1);
+    assert.equal(dataReloader.responseCache.has(id), true);
+  });
+
+  test('registerCallback caches fetched data if cached response does not exist for single key cache', async function (assert) {
+    const cacheKey = 987;
+    const dataReloader = new DataReloader(null, cacheKey);
+    const id = 123;
+    const callback = sinon.spy();
+    const fakeResponse = sinon.fake();
+
+    const fetchDataForIdStub = sinon
+      .stub(dataReloader, 'fetchDataForId')
+      .resolves(fakeResponse);
+
+    await dataReloader.registerCallback('test', id, callback);
+    assert.equal(fetchDataForIdStub.calledOnce, true);
+    assert.equal(fetchDataForIdStub.calledWith(id), true);
+    assert.equal(callback.calledOnce, true);
+    assert.equal(callback.calledWith(fakeResponse), true);
+    assert.equal(dataReloader.responseCache.size, 1);
+    assert.equal(dataReloader.responseCache.has(cacheKey), true);
+  });
+
+  test('removeCallback removes event from queue', function (assert) {
+    const dataReloader = new DataReloader(null);
+
+    dataReloader.registerCallback('test', 123, () => {});
+    dataReloader.registerCallback('test', 987, () => {});
+    dataReloader.registerCallback('abc', 987, () => {});
+
+    dataReloader.removeCallback('test', 987);
+    assert.equal(dataReloader.callbacks.get('test').size, 1);
+    assert.equal(dataReloader.callbacks.get('abc').size, 1);
+    assert.equal(dataReloader.callbacks.get('test').has(123), true);
+    assert.equal(dataReloader.callbacks.get('abc').has(987), true);
+    assert.equal(dataReloader.idSet.size, 2);
+    assert.equal(dataReloader.idCounts.size, 2);
+    assert.equal(dataReloader.idCounts.get(123), 1);
+    assert.equal(dataReloader.idCounts.get(987), 1);
+  });
+
+  test('removeCallback removes last event in queue correctly', function (assert) {
+    const dataReloader = new DataReloader(null);
+
+    dataReloader.registerCallback('test', 123, () => {});
+    dataReloader.registerCallback('test', 987, () => {});
+    dataReloader.registerCallback('abc', 987, () => {});
+
+    dataReloader.removeCallback('abc', 987);
+    assert.equal(dataReloader.callbacks.size, 1);
+    assert.equal(dataReloader.callbacks.get('test').size, 2);
+    assert.equal(dataReloader.callbacks.has('abc'), false);
+    assert.equal(dataReloader.queueNames.has('abc'), false);
+    assert.equal(dataReloader.idSet.size, 2);
+    assert.equal(dataReloader.idCounts.size, 2);
+    assert.equal(dataReloader.idCounts.get(123), 1);
+    assert.equal(dataReloader.idCounts.get(987), 1);
+  });
+
+  test('removeCallback removes last event correctly', function (assert) {
+    const dataReloader = new DataReloader(null);
+
+    dataReloader.registerCallback('test', 123, () => {});
+    dataReloader.registerCallback('test', 987, () => {});
+    dataReloader.registerCallback('abc', 987, () => {});
+
+    dataReloader.removeCallback('test', 123);
+    assert.equal(dataReloader.callbacks.size, 2);
+    assert.equal(dataReloader.callbacks.get('test').size, 1);
+    assert.equal(dataReloader.callbacks.has('abc'), true);
+    assert.equal(dataReloader.queueNames.size, 2);
+    assert.equal(dataReloader.idSet.size, 1);
+    assert.equal(dataReloader.idCounts.size, 1);
+  });
+
+  test('removeCallback removes event in non-existent queue correctly', function (assert) {
+    const dataReloader = new DataReloader(null);
+
+    dataReloader.registerCallback('test', 123, () => {});
+    dataReloader.registerCallback('test', 987, () => {});
+    dataReloader.registerCallback('abc', 987, () => {});
+
+    dataReloader.removeCallback('xyz', 123);
+    assert.equal(dataReloader.callbacks.size, 2);
+    assert.equal(dataReloader.callbacks.has('test'), true);
+    assert.equal(dataReloader.callbacks.has('abc'), true);
+    assert.equal(dataReloader.idSet.size, 2);
+    assert.equal(dataReloader.idCounts.size, 2);
+    assert.equal(dataReloader.idCounts.get(123), 1);
+    assert.equal(dataReloader.idCounts.get(987), 2);
+  });
+
+  test('removeCallback removes non-existent event in queue correctly', function (assert) {
+    const dataReloader = new DataReloader(null);
+
+    dataReloader.registerCallback('test', 123, () => {});
+    dataReloader.registerCallback('test', 987, () => {});
+    dataReloader.registerCallback('abc', 987, () => {});
+
+    dataReloader.removeCallback('abc', 123);
+    assert.equal(dataReloader.callbacks.size, 2);
+    assert.equal(dataReloader.callbacks.has('test'), true);
+    assert.equal(dataReloader.callbacks.has('abc'), true);
+    assert.equal(dataReloader.idSet.size, 2);
+    assert.equal(dataReloader.idCounts.size, 2);
+    assert.equal(dataReloader.idCounts.get(123), 1);
+    assert.equal(dataReloader.idCounts.get(987), 2);
+  });
+
+  test('removeCallback does not remove response cache value', function (assert) {
+    const dataReloader = new DataReloader(null);
+    const queueName = 'test';
+    const id = 123;
+    const fakeResponse = sinon.fake();
+
+    dataReloader.responseCache.set(id, fakeResponse);
+    dataReloader.registerCallback(queueName, id, () => {});
+
+    dataReloader.removeCallback(queueName, id);
+    assert.equal(dataReloader.callbacks.size, 0);
+    assert.equal(dataReloader.queueNames.size, 0);
+    assert.equal(dataReloader.idSet.size, 0);
+    assert.equal(dataReloader.idCounts.size, 0);
+    assert.equal(dataReloader.responseCache.size, 1);
+  });
+});

--- a/tests/unit/workflow-data-reload/latestCommitEventReloader-test.js
+++ b/tests/unit/workflow-data-reload/latestCommitEventReloader-test.js
@@ -1,0 +1,44 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
+import LatestCommitEventReloader from 'screwdriver-ui/workflow-data-reload/latestCommitEventReloader';
+import sinon from 'sinon';
+
+module(
+  'Unit | Service | workflowDataReload | BuildsDataReloader',
+  function (hooks) {
+    setupTest(hooks);
+
+    test('fetchDataForId returns response', async function (assert) {
+      const shuttle = this.owner.lookup('service:shuttle');
+      const pipelineId = 123;
+      const fakeResponse = sinon.fake();
+
+      const latestCommitEventReloader = new LatestCommitEventReloader(shuttle);
+
+      latestCommitEventReloader.setPipelineId(pipelineId);
+      sinon.stub(shuttle, 'fetchFromApi').resolves(fakeResponse);
+
+      const response = await latestCommitEventReloader.fetchDataForId(
+        pipelineId
+      );
+
+      assert.equal(response, fakeResponse);
+    });
+
+    test('fetchDataForId returns null when no commit event exists', async function (assert) {
+      const shuttle = this.owner.lookup('service:shuttle');
+      const pipelineId = 123;
+
+      const latestCommitEventReloader = new LatestCommitEventReloader(shuttle);
+
+      latestCommitEventReloader.setPipelineId(pipelineId);
+      sinon.stub(shuttle, 'fetchFromApi').rejects();
+
+      const response = await latestCommitEventReloader.fetchDataForId(
+        pipelineId
+      );
+
+      assert.equal(response, null);
+    });
+  }
+);


### PR DESCRIPTION
## Context
The workflow data reloading currently mixes both the latest commit event and builds together.  The latest commit event needs to be split off so that more components can receive updates from it.

## Objective
Split the existing API fetches for latest commit event and builds into separate classes for better isolation.  The workflow data reloading will be refactored to use the new classes here to help address and fix some issues around event cards not being able to properly update the latest commit SHA.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
