### PR TITLE
fix: Fixes event propagation on event cards

### DIFF
--- a/app/components/pipeline/event/card/component.js
+++ b/app/components/pipeline/event/card/component.js
@@ -181,14 +181,18 @@ export default class PipelineEventCardComponent extends Component {
   }
 
   @action
-  goToEvent() {
-    const { event } = this;
+  goToEvent(e) {
+    if (e.target.href) {
+      e.stopPropagation();
+    } else {
+      const { event } = this;
 
-    this.router.transitionTo('v2.pipeline.events.show', {
-      event,
-      reloadEventRail: this.queueName !== 'eventRail',
-      id: event.id
-    });
+      this.router.transitionTo('v2.pipeline.events.show', {
+        event,
+        reloadEventRail: this.queueName !== 'eventRail',
+        id: event.id
+      });
+    }
   }
 
   get isHighlighted() {


### PR DESCRIPTION
## Context
When clicking on the anchor links within the V2 event cards, the click event is propagated up to the event card when it does not need to.

## Objective
Stop click event propagation when one of the anchor links within the event card is clicked.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
