### PR TITLE
fix: Autoclose event history modal

### DIFF
--- a/app/components/pipeline/event/card/component.js
+++ b/app/components/pipeline/event/card/component.js
@@ -187,6 +187,10 @@ export default class PipelineEventCardComponent extends Component {
     if (e.target.href) {
       e.stopPropagation();
     } else {
+      if (this.args.onClick) {
+        this.args.onClick();
+      }
+
       const { event } = this;
 
       const route = this.isPR

--- a/app/components/pipeline/modal/event-group-history/template.hbs
+++ b/app/components/pipeline/modal/event-group-history/template.hbs
@@ -19,6 +19,7 @@
         @jobs={{@jobs}}
         @userSettings={{@userSettings}}
         @queueName="eventGroupModal"
+        @onClick={{fn @closeModal}}
       />
     </VerticalCollection>
   </modal.body>


### PR DESCRIPTION
## Context
When selecting an event from the event history modal, the modal should automatically close.

## Objective
Adds in the ability for the event history modal to close automatically when an event card is clicked.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
