### PR TITLE
feat: Update search modal to support PR events

### DIFF
--- a/app/components/pipeline/modal/search-event/component.js
+++ b/app/components/pipeline/modal/search-event/component.js
@@ -4,6 +4,8 @@ import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 export default class PipelineModalSearchEventComponent extends Component {
+  @service router;
+
   @service shuttle;
 
   @tracked sha;
@@ -12,11 +14,15 @@ export default class PipelineModalSearchEventComponent extends Component {
 
   @tracked invalidSha;
 
+  isPr;
+
   constructor() {
     super(...arguments);
 
     this.searchResults = [];
     this.invalidSha = false;
+
+    this.isPr = this.router.currentRouteName.includes('pulls');
   }
 
   @action
@@ -31,14 +37,12 @@ export default class PipelineModalSearchEventComponent extends Component {
       } else {
         this.invalidSha = false;
 
-        this.shuttle
-          .fetchFromApi(
-            'get',
-            `/pipelines/${this.args.pipeline.id}/events?sha=${inputValue}`
-          )
-          .then(events => {
-            this.searchResults = events;
-          });
+        const baseUrl = `/pipelines/${this.args.pipeline.id}/events?sha=${inputValue}&type=`;
+        const url = this.isPr ? `${baseUrl}pr` : `${baseUrl}pipeline`;
+
+        this.shuttle.fetchFromApi('get', url).then(events => {
+          this.searchResults = events;
+        });
       }
     }
   }

--- a/tests/integration/components/pipeline/modal/search-event/component-test.js
+++ b/tests/integration/components/pipeline/modal/search-event/component-test.js
@@ -10,6 +10,10 @@ module(
     setupRenderingTest(hooks);
 
     test('it renders', async function (assert) {
+      const router = this.owner.lookup('service:router');
+
+      sinon.stub(router, 'currentRouteName').value('pipeline');
+
       this.setProperties({
         pipeline: {},
         jobs: [],
@@ -34,8 +38,10 @@ module(
     });
 
     test('it makes API call for valid input', async function (assert) {
+      const router = this.owner.lookup('service:router');
       const shuttle = this.owner.lookup('service:shuttle');
 
+      sinon.stub(router, 'currentRouteName').value('pipeline');
       sinon.stub(shuttle, 'fetchFromApi').resolves([]);
 
       this.setProperties({
@@ -60,8 +66,10 @@ module(
     });
 
     test('it handles invalid input', async function (assert) {
+      const router = this.owner.lookup('service:router');
       const shuttle = this.owner.lookup('service:shuttle');
 
+      sinon.stub(router, 'currentRouteName').value('pipeline');
       sinon.spy(shuttle);
 
       this.setProperties({
@@ -88,8 +96,10 @@ module(
     });
 
     test('it clears input and search results when escape key is pressed', async function (assert) {
+      const router = this.owner.lookup('service:router');
       const shuttle = this.owner.lookup('service:shuttle');
 
+      sinon.stub(router, 'currentRouteName').value('pipeline');
       sinon.stub(shuttle, 'fetchFromApi').resolves([]);
 
       this.setProperties({


### PR DESCRIPTION
## Context
The search modal needs to be updated to support PR events.

## Objective
Adds in the ability for the search event modal to query what event page it is opened on and set the API call with the correct query parameter.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
