### PR TITLE
fix: cannot load next pipelines on search page when private pipelines are filtered

### DIFF
--- a/app/components/search-list/component.js
+++ b/app/components/search-list/component.js
@@ -1,7 +1,6 @@
 import { computed, set } from '@ember/object';
 import { empty } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
-import ENV from 'screwdriver-ui/config/environment';
 import Component from '@ember/component';
 
 export default Component.extend({
@@ -16,14 +15,9 @@ export default Component.extend({
     get() {
       const pipelines = this.filteredPipelines;
 
-      if (
-        Array.isArray(pipelines) &&
-        pipelines.length < ENV.APP.NUM_PIPELINES_LISTED
-      ) {
-        return false;
-      }
-
-      return this.moreToShow;
+      return (
+        Array.isArray(pipelines) && pipelines.length > 0 && this.moreToShow
+      );
     }
   }),
   filteredPipelines: computed('pipelines', {

--- a/app/search/controller.js
+++ b/app/search/controller.js
@@ -57,11 +57,9 @@ export default Controller.extend({
         .then(pipelines => {
           const nextPipelines = pipelines.toArray();
 
-          if (Array.isArray(nextPipelines)) {
-            if (nextPipelines.length < ENV.APP.NUM_PIPELINES_LISTED) {
-              this.set('moreToShow', false);
-            }
-
+          if (!Array.isArray(nextPipelines) || nextPipelines.length === 0) {
+            this.set('moreToShow', false);
+          } else {
             this.set(
               'pipelinesToShow',
               this.pipelinesToShow.concat(nextPipelines)

--- a/tests/acceptance/search-test.js
+++ b/tests/acceptance/search-test.js
@@ -12,7 +12,9 @@ module('Acceptance | search', function (hooks) {
   hooks.beforeEach(function () {
     server = new Pretender();
     server.get('http://localhost:8080/v4/pipelines', request => {
-      if (!request.queryParams.search) {
+      const { search, page } = request.queryParams;
+
+      if (!search) {
         return [
           200,
           { 'Content-Type': 'application/json' },
@@ -59,7 +61,8 @@ module('Acceptance | search', function (hooks) {
           ])
         ];
       }
-      if (request.queryParams.search === 'banana') {
+
+      if (search === 'banana' && page === '1') {
         return [
           200,
           { 'Content-Type': 'application/json' },
@@ -146,8 +149,11 @@ module('Acceptance | search', function (hooks) {
 
     assert.equal(currentURL(), '/search?query=banana ');
     assert.dom('tr').exists({ count: 3 });
-    assert.dom('.showMore').doesNotExist();
+    assert.dom('.showMore').hasText('Show more results...');
     assert.dom('.num-results').hasText('Showing 2 result(s)');
+    await click('.showMore');
+    await waitUntil(() => !find('.showMore'));
+    assert.dom('.showMore').doesNotExist();
   });
 
   test('visiting /search?query=doesnotexist when logged in', async function (assert) {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

`Show more results` button does not appear when search result is less than 50 (default) on the pipeline search page.
Therefore uses cannot load next pipelines if search result includes private pipelines and they are filtered.

e.g.)
The pipeline [yk634/pr-test](https://cd.screwdriver.cd/pipelines/14506) appears on 2nd page of [searching "pr"](https://cd.screwdriver.cd/search?query=pr), but guest uses cannot load 2nd page.
(Some pipelines are private and they are filtered, so the result is less than 50 and `Show more results` button is hidden.)

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Fix showing `Show more results` button conditions. 
After this PR, `Show more results` button will be hidden if the loaded next page is empty.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
