### PR TITLE
fix: First PR reload

### DIFF
--- a/app/v2/pipeline/pulls/show/route.js
+++ b/app/v2/pipeline/pulls/show/route.js
@@ -17,11 +17,13 @@ export default class V2PipelinePullsShowRoute extends Route {
     }
   };
 
-  async model(params) {
+  async model(params, transition) {
     const model = this.modelFor('v2.pipeline.pulls');
-    const { pipeline, pullRequestJobs } = model;
+    const { pipeline } = model;
     const pipelineId = pipeline.id;
-    const prNums = getPrNumbers(pullRequestJobs);
+    const prNums = transition.data.prNums
+      ? new Set(transition.data.prNums)
+      : getPrNumbers(model.pullRequestJobs);
     const prNum = parseInt(params.pull_request_number, 10);
     const { sha } = params;
 

--- a/app/workflow-data-reload/service.js
+++ b/app/workflow-data-reload/service.js
@@ -87,6 +87,14 @@ export default class WorkflowDataReloadService extends Service {
     return this.latestCommitEventReloader.getLatestCommitEvent();
   }
 
+  registerOpenPrsCallback(queueName, id, callback) {
+    this.openPrsReloader.registerCallback(queueName, id, callback);
+  }
+
+  removeOpenPrsCallback(queueName, id) {
+    this.openPrsReloader.removeCallback(queueName, id);
+  }
+
   getPrNums() {
     return this.openPrsReloader.getPrNums();
   }

--- a/tests/integration/components/pipeline/workflow/component-test.js
+++ b/tests/integration/components/pipeline/workflow/component-test.js
@@ -38,11 +38,13 @@ module('Integration | Component | pipeline/workflow', function (hooks) {
 
   test('it renders for pipeline with no PRs', async function (assert) {
     const router = this.owner.lookup('service:router');
+    const shuttle = this.owner.lookup('service:shuttle');
     const workflowDataReload = this.owner.lookup(
       'service:workflow-data-reload'
     );
 
     sinon.stub(router, 'currentRouteName').value('pulls');
+    sinon.stub(shuttle, 'fetchFromApi').resolves([]);
     sinon.stub(workflowDataReload, 'start').callsFake(() => {});
 
     this.setProperties({


### PR DESCRIPTION
## Context
When a user is on the PR view and there are no open PRs, the UI should be reloading open PR data from the API and then redirect the page to the first open PR when it is available.

## Objective
Add in background reloading of open PRs when there are none open at page load.  When a PR is finally opened, the page should redirect to the newly opened PR to load the correct workflow graph and the associated event card in the event rail.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
