### PR TITLE
fix: Do not redirect to current route

### DIFF
--- a/app/components/pipeline/event/card/component.js
+++ b/app/components/pipeline/event/card/component.js
@@ -187,6 +187,10 @@ export default class PipelineEventCardComponent extends Component {
     if (e.target.href) {
       e.stopPropagation();
     } else {
+      if (this.isHighlighted) {
+        return;
+      }
+
       if (this.args.onClick) {
         this.args.onClick();
       }


### PR DESCRIPTION
## Context
When clicking on the highlighted event card, which is the currently selected event, there is no need to have the UI to actually handle the redirect.

## Objective
Removes the redirect when clicking on the currently selected/displaying event.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
