### PR TITLE
fix: Close the search modal when event card is clicked

### DIFF
--- a/app/components/pipeline/modal/search-event/template.hbs
+++ b/app/components/pipeline/modal/search-event/template.hbs
@@ -35,6 +35,7 @@
           @jobs={{@jobs}}
           @userSettings={{@userSettings}}
           @queueName="searchResults"
+          @onClick={{fn @closeModal}}
         />
       </VerticalCollection>
     </div>


### PR DESCRIPTION
## Context
The search modal does not auto close when an event card is selected.

## Objective
Adds in the ability for the search modal to automatically close when an event is selected

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
