### PR TITLE
fix(3227): Allow DOWNLOAD_ARTIFACT_DIR to be set in environment variables

### DIFF
--- a/app/instance-initializers/supplementary-config.js
+++ b/app/instance-initializers/supplementary-config.js
@@ -69,6 +69,14 @@ export function initialize() {
   ) {
     ENV.APP.FEEDBACK_CONFIG = window.SUPPLEMENTARY_CONFIG.FEEDBACK_CONFIG;
   }
+  if (
+    window.SUPPLEMENTARY_CONFIG &&
+    window.SUPPLEMENTARY_CONFIG.DOWNLOAD_ARTIFACT_DIR
+  ) {
+    ENV.APP.DOWNLOAD_ARTIFACT_DIR = convertToBool(
+      window.SUPPLEMENTARY_CONFIG.DOWNLOAD_ARTIFACT_DIR
+    );
+  }
 }
 
 export default {

--- a/nginx.conf
+++ b/nginx.conf
@@ -40,6 +40,7 @@ env FEEDBACK_HOSTNAME;
 env FEEDBACK_SCRIPT;
 env FEEDBACK_CONFIG;
 env FEEDBACK_SCRIPT_CSP_POLICY;
+env DOWNLOAD_ARTIFACT_DIR;
 
 
 #error_log  logs/error.log;
@@ -169,7 +170,7 @@ http {
         # Dynamic configuration for the ember app
         location /assets/supplementary_config.js {
            content_by_lua_block {
-               ngx.say("window.SUPPLEMENTARY_CONFIG = { ROOT_URL: '", os.getenv("ROOT_URL") or "", "', SDAPI_HOSTNAME: '", os.getenv("ECOSYSTEM_API"), "', SDSTORE_HOSTNAME: '", os.getenv("ECOSYSTEM_STORE"), "', SDDOC_URL: '", (os.getenv("SDDOC_URL") or ""), "', SLACK_URL: '", (os.getenv("SLACK_URL") or ""), "', RELEASE_VERSION: '", os.getenv("RELEASE_VERSION") or "", "', SHOW_AVATAR: '", os.getenv("SHOW_AVATAR") or "", "', FEEDBACK_HOSTNAME: '", (os.getenv("FEEDBACK_HOSTNAME") or ""), "', FEEDBACK_SCRIPT: '", (os.getenv("FEEDBACK_SCRIPT") or ""), "', FEEDBACK_CONFIG: '", (os.getenv("FEEDBACK_CONFIG") or ""), "' };")
+               ngx.say("window.SUPPLEMENTARY_CONFIG = { ROOT_URL: '", os.getenv("ROOT_URL") or "", "', SDAPI_HOSTNAME: '", os.getenv("ECOSYSTEM_API"), "', SDSTORE_HOSTNAME: '", os.getenv("ECOSYSTEM_STORE"), "', SDDOC_URL: '", (os.getenv("SDDOC_URL") or ""), "', SLACK_URL: '", (os.getenv("SLACK_URL") or ""), "', RELEASE_VERSION: '", os.getenv("RELEASE_VERSION") or "", "', SHOW_AVATAR: '", os.getenv("SHOW_AVATAR") or "", "', FEEDBACK_HOSTNAME: '", (os.getenv("FEEDBACK_HOSTNAME") or ""), "', FEEDBACK_SCRIPT: '", (os.getenv("FEEDBACK_SCRIPT") or ""), "', FEEDBACK_CONFIG: '", (os.getenv("FEEDBACK_CONFIG") or ""), "', DOWNLOAD_ARTIFACT_DIR: '", (os.getenv("DOWNLOAD_ARTIFACT_DIR") or ""), "' };")
            }
         }
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Feature flags for bulk download of Artifacts were added in #1202 and #1203.

Fix so that feature flags can be overridden by environment variables.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/3227

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
