### PR TITLE
feat: Cache PR jobs data

### DIFF
--- a/app/utils/pipeline/pull-request.js
+++ b/app/utils/pipeline/pull-request.js
@@ -39,3 +39,24 @@ export const newestPrNumber = prNumbers => {
 export const oldestPrNumber = prNumbers => {
   return prNumbers.size ? Math.min(...prNumbers) : null;
 };
+
+/**
+ * Transforms an array of PR jobs into a map of PR number to jobs
+ * @param jobs {Array<Object>} Jobs array with job objects in the shape returned by the API
+ * @returns {Map<number, Array<Object>>}
+ */
+export const getPrJobsMap = jobs => {
+  const prJobsMap = new Map();
+
+  jobs.forEach(job => {
+    const prNumber = getPrNumber(job);
+
+    if (!prJobsMap.has(prNumber)) {
+      prJobsMap.set(prNumber, []);
+    }
+
+    prJobsMap.get(prNumber).push(job);
+  });
+
+  return prJobsMap;
+};

--- a/app/workflow-data-reload/openPrsReloader.js
+++ b/app/workflow-data-reload/openPrsReloader.js
@@ -1,22 +1,35 @@
-import { getPrNumbers } from 'screwdriver-ui/utils/pipeline/pull-request';
+import {
+  getPrJobsMap,
+  getPrNumbers
+} from 'screwdriver-ui/utils/pipeline/pull-request';
 import DataReloader from './dataReloader';
 
 const CACHE_KEY = 'openPrNums';
 
 export default class OpenPrsReloader extends DataReloader {
+  prJobsCache;
+
   constructor(shuttle) {
     super(shuttle, CACHE_KEY);
+
+    this.prJobsCache = new Map();
   }
 
   async fetchDataForId() {
     return this.shuttle
       .fetchFromApi('get', `/pipelines/${this.pipelineId}/jobs?type=pr`)
       .then(prJobs => {
+        this.prJobsCache = getPrJobsMap(prJobs);
+
         return Array.from(getPrNumbers(prJobs)).sort((a, b) => a - b);
       });
   }
 
   getPrNums() {
     return this.responseCache.get(CACHE_KEY);
+  }
+
+  getJobsForPr(prNum) {
+    return this.prJobsCache.get(prNum);
   }
 }

--- a/app/workflow-data-reload/service.js
+++ b/app/workflow-data-reload/service.js
@@ -90,4 +90,8 @@ export default class WorkflowDataReloadService extends Service {
   getPrNums() {
     return this.openPrsReloader.getPrNums();
   }
+
+  getJobsForPr(prNum) {
+    return this.openPrsReloader.getJobsForPr(prNum);
+  }
 }

--- a/tests/unit/utils/pipeline/pull-request-test.js
+++ b/tests/unit/utils/pipeline/pull-request-test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'screwdriver-ui/tests/helpers';
 import {
+  getPrJobsMap,
   getPrNumber,
   getPrNumbers,
   newestPrNumber,
@@ -35,5 +36,19 @@ module('Unit | Route | utils/pipeline/pull-request', function (hooks) {
   test('oldestPrNumber returns correct value', function (assert) {
     assert.equal(oldestPrNumber(new Set([1, 2, 3, 9, 6])), 1);
     assert.equal(oldestPrNumber(new Set()), null);
+  });
+
+  test('getPrJobsMap returns correct map', function (assert) {
+    const jobs = [
+      { name: 'PR-3:foo' },
+      { name: 'PR-4:foo' },
+      { name: 'PR-3:bar' }
+    ];
+
+    const prJobsMap = getPrJobsMap(jobs);
+
+    assert.equal(prJobsMap.size, 2);
+    assert.equal(prJobsMap.get(3).length, 2);
+    assert.equal(prJobsMap.get(4).length, 1);
   });
 });

--- a/tests/unit/workflow-data-reload/openPrsReloader-test.js
+++ b/tests/unit/workflow-data-reload/openPrsReloader-test.js
@@ -37,5 +37,25 @@ module(
 
       assert.equal(spyResponseCache.get.calledOnce, true);
     });
+
+    test('getJobsForPr returns correct value', async function (assert) {
+      const shuttle = this.owner.lookup('service:shuttle');
+      const pipelineId = 123;
+
+      const openPrsReloader = new OpenPrsReloader(shuttle);
+
+      openPrsReloader.setPipelineId(pipelineId);
+
+      sinon
+        .stub(shuttle, 'fetchFromApi')
+        .resolves([{ name: 'PR-2' }, { name: 'PR-4' }, { name: 'PR-3' }]);
+
+      assert.equal(openPrsReloader.getJobsForPr(1), null);
+      assert.equal(openPrsReloader.getJobsForPr(2), null);
+
+      await openPrsReloader.fetchDataForId();
+      assert.equal(openPrsReloader.getJobsForPr(1), null);
+      assert.equal(openPrsReloader.getJobsForPr(2).length, 1);
+    });
   }
 );


### PR DESCRIPTION
## Context
When reloading PR builds in the background, the PR job names can be cached as well.

## Objective
Adds a cache of the job names for each open PR.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
