### PR TITLE
fix: Disable job restart when job has no builds

### DIFF
--- a/app/components/pipeline/workflow/tooltip/component.js
+++ b/app/components/pipeline/workflow/tooltip/component.js
@@ -47,7 +47,7 @@ export default class PipelineWorkflowTooltipComponent extends Component {
     const canRestartPipeline =
       this.session.isAuthenticated && isActivePipeline(this.args.pipeline);
 
-    return canRestartPipeline && !this.tooltipData.job.stageName;
+    return canRestartPipeline && this.tooltipData.job.status;
   }
 
   get canJobStartFromView() {


### PR DESCRIPTION
## Context
When selecting a job from the pipeline workflow graph in the V2 UI, jobs that have no builds for that event should not be allowed to restart.

## Objective
Updates the logic for determining whether a job can be restarted from the pipeline workflow graph.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
