### PR TITLE
feat(3117): Reduce noisy edges to/from stages

### DIFF
--- a/app/components/pipeline/workflow/graph/component.js
+++ b/app/components/pipeline/workflow/graph/component.js
@@ -8,6 +8,7 @@ import {
   addJobIcons,
   addJobNames,
   addStages,
+  addStageEdges,
   getElementSizes,
   getGraphSvg,
   getMaximumJobNameLength,
@@ -86,18 +87,32 @@ export default class PipelineWorkflowGraphComponent extends Component {
       onClickGraph
     );
 
+    const hasStages = this.args.stages.length > 0;
+
     // stages
-    const verticalDisplacements =
-      this.args.stages.length > 0
-        ? addStages(
-            this.graphSvg,
-            this.decoratedGraph,
-            elementSizes,
-            nodeWidth,
-            onClickStageMenu,
-            this.args.displayStageTooltip
-          )
-        : {};
+    const { verticalDisplacements, horizontalDisplacements } = hasStages
+      ? addStages(
+          this.graphSvg,
+          this.decoratedGraph,
+          elementSizes,
+          nodeWidth,
+          onClickStageMenu,
+          this.args.displayStageTooltip
+        )
+      : {};
+
+    // stage edges
+    if (hasStages) {
+      addStageEdges(
+        this.graphSvg,
+        this.decoratedGraph,
+        elementSizes,
+        nodeWidth,
+        isSkipped,
+        verticalDisplacements,
+        horizontalDisplacements
+      );
+    }
 
     // edges
     addEdges(
@@ -106,7 +121,8 @@ export default class PipelineWorkflowGraphComponent extends Component {
       elementSizes,
       nodeWidth,
       isSkippedEvent,
-      verticalDisplacements
+      verticalDisplacements,
+      horizontalDisplacements
     );
 
     // Jobs Icons
@@ -116,6 +132,7 @@ export default class PipelineWorkflowGraphComponent extends Component {
       elementSizes,
       nodeWidth,
       verticalDisplacements,
+      horizontalDisplacements,
       isSkippedEvent,
       onClickNode
     );
@@ -125,7 +142,8 @@ export default class PipelineWorkflowGraphComponent extends Component {
       this.decoratedGraph,
       elementSizes,
       maximumJobNameLength,
-      verticalDisplacements
+      verticalDisplacements,
+      horizontalDisplacements
     );
   }
 

--- a/app/components/workflow-graph-d3/component.js
+++ b/app/components/workflow-graph-d3/component.js
@@ -280,7 +280,7 @@ export default Component.extend({
     this.set('graphNode', svg);
 
     // stages
-    const verticalDisplacements = this.showStages
+    const { verticalDisplacements, horizontalDisplacements } = this.showStages
       ? addStages(
           svg,
           data,
@@ -299,7 +299,8 @@ export default Component.extend({
         this.elementSizes,
         nodeWidth,
         isSkipped,
-        verticalDisplacements
+        verticalDisplacements,
+        horizontalDisplacements
       );
     }
 
@@ -310,7 +311,8 @@ export default Component.extend({
       this.elementSizes,
       nodeWidth,
       isSkipped,
-      verticalDisplacements
+      verticalDisplacements,
+      horizontalDisplacements
     );
 
     // Jobs Icons
@@ -320,6 +322,7 @@ export default Component.extend({
       this.elementSizes,
       nodeWidth,
       verticalDisplacements,
+      horizontalDisplacements,
       isSkipped,
       onClick
     );
@@ -331,7 +334,8 @@ export default Component.extend({
         data,
         this.elementSizes,
         maximumJobNameLength,
-        verticalDisplacements
+        verticalDisplacements,
+        horizontalDisplacements
       );
     }
   }

--- a/app/components/workflow-graph-d3/component.js
+++ b/app/components/workflow-graph-d3/component.js
@@ -12,6 +12,7 @@ import {
   addJobIcons,
   addJobNames,
   addStages,
+  addStageEdges,
   calcNodeCenter,
   getElementSizes,
   getGraphSvg,
@@ -136,7 +137,7 @@ export default Component.extend({
           start: startFrom,
           chainPR: this.prChainEnabled,
           prNum: this.selectedEventObj?.prNum,
-          stages
+          stages: this.minified ? [] : stages
         });
       }
     }
@@ -289,6 +290,18 @@ export default Component.extend({
           this.displayStageMenuHandle
         )
       : {};
+
+    // stage edges
+    if (this.showStages) {
+      addStageEdges(
+        svg,
+        data,
+        this.elementSizes,
+        nodeWidth,
+        isSkipped,
+        verticalDisplacements
+      );
+    }
 
     // edges
     addEdges(

--- a/app/utils/pipeline/graph/d3-graph-util.js
+++ b/app/utils/pipeline/graph/d3-graph-util.js
@@ -120,6 +120,7 @@ export function getHorizontalDisplacementByColumnPosition(
  * Returns the center of a node
  * @param nodePosition
  * @param nodeWidth
+ * @param horizontalDisplacements
  * @returns {number}
  */
 export function calcNodeCenter(
@@ -289,7 +290,6 @@ export function calcStageWidth(
   sizes,
   horizontalDisplacements
 ) {
-  // return stage.graph.meta.width * nodeWidth - sizes.STAGE_GAP;
   const xDisplacement = horizontalDisplacements
     ? getStageHorizontalDisplacementByColumnPosition(
         stage.pos.x,

--- a/tests/integration/components/pipeline/workflow/graph/component-test.js
+++ b/tests/integration/components/pipeline/workflow/graph/component-test.js
@@ -126,7 +126,7 @@ module('Integration | Component | pipeline/workflow/graph', function (hooks) {
 
     assert.dom('svg').exists({ count: 1 });
 
-    assert.equal(this.element.querySelector('svg').children.length, 6);
+    assert.equal(this.element.querySelector('svg').children.length, 7);
   });
 
   test('it renders stage', async function (assert) {
@@ -180,7 +180,7 @@ module('Integration | Component | pipeline/workflow/graph', function (hooks) {
 
     assert.dom('svg').exists({ count: 1 });
 
-    assert.equal(this.element.querySelector('svg').children.length, 12);
+    assert.equal(this.element.querySelector('svg').children.length, 13);
   });
 
   test('it renders with chained PRs', async function (assert) {

--- a/tests/integration/components/pipeline/workflow/graph/component-test.js
+++ b/tests/integration/components/pipeline/workflow/graph/component-test.js
@@ -126,7 +126,7 @@ module('Integration | Component | pipeline/workflow/graph', function (hooks) {
 
     assert.dom('svg').exists({ count: 1 });
 
-    assert.equal(this.element.querySelector('svg').children.length, 7);
+    assert.equal(this.element.querySelector('svg').children.length, 6);
   });
 
   test('it renders stage', async function (assert) {
@@ -180,7 +180,7 @@ module('Integration | Component | pipeline/workflow/graph', function (hooks) {
 
     assert.dom('svg').exists({ count: 1 });
 
-    assert.equal(this.element.querySelector('svg').children.length, 13);
+    assert.equal(this.element.querySelector('svg').children.length, 12);
   });
 
   test('it renders with chained PRs', async function (assert) {

--- a/tests/unit/utils/graph-tools-test.js
+++ b/tests/unit/utils/graph-tools-test.js
@@ -102,6 +102,7 @@ module('Unit | Utility | graph tools', function () {
         }
       ],
       stages: [],
+      stageEdges: [],
       meta: {
         height: 2,
         width: 2
@@ -130,6 +131,7 @@ module('Unit | Utility | graph tools', function () {
         }
       ],
       stages: [],
+      stageEdges: [],
       meta: {
         height: 3,
         width: 2
@@ -168,6 +170,7 @@ module('Unit | Utility | graph tools', function () {
         { src: 'C', dest: 'D', from: { x: 3, y: 0 }, to: { x: 4, y: 0 } }
       ],
       stages: [],
+      stageEdges: [],
       meta: {
         height: 2,
         width: 5
@@ -272,6 +275,7 @@ module('Unit | Utility | graph tools', function () {
         }
       ],
       stages: [],
+      stageEdges: [],
       meta: {
         height: 2,
         width: 5
@@ -378,6 +382,7 @@ module('Unit | Utility | graph tools', function () {
         { src: 'C', dest: 'D', from: { x: 3, y: 0 }, to: { x: 4, y: 0 } }
       ],
       stages: [],
+      stageEdges: [],
       meta: {
         height: 2,
         width: 5
@@ -464,6 +469,7 @@ module('Unit | Utility | graph tools', function () {
         }
       ],
       stages: [],
+      stageEdges: [],
       meta: {
         height: 2,
         width: 3
@@ -513,6 +519,7 @@ module('Unit | Utility | graph tools', function () {
         }
       ],
       stages: [],
+      stageEdges: [],
       meta: {
         height: 4,
         width: 2
@@ -594,6 +601,7 @@ module('Unit | Utility | graph tools', function () {
         }
       ],
       stages: [],
+      stageEdges: [],
       meta: {
         width: 3,
         height: 5
@@ -814,6 +822,7 @@ module('Unit | Utility | graph tools', function () {
             x: 2,
             y: 0
           },
+          hidden: true,
           src: 'publish',
           to: {
             x: 3,
@@ -826,6 +835,7 @@ module('Unit | Utility | graph tools', function () {
             x: 5,
             y: 0
           },
+          hidden: true,
           src: 'ci-certify',
           to: {
             x: 6,
@@ -1039,6 +1049,26 @@ module('Unit | Utility | graph tools', function () {
       }
     ];
 
+    expectedOutput.stageEdges = [
+      {
+        dest: 'stage@integration:setup',
+        destStageName: 'integration',
+        from: expectedOutput.nodes[3],
+        hidden: true,
+        src: 'publish',
+        to: expectedOutput.stages[0]
+      },
+      {
+        dest: 'stage@production:setup',
+        destStageName: 'production',
+        from: expectedOutput.stages[0],
+        hidden: true,
+        src: 'stage@integration:teardown',
+        srcStageName: 'integration',
+        to: expectedOutput.stages[1]
+      }
+    ];
+
     const result = decorateGraph({
       inputGraph: GRAPH,
       stages: STAGES,
@@ -1245,6 +1275,7 @@ module('Unit | Utility | graph tools', function () {
     };
 
     expectedOutput.stages = [];
+    expectedOutput.stageEdges = [];
 
     const result = decorateGraph({
       inputGraph: GRAPH,

--- a/tests/unit/utils/pipeline/graph/d3-graph-util-test.js
+++ b/tests/unit/utils/pipeline/graph/d3-graph-util-test.js
@@ -27,6 +27,7 @@ module('Unit | Utility | pipeline-graph | d3-graph-util', function () {
       TITLE_SIZE: 12,
       ARROWHEAD: 6,
       STAGE_GAP: 4,
+      STAGE_GAP_HORIZONTAL: 108,
       EDGE_GAP: 6
     });
     assert.deepEqual(getElementSizes(true), {
@@ -34,6 +35,7 @@ module('Unit | Utility | pipeline-graph | d3-graph-util', function () {
       TITLE_SIZE: 0,
       ARROWHEAD: 2,
       STAGE_GAP: 12 / 9,
+      STAGE_GAP_HORIZONTAL: 36,
       EDGE_GAP: 2
     });
   });
@@ -124,7 +126,14 @@ module('Unit | Utility | pipeline-graph | d3-graph-util', function () {
   });
 
   test('calcStageX returns correct value for x position of stage', function (assert) {
-    assert.equal(calcStageX({ pos: { x: 2 } }, 10, { STAGE_GAP: 5 }), 25);
+    const stage = { pos: { x: 2 } };
+    const sizes = {
+      STAGE_GAP: 5
+    };
+    const horizontalDisplacements = { 0: 23, 1: 23, 2: 45 };
+
+    assert.equal(calcStageX(stage, 10, sizes), 25);
+    assert.equal(calcStageX(stage, 10, sizes, horizontalDisplacements), 70);
   });
 
   test('calcStageY returns correct value for y position of stage', function (assert) {
@@ -137,18 +146,31 @@ module('Unit | Utility | pipeline-graph | d3-graph-util', function () {
   });
 
   test('calcStageWidth returns correct value for width of stage', function (assert) {
+    const stage = { graph: { meta: { width: 3 } }, pos: { x: 2 } };
+    const stageVerticalDisplacements = {
+      0: 23,
+      1: 35,
+      2: 13,
+      3: 13,
+      4: 43,
+      5: 23
+    };
+    const sizes = { STAGE_GAP: 5 };
+
+    assert.equal(calcStageWidth(stage, 10, sizes), 25);
     assert.equal(
-      calcStageWidth({ graph: { meta: { width: 3 } } }, 10, { STAGE_GAP: 5 }),
-      25
+      calcStageWidth(stage, 10, sizes, stageVerticalDisplacements),
+      55
     );
   });
 
   test('calcStageHeight returns correct value for height of stage', function (assert) {
-    const stage = { graph: { meta: { height: 3 } } };
+    const stage = { graph: { meta: { height: 3 } }, pos: { y: 2 } };
+    const stageVerticalDisplacements = { 0: 23, 1: 35, 2: 13, 4: 10, 5: 23 };
     const sizes = { ICON_SIZE: 10, STAGE_GAP: 3 };
 
     assert.equal(calcStageHeight(stage, sizes), 57);
-    assert.equal(calcStageHeight(stage, sizes, 6), 63);
+    assert.equal(calcStageHeight(stage, sizes, stageVerticalDisplacements), 80);
   });
 
   test('getStageVerticalDisplacementByRowPosition returns correct vertical stage displacement', function (assert) {


### PR DESCRIPTION
## Context

When a stage has implicit setup/teardown jobs, in the workflow graph

1. nodes corresponding to implicit setup/teardown are hidden
2. edges to `setup` are redrawn to point to all the root nodes of that stage workflow
3. edges from `teardown` are redrawn to start from all the leaf nodes of that stage workflow

If the stage has multiple root/leaf nodes, we end up having too many edges leading to/from stages which makes the workflow graph convoluted.

Sample pipeline: https://cd.screwdriver.cd/pipelines/15595/events/826742
![image](https://github.com/user-attachments/assets/0b1ed7f2-102c-4c9e-bdad-d3221025f785)


## Objective
Replace the edges to `setup` node or from `teardown` node with edges originating or leading to stage border.

![image](https://github.com/user-attachments/assets/7c74a470-205e-4ba3-9c6d-020db7a9dab9)




## References

https://github.com/screwdriver-cd/screwdriver/issues/3117

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
