### PR TITLE
fix: maximum node depth

### DIFF
--- a/app/utils/graph-tools.js
+++ b/app/utils/graph-tools.js
@@ -497,7 +497,7 @@ const positionGraphNodes = graph => {
   Object.values(nodeDepth).forEach(d => {
     maxNodeDepth = Math.max(maxNodeDepth, d);
   });
-  let y = Array(maxNodeDepth).fill(0); // accumulator for column heights
+  let y = Array(maxNodeDepth + 1).fill(0); // accumulator for column heights
 
   nodes.forEach(n => {
     // Set root nodes on left


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

https://github.com/screwdriver-cd/ui/pull/1327 initialize the array `y`, but the node depth is 0-based counted.
Thus if the pipeline has detached jobs only, `y` is empty array.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Fix the maximum depth.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

PR - https://github.com/screwdriver-cd/ui/pull/1327

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
