### PR TITLE
feat: Add fill color for created job nodes in V2 UI

### DIFF
--- a/app/components/pipeline/workflow/graph/styles.scss
+++ b/app/components/pipeline/workflow/graph/styles.scss
@@ -45,6 +45,7 @@
       }
 
       &.build-running,
+      &.build-created,
       &.build-queued,
       &.build-blocked,
       &.build-skipped {


### PR DESCRIPTION
## Context
Job nodes that are created do not have any fill colors and are not apparent until the user hovers over the job node.

## Objective
Adds a fill color for created job nodes to better indicate to the user that a job has a build created for it

![Screenshot 2025-01-24 at 15-42-45 VonnyJap_screwdriver-config Events](https://github.com/user-attachments/assets/ed21140d-802c-408b-9b89-cee0935e3902)

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
