### PR TITLE
fix: Close modal and transition to new event on success

### DIFF
--- a/app/components/pipeline/modal/start-event/component.js
+++ b/app/components/pipeline/modal/start-event/component.js
@@ -9,13 +9,13 @@ import {
 import { buildPostBody } from 'screwdriver-ui/utils/pipeline/modal/request';
 
 export default class PipelineModalStartEventComponent extends Component {
+  @service router;
+
   @service shuttle;
 
   @service session;
 
   @tracked errorMessage = null;
-
-  @tracked successMessage = null;
 
   @tracked isAwaitingResponse = false;
 
@@ -68,9 +68,13 @@ export default class PipelineModalStartEventComponent extends Component {
 
     await this.shuttle
       .fetchFromApi('post', '/events', data)
-      .then(() => {
-        this.wasActionSuccessful = true;
-        this.successMessage = `Started successfully`;
+      .then(event => {
+        this.args.closeModal();
+        this.router.transitionTo('v2.pipeline.events.show', {
+          event,
+          reloadEventRail: true,
+          id: event.id
+        });
       })
       .catch(err => {
         this.wasActionSuccessful = false;

--- a/app/components/pipeline/modal/start-event/template.hbs
+++ b/app/components/pipeline/modal/start-event/template.hbs
@@ -16,14 +16,6 @@
         @dismissible={{false}}
       />
     {{/if}}
-    {{#if this.successMessage}}
-      <InfoMessage
-        @message={{this.successMessage}}
-        @type="success"
-        @icon="check-circle"
-        @dismissible={{false}}
-      />
-    {{/if}}
 
     {{#if @notice}}
       <div

--- a/tests/integration/components/pipeline/modal/start-event/component-test.js
+++ b/tests/integration/components/pipeline/modal/start-event/component-test.js
@@ -1,7 +1,8 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
-import { render } from '@ember/test-helpers';
+import { click, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
 
 module(
   'Integration | Component | pipeline/modal/start-event',
@@ -64,6 +65,29 @@ module(
       );
 
       assert.dom('#user-notice').exists({ count: 1 });
+    });
+
+    test('it closes modal on success', async function (assert) {
+      const shuttle = this.owner.lookup('service:shuttle');
+      const shuttleStub = sinon.stub(shuttle, 'fetchFromApi').resolves();
+      const closeModalSpy = sinon.spy();
+
+      this.setProperties({
+        pipeline: {},
+        jobs: [],
+        closeModal: closeModalSpy
+      });
+      await render(
+        hbs`<Pipeline::Modal::StartEvent
+            @pipeline={{this.pipeline}}
+            @jobs={{this.jobs}}
+            @closeModal={{this.closeModal}}
+        />`
+      );
+      await click('#submit-action');
+
+      assert.equal(shuttleStub.calledOnce, true);
+      assert.equal(closeModalSpy.calledOnce, true);
     });
   }
 );


### PR DESCRIPTION
## Context
When starting a new event, the modal should automatically close and transition the UI to the newly created event.

## Objective
Updates the start event modal to close and transition to the newly created event on API success.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
