### PR TITLE
fix: Remove start event button for PRs

### DIFF
--- a/app/components/pipeline/workflow/event-rail/component.js
+++ b/app/components/pipeline/workflow/event-rail/component.js
@@ -4,6 +4,8 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import ENV from 'screwdriver-ui/config/environment';
 
+const PIPELINE_EVENT = 'pipeline';
+const PR_EVENT = 'pr';
 const EVENT_BATCH_SIZE = 10;
 
 export default class PipelineWorkflowEventRailComponent extends Component {
@@ -31,8 +33,8 @@ export default class PipelineWorkflowEventRailComponent extends Component {
     super(...arguments);
 
     this.eventType = this.router.currentRouteName.includes('events')
-      ? 'pipeline'
-      : 'pr';
+      ? PIPELINE_EVENT
+      : PR_EVENT;
 
     const { event } = this.args;
 
@@ -50,6 +52,10 @@ export default class PipelineWorkflowEventRailComponent extends Component {
       clearInterval(this.intervalId);
       this.intervalId = null;
     }
+  }
+
+  get isPR() {
+    return this.eventType === PR_EVENT;
   }
 
   @action

--- a/app/components/pipeline/workflow/event-rail/template.hbs
+++ b/app/components/pipeline/workflow/event-rail/template.hbs
@@ -21,20 +21,22 @@
         />
       {{/if}}
     </BsButton>
-    <BsButton
-      id="start-event-button"
-      @type="primary"
-      @outline={{true}}
-      @defaultText="Start a new event"
-      @onClick={{this.openStartEventModal}}
-      title="Start a new event"
-    />
-    {{#if this.showStartEventModal}}
-      <Pipeline::Modal::StartEvent
-        @pipeline={{@pipeline}}
-        @jobs={{@jobs}}
-        @closeModal={{this.closeStartEventModal}}
+    {{#if (not this.isPR)}}
+      <BsButton
+        id="start-event-button"
+        @type="primary"
+        @outline={{true}}
+        @defaultText="Start a new event"
+        @onClick={{this.openStartEventModal}}
+        title="Start a new event"
       />
+      {{#if this.showStartEventModal}}
+        <Pipeline::Modal::StartEvent
+          @pipeline={{@pipeline}}
+          @jobs={{@jobs}}
+          @closeModal={{this.closeStartEventModal}}
+        />
+      {{/if}}
     {{/if}}
   </div>
 

--- a/tests/integration/components/pipeline/workflow/event/rail/component-test.js
+++ b/tests/integration/components/pipeline/workflow/event/rail/component-test.js
@@ -22,5 +22,19 @@ module(
       assert.dom('#start-event-button').exists({ count: 1 });
       assert.dom('#event-cards-container').exists({ count: 1 });
     });
+
+    test('it renders for pull requests', async function (assert) {
+      const router = this.owner.lookup('service:router');
+
+      sinon.stub(router, 'currentRouteName').value('pulls');
+
+      await render(hbs`<Pipeline::Workflow::EventRail/>`);
+
+      assert.dom('#event-rail-actions').exists({ count: 1 });
+      assert.dom('#search-for-event-button').exists({ count: 1 });
+      assert.dom('#search-for-event-button').isDisabled();
+      assert.dom('#start-event-button').doesNotExist();
+      assert.dom('#event-cards-container').exists({ count: 1 });
+    });
   }
 );


### PR DESCRIPTION
## Context
The start event button in the event rail is not needed for the PR page and should be removed.

## Objective
Remove the start event button when used in the PR page.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
