### PR TITLE
feat(3279): Job nodes are missing in the workflow graph for pipelines with sequential stages

### DIFF
--- a/app/utils/pipeline/graph/d3-graph-util.js
+++ b/app/utils/pipeline/graph/d3-graph-util.js
@@ -546,16 +546,25 @@ export function addStages(
       'y',
       calcStageY(stage, sizes, verticalDisplacements, yDisplacement)
     );
-
-    svg.attr(
-      'height',
-      Number.parseInt(svg.attr('height'), 10) +
-        getVerticalDisplacementByRowPosition(
-          data.meta.height - 1,
-          verticalDisplacements
-        )
-    );
   });
+
+  svg.attr(
+    'height',
+    Number.parseInt(svg.attr('height'), 10) +
+      getVerticalDisplacementByRowPosition(
+        data.meta.height - 1,
+        verticalDisplacements
+      )
+  );
+
+  svg.attr(
+    'width',
+    Number.parseInt(svg.attr('width'), 10) +
+      getHorizontalDisplacementByColumnPosition(
+        data.meta.width - 1,
+        horizontalDisplacements
+      )
+  );
 
   return {
     verticalDisplacements,


### PR DESCRIPTION
## Context

https://github.com/screwdriver-cd/screwdriver/issues/3117 added more horizontal spacing between the stages. This created a regression as the additional spacing introduced is not accounted to adjust the overall width of the graph. Due to this, few jobs at the end of the workflow are not visible

![image](https://github.com/user-attachments/assets/13cce189-ef7f-4e2d-942e-694c2e0c4511)


## Objective

When horizontal spacing is added between the stages, the overall width of the graph needs to expanded accordingly.

After fix:
<img width="1104" alt="image" src="https://github.com/user-attachments/assets/211b6e86-1645-4ab4-9a50-d3a7de56da0b" />


## References

https://github.com/screwdriver-cd/screwdriver/issues/3279

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
