### PR TITLE
fix: Fix bug with fetching latest commit event

### DIFF
--- a/app/workflow-data-reload/dataReloader.js
+++ b/app/workflow-data-reload/dataReloader.js
@@ -79,7 +79,9 @@ export default class DataReloader {
 
     this.callbacks.get(queueName).set(id, callback);
 
-    this.idSet.add(id);
+    if (!this.cacheKey) {
+      this.idSet.add(id);
+    }
 
     if (this.idCounts.has(id)) {
       this.idCounts.set(id, this.idCounts.get(id) + 1);
@@ -111,7 +113,10 @@ export default class DataReloader {
 
         if (this.idCounts.get(id) === 1) {
           this.idCounts.delete(id);
-          this.idSet.delete(id);
+
+          if (!this.cacheKey) {
+            this.idSet.delete(id);
+          }
         } else {
           this.idCounts.set(id, this.idCounts.get(id) - 1);
         }

--- a/app/workflow-data-reload/latestCommitEventReloader.js
+++ b/app/workflow-data-reload/latestCommitEventReloader.js
@@ -11,6 +11,8 @@ export default class LatestCommitEventReloader extends DataReloader {
 
   setPipelineId(pipelineId) {
     this.pipelineId = pipelineId;
+    this.idSet.clear();
+    this.idSet.add(pipelineId);
   }
 
   async fetchDataForId() {

--- a/tests/unit/workflow-data-reload/latestCommitEventReloader-test.js
+++ b/tests/unit/workflow-data-reload/latestCommitEventReloader-test.js
@@ -41,6 +41,17 @@ module(
       assert.equal(response, null);
     });
 
+    test('setPipelineId sets pipelineId correctly', async function (assert) {
+      const latestCommitEventReloader = new LatestCommitEventReloader(null);
+      const pipelineId = 123;
+
+      latestCommitEventReloader.setPipelineId(pipelineId);
+
+      assert.equal(latestCommitEventReloader.pipelineId, pipelineId);
+      assert.equal(latestCommitEventReloader.idSet.size, 1);
+      assert.equal(latestCommitEventReloader.idSet.has(pipelineId), true);
+    });
+
     test('getLatestCommitEvent returns correct value', async function (assert) {
       const latestCommitEventReloader = new LatestCommitEventReloader(null);
       const spyResponseCache = sinon.spy(new Map());


### PR DESCRIPTION
## Context
There's a bug with the latest commit event refreshing both requiring a callback to be registered before making API calls and also making redundant API calls when only one is needed.

## Objective
Fix a bug with the latest commit event data refresh.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
