### PR TITLE
fix: Fix reload event rail bug

### DIFF
--- a/app/components/pipeline/workflow/event-rail/component.js
+++ b/app/components/pipeline/workflow/event-rail/component.js
@@ -67,6 +67,7 @@ export default class PipelineWorkflowEventRailComponent extends Component {
   update(element, [event, reloadEvents]) {
     if (reloadEvents) {
       this.firstItemId = event.id;
+      this.newestEvent = event;
       this.events = [event];
     }
   }


### PR DESCRIPTION
## Context
When the event rail is reloaded the newest event is added into the event rail twice.  This is because the newest event marker isn't reset correctly.

## Objective
Fixes the issue where the newest is added twice.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
