### PR TITLE
fix: Fix issue with horizontal graph overflow

### DIFF
--- a/app/components/pipeline/workflow/styles.scss
+++ b/app/components/pipeline/workflow/styles.scss
@@ -21,6 +21,7 @@
 
     #workflow-graph-container {
       grid-area: workflow;
+      overflow: auto;
       $graph-controls-height: 2.5rem;
 
       #workflow-graph-controls {


### PR DESCRIPTION
## Context
When a pipeline graph is wide, the scroll is added to the wrong container in the V2 UI

## Objective
Fix the overflow to be contained in the pipeline graph containing element

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
