### PR TITLE
fix: Only fetch pipeline jobs

### DIFF
--- a/app/v2/pipeline/events/show/route.js
+++ b/app/v2/pipeline/events/show/route.js
@@ -37,7 +37,7 @@ export default class NewPipelineEventsShowRoute extends Route {
 
     const jobs = await this.shuttle.fetchFromApi(
       'get',
-      `/pipelines/${pipelineId}/jobs`
+      `/pipelines/${pipelineId}/jobs?type=pipeline`
     );
 
     const stages = await this.shuttle.fetchFromApi(


### PR DESCRIPTION
## Context
The jobs API can filter out all of the PR jobs thereby reducing the total payload of the jobs API call.

## Objective
Improve the jobs API fetch performance.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
