### PR TITLE
fix: Update stop build modal to auto close on success

### DIFF
--- a/app/components/pipeline/modal/stop-build/component.js
+++ b/app/components/pipeline/modal/stop-build/component.js
@@ -6,11 +6,7 @@ import { tracked } from '@glimmer/tracking';
 export default class PipelineModalStopBuildComponent extends Component {
   @service shuttle;
 
-  @tracked isDisabled = false;
-
   @tracked errorMessage = null;
-
-  @tracked successMessage = null;
 
   @action
   async stopBuild() {
@@ -18,8 +14,7 @@ export default class PipelineModalStopBuildComponent extends Component {
       await this.shuttle
         .fetchFromApi('put', `/events/${this.args.eventId}/stop`)
         .then(() => {
-          this.successMessage = 'All builds for the event stopped successfully';
-          this.isDisabled = true;
+          this.args.closeModal();
         })
         .catch(err => {
           this.errorMessage = err.message;
@@ -30,8 +25,7 @@ export default class PipelineModalStopBuildComponent extends Component {
           status: 'ABORTED'
         })
         .then(() => {
-          this.successMessage = 'Build stopped successfully';
-          this.isDisabled = true;
+          this.args.closeModal();
         })
         .catch(err => {
           this.errorMessage = err.message;

--- a/app/components/pipeline/modal/stop-build/template.hbs
+++ b/app/components/pipeline/modal/stop-build/template.hbs
@@ -18,14 +18,6 @@
         @dismissible={{false}}
       />
     {{/if}}
-    {{#if this.successMessage}}
-      <InfoMessage
-        @message={{this.successMessage}}
-        @type="success"
-        @icon="check-circle"
-        @dismissible={{false}}
-      />
-    {{/if}}
     Are you sure you want to stop the build?
   </modal.body>
   <modal.footer>
@@ -33,7 +25,6 @@
       id="stop-build"
       @type="primary"
       @onClick={{modal.submit}}
-      disabled={{this.isDisabled}}
     >
       Yes
     </BsButton>

--- a/tests/integration/components/pipeline/modal/stop-build/component-test.js
+++ b/tests/integration/components/pipeline/modal/stop-build/component-test.js
@@ -51,13 +51,14 @@ module('Integration | Component | pipeline/modal/stop-build', function (hooks) {
     assert.dom('.alert > span').hasText(errorMessage);
   });
 
-  test('it displays success message when stop succeeds', async function (assert) {
+  test('it closes modal when stop succeeds', async function (assert) {
     const shuttle = this.owner.lookup('service:shuttle');
     const shuttleStub = sinon.stub(shuttle, 'fetchFromApi').resolves();
+    const closeModalSpy = sinon.spy();
 
     this.setProperties({
       buildId: 1,
-      closeModal: () => {}
+      closeModal: closeModalSpy
     });
 
     await render(
@@ -70,9 +71,7 @@ module('Integration | Component | pipeline/modal/stop-build', function (hooks) {
     await click('#stop-build');
 
     assert.equal(shuttleStub.calledOnce, true);
-    assert.dom('.alert').exists({ count: 1 });
-    assert.dom('.alert > span').hasText('Build stopped successfully');
-    assert.dom('#stop-build').isDisabled();
+    assert.equal(closeModalSpy.calledOnce, true);
   });
 
   test('it calls correct API when no builds are configured', async function (assert) {


### PR DESCRIPTION
## Context
The stop build action should automatically close the modal when the API call succeeds

## Objective
Simplify the stop build modal to automatically close when the API call succeeds.  Also removes associated messaging within the modal since the user will never see that information anymore.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
