### PR TITLE
feat: Handle restrict pr

### DIFF
--- a/app/components/pipeline/event/card/component.js
+++ b/app/components/pipeline/event/card/component.js
@@ -56,6 +56,8 @@ export default class PipelineEventCardComponent extends Component {
 
   @tracked showEventHistoryModal;
 
+  @tracked showStartEventModal;
+
   queueName;
 
   userSettings;
@@ -338,5 +340,15 @@ export default class PipelineEventCardComponent extends Component {
   @action
   closeEventHistoryModal() {
     this.showEventHistoryModal = false;
+  }
+
+  @action
+  openStartEventModal() {
+    this.showStartEventModal = true;
+  }
+
+  @action
+  closeStartEventModal() {
+    this.showStartEventModal = false;
   }
 }

--- a/app/components/pipeline/event/card/styles.scss
+++ b/app/components/pipeline/event/card/styles.scss
@@ -91,7 +91,8 @@
         }
       }
 
-      .abort-event-button {
+      .abort-event-button,
+      .start-event-button {
         margin-left: auto;
         background-color: colors.$sd-white;
       }

--- a/app/components/pipeline/event/card/template.hbs
+++ b/app/components/pipeline/event/card/template.hbs
@@ -75,7 +75,6 @@
               @pipeline={{@pipeline}}
               @jobs={{@jobs}}
               @event={{@event}}
-              @isRestrictPR={{true}}
               @closeModal={{this.closeStartEventModal}}
             />
           {{/if}}

--- a/app/components/pipeline/event/card/template.hbs
+++ b/app/components/pipeline/event/card/template.hbs
@@ -35,7 +35,7 @@
       </a>
     </div>
     {{#if (eq this.status "RUNNING")}}
-      {{#if @showAbort}}
+      {{#if @allowEventAction}}
         <BsButton
           class="abort-event-button"
           @type="danger"
@@ -52,6 +52,31 @@
             <Pipeline::Modal::StopBuild
               @eventId={{@event.id}}
               @closeModal={{this.closeAbortBuildModal}}
+            />
+          {{/if}}
+        </BsButton>
+      {{/if}}
+    {{else}}
+      {{#if (and @allowEventAction this.isPR)}}
+        <BsButton
+          class="start-event-button"
+          @type="primary"
+          @outline={{true}}
+          @onClick={{fn this.openStartEventModal}}
+          title="Start PR event"
+        >
+          <FaIcon
+            @icon="play-circle"
+            @fixedWidth="true"
+            @prefix="far"
+          />
+          {{#if this.showStartEventModal}}
+            <Pipeline::Modal::StartEvent
+              @pipeline={{@pipeline}}
+              @jobs={{@jobs}}
+              @event={{@event}}
+              @isRestrictPR={{true}}
+              @closeModal={{this.closeStartEventModal}}
             />
           {{/if}}
         </BsButton>

--- a/app/components/pipeline/modal/start-event/component.js
+++ b/app/components/pipeline/modal/start-event/component.js
@@ -66,7 +66,7 @@ export default class PipelineModalStartEventComponent extends Component {
       this.session.data.authenticated.username,
       this.pipeline.id,
       this.args.job,
-      null,
+      this.args.event,
       this.parameters,
       false,
       null

--- a/app/components/pipeline/workflow/component.js
+++ b/app/components/pipeline/workflow/component.js
@@ -10,6 +10,7 @@ const PR_EVENT = 'pr';
 const BUILD_QUEUE_NAME = 'graph';
 const LATEST_COMMIT_EVENT_QUEUE_NAME = 'latestCommitEvent';
 const OPEN_PRS_QUEUE_NAME = 'openPrs';
+const RESTRICT_PR_ANNOTATION = 'screwdriver.cd/restrictPR';
 
 export default class PipelineWorkflowComponent extends Component {
   @service router;
@@ -222,6 +223,43 @@ export default class PipelineWorkflowComponent extends Component {
       this.workflowGraph.nodes.length !==
       this.workflowGraphWithDownstreamTriggers.nodes.length
     );
+  }
+
+  get hasPrRestrictions() {
+    if (!this.isPR) {
+      return false;
+    }
+
+    if (
+      this.pipeline.annotations &&
+      Object.hasOwn(this.pipeline.annotations, RESTRICT_PR_ANNOTATION)
+    ) {
+      const restriction = this.pipeline.annotations[RESTRICT_PR_ANNOTATION];
+
+      return restriction !== 'none';
+    }
+
+    return false;
+  }
+
+  get hasForkPrRestriction() {
+    if (!this.hasPrRestrictions) {
+      return false;
+    }
+
+    const restriction = this.pipeline.annotations[RESTRICT_PR_ANNOTATION];
+
+    return restriction === 'fork' || restriction === 'all';
+  }
+
+  get hasBranchPrRestriction() {
+    if (!this.hasPrRestrictions) {
+      return false;
+    }
+
+    const restriction = this.pipeline.annotations[RESTRICT_PR_ANNOTATION];
+
+    return restriction === 'branch' || restriction === 'all';
   }
 
   @action

--- a/app/components/pipeline/workflow/event-rail/template.hbs
+++ b/app/components/pipeline/workflow/event-rail/template.hbs
@@ -52,7 +52,7 @@
         @jobs={{@jobs}}
         @userSettings={{@userSettings}}
         @queueName="eventRail"
-        @showAbort={{true}}
+        @allowEventAction={{true}}
         @showParameters={{true}}
         @showEventGroup={{true}}
         @handleFilter={{true}}

--- a/app/components/pipeline/workflow/styles.scss
+++ b/app/components/pipeline/workflow/styles.scss
@@ -25,15 +25,16 @@
 
     #workflow-display-container {
       grid-area: workflow;
+      display: flex;
+      flex-direction: column;
       overflow: auto;
       padding-right: 1rem;
-      $graph-controls-height: 2.5rem;
 
       #workflow-display-controls {
         display: flex;
         align-content: center;
         padding-left: 1rem;
-        height: $graph-controls-height;
+        height: 2.5rem;
 
         #show-workflow-graph-button,
         #show-workflow-table-button {
@@ -88,9 +89,34 @@
         }
       }
 
+      #pr-restrictions {
+        display: flex;
+        height: 2.5rem;
+        margin-left: 1rem;
+        color: colors.$sd-warning;
+
+        .restriction-message {
+          margin-top: auto;
+          margin-bottom: auto;
+          margin-right: 0.25rem;
+        }
+
+        svg {
+          margin-top: auto;
+          margin-bottom: auto;
+
+          &.restriction-icon-container {
+            width: 1rem;
+            height: 1rem;
+            margin-left: 0.25rem;
+            margin-right: 0.25rem;
+          }
+        }
+      }
+
       #display-container {
         position: relative;
-        height: calc(100% - $graph-controls-height);
+        flex: 1;
         padding-top: 1rem;
         overflow: auto;
 

--- a/app/components/pipeline/workflow/styles.scss
+++ b/app/components/pipeline/workflow/styles.scss
@@ -93,11 +93,13 @@
         display: flex;
         height: 2.5rem;
         margin-left: 1rem;
-        color: colors.$sd-warning;
+        color: hsl(from colors.$sd-warning h s 40%);
+        background-color: rgba(colors.$sd-warning, 0.25);
 
         .restriction-message {
           margin-top: auto;
           margin-bottom: auto;
+          margin-left: 1rem;
           margin-right: 0.25rem;
         }
 

--- a/app/components/pipeline/workflow/template.hbs
+++ b/app/components/pipeline/workflow/template.hbs
@@ -60,7 +60,33 @@
           </div>
         {{/if}}
       </div>
-
+      {{#if this.hasPrRestrictions}}
+        <div id="pr-restrictions">
+          <div class="restriction-message">
+            Pipeline configuration has restricted automatic building of Pull Requests:
+          </div>
+          {{#if this.hasBranchPrRestriction}}
+            <svg class="restriction-icon-container">
+              <FaIcon
+                @icon="code-branch"
+                @fixedWidth="true"
+                @prefix="fa"
+              />
+              <title>Pull requests from branches are disabled from automatically running</title>
+            </svg>
+          {{/if}}
+          {{#if this.hasForkPrRestriction}}
+            <svg class="restriction-icon-container">
+              <FaIcon
+                @icon="code-fork"
+                @fixedWidth="true"
+                @prefix="fa"
+              />
+              <title>Pull requests from forked repositories are disabled from automatically running</title>
+            </svg>
+          {{/if}}
+        </div>
+      {{/if}}
       <div id="display-container">
         {{#if this.showGraph}}
           <Pipeline::Workflow::Graph

--- a/tests/integration/components/pipeline/event/card/component-test.js
+++ b/tests/integration/components/pipeline/event/card/component-test.js
@@ -119,6 +119,7 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
     assert.dom('.event-card-title .event-status svg').exists({ count: 1 });
     assert.dom('.event-card-title pr-title').doesNotExist();
     assert.dom('.event-card-title .sha').exists({ count: 1 });
+    assert.dom('.event-card-title .start-event-button').doesNotExist();
 
     assert.dom('.event-card-body').exists({ count: 1 });
     assert.dom('.event-card-body .message').exists({ count: 1 });
@@ -331,7 +332,7 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
       hbs`<Pipeline::Event::Card
         @event={{this.event}}
         @userSettings={{this.userSettings}}
-        @showAbort={{true}}
+        @allowEventAction={{true}}
       />`
     );
 
@@ -736,6 +737,46 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
 
     assert.dom('.event-card-title .pr-title').exists({ count: 1 });
     assert.dom('.event-card-title .pr-title').containsText('PR-4');
+    assert.dom('.event-card-title .start-event-button').doesNotExist();
+  });
+
+  test('it renders start event button for PR', async function (assert) {
+    const router = this.owner.lookup('service:router');
+    const workflowDataReload = this.owner.lookup(
+      'service:workflow-data-reload'
+    );
+
+    sinon.stub(router, 'currentURL').value('/v2/pipelines/1/pulls/2');
+    sinon
+      .stub(workflowDataReload, 'registerLatestCommitEventCallback')
+      .callsFake(() => {});
+    sinon
+      .stub(workflowDataReload, 'registerBuildsCallback')
+      .callsFake(() => {});
+
+    this.setProperties({
+      event: {
+        id: 11,
+        groupEventId: 11,
+        sha: 'abc123def456',
+        commit: { author: { name: 'batman' }, message: 'Some amazing changes' },
+        creator: { name: 'batman' },
+        meta: {},
+        type: 'pr',
+        prNum: 4
+      },
+      userSettings: {}
+    });
+
+    await render(
+      hbs`<Pipeline::Event::Card
+        @event={{this.event}}
+        @userSettings={{this.userSettings}}
+        @allowEventAction={{true}}
+      />`
+    );
+
+    assert.dom('.event-card-title .start-event-button').exists({ count: 1 });
   });
 
   test('it does not render highlight for PR', async function (assert) {


### PR DESCRIPTION
## Context
When a pipeline has the `restrictPR annotation`, pull request events need the ability to be manually started.

https://github.com/screwdriver-cd/ui/pull/1346 should be merged prior to this.

## Objective
Adds in a manual start button to the event card for pipelines with the `restrictPR` annotation
![Screenshot 2024-12-12 at 17-40-45 minghay_restrict-fork Pulls](https://github.com/user-attachments/assets/6d8b7882-bb73-49c5-a638-59ada8b3a244)

Also adds a notice within the UI to inform users what restrictions exist on the pipeline.  The hover state over the icons provides longer text to the user explaining what the restriction is.
![Screenshot 2025-02-20 at 12-08-39 Pulls](https://github.com/user-attachments/assets/4b3a6ea3-1153-4d49-abc1-c2429419bed0)

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200
https://github.com/screwdriver-cd/ui/pull/1346

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
