### PR TITLE
feat(3241): add more options to build historical view

### DIFF
--- a/app/components/pipeline-list-view/component.js
+++ b/app/components/pipeline-list-view/component.js
@@ -23,7 +23,7 @@ export default Component.extend({
   lastRows: [],
   moreJobs: true,
   timestampPreference: null,
-  buildsHistoryOptions: [5, 10, 15, 20, 25, 30],
+  buildsHistoryOptions: [5, 10, 15, 20, 25, 30, 35, 40, 45, 50],
   columns: [
     {
       title: 'JOB',

--- a/app/components/pipeline/jobs/table/component.js
+++ b/app/components/pipeline/jobs/table/component.js
@@ -60,7 +60,11 @@ export default class PipelineJobsTableComponent extends Component {
         '15',
         '20',
         '25',
-        '30'
+        '30',
+        '35',
+        '40',
+        '45',
+        '50'
       ];
       historyColumnConfiguration.filterFunction = async (_, filterVal) => {
         await this.dataReloader.setNumBuilds(filterVal);


### PR DESCRIPTION
## Context

As of now users can only see up to 30 historical builds in the jobs list view. 

## Objective

This change is to add more options to allow users to view up to 50 historical builds. 

## References

https://github.com/screwdriver-cd/screwdriver/issues/3241
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
