### PR TITLE
fix: Tooltips not closing when selecting new events

### DIFF
--- a/app/components/pipeline/workflow/component.js
+++ b/app/components/pipeline/workflow/component.js
@@ -108,6 +108,8 @@ export default class PipelineWorkflowComponent extends Component {
 
     this.event = event;
     this.builds = builds;
+    this.showTooltip = false;
+    this.showStageTooltip = false;
 
     this.setWorkflowGraphFromEvent();
   }


### PR DESCRIPTION
## Context
If the graph tooltips are open and a new event is selected from the event rail, the tooltips do not close.

## Objective
Automatically close the graph tooltips when a new event is selected in the event rail.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
