### PR TITLE
feat: Update event group modal to support PRs

### DIFF
--- a/app/components/pipeline/modal/event-group-history/component.js
+++ b/app/components/pipeline/modal/event-group-history/component.js
@@ -29,17 +29,25 @@ export default class PipelineModalEventGroupHistoryComponent extends Component {
     }
   }
 
+  get modalHeaderText() {
+    if (this.args.isPR) {
+      return `Events in PR: ${this.args.event.prNum}`;
+    }
+
+    return `Events in group: ${this.args.event.groupEventId}`;
+  }
+
   @action
   fetchGroupEvents() {
-    this.shuttle
-      .fetchFromApi(
-        'get',
-        `/pipelines/${this.args.pipeline.id}/events?groupEventId=${this.args.event.groupEventId}`
-      )
-      .then(events => {
-        if (this.events.length < events.length) {
-          this.events = events;
-        }
-      });
+    const baseUrl = `/pipelines/${this.args.pipeline.id}/events?`;
+    const url = this.args.isPR
+      ? `${baseUrl}prNum=${this.args.event.prNum}`
+      : `${baseUrl}groupEventId=${this.args.event.groupEventId}`;
+
+    this.shuttle.fetchFromApi('get', url).then(events => {
+      if (this.events.length < events.length) {
+        this.events = events;
+      }
+    });
   }
 }

--- a/app/components/pipeline/modal/event-group-history/template.hbs
+++ b/app/components/pipeline/modal/event-group-history/template.hbs
@@ -4,7 +4,7 @@
   as |modal|
 >
   <modal.header>
-    <div class="modal-title">Events in group: {{@event.groupEventId}}</div>
+    <div class="modal-title">{{this.modalHeaderText}}</div>
   </modal.header>
   <modal.body>
     <VerticalCollection

--- a/tests/integration/components/pipeline/modal/event-group-history/component-test.js
+++ b/tests/integration/components/pipeline/modal/event-group-history/component-test.js
@@ -53,5 +53,45 @@ module(
 
       await clearRender();
     });
+
+    test('it renders correct modal header for pull request', async function (assert) {
+      const router = this.owner.lookup('service:router');
+      const shuttle = this.owner.lookup('service:shuttle');
+      const prNum = 1;
+      const mockEvent = {
+        prNum,
+        sha: 'abc123def456',
+        commit: { author: { name: 'batman' }, message: 'Some amazing changes' },
+        creator: { name: 'batman' },
+        meta: {},
+        groupEventId: 1
+      };
+
+      sinon.stub(router, 'currentURL').value('');
+      sinon.stub(shuttle, 'fetchFromApi').resolves([]);
+
+      this.setProperties({
+        pipeline: {},
+        event: { ...mockEvent, id: 1 },
+        jobs: {},
+        userSettings: {},
+        closeModal: () => {}
+      });
+
+      await render(
+        hbs`<Pipeline::Modal::EventGroupHistory
+            @pipeline={{this.pipeline}}
+            @event={{this.event}}
+            @jobs={{this.jobs}}
+            @userSettings={{this.userSettings}}
+            @isPR={{true}}
+            @closeModal={{this.closeModal}}
+        />`
+      );
+
+      assert.dom('.modal-header').hasText(`Events in PR: ${prNum} ×`);
+
+      await clearRender();
+    });
   }
 );


### PR DESCRIPTION
## Context
The event group history modal needs some updates to better handle pull request events

## Objective
Updates the event group history modal to have improved cosmetics for pull request events.  Also updates the background event refreshing while the modal is open to support pull request events.

Modal header title updated for pull requests
![Screenshot 2024-11-22 at 17-28-37 minghay_pr-complex Pulls](https://github.com/user-attachments/assets/0bfa9dd9-f143-4041-a321-0db4d39d6fdf)

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
