### PR TITLE
fix: Fix alignment issue for created job history

### DIFF
--- a/app/components/pipeline/jobs/table/cell/history/styles.scss
+++ b/app/components/pipeline/jobs/table/cell/history/styles.scss
@@ -7,7 +7,8 @@
     .build-history-container {
       padding: 1rem 0;
 
-      a {
+      a,
+      .created {
         display: flex;
 
         svg {

--- a/app/components/pipeline/jobs/table/cell/history/template.hbs
+++ b/app/components/pipeline/jobs/table/cell/history/template.hbs
@@ -1,40 +1,42 @@
 <div class="history-cell">
   {{#if this.latestBuilds}}
     {{#each this.latestBuilds as |build|}}
-      {{#if (not-eq build.status "CREATED")}}
-        <span class="build-history-container">
-          <LinkTo
-            @route="pipeline.build"
-            @models={{array @record.job.pipelineId build.id}}
-            @title={{build.id}}
-          >
+      <span class="build-history-container">
+        {{#if (not-eq build.status "CREATED")}}
+            <LinkTo
+              @route="pipeline.build"
+              @models={{array @record.job.pipelineId build.id}}
+              @title={{build.id}}
+            >
+              <FaIcon
+                @icon="circle"
+                @fixedWidth="true"
+                class={{build.status}}
+              />
+            </LinkTo>
+            <BsTooltip
+              @placement="bottom"
+              @renderInPlace={{true}}
+              class="tooltip"
+            >
+              <p>Build# {{build.id}}</p>
+              {{#if build.startTime}}
+                <p>Start - {{moment-format build.startTime "MM/DD/YYYY HH:mmA"}}</p>
+              {{/if}}
+              {{#if build.endTime}}
+                <p>End - {{moment-format build.endTime "MM/DD/YYYY HH:mmA"}}</p>
+              {{/if}}
+            </BsTooltip>
+        {{else}}
+          <div class="created">
             <FaIcon
               @icon="circle"
               @fixedWidth="true"
               class={{build.status}}
             />
-          </LinkTo>
-          <BsTooltip
-            @placement="bottom"
-            @renderInPlace={{true}}
-            class="tooltip"
-          >
-            <p>Build# {{build.id}}</p>
-            {{#if build.startTime}}
-              <p>Start - {{moment-format build.startTime "MM/DD/YYYY HH:mmA"}}</p>
-            {{/if}}
-            {{#if build.endTime}}
-              <p>End - {{moment-format build.endTime "MM/DD/YYYY HH:mmA"}}</p>
-            {{/if}}
-          </BsTooltip>
-        </span>
-      {{else}}
-        <FaIcon
-          @icon="circle"
-          @fixedWidth="true"
-          class={{build.status}}
-        />
-      {{/if}}
+          </div>
+        {{/if}}
+      </span>
     {{/each}}
   {{/if}}
 </div>


### PR DESCRIPTION
## Context
For created jobs, the history icon is not aligned properly
![Screenshot 2024-12-12 at 09-49-14 sports_sports Jobs](https://github.com/user-attachments/assets/54f18a88-5ba2-41a8-b7d0-5f6bce3254a6)

## Objective
Fix the alignment problem with created job icons

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
