### PR TITLE
feat: Update job table history size

### DIFF
--- a/app/components/pipeline/jobs/table/cell/history/styles.scss
+++ b/app/components/pipeline/jobs/table/cell/history/styles.scss
@@ -1,8 +1,12 @@
 @mixin styles {
   .history-cell {
     display: flex;
+    max-width: 9rem;
+    overflow: scroll;
 
     .build-history-container {
+      padding: 1rem 0;
+
       a {
         display: flex;
 

--- a/app/components/pipeline/jobs/table/cell/job/styles.scss
+++ b/app/components/pipeline/jobs/table/cell/job/styles.scss
@@ -8,6 +8,7 @@
       display: flex;
       height: 1.5rem;
       width: 1.5rem;
+      margin: 1rem 0;
 
       a {
         display: flex;
@@ -19,6 +20,7 @@
     }
 
     .job-name {
+      padding: 1rem 0;
       overflow: scroll;
     }
   }

--- a/app/components/pipeline/jobs/table/component.js
+++ b/app/components/pipeline/jobs/table/component.js
@@ -67,7 +67,8 @@ export default class PipelineJobsTableComponent extends Component {
     this.dataReloader = new DataReloader(
       this.shuttle,
       jobIds,
-      INITIAL_PAGE_SIZE
+      INITIAL_PAGE_SIZE,
+      this.args.numBuilds
     );
     const initialJobIds = this.dataReloader.newJobIds();
 

--- a/app/components/pipeline/jobs/table/dataReloader.js
+++ b/app/components/pipeline/jobs/table/dataReloader.js
@@ -14,13 +14,17 @@ export default class DataReloader {
 
   intervalId;
 
-  constructor(shuttle, jobIds, pageSize) {
+  numBuilds;
+
+  constructor(shuttle, jobIds, pageSize, numBuilds) {
     this.shuttle = shuttle;
     this.jobIdsMatchingFilter = jobIds.slice(0, pageSize);
 
     jobIds.forEach(jobId => {
       this.builds[jobId] = [];
     });
+
+    this.numBuilds = numBuilds || ENV.APP.NUM_BUILDS_LISTED;
   }
 
   setCorrectBuildStatus(builds) {
@@ -73,7 +77,7 @@ export default class DataReloader {
       .fetchFromApi(
         'get',
         `/builds/statuses?jobIds=${jobIds.join('&jobIds=')}&numBuilds=${
-          ENV.APP.NUM_BUILDS_LISTED
+          this.numBuilds
         }`
       )
       .then(response => {
@@ -91,6 +95,10 @@ export default class DataReloader {
           }
         });
       });
+  }
+
+  setNumBuilds(numBuilds) {
+    this.numBuilds = numBuilds;
   }
 
   start() {

--- a/app/components/pipeline/jobs/table/styles.scss
+++ b/app/components/pipeline/jobs/table/styles.scss
@@ -57,6 +57,7 @@
 
           tr {
             color: colors.$sd-text;
+            height: 4rem;
 
             &:hover {
               color: colors.$sd-text;


### PR DESCRIPTION
## Context
The jobs table history size is fixed to a default size and should be adjustable.

## Objective
Updates the jobs table to allow for configuration of the build history size.  Additionally updates the styling on the table to better handle potential overflows so that the scroll bar does not get overlayed on top of the content

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
