### PR TITLE
fix(3262): Allow anchor tags within the nav banner

### DIFF
--- a/app/components/nav-banner/template.hbs
+++ b/app/components/nav-banner/template.hbs
@@ -11,7 +11,7 @@
         />
         <div class="banner-message">
           <span>
-            {{banner.message}}
+            {{{input-sanitizer banner.message}}}
           </span>
         </div>
       </div>

--- a/tests/integration/components/nav-banner/component-test.js
+++ b/tests/integration/components/nav-banner/component-test.js
@@ -27,4 +27,47 @@ module('Integration | Component | nav banner', function (hooks) {
 
     assert.dom('.banner').hasText('× shutdown imminent');
   });
+
+  test('it renders banner with image tag', async function (assert) {
+    const bannerStub = Service.extend({
+      fetchBanners: () =>
+        resolve([
+          EmberObject.create({
+            id: 2,
+            isActive: true,
+            message: `Image tag: <img src="#notanimage" onerror="alert('unsafe script injection from warning!')" />`
+          })
+        ])
+    });
+
+    this.owner.register('service:banner', bannerStub);
+
+    await render(hbs`<NavBanner />`);
+
+    assert.dom('.banner-message').hasText('Image tag:');
+  });
+
+  test('it renders with link', async function (assert) {
+    const bannerStub = Service.extend({
+      fetchBanners: () =>
+        resolve([
+          EmberObject.create({
+            id: 3,
+            isActive: true,
+            message: `test - <a href="https://docs.screwdriver.cd/" onclick="alert('xss test');">screwdriver docs</a>`
+          })
+        ])
+    });
+
+    this.owner.register('service:banner', bannerStub);
+
+    await render(hbs`<NavBanner />`);
+
+    assert.dom('.banner-message').hasText('test - screwdriver docs');
+    assert
+      .dom('.banner-message > span > a')
+      .hasAttribute('href', 'https://docs.screwdriver.cd/');
+    assert.dom('.banner-message > span > a').hasNoAttribute('rel');
+    assert.dom('.banner-message > span > a').hasNoAttribute('onclick');
+  });
 });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

I fixed the issue that prevented anchor tags from being used within the nav banner.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

I implemented sanitization while allowing anchor tags to be displayed.
The sanitization mechanism is based on [other parts of the code](https://github.com/screwdriver-cd/ui/blob/master/app/components/info-message/template.hbs#L12-L27).

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

https://github.com/screwdriver-cd/screwdriver/issues/3262

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
