### PR TITLE
fix: other branch pipeline link on pipeline header does not include all of sibling pipelines

### DIFF
--- a/app/pipeline/service.js
+++ b/app/pipeline/service.js
@@ -11,9 +11,9 @@ export default Service.extend({
     this.set('buildsLink', buildsLink);
   },
 
-  getSiblingPipeline(scmRepo) {
+  getSiblingPipeline(scmRepo, page) {
     const pipelineListConfig = {
-      page: 1,
+      page,
       count: ENV.APP.NUM_PIPELINES_LISTED,
       search: scmRepo,
       sortBy: 'name',

--- a/tests/integration/components/pipeline-header/component-test.js
+++ b/tests/integration/components/pipeline-header/component-test.js
@@ -118,6 +118,122 @@ module('Integration | Component | pipeline header', function (hooks) {
     assert.dom('li.branch-item:nth-child(4)').hasText('link efg:src');
   });
 
+  test('it renders branch-move when API returns multiple pages', async function (assert) {
+    const pipelineMock = EmberObject.create({
+      id: 1,
+      scmContext: 'github:github.com',
+      scmUri: 'github.com:123456:master',
+      scmRepo: {
+        name: 'batman/batmobile'
+      }
+    });
+
+    const createSiblingPipelineMock = id => {
+      return {
+        id,
+        scmRepo: {
+          name: pipelineMock.scmRepo.name,
+          branch: `branch-${id}`
+        },
+        scmUri: pipelineMock.scmUri
+      };
+    };
+
+    // In test, NUM_PIPELINES_LISTED is 3
+    const firstPageSiblingPipelines = [
+      pipelineMock,
+      createSiblingPipelineMock(2),
+      createSiblingPipelineMock(3)
+    ];
+    const secondPageSiblingPipelines = [
+      createSiblingPipelineMock(4),
+      createSiblingPipelineMock(5),
+      createSiblingPipelineMock(6)
+    ];
+
+    const pipelineStub = Service.extend({
+      getSiblingPipeline(_, page) {
+        if (page === 1) return Promise.resolve(firstPageSiblingPipelines);
+        if (page === 2) return Promise.resolve(secondPageSiblingPipelines);
+        if (page === 3) return Promise.resolve([]);
+
+        return assert.fails('This line should not run.');
+      }
+    });
+
+    this.owner.unregister('service:pipeline');
+    this.owner.register('service:pipeline', pipelineStub);
+
+    injectScmServiceStub(this);
+
+    this.set('pipelineMock', pipelineMock);
+    await render(hbs`<PipelineHeader @pipeline={{this.pipelineMock}} />`);
+
+    await click('span.branch');
+    assert.dom('li.branch-item').exists({ count: 5 });
+  });
+
+  test('it renders branch-move when API returns multiple pages with other name pipeline', async function (assert) {
+    const pipelineMock = EmberObject.create({
+      id: 1,
+      scmContext: 'github:github.com',
+      scmUri: 'github.com:123456:master',
+      scmRepo: {
+        name: 'batman/batmobile'
+      }
+    });
+
+    const createSiblingPipelineMock = id => {
+      return {
+        id,
+        scmRepo: {
+          name: pipelineMock.scmRepo.name,
+          branch: `branch-${id}`
+        },
+        scmUri: pipelineMock.scmUri
+      };
+    };
+
+    // In test, NUM_PIPELINES_LISTED is 3
+    const firstPageSiblingPipelines = [
+      pipelineMock,
+      createSiblingPipelineMock(2),
+      createSiblingPipelineMock(3)
+    ];
+    const secondPageSiblingPipelines = [
+      createSiblingPipelineMock(4),
+      createSiblingPipelineMock(5),
+      {
+        id: 6,
+        scmRepo: {
+          name: 'batman/batmobile-other',
+          branch: `main`
+        },
+        scmUri: 'github.com:789:master'
+      }
+    ];
+
+    const pipelineStub = Service.extend({
+      getSiblingPipeline(_, page) {
+        if (page === 1) return Promise.resolve(firstPageSiblingPipelines);
+        if (page === 2) return Promise.resolve(secondPageSiblingPipelines);
+
+        return assert.fails('This line should not run.');
+      }
+    });
+
+    this.owner.unregister('service:pipeline');
+    this.owner.register('service:pipeline', pipelineStub);
+
+    injectScmServiceStub(this);
+
+    this.set('pipelineMock', pipelineMock);
+    await render(hbs`<PipelineHeader @pipeline={{this.pipelineMock}} />`);
+
+    await click('span.branch');
+    assert.dom('li.branch-item').exists({ count: 4 });
+  });
+
   test('it renders link to parent pipeline for child pipeline', async function (assert) {
     const pipelineMock = EmberObject.create({
       appId: 'batman/batmobile',


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Sibling pipeline link does not have all links when the pipeline has too many other branch pipelines (over 50 by default).

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Fetch sibling pipeline from API properly with pagination.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
