### PR TITLE
fix: Keep external jobs if they are not sink nodes

### DIFF
--- a/tests/unit/components/pipeline/workflow/util-test.js
+++ b/tests/unit/components/pipeline/workflow/util-test.js
@@ -20,6 +20,19 @@ module('Unit | Component | pipeline/workflow/util', function () {
     );
   });
 
+  test('getFilteredGraph returns original graph if there are no external jobs', function (assert) {
+    assert.deepEqual(
+      getFilteredGraph({
+        nodes: [{ name: 'main' }, { name: 'build' }],
+        edges: [{ src: 'main', dest: 'build' }]
+      }),
+      {
+        nodes: [{ name: 'main' }, { name: 'build' }],
+        edges: [{ src: 'main', dest: 'build' }]
+      }
+    );
+  });
+
   test('getFilteredGraph removes nodes that trigger external pipelines', function (assert) {
     assert.deepEqual(
       getFilteredGraph({
@@ -32,6 +45,25 @@ module('Unit | Component | pipeline/workflow/util', function () {
       {
         nodes: [{ name: 'main' }, { name: 'build' }],
         edges: [{ src: 'main', dest: 'build' }]
+      }
+    );
+  });
+
+  test('getFilteredGraph keeps external pipeline nodes in the middle of the graph', function (assert) {
+    assert.deepEqual(
+      getFilteredGraph({
+        nodes: [{ name: 'sd@123' }, { name: 'main' }, { name: 'build' }],
+        edges: [
+          { src: 'main', dest: 'sd@123' },
+          { src: 'sd@123', dest: 'build' }
+        ]
+      }),
+      {
+        nodes: [{ name: 'sd@123' }, { name: 'main' }, { name: 'build' }],
+        edges: [
+          { src: 'main', dest: 'sd@123' },
+          { src: 'sd@123', dest: 'build' }
+        ]
       }
     );
   });


### PR DESCRIPTION
## Context
The V2 UI graph is not handling pipelines that have external jobs in the middle of the graph.

## Objective
Fixes the V2 pipeline graph to only remove external jobs if they are sink nodes

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
