### PR TITLE
fix: Fix null for cases of PR events

### DIFF
--- a/app/components/pipeline/modal/confirm-action/component.js
+++ b/app/components/pipeline/modal/confirm-action/component.js
@@ -41,7 +41,7 @@ export default class PipelineModalConfirmActionComponent extends Component {
   }
 
   get isLatestCommitEvent() {
-    return this.args.event.sha === this.latestCommitEvent.sha;
+    return this.args.event.sha === this.latestCommitEvent?.sha;
   }
 
   get commitUrl() {


### PR DESCRIPTION
## Context
The latest commit event is not needed for PR views and will subsequently be null

## Objective
Fix a null dereference for cases where the modal is created in the PR view

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
