### PR TITLE
fix: Fix undefined displayJobNameLength

### DIFF
--- a/app/components/workflow-graph-d3/component.js
+++ b/app/components/workflow-graph-d3/component.js
@@ -177,7 +177,7 @@ export default Component.extend({
       this.draw(decoratedGraph);
       set(this, 'lastGraph', wg);
     } else {
-      this.redraw(decoratedGraph);
+      this.redraw(decoratedGraph).then(() => {});
     }
   },
   actions: {
@@ -197,15 +197,17 @@ export default Component.extend({
       }
     }
   },
-  redraw(data) {
+  async redraw(data) {
     if (!data) return;
     const el = d3.select(this.element);
 
     const elementSizes = getElementSizes();
     const { ICON_SIZE } = elementSizes;
+    const desiredJobNameLength =
+      await this.userSettings.getDisplayJobNameLength();
     const maximumJobNameLength = getMaximumJobNameLength(
       this.decoratedGraph,
-      this.args.displayJobNameLength
+      desiredJobNameLength
     );
     const nodeWidth = getNodeWidth(elementSizes, maximumJobNameLength);
 


### PR DESCRIPTION
## Context
https://github.com/screwdriver-cd/ui/pull/1302 introduced a dereference of an undefined arg in a classic Ember component when attempting to determine what the configured display name length should be.

## Objective
Fix the value for the configured display name length.

## References
https://github.com/screwdriver-cd/ui/pull/1302

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
