### PR TITLE
fix: Flip card highlight colors

### DIFF
--- a/app/components/pipeline/event/card/styles.scss
+++ b/app/components/pipeline/event/card/styles.scss
@@ -13,15 +13,11 @@
     cursor: pointer;
 
     &:hover {
-      background: rgba(colors.$sd-pale-purple, 0.5);
+      background: rgba(colors.$sd-highlight, 0.75);
     }
 
     &.highlighted {
-      background: rgba(colors.$sd-highlight, 0.75);
-
-      &:hover {
-        background: rgba(colors.$sd-pale-purple, 0.5);
-      }
+      background: rgba(colors.$sd-pale-purple, 0.5);
     }
 
     .event-card-title {


### PR DESCRIPTION
## Context
When scrolling quickly through the event card rail in the v2 UI, the selected event is difficult to notice with the current background color.  By flipping the event card highlight to the darker color, the card is more noticeable in the list of events.

## Objective
Flip the highlight colors in the event cards and remove the hover color change for the selected event.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
