### PR TITLE
fix: disable x-scroll bar on banner

### DIFF
--- a/app/components/nav-banner/style.scss
+++ b/app/components/nav-banner/style.scss
@@ -29,7 +29,7 @@
       align-content: center;
 
       .banner-message {
-        overflow: scroll;
+        overflow-y: scroll;
       }
     }
   }


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Horizontal scroll bar on banner appears if user sets `Always` to `Settings > Appearance > Show scroll bars` on their Mac.
It is annoying to read the message on the banner.

![before](https://github.com/user-attachments/assets/14aadf5f-7050-4212-9b33-895fa98f4660)

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Disable horizontal scroll bar since it was originally not useable.

![after](https://github.com/user-attachments/assets/b8b6c1fe-2f09-4261-b993-62b007832082)

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
