### PR TITLE
fix: Autoclose confirm action modal

### DIFF
--- a/app/components/pipeline/modal/confirm-action/component.js
+++ b/app/components/pipeline/modal/confirm-action/component.js
@@ -14,8 +14,6 @@ export default class PipelineModalConfirmActionComponent extends Component {
 
   @tracked errorMessage = null;
 
-  @tracked successMessage = null;
-
   @tracked isAwaitingResponse = false;
 
   @tracked wasActionSuccessful = false;
@@ -114,10 +112,7 @@ export default class PipelineModalConfirmActionComponent extends Component {
     await this.shuttle
       .fetchFromApi('post', '/events', data)
       .then(() => {
-        this.successMessage = `${capitalizeFirstLetter(
-          this.action
-        )}ed successfully`;
-        this.wasActionSuccessful = true;
+        this.args.closeModal();
       })
       .catch(err => {
         this.wasActionSuccessful = false;

--- a/app/components/pipeline/modal/confirm-action/component.js
+++ b/app/components/pipeline/modal/confirm-action/component.js
@@ -6,6 +6,8 @@ import { buildPostBody } from 'screwdriver-ui/utils/pipeline/modal/request';
 import { capitalizeFirstLetter, truncateMessage } from './util';
 
 export default class PipelineModalConfirmActionComponent extends Component {
+  @service router;
+
   @service shuttle;
 
   @service workflowDataReload;
@@ -111,8 +113,13 @@ export default class PipelineModalConfirmActionComponent extends Component {
 
     await this.shuttle
       .fetchFromApi('post', '/events', data)
-      .then(() => {
+      .then(event => {
         this.args.closeModal();
+        this.router.transitionTo('v2.pipeline.events.show', {
+          event,
+          reloadEventRail: true,
+          id: event.id
+        });
       })
       .catch(err => {
         this.wasActionSuccessful = false;

--- a/app/components/pipeline/modal/confirm-action/template.hbs
+++ b/app/components/pipeline/modal/confirm-action/template.hbs
@@ -16,14 +16,6 @@
         @dismissible={{false}}
       />
     {{/if}}
-    {{#if this.successMessage}}
-      <InfoMessage
-        @message={{this.successMessage}}
-        @type="success"
-        @icon="check-circle"
-        @dismissible={{false}}
-      />
-    {{/if}}
     {{#if @stage}}
       <div id="confirm-action-stage">Stage: <code>{{@stage.name}}</code></div>
     {{else}}

--- a/tests/integration/components/pipeline/modal/confirm-action/component-test.js
+++ b/tests/integration/components/pipeline/modal/confirm-action/component-test.js
@@ -279,9 +279,10 @@ module(
       assert.dom('#submit-action').isEnabled();
     });
 
-    test('it display success message', async function (assert) {
+    test('it closes modal on success', async function (assert) {
       const shuttle = this.owner.lookup('service:shuttle');
       const shuttleStub = sinon.stub(shuttle, 'fetchFromApi').resolves();
+      const closeModalSpy = sinon.spy();
 
       this.setProperties({
         pipeline: { parameters: {} },
@@ -291,7 +292,7 @@ module(
         },
         jobs: [],
         job: { name: 'main' },
-        closeModal: () => {}
+        closeModal: closeModalSpy
       });
 
       await render(
@@ -309,9 +310,7 @@ module(
       await click('#submit-action');
 
       assert.equal(shuttleStub.calledOnce, true);
-      assert.dom('#submit-action').isDisabled();
-      assert.dom('.alert').exists({ count: 1 });
-      assert.dom('.alert > span').hasText('Started successfully');
+      assert.equal(closeModalSpy.calledOnce, true);
     });
 
     test('it displays error message when API call fails', async function (assert) {


### PR DESCRIPTION
## Context
The confirm action modal should autoclose and transition the route to the newly created event

## Objective
Updates the confirm action modal to remove the messaging when the API call succeeds.  Adds in the autoclose functionality to the the modal and also transitions the UI route to the newly created event.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
