### PR TITLE
fix: Use route to resolve model for transition

### DIFF
--- a/app/components/pipeline/workflow/component.js
+++ b/app/components/pipeline/workflow/component.js
@@ -60,29 +60,12 @@ export default class PipelineWorkflowComponent extends Component {
           if (latestCommitEvent) {
             this.workflowDataReload.removeLatestCommitCallback();
 
-            const pipelineId = pipeline.id;
+            const transition = this.router.replaceWith(
+              'v2.pipeline.events.show',
+              latestCommitEvent.id
+            );
 
-            Promise.all([
-              this.shuttle.fetchFromApi('get', `/pipelines/${pipelineId}/jobs`),
-              this.shuttle.fetchFromApi(
-                'get',
-                `/pipelines/${pipelineId}/stages`
-              ),
-              this.shuttle.fetchFromApi(
-                'get',
-                `/pipelines/${pipelineId}/triggers`
-              )
-            ]).then(([jobs, stages, triggers]) => {
-              this.router.replaceWith('v2.pipeline.events.show', {
-                ...this.args,
-                noEvents: false,
-                event: latestCommitEvent,
-                jobs,
-                stages,
-                triggers,
-                id: latestCommitEvent.id
-              });
-            });
+            transition.data = { latestCommitEvent };
           }
         }
       );


### PR DESCRIPTION
## Context
When a pipeline has no events the pipeline page will monitor for a new commit event to occur on the pipeline.  When that event occurs, the page will update itself with the latest commit event's data.  The current implementation of this transition will update the displaying page's model, but is a bit more brittle as and changes in the model may now need to be made in two places.  By having the transition rely on the route to resolve the model, the page effectively does a hard reload which is less smooth than the existing implementation, but does become more resilient to changes to the model.

## Objective
Use the route to resolve the model for the route transition.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
