### PR TITLE
fix: display of tags on job/pipeline template details page

### DIFF
--- a/app/templates/job/detail/route.js
+++ b/app/templates/job/detail/route.js
@@ -61,18 +61,14 @@ export default Route.extend(AuthenticatedRouteMixin, {
         this.router.transitionTo('/404');
       }
 
-      templateTagData.forEach(tagObj => {
-        [templateData, templateDataFiltered].forEach(verPayload => {
-          const taggedVerObj = verPayload.find(
-            verObj => verObj.version === tagObj.version
-          );
+      [...templateData, ...templateDataFiltered].forEach(template => {
+        const tags = templateTagData.filter(
+          tag => template.version === tag.version
+        );
 
-          if (taggedVerObj) {
-            taggedVerObj.tag = taggedVerObj.tag
-              ? `${taggedVerObj.tag} ${tagObj.tag}`
-              : tagObj.tag;
-          }
-        });
+        if (!template.tag) {
+          template.tag = tags.map(tag => tag.tag).join(' ');
+        }
       });
 
       this.setProperties({

--- a/app/templates/pipeline/detail/controller.js
+++ b/app/templates/pipeline/detail/controller.js
@@ -137,11 +137,12 @@ export default class TemplatesPipelineDetailController extends Controller {
   }
 
   get filteredTemplates() {
+    const { pipelineTemplateVersions, pipelineTemplateTags } = this.model;
     const { startTime, endTime } = this;
     const startTimeInDate = new Date(startTime);
     const endTimeInDate = new Date(endTime);
 
-    let filteredVersions = this.model.pipelineTemplateVersions.filter(v => {
+    const filteredVersions = pipelineTemplateVersions.filter(v => {
       // TODO: polyfill pipeline template metrics data
       v.metrics = {
         jobs: { count: '' },
@@ -154,6 +155,16 @@ export default class TemplatesPipelineDetailController extends Controller {
       return (
         createTimeInDate >= startTimeInDate && createTimeInDate <= endTimeInDate
       );
+    });
+
+    filteredVersions.forEach(template => {
+      const tags = pipelineTemplateTags.filter(
+        tag => template.version === tag.version
+      );
+
+      if (!template.tag) {
+        template.tag = tags.map(tag => tag.tag).join(' ');
+      }
     });
 
     return filteredVersions;

--- a/tests/acceptance/pipeline-template-test.js
+++ b/tests/acceptance/pipeline-template-test.js
@@ -431,5 +431,9 @@ module('Acceptance | pipeline template', function (hooks) {
     assert
       .dom('div.parameters > span.value > ul > li > span.value')
       .includesText('value1');
+
+    assert
+      .dom('table.table td div.version-cell')
+      .includesText('1.0.3 - latest');
   });
 });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Tags of job/pipeline template is shown on versions table. But

1. Tags will be duplicate when transition between the job template detail page and other page

https://github.com/user-attachments/assets/b8cedbec-6407-418b-a731-6ffe4f57c959

2. Tags does not appear on the pipeline template pages

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

This PR will fix display tags on template detail pages.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
