### PR TITLE
fix: Use cached value of latest commit event

### DIFF
--- a/app/components/pipeline/modal/confirm-action/component.js
+++ b/app/components/pipeline/modal/confirm-action/component.js
@@ -8,6 +8,8 @@ import { capitalizeFirstLetter, truncateMessage } from './util';
 export default class PipelineModalConfirmActionComponent extends Component {
   @service shuttle;
 
+  @service workflowDataReload;
+
   @service session;
 
   @tracked errorMessage = null;
@@ -22,6 +24,14 @@ export default class PipelineModalConfirmActionComponent extends Component {
 
   parameters;
 
+  latestCommitEvent;
+
+  constructor() {
+    super(...arguments);
+
+    this.latestCommitEvent = this.workflowDataReload.getLatestCommitEvent();
+  }
+
   get action() {
     return this.args.job.status ? 'restart' : 'start';
   }
@@ -31,7 +41,7 @@ export default class PipelineModalConfirmActionComponent extends Component {
   }
 
   get isLatestCommitEvent() {
-    return this.args.event.sha === this.args.latestCommitEvent.sha;
+    return this.args.event.sha === this.latestCommitEvent.sha;
   }
 
   get commitUrl() {

--- a/app/components/pipeline/workflow/template.hbs
+++ b/app/components/pipeline/workflow/template.hbs
@@ -52,7 +52,6 @@
             @builds={{this.builds}}
             @workflowGraph={{this.workflowGraphToDisplay}}
             @pipeline={{this.pipeline}}
-            @latestCommitEvent={{this.latestCommitEvent}}
           />
         {{/if}}
         {{#if this.showStageTooltip}}
@@ -63,7 +62,6 @@
             @builds={{this.builds}}
             @workflowGraph={{this.workflowGraphToDisplay}}
             @pipeline={{this.pipeline}}
-            @latestCommitEvent={{this.latestCommitEvent}}
           />
         {{/if}}
       </div>

--- a/app/components/pipeline/workflow/tooltip/stage/template.hbs
+++ b/app/components/pipeline/workflow/tooltip/stage/template.hbs
@@ -19,7 +19,6 @@
     @pipeline={{@pipeline}}
     @event={{@event}}
     @jobs={{@jobs}}
-    @latestCommitEvent={{@latestCommitEvent}}
     @job={{this.job}}
     @stage={{@d3Data.stage}}
     @closeModal={{this.closeConfirmActionModal}}

--- a/app/components/pipeline/workflow/tooltip/template.hbs
+++ b/app/components/pipeline/workflow/tooltip/template.hbs
@@ -134,7 +134,6 @@
     @pipeline={{@pipeline}}
     @event={{@event}}
     @jobs={{@jobs}}
-    @latestCommitEvent={{@latestCommitEvent}}
     @job={{this.tooltipData.job}}
     @closeModal={{this.closeConfirmActionModal}}
   />

--- a/tests/integration/components/pipeline/modal/confirm-action/component-test.js
+++ b/tests/integration/components/pipeline/modal/confirm-action/component-test.js
@@ -9,6 +9,16 @@ module(
   function (hooks) {
     setupRenderingTest(hooks);
 
+    hooks.beforeEach(function () {
+      const workflowDataReload = this.owner.lookup(
+        'service:workflow-data-reload'
+      );
+
+      sinon
+        .stub(workflowDataReload, 'getLatestCommitEvent')
+        .returns({ sha: 'deadbeef0123456789' });
+    });
+
     test('it renders start action', async function (assert) {
       this.setProperties({
         pipeline: { parameters: {} },
@@ -17,7 +27,6 @@ module(
           sha: 'deadbeef0123456789'
         },
         jobs: [],
-        latestCommitEvent: { sha: 'deadbeef0123456789' },
         job: { name: 'main' },
         closeModal: () => {}
       });
@@ -26,7 +35,6 @@ module(
             @pipeline={{this.pipeline}}
             @event={{this.event}}
             @jobs={{this.jobs}}
-            @latestCommitEvent={{this.latestCommitEvent}}
             @job={{this.job}}
             @closeModal={{this.closeModal}}
         />`
@@ -50,7 +58,6 @@ module(
           sha: 'deadbeef0123456789'
         },
         jobs: [],
-        latestCommitEvent: { sha: 'deadbeef0123456789' },
         job: { name: 'main', status: 'SUCCESS' },
         closeModal: () => {}
       });
@@ -59,7 +66,6 @@ module(
             @pipeline={{this.pipeline}}
             @event={{this.event}}
             @jobs={{this.jobs}}
-            @latestCommitEvent={{this.latestCommitEvent}}
             @job={{this.job}}
             @closeModal={{this.closeModal}}
         />`
@@ -76,7 +82,6 @@ module(
           sha: 'deadbeef0123456789'
         },
         jobs: [],
-        latestCommitEvent: { sha: 'deadbeef0123456789' },
         job: { name: 'main' },
         stage: { name: 'stage' },
         closeModal: () => {}
@@ -86,7 +91,6 @@ module(
             @pipeline={{this.pipeline}}
             @event={{this.event}}
             @jobs={{this.jobs}}
-            @latestCommitEvent={{this.latestCommitEvent}}
             @job={{this.job}}
             @stage={{this.stage}}
             @closeModal={{this.closeModal}}
@@ -106,7 +110,6 @@ module(
           sha: '0123456789deadbeef'
         },
         jobs: [],
-        latestCommitEvent: { sha: 'deadbeef0123456789' },
         job: { name: 'main' },
         closeModal: () => {}
       });
@@ -115,7 +118,6 @@ module(
             @pipeline={{this.pipeline}}
             @event={{this.event}}
             @jobs={{this.jobs}}
-            @latestCommitEvent={{this.latestCommitEvent}}
             @job={{this.job}}
             @closeModal={{this.closeModal}}
         />`
@@ -133,7 +135,6 @@ module(
           type: 'pr'
         },
         jobs: [],
-        latestCommitEvent: { sha: 'deadbeef0123456789' },
         job: { name: 'main' },
         closeModal: () => {}
       });
@@ -142,7 +143,6 @@ module(
             @pipeline={{this.pipeline}}
             @event={{this.event}}
             @jobs={{this.jobs}}
-            @latestCommitEvent={{this.latestCommitEvent}}
             @job={{this.job}}
             @closeModal={{this.closeModal}}
         />`
@@ -158,7 +158,6 @@ module(
           type: 'pr'
         },
         jobs: [],
-        latestCommitEvent: { sha: 'deadbeef0123456789' },
         job: { name: 'main' },
         closeModal: () => {}
       });
@@ -167,7 +166,6 @@ module(
             @pipeline={{this.pipeline}}
             @event={{this.event}}
             @jobs={{this.jobs}}
-            @latestCommitEvent={{this.latestCommitEvent}}
             @job={{this.job}}
             @closeModal={{this.closeModal}}
         />`
@@ -184,7 +182,6 @@ module(
           sha: 'deadbeef0123456789'
         },
         jobs: [],
-        latestCommitEvent: { sha: 'deadbeef0123456789' },
         job: { name: 'main', status: 'FROZEN' },
         closeModal: () => {}
       });
@@ -193,7 +190,6 @@ module(
             @pipeline={{this.pipeline}}
             @event={{this.event}}
             @jobs={{this.jobs}}
-            @latestCommitEvent={{this.latestCommitEvent}}
             @job={{this.job}}
             @closeModal={{this.closeModal}}
         />`
@@ -217,7 +213,6 @@ module(
           }
         },
         jobs: [],
-        latestCommitEvent: { sha: 'deadbeef0123456789' },
         job: { name: 'main' },
         closeModal: () => {}
       });
@@ -226,7 +221,6 @@ module(
             @pipeline={{this.pipeline}}
             @event={{this.event}}
             @jobs={{this.jobs}}
-            @latestCommitEvent={{this.latestCommitEvent}}
             @job={{this.job}}
             @closeModal={{this.closeModal}}
         />`
@@ -243,7 +237,6 @@ module(
           sha: 'deadbeef0123456789'
         },
         jobs: [],
-        latestCommitEvent: { sha: 'deadbeef0123456789' },
         job: { name: 'main', status: 'FROZEN' },
         closeModal: () => {}
       });
@@ -252,7 +245,6 @@ module(
             @pipeline={{this.pipeline}}
             @event={{this.event}}
             @jobs={{this.jobs}}
-            @latestCommitEvent={{this.latestCommitEvent}}
             @job={{this.job}}
             @closeModal={{this.closeModal}}
         />`
@@ -269,7 +261,6 @@ module(
           sha: 'deadbeef0123456789'
         },
         jobs: [],
-        latestCommitEvent: { sha: 'deadbeef0123456789' },
         job: { name: 'main', status: 'FROZEN' },
         closeModal: () => {}
       });
@@ -278,7 +269,6 @@ module(
             @pipeline={{this.pipeline}}
             @event={{this.event}}
             @jobs={{this.jobs}}
-            @latestCommitEvent={{this.latestCommitEvent}}
             @job={{this.job}}
             @closeModal={{this.closeModal}}
         />`
@@ -300,7 +290,6 @@ module(
           sha: 'deadbeef0123456789'
         },
         jobs: [],
-        latestCommitEvent: { sha: 'deadbeef0123456789' },
         job: { name: 'main' },
         closeModal: () => {}
       });
@@ -310,7 +299,6 @@ module(
             @pipeline={{this.pipeline}}
             @event={{this.event}}
             @jobs={{this.jobs}}
-            @latestCommitEvent={{this.latestCommitEvent}}
             @job={{this.job}}
             @closeModal={{this.closeModal}}
         />`
@@ -341,7 +329,6 @@ module(
           sha: 'deadbeef0123456789'
         },
         jobs: [],
-        latestCommitEvent: { sha: 'deadbeef0123456789' },
         job: { name: 'main' },
         closeModal: () => {}
       });
@@ -351,7 +338,6 @@ module(
             @pipeline={{this.pipeline}}
             @event={{this.event}}
             @jobs={{this.jobs}}
-            @latestCommitEvent={{this.latestCommitEvent}}
             @job={{this.job}}
             @closeModal={{this.closeModal}}
         />`


### PR DESCRIPTION
## Context
The latest commit event response is now cached in the data reload service.  The `Confirm Action` modal can inject the service and get the cached value of the latest commit event directly.

## Objective
Refactors the `Confirm Action` modal to use the cached latest commit event rather than having it passed in as a component argument.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
