### PR TITLE
fix(3268): Fix build warning determination

### DIFF
--- a/app/utils/pipeline/build.js
+++ b/app/utils/pipeline/build.js
@@ -5,7 +5,15 @@
  */
 
 export const hasWarning = build => {
-  return !!build?.meta?.build?.warning?.message;
+  if (build?.meta?.build?.warning) {
+    if (typeof build.meta.build.warning === 'boolean') {
+      return build.meta.build.warning;
+    }
+
+    return !!build.meta.build.warning.message;
+  }
+
+  return false;
 };
 
 /**

--- a/tests/unit/utils/pipeline/build-test.js
+++ b/tests/unit/utils/pipeline/build-test.js
@@ -10,6 +10,8 @@ module('Unit | Utility | Pipeline | build', function () {
     assert.equal(hasWarning({}), false);
     assert.equal(hasWarning({ meta: {} }), false);
     assert.equal(hasWarning({ meta: { build: {} } }), false);
+    assert.equal(hasWarning({ meta: { build: { warning: false } } }), false);
+    assert.equal(hasWarning({ meta: { build: { warning: true } } }), true);
     assert.equal(hasWarning({ meta: { build: { warning: {} } } }), false);
     assert.equal(
       hasWarning({ meta: { build: { warning: { message: '' } } } }),


### PR DESCRIPTION
## Context
When the meta for warning is as a boolean value, the UI does not correctly display the warning status of the build.

## Objective
Updates the build status logic to account for the meta warning value to handle boolean values.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3268

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
