### PR TITLE
fix(2330): Calculate the maximum depth of the node on workflow graph

### DIFF
--- a/app/utils/graph-tools.js
+++ b/app/utils/graph-tools.js
@@ -240,6 +240,10 @@ const positionStage = (x, y, stage) => {
   const stageStartX = x;
   const stageEndX = stageStartX + stageGraph.meta.width - 1;
 
+  for (let i = stageStartX; i <= stageEndX; i += 1) {
+    if (!y[i]) y[i] = y[0] - 1;
+  }
+
   // Find a row with no items for all the stage columns
   const stageStartY = Math.max(...y.slice(stageStartX, stageEndX + 1));
 
@@ -264,6 +268,61 @@ const positionStage = (x, y, stage) => {
   }
 };
 
+const calcNodeDepth = graph => {
+  const result = [];
+  const nodes = {};
+  const edges = {};
+  const srcEdges = {};
+  const visited = {};
+  const depth = {};
+
+  graph.nodes.forEach(n => {
+    nodes[n.name] = n;
+    depth[n.name] = 0;
+  });
+  graph.edges.forEach(({ src, dest }) => {
+    if (!edges[src]) {
+      edges[src] = [];
+    }
+
+    if (!srcEdges[dest]) {
+      srcEdges[dest] = [];
+    }
+
+    edges[src].push(dest);
+    srcEdges[dest].push(src);
+  });
+
+  // Topological sort
+  const search = n => {
+    if (!visited[n.name]) {
+      visited[n.name] = true;
+      if (edges[n.name]) edges[n.name].forEach(dest => search(nodes[dest]));
+      result.push(n);
+    }
+  };
+
+  graph.nodes.forEach(n => search(n));
+  const sortedNodes = result.reverse();
+
+  // Set graph depth
+  for (const n of sortedNodes) {
+    let x = -1;
+
+    if (srcEdges[n.name]) {
+      for (const src of srcEdges[n.name]) {
+        x = Math.max(x, depth[src]);
+      }
+    }
+
+    x += 1;
+
+    depth[n.name] = x;
+  }
+
+  return depth;
+};
+
 /**
  * Walks the graph to find siblings and set their positions
  * @method walkGraph
@@ -273,14 +332,16 @@ const positionStage = (x, y, stage) => {
  * @param  {Array}   y                    Accumulator of column depth
  * @param  {Object}  stageNameToStageMap  Map of stage name to stage metadata (also includes workflow graph)
  */
-const walkGraph = (graph, start, x, y, stageNameToStageMap) => {
-  if (!y[x]) {
-    y[x] = y[0] - 1;
-  }
+const walkGraph = (graph, start, y, stageNameToStageMap, nodeDepth) => {
   const nodeNames = graph.edges.filter(e => e.src === start).map(e => e.dest);
 
   nodeNames.forEach(name => {
     const obj = node(graph.nodes, name);
+    const x = nodeDepth[name];
+
+    if (!y[x]) {
+      y[x] = y[0] - 1;
+    }
 
     const { stageName } = obj;
 
@@ -292,13 +353,13 @@ const walkGraph = (graph, start, x, y, stageNameToStageMap) => {
       }
 
       // walk if not yet visited
-      walkGraph(graph, name, x + 1, y, stageNameToStageMap);
+      walkGraph(graph, name, y, stageNameToStageMap, nodeDepth);
     } else if (!obj.pos) {
       obj.pos = { x, y: y[x] };
       y[x] += 1;
 
       // walk if not yet visited
-      walkGraph(graph, name, x + 1, y, stageNameToStageMap);
+      walkGraph(graph, name, y, stageNameToStageMap, nodeDepth);
     }
   });
 };
@@ -384,6 +445,7 @@ const positionGraphNodes = graph => {
       : null;
 
   let y = [0]; // accumulator for column heights
+  const nodeDepth = calcNodeDepth(graph);
 
   nodes.forEach(n => {
     // Set root nodes on left
@@ -413,7 +475,7 @@ const positionGraphNodes = graph => {
       }
 
       // recursively walk the graph from root/ detached node
-      walkGraph(graph, n.name, 1, y, stageNameToStageMap);
+      walkGraph(graph, n.name, y, stageNameToStageMap, nodeDepth);
     }
   });
 
@@ -421,7 +483,7 @@ const positionGraphNodes = graph => {
   graph.meta = {
     // Validator starts with a graph with no nodes or edges. Should have a size of at least 1
     height: Math.max(1, ...y),
-    width: Math.max(1, y.length - 1)
+    width: Math.max(1, y.length)
   };
 
   return graph;

--- a/app/utils/graph-tools.js
+++ b/app/utils/graph-tools.js
@@ -268,7 +268,12 @@ const positionStage = (x, y, stage) => {
   }
 };
 
-const calcNodeDepth = graph => {
+/**
+ * Calculate depth of each nodes
+ * @param  {Object}  graph  Raw graph definition
+ * @returns {Object}        Map of node name to its depth
+ */
+const calcNodeDepths = graph => {
   const result = [];
   const nodes = {};
   const edges = {};
@@ -328,9 +333,9 @@ const calcNodeDepth = graph => {
  * @method walkGraph
  * @param  {Object}  graph                Raw graph definition
  * @param  {String}  start                The job name to start from for this iteration
- * @param  {Number}  x                    The column for this iteration
  * @param  {Array}   y                    Accumulator of column depth
  * @param  {Object}  stageNameToStageMap  Map of stage name to stage metadata (also includes workflow graph)
+ * @param  {Object}  nodeDepth            Map of node name to its depth
  */
 const walkGraph = (graph, start, y, stageNameToStageMap, nodeDepth) => {
   const nodeNames = graph.edges.filter(e => e.src === start).map(e => e.dest);
@@ -444,8 +449,9 @@ const positionGraphNodes = graph => {
         }, new Map())
       : null;
 
+  const nodeDepth = calcNodeDepths(graph);
+
   let y = [0]; // accumulator for column heights
-  const nodeDepth = calcNodeDepth(graph);
 
   nodes.forEach(n => {
     // Set root nodes on left


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Nodes in workflow graph are placed at first calculated depth by "depth-first search".
Hence it can be smaller than the depth related from other root tree.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Introduce the "Topological sort" and calculate the depth of nodes before walk around the workflow graph.

Example:

```yaml
shared:
  image: node:12
  steps:
    - test: echo 'Foo'
jobs:
  A:
    requires: [~pr, B, stage@foo]
  B:
    requires: [~pr, ~commit]
  C:
    requires: []
  D:
    requires: []
  E:
    requires: [ C ]

stages:
  foo:
    jobs: [ C, E ]
    setup:
      steps:
        - foo: bar
    teardown:
      steps:
        - foo: bar
  bar:
    jobs: [ D ]
    requires: [ B, A ]
    setup:
      steps:
        - foo: bar
```

Before:
![before](https://github.com/user-attachments/assets/d5703ed1-92f3-4676-a159-8802994afd79)

After:
![after](https://github.com/user-attachments/assets/9e985534-3c27-4f84-83d4-b2dc9315feba)

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

Issue - https://github.com/screwdriver-cd/screwdriver/issues/2330

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
