### PR TITLE
fix: Fix parameters drop down

### DIFF
--- a/app/components/pipeline/parameters/component.js
+++ b/app/components/pipeline/parameters/component.js
@@ -59,29 +59,6 @@ export default class PipelineParametersComponent extends Component {
   }
 
   @action
-  openSelect(powerSelectObject) {
-    setTimeout(() => {
-      const container = document.getElementsByClassName('parameters-container');
-      const scrollFrame = container[0];
-      const optionsBox = document.getElementById(
-        `ember-power-select-options-${powerSelectObject.uniqueId}`
-      );
-
-      if (optionsBox === null) {
-        return;
-      }
-
-      const optionsBoxRect = optionsBox.getBoundingClientRect();
-      const scrollFrameRect = scrollFrame.getBoundingClientRect();
-      const hiddenAreaHeight = optionsBoxRect.bottom - scrollFrameRect.bottom;
-
-      if (hiddenAreaHeight > 0) {
-        scrollFrame.scrollBy({ top: hiddenAreaHeight + 10 });
-      }
-    }, 100);
-  }
-
-  @action
   onInput(parameterGroup, parameter, event) {
     this.updateParameter(parameterGroup, parameter, event.target.value);
   }

--- a/app/components/pipeline/parameters/selectable/styles.scss
+++ b/app/components/pipeline/parameters/selectable/styles.scss
@@ -16,10 +16,14 @@
     }
 
     .ember-basic-dropdown-content-wormhole-origin {
-      .ember-power-select-options {
-        li {
-          overflow: scroll;
-          text-overflow: ellipsis;
+      .ember-power-select-dropdown {
+        position: relative;
+
+        .ember-power-select-options {
+          li {
+            overflow: scroll;
+            text-overflow: ellipsis;
+          }
         }
       }
     }

--- a/app/components/pipeline/parameters/selectable/template.hbs
+++ b/app/components/pipeline/parameters/selectable/template.hbs
@@ -7,7 +7,6 @@
   @selected={{this.value}}
   @searchPlaceholder="Type to filter"
   @noMatchesMessage="Press enter to override"
-  @onOpen={{fn @onOpen}}
   @onChange={{this.selectOption}}
   @onInput={{this.handleInput}}
   @onKeydown={{this.handleKeydown}}

--- a/app/components/pipeline/parameters/styles.scss
+++ b/app/components/pipeline/parameters/styles.scss
@@ -42,12 +42,11 @@
 
           .parameter {
             display: flex;
+            align-items: baseline;
             padding: 0.2rem;
 
             label {
               display: flex;
-              margin-top: auto;
-              margin-bottom: auto;
               padding-right: 0.5rem;
               flex-basis: 25%;
               max-width: 50%;

--- a/tests/integration/components/pipeline/parameters/selectable/component-test.js
+++ b/tests/integration/components/pipeline/parameters/selectable/component-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
-import { click, render, triggerKeyEvent } from '@ember/test-helpers';
+import { render, triggerKeyEvent } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { selectChoose, selectSearch } from 'ember-power-select/test-support';
 import sinon from 'sinon';
@@ -16,43 +16,17 @@ module(
           defaultValues: ['foo', 'bar'],
           value: 'foo'
         },
-        onOpen: () => {},
         onSelectValue: () => {}
       });
 
       await render(
         hbs`<Pipeline::Parameters::Selectable
             @parameter={{this.parameter}}
-            @onOpen={{this.onOpen}}
             @onSelectValue={{this.onSelectValue}}
         />`
       );
 
       assert.dom(this.element).hasText('foo');
-    });
-
-    test('it calls onOpen callback', async function (assert) {
-      const onOpen = sinon.spy();
-
-      this.setProperties({
-        parameter: {
-          defaultValues: ['foo', 'bar'],
-          value: 'foo'
-        },
-        onOpen,
-        onSelectValue: () => {}
-      });
-
-      await render(
-        hbs`<Pipeline::Parameters::Selectable
-            @parameter={{this.parameter}}
-            @onOpen={{this.onOpen}}
-            @onSelectValue={{this.onSelectValue}}
-        />`
-      );
-      await click('.ember-power-select-trigger');
-
-      assert.equal(onOpen.callCount, 1);
     });
 
     test('it calls onSelectValue callback when selection is made', async function (assert) {
@@ -64,14 +38,12 @@ module(
 
       this.setProperties({
         parameter,
-        onOpen: () => {},
         onSelectValue
       });
 
       await render(
         hbs`<Pipeline::Parameters::Selectable
             @parameter={{this.parameter}}
-            @onOpen={{this.onOpen}}
             @onSelectValue={{this.onSelectValue}}
         />`
       );
@@ -92,14 +64,12 @@ module(
 
       this.setProperties({
         parameter,
-        onOpen: () => {},
         onSelectValue
       });
 
       await render(
         hbs`<Pipeline::Parameters::Selectable
             @parameter={{this.parameter}}
-            @onOpen={{this.onOpen}}
             @onSelectValue={{this.onSelectValue}}
         />`
       );


### PR DESCRIPTION
## Context
The dropdown menu for a pipeline's parameters in the V2 UI doesn't always stay open and therefore has an unintended effect where it is difficult to select an option from the drop down.

## Objective
Fix the dropdown spacing to all be done handled with CSS and removes the additional scroll logic that previously existed.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
