### PR TITLE
fix: Remove admin requirement

### DIFF
--- a/app/components/app-header/component.js
+++ b/app/components/app-header/component.js
@@ -13,44 +13,27 @@ export default Component.extend({
   slackUrl: ENV.APP.SLACK_URL,
   releaseVersion: ENV.APP.RELEASE_VERSION,
   searchTerm: '',
-  isAdmin: computed(
-    'session.data.authenticated.scope',
-    function isAdminFunction() {
-      const isAdmin = (this.session.data.authenticated.scope || []).includes(
-        'admin'
-      );
-
-      return isAdmin;
-    }
-  ),
-  isNewUI: computed('router.{currentRouteName,currentURL}', {
+  isNewUI: computed('router.currentURL', {
     get() {
       const currentURL = get(this, 'router.currentURL');
-      const isNewUIRoute = currentURL.includes('/v2/');
 
-      return isNewUIRoute;
+      return currentURL.includes('/v2/');
     }
   }),
-  hasAlternativeRoute: computed(
-    'isNewUI',
-    'router.{currentRouteName,currentURL}',
-    {
-      get() {
-        const routeName = this.router.currentRouteName;
+  hasAlternativeRoute: computed('isNewUI', 'router.currentRouteName', {
+    get() {
+      const routeName = this.router.currentRouteName;
 
-        let alterRouteName = `v2.${this.router.currentRouteName}`;
+      let alterRouteName = `v2.${this.router.currentRouteName}`;
 
-        if (this.isNewUI) {
-          // to remove v2. prefix
-          alterRouteName = routeName.slice(3);
-        }
-
-        const alterRoute = getOwner(this).lookup(`route:${alterRouteName}`);
-
-        return alterRoute;
+      if (this.isNewUI) {
+        // to remove v2. prefix
+        alterRouteName = routeName.slice(3);
       }
+
+      return getOwner(this).lookup(`route:${alterRouteName}`);
     }
-  ),
+  }),
   actions: {
     invalidateSession() {
       this.onInvalidate();

--- a/app/components/app-header/template.hbs
+++ b/app/components/app-header/template.hbs
@@ -185,9 +185,10 @@
               <ddm.item>
                 {{#if this.hasAlternativeRoute}}
                   <span class="switch-ui dropdown-item"
-                    title="Switch to {{if this.isNewUIRoute "Old" "New"}}"
+                    title="{{if this.isNewUIRoute "Back to classic" "Try new"}} interface"
                     {{action "switchUI"}}
-                  >Switch to {{if this.isNewUI "Old" "New"}} UI
+                  >
+                    {{if this.isNewUI "Back to classic" "Try new"}} interface
                   </span>
                 {{/if}}
               </ddm.item>

--- a/app/components/app-header/template.hbs
+++ b/app/components/app-header/template.hbs
@@ -182,7 +182,6 @@
                 {{/unless}}
               {{/each}}
               {{ddm.divider}}
-              {{#if this.isAdmin}}
               <ddm.item>
                 {{#if this.hasAlternativeRoute}}
                   <span class="switch-ui dropdown-item"
@@ -192,7 +191,6 @@
                   </span>
                 {{/if}}
               </ddm.item>
-              {{/if}}
               {{#if (not @session.data.authenticated.isGuest)}}
                 <ddm.item>
                   <ddm.linkTo @route="user-settings" @title="User Settings">

--- a/tests/integration/components/app-header/component-test.js
+++ b/tests/integration/components/app-header/component-test.js
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import sinon from 'sinon';
 import injectScmServiceStub from '../../../helpers/inject-scm';
 
 const fakeToken =
@@ -9,6 +10,13 @@ const fakeToken =
 
 module('Integration | Component | app header', function (hooks) {
   setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    const router = this.owner.lookup('service:router');
+
+    sinon.stub(router, 'currentURL').value('');
+    sinon.stub(router, 'currentRouteName').value('home');
+  });
 
   // this test should pass when search bar feature flag is turned off
   test('it renders when search flag is off', async function (assert) {


### PR DESCRIPTION
## Context
The dropdown menu for switching between the UI interfaces is still checking for admin privileges.

## Objective
Remove the requirement for being an admin.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
