### PR TITLE
fix: stage name to be displayed in the modal to start stage build

### DIFF
--- a/app/components/pipeline-workflow/template.hbs
+++ b/app/components/pipeline-workflow/template.hbs
@@ -54,7 +54,7 @@
         {{#if (eq this.newEventStartFromType 'STAGE')}}
           Stage:
           <code>
-            {{this.menuData.stage.name}}
+            {{this.stageMenuData.stage.name}}
           </code>
         {{else}}
           Job:


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
When starting a stage build from the UI, the stage name is not displayed in the modal.

![image](https://github.com/user-attachments/assets/b0f1adc9-47a7-4723-abba-960982b4c6d0)

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Fix it so that the stage name is displayed.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
