### PR TITLE
Getter for latest commit event from response cache

### DIFF
--- a/app/workflow-data-reload/latestCommitEventReloader.js
+++ b/app/workflow-data-reload/latestCommitEventReloader.js
@@ -1,7 +1,13 @@
 import DataReloader from './dataReloader';
 
+const CACHE_KEY = 'latestCommitEvent';
+
 export default class LatestCommitEventReloader extends DataReloader {
   pipelineId;
+
+  constructor(shuttle) {
+    super(shuttle, CACHE_KEY);
+  }
 
   setPipelineId(pipelineId) {
     this.pipelineId = pipelineId;
@@ -16,5 +22,9 @@ export default class LatestCommitEventReloader extends DataReloader {
       .catch(() => {
         return null;
       });
+  }
+
+  getLatestCommitEvent() {
+    return this.responseCache.get(CACHE_KEY);
   }
 }

--- a/app/workflow-data-reload/service.js
+++ b/app/workflow-data-reload/service.js
@@ -50,4 +50,8 @@ export default class WorkflowDataReloadService extends Service {
   removeLatestCommitEventCallback(queueName, id) {
     this.latestCommitEventReloader.removeCallback(queueName, id);
   }
+
+  getLatestCommitEvent() {
+    return this.latestCommitEventReloader.getLatestCommitEvent();
+  }
 }

--- a/tests/unit/workflow-data-reload/dataReloader-test.js
+++ b/tests/unit/workflow-data-reload/dataReloader-test.js
@@ -41,7 +41,7 @@ module('Unit | Service | workflowDataReload | DataReloader', function (hooks) {
   });
 
   test('fetchData caches data correctly for single key cache', async function (assert) {
-    const cacheKey = 987;
+    const cacheKey = 'cacheKey';
     const dataReloader = new DataReloader(null, cacheKey);
     const id = 123;
 
@@ -118,7 +118,7 @@ module('Unit | Service | workflowDataReload | DataReloader', function (hooks) {
   });
 
   test('registerCallback calls callback if response exists in cache for single key cache', function (assert) {
-    const cacheKey = 987;
+    const cacheKey = 'cacheKey';
     const dataReloader = new DataReloader(null, cacheKey);
     const id = 123;
     const callback = sinon.spy();
@@ -170,7 +170,7 @@ module('Unit | Service | workflowDataReload | DataReloader', function (hooks) {
   });
 
   test('registerCallback caches fetched data if cached response does not exist for single key cache', async function (assert) {
-    const cacheKey = 987;
+    const cacheKey = 'cacheKey';
     const dataReloader = new DataReloader(null, cacheKey);
     const id = 123;
     const callback = sinon.spy();

--- a/tests/unit/workflow-data-reload/latestCommitEventReloader-test.js
+++ b/tests/unit/workflow-data-reload/latestCommitEventReloader-test.js
@@ -40,5 +40,16 @@ module(
 
       assert.equal(response, null);
     });
+
+    test('getLatestCommitEvent returns correct value', async function (assert) {
+      const latestCommitEventReloader = new LatestCommitEventReloader(null);
+      const spyResponseCache = sinon.spy(new Map());
+
+      latestCommitEventReloader.responseCache = spyResponseCache;
+
+      latestCommitEventReloader.getLatestCommitEvent();
+
+      assert.equal(spyResponseCache.get.calledOnce, true);
+    });
   }
 );


### PR DESCRIPTION
## Context
The latest commit event should be available to be pulled from the cached response.

## Objective
Exposes a getter for the latest commit event that has been cached.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
