### PR TITLE
fix(3247): virtual job icon is not used when the graph redraw

### DIFF
--- a/app/components/workflow-graph-d3/component.js
+++ b/app/components/workflow-graph-d3/component.js
@@ -205,7 +205,7 @@ export default Component.extend({
       if (n) {
         const txt = n.select('text');
 
-        txt.text(icon(node.status));
+        txt.text(icon(node.status, node.virtual));
         n.attr(
           'class',
           `graph-node${

--- a/app/utils/pipeline/graph/d3-graph-util.js
+++ b/app/utils/pipeline/graph/d3-graph-util.js
@@ -28,7 +28,7 @@ const STATUS_MAP = {
  * @return {String}        Unicode character that maps to an icon in screwdriver icon font
  */
 export function icon(status, isVirtual) {
-  if (isVirtual && (!status || ['SUCCESS', 'WARNING', 'CREATED'])) {
+  if (isVirtual) {
     return STATUS_MAP.VIRTUAL.icon;
   }
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Virtual job icon is not used after the workflow graph is redrew. (e.g. Uses stops the build)

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Use virtual job icon correctly when the workflow graph is redrew.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

Issue: https://github.com/screwdriver-cd/screwdriver/issues/3247

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
