### PR TITLE
fix: Prevent empty slots

### DIFF
--- a/app/utils/graph-tools.js
+++ b/app/utils/graph-tools.js
@@ -492,7 +492,12 @@ const positionGraphNodes = graph => {
 
   const nodeDepth = calcNodeDepths(graph);
 
-  let y = [0]; // accumulator for column heights
+  let maxNodeDepth = 0;
+
+  Object.values(nodeDepth).forEach(d => {
+    maxNodeDepth = Math.max(maxNodeDepth, d);
+  });
+  let y = Array(maxNodeDepth).fill(0); // accumulator for column heights
 
   nodes.forEach(n => {
     // Set root nodes on left


### PR DESCRIPTION
## Context
https://github.com/screwdriver-cd/ui/pull/1320 inadvertently creates a spares array with empty slots in the following code block:
https://github.com/screwdriver-cd/ui/pull/1320/files#diff-1e81a193b56d9ac00e3e89b9f7bb4d446837f1dea429e5534e19d64bfa4b8019R243-R246

This sparse array is problematic because the `Math.max` returns `NaN` when a spare array is passed in at this line of code https://github.com/screwdriver-cd/ui/pull/1320/files#diff-1e81a193b56d9ac00e3e89b9f7bb4d446837f1dea429e5534e19d64bfa4b8019R461

The resulting value of `y` after the above line of code is that `y` is an array of `NaN` values and breaks any downstream calculations using `y`.

## Objective
Initializes `y` to be an array of the proper length filled with 0 values.  This prevents the `y` from being resized to a larger array in downstream calculations and also prevents the creation of a sparse array with empty slots.

## References
https://github.com/screwdriver-cd/ui/pull/1320

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
