### PR TITLE
feat: PR event card

### DIFF
--- a/app/components/pipeline/event/card/component.js
+++ b/app/components/pipeline/event/card/component.js
@@ -191,8 +191,18 @@ export default class PipelineEventCardComponent extends Component {
     });
   }
 
+  get isPR() {
+    return this.event.type === 'pr';
+  }
+
+  get prTitle() {
+    return `PR-${this.event.prNum}`;
+  }
+
   get isHighlighted() {
-    return this.router.currentURL.endsWith(this.event.id);
+    const eventId = this.isPR ? this.event.prNum : this.event.id;
+
+    return this.router.currentURL.endsWith(eventId);
   }
 
   get title() {

--- a/app/components/pipeline/event/card/styles.scss
+++ b/app/components/pipeline/event/card/styles.scss
@@ -77,6 +77,7 @@
         }
       }
 
+      .pr-title,
       .sha {
         display: flex;
         padding-left: 1rem;

--- a/app/components/pipeline/event/card/template.hbs
+++ b/app/components/pipeline/event/card/template.hbs
@@ -15,6 +15,16 @@
         @flip={{this.icon.flip}}
       />
     </div>
+    {{#if this.isPR}}
+      <div class="pr-title" title={{this.prTitle}}>
+        <a
+          href={{@event.pr.url}}
+          target="_blank"
+        >
+          {{this.prTitle}}
+        </a>
+      </div>
+    {{/if}}
     <div class="sha" title={{this.truncatedSha}}>
       <a
         class={{if this.isLatestCommit "latest-commit"}}

--- a/app/components/pipeline/event/card/template.hbs
+++ b/app/components/pipeline/event/card/template.hbs
@@ -19,6 +19,7 @@
       <a
         class={{if this.isLatestCommit "latest-commit"}}
         href={{@event.commit.url}}
+        target="_blank"
       >
         {{this.truncatedSha}}
       </a>
@@ -65,7 +66,10 @@
       {{#if this.isCommitterDifferent}}
         <div>
           Committed by:
-          <a href={{@event.commit.author.url}}>
+          <a
+            href={{@event.commit.author.url}}
+            target="_blank"
+          >
             {{@event.commit.author.name}}
           </a>
         </div>
@@ -79,7 +83,10 @@
               External Trigger
             </LinkTo>
           {{else}}
-            <a href={{@event.creator.url}}>
+            <a
+              href={{@event.creator.url}}
+              target="_blank"
+            >
               {{@event.creator.name}}
             </a>
           {{/if}}
@@ -88,14 +95,20 @@
         {{#if @event.meta.subscribedSourceUrl}}
           <div>
             Started by subscribed event:
-            <a href={{@event.meta.subscribedSourceUrl}}>
+            <a
+              href={{@event.meta.subscribedSourceUrl}}
+              target="_blank"
+            >
               Subscribed Source
             </a>
           </div>
         {{else}}
           <div>
             Started and committed by:
-            <a href={{@event.creator.url}}>
+            <a
+              href={{@event.creator.url}}
+              target="_blank"
+            >
               {{@event.creator.name}}
             </a>
           </div>

--- a/tests/integration/components/pipeline/event/card/component-test.js
+++ b/tests/integration/components/pipeline/event/card/component-test.js
@@ -123,6 +123,7 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
     assert.dom('.event-card-title .event-status').exists({ count: 1 });
     assert.dom('.event-card-title .event-status').hasClass('SUCCESS');
     assert.dom('.event-card-title .event-status svg').exists({ count: 1 });
+    assert.dom('.event-card-title pr-title').doesNotExist();
     assert.dom('.event-card-title .sha').exists({ count: 1 });
 
     assert.dom('.event-card-body').exists({ count: 1 });
@@ -727,5 +728,126 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
 
     assert.dom('.event-card-title .event-status').hasClass('FAILURE');
     assert.dom('.event-card-title .sha').hasText('#deadbee');
+  });
+
+  test('it renders PR title', async function (assert) {
+    const router = this.owner.lookup('service:router');
+    const workflowDataReload = this.owner.lookup(
+      'service:workflow-data-reload'
+    );
+
+    sinon.stub(router, 'currentURL').value('/v2/pipelines/1/pulls/2');
+    sinon
+      .stub(workflowDataReload, 'registerLatestCommitEventCallback')
+      .callsFake(() => {});
+    sinon
+      .stub(workflowDataReload, 'registerBuildsCallback')
+      .callsFake(() => {});
+
+    this.setProperties({
+      event: {
+        id: 11,
+        groupEventId: 11,
+        sha: 'abc123def456',
+        commit: { author: { name: 'batman' }, message: 'Some amazing changes' },
+        creator: { name: 'batman' },
+        meta: {},
+        type: 'pr',
+        prNum: 4
+      },
+      pipeline: {},
+      userSettings: {}
+    });
+
+    await render(
+      hbs`<Pipeline::Event::Card
+        @event={{this.event}}
+        @pipeline={{this.pipeline}}
+        @userSettings={{this.userSettings}}
+      />`
+    );
+
+    assert.dom('.event-card-title .pr-title').exists({ count: 1 });
+    assert.dom('.event-card-title .pr-title').containsText('PR-4');
+  });
+
+  test('it does not render highlight for PR', async function (assert) {
+    const router = this.owner.lookup('service:router');
+    const workflowDataReload = this.owner.lookup(
+      'service:workflow-data-reload'
+    );
+
+    sinon.stub(router, 'currentURL').value('/v2/pipelines/1/pulls/2');
+    sinon
+      .stub(workflowDataReload, 'registerLatestCommitEventCallback')
+      .callsFake(() => {});
+    sinon
+      .stub(workflowDataReload, 'registerBuildsCallback')
+      .callsFake(() => {});
+
+    this.setProperties({
+      event: {
+        id: 11,
+        groupEventId: 11,
+        sha: 'abc123def456',
+        commit: { author: { name: 'batman' }, message: 'Some amazing changes' },
+        creator: { name: 'batman' },
+        meta: {},
+        type: 'pr',
+        prNum: 4
+      },
+      pipeline: {},
+      userSettings: {}
+    });
+
+    await render(
+      hbs`<Pipeline::Event::Card
+        @event={{this.event}}
+        @pipeline={{this.pipeline}}
+        @userSettings={{this.userSettings}}
+      />`
+    );
+
+    assert.dom('.highlighted').doesNotExist();
+  });
+
+  test('it renders PR highlight', async function (assert) {
+    const router = this.owner.lookup('service:router');
+    const workflowDataReload = this.owner.lookup(
+      'service:workflow-data-reload'
+    );
+
+    sinon.stub(router, 'currentURL').value('/v2/pipelines/1/pulls/4');
+    sinon
+      .stub(workflowDataReload, 'registerLatestCommitEventCallback')
+      .callsFake(() => {});
+    sinon
+      .stub(workflowDataReload, 'registerBuildsCallback')
+      .callsFake(() => {});
+
+    this.setProperties({
+      event: {
+        id: 11,
+        groupEventId: 11,
+        sha: 'abc123def456',
+        commit: { author: { name: 'batman' }, message: 'Some amazing changes' },
+        creator: { name: 'batman' },
+        meta: {},
+        type: 'pr',
+        prNum: 4
+      },
+      pipeline: {},
+      userSettings: {}
+    });
+
+    await render(
+      hbs`<Pipeline::Event::Card
+        @event={{this.event}}
+        @pipeline={{this.pipeline}}
+        @userSettings={{this.userSettings}}
+      />`
+    );
+
+    assert.dom('.highlighted').exists({ count: 1 });
   });
 });


### PR DESCRIPTION
## Context
The V2 event cards need some additional updates to properly support PR events.

## Objective
- Make all anchor links in the event card open in a new window/tab
- Updates the event card component to include a PR event title and properly handle the highlighting of the card

The PR card title is added in between the build status and the commit SHA
![Screenshot 2024-11-20 at 11-51-23 New Pipeline Pulls](https://github.com/user-attachments/assets/3be1a0a8-cc9d-4fce-8f8f-0a19d83d7582)

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
