### PR TITLE
fix: Fix graph reloading bug

### DIFF
--- a/app/components/pipeline/workflow/component.js
+++ b/app/components/pipeline/workflow/component.js
@@ -117,6 +117,14 @@ export default class PipelineWorkflowComponent extends Component {
   update(element, [event]) {
     const builds = this.workflowDataReload.getBuildsForEvent(event.id);
 
+    if (!this.isEventComplete(event, builds)) {
+      this.workflowDataReload.registerBuildsCallback(
+        BUILD_QUEUE_NAME,
+        event.id,
+        this.buildsCallback
+      );
+    }
+
     this.event = event;
     this.builds = builds;
     this.showTooltip = false;
@@ -141,12 +149,16 @@ export default class PipelineWorkflowComponent extends Component {
   buildsCallback(builds) {
     this.builds = builds;
 
-    if (isSkipped(this.event, builds) || isComplete(builds)) {
+    if (this.isEventComplete(this.event, builds)) {
       this.workflowDataReload.removeBuildsCallback(
         BUILD_QUEUE_NAME,
         this.event.id
       );
     }
+  }
+
+  isEventComplete(event, builds) {
+    return !!(isSkipped(this.event, builds) || isComplete(builds));
   }
 
   get isPR() {

--- a/app/components/pipeline/workflow/component.js
+++ b/app/components/pipeline/workflow/component.js
@@ -117,6 +117,11 @@ export default class PipelineWorkflowComponent extends Component {
   update(element, [event]) {
     const builds = this.workflowDataReload.getBuildsForEvent(event.id);
 
+    this.workflowDataReload.removeBuildsCallback(
+      BUILD_QUEUE_NAME,
+      this.event.id
+    );
+
     if (!this.isEventComplete(event, builds)) {
       this.workflowDataReload.registerBuildsCallback(
         BUILD_QUEUE_NAME,


### PR DESCRIPTION
## Context
When switching to a different event via the event cards in the event rail, if the event that is switched to is not complete, the workflow graph does not update correctly.

## Objective
Adds in the missing builds monitoring for an event that isn't complete.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
