### PR TITLE
Use latest event instead of latest commit event

### DIFF
--- a/app/components/pipeline/workflow/component.js
+++ b/app/components/pipeline/workflow/component.js
@@ -31,7 +31,7 @@ export default class PipelineWorkflowComponent extends Component {
 
   @tracked selectedEvent;
 
-  @tracked latestCommitEvent;
+  @tracked latestEvent;
 
   @tracked builds;
 
@@ -54,6 +54,7 @@ export default class PipelineWorkflowComponent extends Component {
 
     this.pipeline = pipeline;
     this.userSettings = this.args.userSettings;
+    this.latestEvent = this.args.latestEvent;
 
     this.workflowDataReload.start(this.args.pipeline.id);
 
@@ -73,7 +74,7 @@ export default class PipelineWorkflowComponent extends Component {
               latestCommitEvent.id
             );
 
-            transition.data = { latestCommitEvent };
+            transition.data = { latestEvent: latestCommitEvent };
           }
         }
       );
@@ -81,7 +82,6 @@ export default class PipelineWorkflowComponent extends Component {
       this.jobs = this.args.jobs;
       this.stages = this.args.stages;
       this.triggers = this.args.triggers;
-      this.latestCommitEvent = this.args.latestCommitEvent;
 
       if (this.args.event) {
         this.event = this.args.event;
@@ -127,9 +127,8 @@ export default class PipelineWorkflowComponent extends Component {
   }
 
   @action
-  buildsCallback(builds, latestCommitEvent) {
+  buildsCallback(builds) {
     this.builds = builds;
-    this.latestCommitEvent = latestCommitEvent;
 
     if (isSkipped(this.event, builds) || isComplete(builds)) {
       this.workflowDataReload.removeBuildsCallback(
@@ -140,7 +139,7 @@ export default class PipelineWorkflowComponent extends Component {
   }
 
   get eventRailAnchor() {
-    return this.args.invalidEvent ? this.latestCommitEvent : this.event;
+    return this.args.invalidEvent ? this.latestEvent : this.event;
   }
 
   get displayJobNameLength() {

--- a/app/v2/pipeline/events/index/route.js
+++ b/app/v2/pipeline/events/index/route.js
@@ -1,6 +1,5 @@
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
-import { NotFoundError } from 'ember-ajax/errors';
 
 export default class NewPipelineEventsIndexRoute extends Route {
   @service shuttle;
@@ -9,33 +8,26 @@ export default class NewPipelineEventsIndexRoute extends Route {
     const model = this.modelFor('v2.pipeline.events');
     const pipelineId = model.pipeline.id;
 
-    const latestCommitEvent = await this.shuttle
-      .fetchFromApi('get', `/pipelines/${pipelineId}/latestCommitEvent`)
-      .then(event => {
-        return event;
-      })
-      .catch(err => {
-        if (err instanceof NotFoundError) {
-          return null;
-        }
-
-        return undefined;
+    const latestEvent = await this.shuttle
+      .fetchFromApi('get', `/pipelines/${pipelineId}/events?count=1`)
+      .then(events => {
+        return events[0];
       });
 
-    return { ...model, latestCommitEvent };
+    return { ...model, latestEvent };
   }
 
   afterModel(model) {
-    const { latestCommitEvent } = model;
+    const { latestEvent } = model;
 
-    if (latestCommitEvent) {
+    if (latestEvent) {
       const transition = this.replaceWith(
         'v2.pipeline.events.show',
-        latestCommitEvent.id
+        latestEvent.id
       );
 
       transition.data = {
-        latestCommitEvent
+        latestEvent
       };
     }
   }

--- a/app/v2/pipeline/events/show/template.hbs
+++ b/app/v2/pipeline/events/show/template.hbs
@@ -5,7 +5,7 @@
   @jobs={{this.model.jobs}}
   @stages={{this.model.stages}}
   @triggers={{this.model.triggers}}
-  @latestCommitEvent={{this.model.latestCommitEvent}}
+  @latestEvent={{this.model.latestEvent}}
   @invalidEvent={{this.model.invalidEvent}}
   @reloadEventRail={{this.model.reloadEventRail}}
 />


### PR DESCRIPTION
## Context
The main events page should go to the latest event instead of the latest commit event.  Only for pipelines without any events will the latest commit event and the latest event be the same.  Additionally, when an invalid event has been entered, the events rail should anchor off of the latest event instead of the latest commit event.

## Objective
Refactor the V2 event routes to use the latest event instead of the latest commit event.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
