### PR TITLE
fix(3247): Virtual job icon is broken while redrawing workflow graph with build statuses

### DIFF
--- a/app/components/pipeline/workflow/graph/component.js
+++ b/app/components/pipeline/workflow/graph/component.js
@@ -131,6 +131,13 @@ export default class PipelineWorkflowGraphComponent extends Component {
 
   @action
   redraw(element, [workflowGraph, builds, event]) {
+    const elementSizes = getElementSizes();
+    const maximumJobNameLength = getMaximumJobNameLength(
+      this.decoratedGraph,
+      this.args.displayJobNameLength
+    );
+    const nodeWidth = getNodeWidth(elementSizes, maximumJobNameLength);
+
     if (
       this.event.id !== event.id ||
       this.decoratedGraph.nodes.length !== workflowGraph.nodes.length
@@ -149,6 +156,11 @@ export default class PipelineWorkflowGraphComponent extends Component {
 
     this.getDecoratedGraph(workflowGraph, builds, event);
     updateEdgeStatuses(this.graphSvg, this.decoratedGraph);
-    updateJobStatuses(this.graphSvg, this.decoratedGraph);
+    updateJobStatuses(
+      this.graphSvg,
+      this.decoratedGraph,
+      elementSizes,
+      nodeWidth
+    );
   }
 }

--- a/app/components/workflow-graph-d3/component.js
+++ b/app/components/workflow-graph-d3/component.js
@@ -12,11 +12,13 @@ import {
   addJobIcons,
   addJobNames,
   addStages,
+  calcNodeCenter,
   getElementSizes,
   getGraphSvg,
   getMaximumJobNameLength,
   getNodeWidth,
-  icon
+  icon,
+  STATUS_MAP
 } from 'screwdriver-ui/utils/pipeline/graph/d3-graph-util';
 
 export default Component.extend({
@@ -199,6 +201,14 @@ export default Component.extend({
     if (!data) return;
     const el = d3.select(this.element);
 
+    const elementSizes = getElementSizes();
+    const { ICON_SIZE } = elementSizes;
+    const maximumJobNameLength = getMaximumJobNameLength(
+      this.decoratedGraph,
+      this.args.displayJobNameLength
+    );
+    const nodeWidth = getNodeWidth(elementSizes, maximumJobNameLength);
+
     data.nodes.forEach(node => {
       const n = el.select(`g.graph-node[data-job="${node.name}"]`);
 
@@ -211,7 +221,23 @@ export default Component.extend({
           `graph-node${
             node.status ? ` build-${node.status.toLowerCase()}` : ''
           }`
-        );
+        )
+          .attr(
+            'font-size',
+            `${
+              icon(node.status, node.virtual) === STATUS_MAP.VIRTUAL.icon
+                ? ICON_SIZE * 2
+                : ICON_SIZE
+            }px`
+          )
+          .style('text-anchor', 'middle')
+          .attr(
+            'x',
+            calcNodeCenter(node.pos.x, nodeWidth) +
+              (icon(node.status, node.virtual) === STATUS_MAP.VIRTUAL.icon
+                ? ICON_SIZE / 2
+                : 0)
+          );
       }
     });
   },

--- a/app/utils/pipeline/graph/d3-graph-util.js
+++ b/app/utils/pipeline/graph/d3-graph-util.js
@@ -20,6 +20,8 @@ const STATUS_MAP = {
   VIRTUAL: { icon: '\ue911' }
 };
 
+export { STATUS_MAP };
+
 /**
  * Find the icon to set as the text for a node
  * @method icon
@@ -28,7 +30,10 @@ const STATUS_MAP = {
  * @return {String}        Unicode character that maps to an icon in screwdriver icon font
  */
 export function icon(status, isVirtual) {
-  if (isVirtual) {
+  if (
+    isVirtual &&
+    (!status || ['SUCCESS', 'WARNING', 'CREATED'].includes(status))
+  ) {
     return STATUS_MAP.VIRTUAL.icon;
   }
 
@@ -625,8 +630,12 @@ export function addJobNames(
  * Updates the job statuses in the existing graph SVG
  * @param svg
  * @param data
+ * @param sizes
+ * @param nodeWidth
  */
-export function updateJobStatuses(svg, data) {
+export function updateJobStatuses(svg, data, sizes, nodeWidth) {
+  const { ICON_SIZE } = sizes;
+
   svg
     .selectAll('.graph-node')
     .data(data.nodes)
@@ -636,9 +645,24 @@ export function updateJobStatuses(svg, data) {
         node.status ? ` build-${node.status.toLowerCase()}` : ''
       }`;
     })
+    .attr('font-size', node => {
+      return `${
+        icon(node.status, node.virtual) === STATUS_MAP.VIRTUAL.icon
+          ? ICON_SIZE * 2
+          : ICON_SIZE
+      }px`;
+    })
+    .attr('x', node => {
+      return (
+        calcNodeCenter(node.pos.x, nodeWidth) +
+        (icon(node.status, node.virtual) === STATUS_MAP.VIRTUAL.icon
+          ? ICON_SIZE / 2
+          : 0)
+      );
+    })
     .select('text')
     .html(node => {
-      return icon(node.status);
+      return icon(node.status, node.virtual);
     });
 }
 


### PR DESCRIPTION
## Context

Changes were made in this PR https://github.com/screwdriver-cd/ui/pull/1229 to show a different icon for virtual jobs to visually differentiate with other jobs.

When the workflow graph is redrawn after refreshing the status of builds for an active event, the icon for virtual jobs is not rendered as expected.

The redraw logic does not consider where the job is virtual or not.

## Objective

Update the redraw logic to consider if a node is virtual or not while determining/drawing the icon based on the updated status.

## References

https://github.com/screwdriver-cd/screwdriver/issues/3247

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
