### PR TITLE
fix: Fix dereference of undefined

### DIFF
--- a/app/components/pipeline/workflow/event-rail/component.js
+++ b/app/components/pipeline/workflow/event-rail/component.js
@@ -76,7 +76,7 @@ export default class PipelineWorkflowEventRailComponent extends Component {
     const pipelineId = this.args.pipeline.id;
 
     if (this.isPR) {
-      if (this.prNums.length === 0) {
+      if (!this.prNums || this.prNums.length === 0) {
         return [];
       }
 


### PR DESCRIPTION
## Context
When switching from the event view to the PR view, the event rail is reloaded but has no assigned value for `prNums`

## Objective
Fix an invalid dereference

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
