### PR TITLE
fix: Clear out tracking variables

### DIFF
--- a/app/components/pipeline/workflow/event-rail/component.js
+++ b/app/components/pipeline/workflow/event-rail/component.js
@@ -69,6 +69,12 @@ export default class PipelineWorkflowEventRailComponent extends Component {
       this.firstItemId = event.id;
       this.newestEvent = event;
       this.events = [event];
+      this.oldestEvent = null;
+
+      if (this.intervalId) {
+        clearInterval(this.intervalId);
+        this.intervalId = null;
+      }
     }
   }
 


### PR DESCRIPTION
## Context
The event rail component allows for doing a reload when args are updated on it.  There are a couple extra tracking variables that should also get reset when the component is requested to be reset.

## Objective
Clear out the remaining tracking variables for the event rail when the component should be reloaded.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
