### PR TITLE
fix: Update metrics icon for consistency

### DIFF
--- a/app/components/pipeline/nav/template.hbs
+++ b/app/components/pipeline/nav/template.hbs
@@ -9,6 +9,6 @@
     <FaIcon @icon="wrench" @size="16x" />
   </LinkTo>
   <LinkTo @route="v2.pipeline.metrics" title="Metrics">
-    <FaIcon @icon="water" @size="16x" />
+    <FaIcon @icon="chart-line" @size="16x" />
   </LinkTo>
 </div>


### PR DESCRIPTION
## Context
The navbar icon for the metrics link isn't consistent in the V2 UI

## Objective
Update the metrics icon to be consistent
![Screenshot 2024-11-26 at 15-36-33 minghay_stages Events](https://github.com/user-attachments/assets/fd058fc9-c790-44e1-b27d-939e7c4ea754)

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
