### PR TITLE
feat: Pull request reloader

### DIFF
--- a/app/workflow-data-reload/dataReloader.js
+++ b/app/workflow-data-reload/dataReloader.js
@@ -17,6 +17,8 @@ export default class DataReloader {
 
   idCounts;
 
+  pipelineId;
+
   constructor(shuttle, cacheKey = null) {
     this.shuttle = shuttle;
     this.cacheKey = cacheKey;
@@ -50,6 +52,12 @@ export default class DataReloader {
       this.idSet.clear();
       this.idCounts.clear();
     }
+  }
+
+  setPipelineId(pipelineId) {
+    this.pipelineId = pipelineId;
+    this.idSet.clear();
+    this.idSet.add(pipelineId);
   }
 
   async fetchData() {

--- a/app/workflow-data-reload/latestCommitEventReloader.js
+++ b/app/workflow-data-reload/latestCommitEventReloader.js
@@ -3,16 +3,8 @@ import DataReloader from './dataReloader';
 const CACHE_KEY = 'latestCommitEvent';
 
 export default class LatestCommitEventReloader extends DataReloader {
-  pipelineId;
-
   constructor(shuttle) {
     super(shuttle, CACHE_KEY);
-  }
-
-  setPipelineId(pipelineId) {
-    this.pipelineId = pipelineId;
-    this.idSet.clear();
-    this.idSet.add(pipelineId);
   }
 
   async fetchDataForId() {

--- a/app/workflow-data-reload/openPrsReloader.js
+++ b/app/workflow-data-reload/openPrsReloader.js
@@ -1,0 +1,22 @@
+import { getPrNumbers } from 'screwdriver-ui/utils/pipeline/pull-request';
+import DataReloader from './dataReloader';
+
+const CACHE_KEY = 'openPrNums';
+
+export default class OpenPrsReloader extends DataReloader {
+  constructor(shuttle) {
+    super(shuttle, CACHE_KEY);
+  }
+
+  async fetchDataForId() {
+    return this.shuttle
+      .fetchFromApi('get', `/pipelines/${this.pipelineId}/jobs?type=pr`)
+      .then(prJobs => {
+        return Array.from(getPrNumbers(prJobs)).sort((a, b) => a - b);
+      });
+  }
+
+  getPrNums() {
+    return this.responseCache.get(CACHE_KEY);
+  }
+}

--- a/tests/unit/workflow-data-reload/dataReloader-test.js
+++ b/tests/unit/workflow-data-reload/dataReloader-test.js
@@ -6,6 +6,17 @@ import sinon from 'sinon';
 module('Unit | Service | workflowDataReload | DataReloader', function (hooks) {
   setupTest(hooks);
 
+  test('setPipelineId sets pipelineId correctly', async function (assert) {
+    const dataReloader = new DataReloader(null);
+    const pipelineId = 123;
+
+    dataReloader.setPipelineId(pipelineId);
+
+    assert.equal(dataReloader.pipelineId, pipelineId);
+    assert.equal(dataReloader.idSet.size, 1);
+    assert.equal(dataReloader.idSet.has(pipelineId), true);
+  });
+
   test('fetchData calls callback with correct data', async function (assert) {
     const dataReloader = new DataReloader(null);
     const queueName = 'test';

--- a/tests/unit/workflow-data-reload/latestCommitEventReloader-test.js
+++ b/tests/unit/workflow-data-reload/latestCommitEventReloader-test.js
@@ -41,17 +41,6 @@ module(
       assert.equal(response, null);
     });
 
-    test('setPipelineId sets pipelineId correctly', async function (assert) {
-      const latestCommitEventReloader = new LatestCommitEventReloader(null);
-      const pipelineId = 123;
-
-      latestCommitEventReloader.setPipelineId(pipelineId);
-
-      assert.equal(latestCommitEventReloader.pipelineId, pipelineId);
-      assert.equal(latestCommitEventReloader.idSet.size, 1);
-      assert.equal(latestCommitEventReloader.idSet.has(pipelineId), true);
-    });
-
     test('getLatestCommitEvent returns correct value', async function (assert) {
       const latestCommitEventReloader = new LatestCommitEventReloader(null);
       const spyResponseCache = sinon.spy(new Map());

--- a/tests/unit/workflow-data-reload/openPrsReloader-test.js
+++ b/tests/unit/workflow-data-reload/openPrsReloader-test.js
@@ -1,0 +1,41 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
+import OpenPrsReloader from 'screwdriver-ui/workflow-data-reload/openPrsReloader';
+import sinon from 'sinon';
+
+module(
+  'Unit | Service | workflowDataReload | OpenPrsReloader',
+  function (hooks) {
+    setupTest(hooks);
+
+    test('fetchDataForId returns response', async function (assert) {
+      const shuttle = this.owner.lookup('service:shuttle');
+      const pipelineId = 123;
+
+      const openPrsReloader = new OpenPrsReloader(shuttle);
+
+      openPrsReloader.setPipelineId(pipelineId);
+      sinon
+        .stub(shuttle, 'fetchFromApi')
+        .resolves([{ name: 'PR-2' }, { name: 'PR-4' }, { name: 'PR-3' }]);
+
+      const response = await openPrsReloader.fetchDataForId(pipelineId);
+
+      assert.equal(response.length, 3);
+      assert.equal(response[0], 2);
+      assert.equal(response[1], 3);
+      assert.equal(response[2], 4);
+    });
+
+    test('getPrNums returns correct value', async function (assert) {
+      const openPrsReloader = new OpenPrsReloader(null);
+      const spyResponseCache = sinon.spy([1, 2, 3]);
+
+      openPrsReloader.responseCache = spyResponseCache;
+
+      openPrsReloader.getPrNums();
+
+      assert.equal(spyResponseCache.get.calledOnce, true);
+    });
+  }
+);


### PR DESCRIPTION
## Context
The pull request page needs to be able to reload the open pull requests in order to populate the event rail correctly.

## Objective
- Refactors the `pipelineId` variable to reside in the `DataLoader` class as both the new data loader and the `LatestCommitEventReloader` requires the `pipelineId` 
- Creates a new data reloader that monitors the open pull requests for a given pipeline.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
