### PR TITLE
fix: Fix start event from job to have event group

### DIFF
--- a/app/utils/pipeline/modal/request.js
+++ b/app/utils/pipeline/modal/request.js
@@ -23,12 +23,10 @@ export function buildPostBody( // eslint-disable-line import/prefer-default-expo
     causeMessage: `Manually started by ${username}`
   };
 
-  if (job?.status) {
+  if (event && job) {
     data.startFrom = job.name;
     data.groupEventId = event.groupEventId;
     data.parentEventId = event.id;
-  } else if (job?.name) {
-    data.startFrom = job.name;
   } else {
     data.startFrom = '~commit';
   }

--- a/tests/unit/utils/pipeline/modal/request-test.js
+++ b/tests/unit/utils/pipeline/modal/request-test.js
@@ -26,11 +26,21 @@ module('Unit | Utility | pipeline/modal/request', function () {
 
   test('buildPostBody sets correct values for new event starting from job', function (assert) {
     assert.deepEqual(
-      buildPostBody('foobar', 123, { name: 'main' }, null, null, false, null),
+      buildPostBody(
+        'foobar',
+        123,
+        { name: 'main' },
+        { id: 987, groupEventId: 999 },
+        null,
+        false,
+        null
+      ),
       {
         pipelineId: 123,
         causeMessage: 'Manually started by foobar',
-        startFrom: 'main'
+        startFrom: 'main',
+        groupEventId: 999,
+        parentEventId: 987
       }
     );
   });


### PR DESCRIPTION
## Context
When starting an new event from the workflow graph in the V2 UI, the new event is not attached to the original event group

## Objective
Fixes events started from the workflow graph to be attached to the correct event group

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
