### PR TITLE
feat: Set up new pull request routes

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -139,7 +139,9 @@ Router.map(function route() {
           this.route('show', { path: '/:event_id' });
         });
         this.route('jobs');
-        this.route('pulls');
+        this.route('pulls', function pullsRoute() {
+          this.route('show', { path: '/:pull_request_number' });
+        });
         this.route(
           'build',
           { path: 'builds/:build_id' },

--- a/app/v2/pipeline/pulls/index/route.js
+++ b/app/v2/pipeline/pulls/index/route.js
@@ -1,0 +1,13 @@
+import Route from '@ember/routing/route';
+
+export default class V2PipelinePullsIndexRoute extends Route {
+  model() {
+    return this.modelFor('v2.pipeline.pulls');
+  }
+
+  afterModel(model) {
+    if (model.newestPrNum) {
+      this.replaceWith('v2.pipeline.pulls.show', model.newestPrNum);
+    }
+  }
+}

--- a/app/v2/pipeline/pulls/index/template.hbs
+++ b/app/v2/pipeline/pulls/index/template.hbs
@@ -1,0 +1,5 @@
+<Pipeline::Workflow
+  @pipeline={{this.model.pipeline}}
+  @userSettings={{this.model.userSettings}}
+  @noEvents={{true}}
+/>

--- a/app/v2/pipeline/pulls/route.js
+++ b/app/v2/pipeline/pulls/route.js
@@ -1,3 +1,54 @@
 import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+import { getPrNumber, newestPrNumber } from './util';
 
-export default class NewPipelinePullsRoute extends Route {}
+export default class NewPipelinePullsRoute extends Route {
+  @service shuttle;
+
+  async model() {
+    const model = this.modelFor('v2.pipeline');
+    const pipelineId = model.pipeline.id;
+
+    const userSettings = await this.shuttle.fetchFromApi(
+      'get',
+      '/users/settings'
+    );
+
+    const jobs = await this.shuttle.fetchFromApi(
+      'get',
+      `/pipelines/${pipelineId}/jobs?type=pipeline`
+    );
+
+    const stages = await this.shuttle.fetchFromApi(
+      'get',
+      `/pipelines/${pipelineId}/stages`
+    );
+
+    const triggers = await this.shuttle.fetchFromApi(
+      'get',
+      `/pipelines/${pipelineId}/triggers`
+    );
+
+    const pullRequestIds = new Set();
+
+    await this.shuttle
+      .fetchFromApi('get', `/pipelines/${pipelineId}/jobs?type=pr`)
+      .then(prJobs => {
+        prJobs.forEach(prJob => {
+          pullRequestIds.add(getPrNumber(prJob));
+        });
+      });
+
+    const newestPrNum = newestPrNumber(pullRequestIds);
+
+    return {
+      ...model,
+      userSettings,
+      jobs,
+      stages,
+      triggers,
+      pullRequestIds,
+      newestPrNum
+    };
+  }
+}

--- a/app/v2/pipeline/pulls/route.js
+++ b/app/v2/pipeline/pulls/route.js
@@ -14,11 +14,6 @@ export default class NewPipelinePullsRoute extends Route {
       '/users/settings'
     );
 
-    const jobs = await this.shuttle.fetchFromApi(
-      'get',
-      `/pipelines/${pipelineId}/jobs?type=pipeline`
-    );
-
     const stages = await this.shuttle.fetchFromApi(
       'get',
       `/pipelines/${pipelineId}/stages`
@@ -31,12 +26,14 @@ export default class NewPipelinePullsRoute extends Route {
 
     const pullRequestIds = new Set();
 
-    await this.shuttle
+    const pullRequestJobs = await this.shuttle
       .fetchFromApi('get', `/pipelines/${pipelineId}/jobs?type=pr`)
       .then(prJobs => {
         prJobs.forEach(prJob => {
           pullRequestIds.add(getPrNumber(prJob));
         });
+
+        return prJobs;
       });
 
     const newestPrNum = newestPrNumber(pullRequestIds);
@@ -44,9 +41,9 @@ export default class NewPipelinePullsRoute extends Route {
     return {
       ...model,
       userSettings,
-      jobs,
       stages,
       triggers,
+      pullRequestJobs,
       pullRequestIds,
       newestPrNum
     };

--- a/app/v2/pipeline/pulls/show/route.js
+++ b/app/v2/pipeline/pulls/show/route.js
@@ -1,11 +1,14 @@
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
+import { getPrNumber } from '../util';
 
 export default class V2PipelinePullsShowRoute extends Route {
   @service shuttle;
 
   async model(params) {
     const model = this.modelFor('v2.pipeline.pulls');
+    const { pipeline } = model;
+    const pipelineId = pipeline.id;
     const prNum = parseInt(params.pull_request_number, 10);
 
     let latestEvent;
@@ -14,10 +17,7 @@ export default class V2PipelinePullsShowRoute extends Route {
 
     if (model.pullRequestIds.has(prNum)) {
       event = await this.shuttle
-        .fetchFromApi(
-          'get',
-          `/pipelines/${model.pipeline.id}/events?prNum=${prNum}`
-        )
+        .fetchFromApi('get', `/pipelines/${pipelineId}/events?prNum=${prNum}`)
         .then(events => {
           return events[0];
         });
@@ -26,15 +26,31 @@ export default class V2PipelinePullsShowRoute extends Route {
       latestEvent = await this.shuttle
         .fetchFromApi(
           'get',
-          `/pipelines/${model.pipeline.id}/events?prNum=${model.newestPrNum}`
+          `/pipelines/${pipelineId}/events?prNum=${model.newestPrNum}`
         )
         .then(events => {
           return events[0];
         });
     }
 
+    let jobs = [];
+
+    if (event && !pipeline.chainPR) {
+      jobs = await this.shuttle.fetchFromApi(
+        'get',
+        `/pipelines/${pipelineId}/jobs?type=pipeline`
+      );
+
+      model.pullRequestJobs.forEach(prJob => {
+        if (getPrNumber(prJob) === prNum) {
+          jobs.push({ ...prJob, group: prNum });
+        }
+      });
+    }
+
     return {
       ...model,
+      jobs,
       event,
       latestEvent,
       invalidEvent: event === undefined

--- a/app/v2/pipeline/pulls/show/route.js
+++ b/app/v2/pipeline/pulls/show/route.js
@@ -1,0 +1,43 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class V2PipelinePullsShowRoute extends Route {
+  @service shuttle;
+
+  async model(params) {
+    const model = this.modelFor('v2.pipeline.pulls');
+    const prNum = parseInt(params.pull_request_number, 10);
+
+    let latestEvent;
+
+    let event;
+
+    if (model.pullRequestIds.has(prNum)) {
+      event = await this.shuttle
+        .fetchFromApi(
+          'get',
+          `/pipelines/${model.pipeline.id}/events?prNum=${prNum}`
+        )
+        .then(events => {
+          return events[0];
+        });
+      latestEvent = event;
+    } else {
+      latestEvent = await this.shuttle
+        .fetchFromApi(
+          'get',
+          `/pipelines/${model.pipeline.id}/events?prNum=${model.newestPrNum}`
+        )
+        .then(events => {
+          return events[0];
+        });
+    }
+
+    return {
+      ...model,
+      event,
+      latestEvent,
+      invalidEvent: event === undefined
+    };
+  }
+}

--- a/app/v2/pipeline/pulls/show/template.hbs
+++ b/app/v2/pipeline/pulls/show/template.hbs
@@ -1,0 +1,11 @@
+<Pipeline::Workflow
+  @pipeline={{this.model.pipeline}}
+  @userSettings={{this.model.userSettings}}
+  @event={{this.model.event}}
+  @jobs={{this.model.jobs}}
+  @stages={{this.model.stages}}
+  @triggers={{this.model.triggers}}
+  @latestEvent={{this.model.latestEvent}}
+  @invalidEvent={{this.model.invalidEvent}}
+  @reloadEventRail={{this.model.reloadEventRail}}
+/>

--- a/app/v2/pipeline/pulls/template.hbs
+++ b/app/v2/pipeline/pulls/template.hbs
@@ -1,5 +1,5 @@
 {{page-title "Pulls"}}
-<div class="pipeline-pulls">
-  <div>pulls content</div>
-  {{outlet}}
-</div>
+
+<Pipeline::Tab />
+
+{{outlet}}

--- a/app/v2/pipeline/pulls/util.js
+++ b/app/v2/pipeline/pulls/util.js
@@ -1,0 +1,17 @@
+/**
+ * Get the PR number from the job
+ * @param job {Object} Job in the shape returned by the API
+ * @returns {number|null}
+ */
+export const getPrNumber = job => {
+  return parseInt(job.name.slice('PR-'.length), 10);
+};
+
+/**
+ * Get the newest PR number from the set of PR numbers
+ * @param prNumbers {Set<number>} Set of PR numbers
+ * @returns {number}
+ */
+export const newestPrNumber = prNumbers => {
+  return prNumbers.size ? Math.max(...prNumbers) : null;
+};

--- a/tests/unit/v2/pipeline/pulls/index/route-test.js
+++ b/tests/unit/v2/pipeline/pulls/index/route-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
+
+module('Unit | Route | v2/pipeline/pulls/index', function (hooks) {
+  setupTest(hooks);
+
+  test('it exists', function (assert) {
+    let route = this.owner.lookup('route:v2/pipeline/pulls/index');
+
+    assert.ok(route);
+  });
+});

--- a/tests/unit/v2/pipeline/pulls/show/route-test.js
+++ b/tests/unit/v2/pipeline/pulls/show/route-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
+
+module('Unit | Route | v2/pipeline/pulls/show', function (hooks) {
+  setupTest(hooks);
+
+  test('it exists', function (assert) {
+    let route = this.owner.lookup('route:v2/pipeline/pulls/show');
+
+    assert.ok(route);
+  });
+});

--- a/tests/unit/v2/pipeline/pulls/util-test.js
+++ b/tests/unit/v2/pipeline/pulls/util-test.js
@@ -1,0 +1,19 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
+import {
+  getPrNumber,
+  newestPrNumber
+} from 'screwdriver-ui/v2/pipeline/pulls/util';
+
+module('Unit | Route | v2/pipeline/pulls/util', function (hooks) {
+  setupTest(hooks);
+
+  test('getPrNumber returns correct value', function (assert) {
+    assert.equal(getPrNumber({ name: 'PR-3:foo' }), 3);
+  });
+
+  test('newestPrNumber returns correct value', function (assert) {
+    assert.equal(newestPrNumber(new Set([1, 2, 3, 9, 6])), 9);
+    assert.equal(newestPrNumber(new Set()), null);
+  });
+});


### PR DESCRIPTION
## Context
Sets up new pull request routes that largely mirror the route structure of the event routes.  A new addition in the V2 UI is that pull requests can now be directly linked via the pull request number (e.g. /pulls/5).

## Objective
Set up the new pull request routes to leverage the V2 workflow component.  There is still more work that needs to go into updating other components like the event rail and background data reloading.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
