### PR TITLE
feat: Event rail monitors latest event

### DIFF
--- a/app/components/pipeline/workflow/event-rail/component.js
+++ b/app/components/pipeline/workflow/event-rail/component.js
@@ -20,7 +20,7 @@ export default class PipelineWorkflowEventRailComponent extends Component {
 
   eventType;
 
-  oldestCommitEventId = null;
+  oldestEvent = null;
 
   constructor() {
     super(...arguments);
@@ -67,16 +67,16 @@ export default class PipelineWorkflowEventRailComponent extends Component {
 
   @action
   async fetchOlderEvents(event) {
-    if (event.id === this.oldestCommitEventId) {
+    if (event.id === this.oldestEvent?.id) {
       return [];
     }
 
     return this.fetchEvents(event.id, 'lt').then(events => {
       if (events.length < EVENT_BATCH_SIZE) {
         if (events.length === 0) {
-          this.oldestCommitEventId = event.id;
+          this.oldestEvent = event;
         } else {
-          this.oldestCommitEventId = events[events.length - 1].id;
+          this.oldestEvent = events[events.length - 1];
         }
       }
 

--- a/app/components/pipeline/workflow/event-rail/component.js
+++ b/app/components/pipeline/workflow/event-rail/component.js
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
+import ENV from 'screwdriver-ui/config/environment';
 
 const EVENT_BATCH_SIZE = 10;
 
@@ -20,7 +21,11 @@ export default class PipelineWorkflowEventRailComponent extends Component {
 
   eventType;
 
+  newestEvent = null;
+
   oldestEvent = null;
+
+  intervalId = null;
 
   constructor() {
     super(...arguments);
@@ -33,7 +38,17 @@ export default class PipelineWorkflowEventRailComponent extends Component {
 
     if (event) {
       this.firstItemId = event.id;
+      this.newestEvent = event;
       this.events = [event];
+    }
+  }
+
+  willDestroy() {
+    super.willDestroy();
+
+    if (this.intervalId) {
+      clearInterval(this.intervalId);
+      this.intervalId = null;
     }
   }
 
@@ -88,6 +103,11 @@ export default class PipelineWorkflowEventRailComponent extends Component {
     this.fetchNewerEvents(event).then(newerEvents => {
       if (newerEvents.length > 0) {
         this.events = newerEvents.concat(this.events);
+        this.newestEvent = newerEvents[0];
+      } else if (!this.intervalId) {
+        this.intervalId = setInterval(() => {
+          this.addNewerEvents(this.newestEvent);
+        }, ENV.APP.BUILD_RELOAD_TIMER);
       }
     });
   }


### PR DESCRIPTION
## Context
The event rail should monitor for any new events when it has fetched the newest events for the pipeline.

## Objective
Refactors the oldest event and newest event to be consistent.  Adds in monitoring for newer events when the event rail is at the most recent events.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
