### PR TITLE
fix: redirect routes when closing modals

### DIFF
--- a/app/components/pipeline/modal/confirm-action/component.js
+++ b/app/components/pipeline/modal/confirm-action/component.js
@@ -115,11 +115,22 @@ export default class PipelineModalConfirmActionComponent extends Component {
       .fetchFromApi('post', '/events', data)
       .then(event => {
         this.args.closeModal();
-        this.router.transitionTo('v2.pipeline.events.show', {
-          event,
-          reloadEventRail: true,
-          id: event.id
-        });
+
+        if (this.router.currentRouteName === 'v2.pipeline.events.show') {
+          this.router.transitionTo('v2.pipeline.events.show', {
+            event,
+            reloadEventRail: true,
+            id: event.id
+          });
+        } else if (this.router.currentRouteName === 'v2.pipeline.pulls.show') {
+          this.router.transitionTo('v2.pipeline.pulls.show', {
+            event,
+            reloadEventRail: true,
+            id: event.prNum,
+            pull_request_number: event.prNum,
+            sha: event.sha
+          });
+        }
       })
       .catch(err => {
         this.wasActionSuccessful = false;

--- a/app/components/pipeline/modal/start-event/component.js
+++ b/app/components/pipeline/modal/start-event/component.js
@@ -70,11 +70,22 @@ export default class PipelineModalStartEventComponent extends Component {
       .fetchFromApi('post', '/events', data)
       .then(event => {
         this.args.closeModal();
-        this.router.transitionTo('v2.pipeline.events.show', {
-          event,
-          reloadEventRail: true,
-          id: event.id
-        });
+
+        if (this.router.currentRouteName === 'v2.pipeline.events.show') {
+          this.router.transitionTo('v2.pipeline.events.show', {
+            event,
+            reloadEventRail: true,
+            id: event.id
+          });
+        } else if (this.router.currentRouteName === 'v2.pipeline.pulls.show') {
+          this.router.transitionTo('v2.pipeline.pulls.show', {
+            event,
+            reloadEventRail: true,
+            id: event.prNum,
+            pull_request_number: event.prNum,
+            sha: event.sha
+          });
+        }
       })
       .catch(err => {
         this.wasActionSuccessful = false;


### PR DESCRIPTION
## Context
The start event and confirm action modals are used in a few different routes (i.e., events, pulls, and jobs).  Each of these routes have different requirements for whether the transition should be made and to where.

## Objective
Fix the transitions so that they redirect to the current route when the modal auto closes.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
