### PR TITLE
fix(3197): Stage sort in jobs list view

### DIFF
--- a/app/components/pipeline-list-view/component.js
+++ b/app/components/pipeline-list-view/component.js
@@ -61,7 +61,7 @@ export default Component.extend({
     },
     {
       title: 'STAGE',
-      propertyName: 'stage',
+      propertyName: 'job',
       component: 'pipeline-list-stage-cell',
       sortFunction: (a, b) => collator.compare(a.stageName, b.stageName)
     },


### PR DESCRIPTION
## Context

Sort by stage name is broken after https://github.com/screwdriver-cd/ui/pull/1242.

## Objective

This PR fixes stage name sort in jobs list view.
<img width="1466" alt="Screenshot 2024-11-20 at 11 44 07 AM" src="https://github.com/user-attachments/assets/b3132d07-92e6-4260-8954-118c0eb6401c">

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/3197

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
