### PR TITLE
fix: Fix data reloading issues

### DIFF
--- a/app/components/pipeline/workflow/component.js
+++ b/app/components/pipeline/workflow/component.js
@@ -51,6 +51,8 @@ export default class PipelineWorkflowComponent extends Component {
 
   eventType;
 
+  dataReloadId;
+
   constructor() {
     super(...arguments);
 
@@ -64,9 +66,9 @@ export default class PipelineWorkflowComponent extends Component {
       : PR_EVENT;
 
     if (this.eventType === PIPELINE_EVENT) {
-      this.workflowDataReload.start(pipeline.id, false);
+      this.dataReloadId = this.workflowDataReload.start(pipeline.id, false);
     } else {
-      this.workflowDataReload.start(pipeline.id, true);
+      this.dataReloadId = this.workflowDataReload.start(pipeline.id, true);
     }
 
     if (this.args.noEvents) {
@@ -110,7 +112,7 @@ export default class PipelineWorkflowComponent extends Component {
   willDestroy() {
     super.willDestroy();
 
-    this.workflowDataReload.stop();
+    this.workflowDataReload.stop(this.dataReloadId);
   }
 
   @action


### PR DESCRIPTION
## Context
When switching between the `Events` and `Pulls` tabs in the v2 UI, the background data reloading stops working.  This is because Ember creates a new workflow component before destroying the old workflow component.

## Objective
Adds in ID tracking for the data reloading so that the data reloading class can handle cases where the previous reloading has already stopped due to the `start` function being called.  Also fixes an issue where the data reloading for pull request data stops properly.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
