### PR TITLE
Extract isParameterized to a util

### DIFF
--- a/app/components/pipeline/modal/confirm-action/component.js
+++ b/app/components/pipeline/modal/confirm-action/component.js
@@ -3,7 +3,11 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import { buildPostBody } from 'screwdriver-ui/utils/pipeline/modal/request';
-import { capitalizeFirstLetter, truncateMessage } from './util';
+import {
+  capitalizeFirstLetter,
+  isParameterized,
+  truncateMessage
+} from './util';
 
 export default class PipelineModalConfirmActionComponent extends Component {
   @service router;
@@ -61,13 +65,7 @@ export default class PipelineModalConfirmActionComponent extends Component {
   }
 
   get isParameterized() {
-    const pipelineParameters = this.args.pipeline.parameters || {};
-    const eventParameters = this.args.event.meta?.parameters || {};
-
-    return (
-      Object.keys(pipelineParameters).length > 0 ||
-      Object.keys(eventParameters).length > 0
-    );
+    return isParameterized(this.args.pipeline, this.args.event);
   }
 
   get isSubmitButtonDisabled() {

--- a/app/components/pipeline/modal/confirm-action/util.js
+++ b/app/components/pipeline/modal/confirm-action/util.js
@@ -19,3 +19,19 @@ export function truncateMessage(commitMessage) {
 export function capitalizeFirstLetter(string) {
   return string.charAt(0).toUpperCase() + string.slice(1);
 }
+
+/**
+ * Determine if the action has parameters
+ * @param pipeline
+ * @param event
+ * @returns {boolean}
+ */
+export function isParameterized(pipeline, event) {
+  const pipelineParameters = pipeline.parameters || {};
+  const eventParameters = event.meta?.parameters || {};
+
+  return (
+    Object.keys(pipelineParameters).length > 0 ||
+    Object.keys(eventParameters).length > 0
+  );
+}

--- a/tests/unit/components/pipeline/modal/confirm-action/util-test.js
+++ b/tests/unit/components/pipeline/modal/confirm-action/util-test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import {
   capitalizeFirstLetter,
+  isParameterized,
   truncateMessage
 } from 'screwdriver-ui/components/pipeline/modal/confirm-action/util';
 
@@ -21,5 +22,22 @@ module('Unit | Component | pipeline/modal/confirm-action/util', function () {
 
   test('capitalizeFirstLetter capitalizes first letter of string', function (assert) {
     assert.equal(capitalizeFirstLetter('foo'), 'Foo');
+  });
+
+  test('isParameterized returns true if pipeline or event has parameters', function (assert) {
+    assert.equal(isParameterized({}, {}), false);
+    assert.equal(isParameterized({ parameters: { a: 4 } }, {}), true);
+    assert.equal(isParameterized({}, { meta: {} }), false);
+    assert.equal(
+      isParameterized({}, { meta: { parameters: { p1: { value: 'foo' } } } }),
+      true
+    );
+    assert.equal(
+      isParameterized(
+        { parameters: { a: 4 } },
+        { meta: { parameters: { p1: { value: 'foo' } } } }
+      ),
+      true
+    );
   });
 });


### PR DESCRIPTION
## Context
Extracting the `isParameterized` function into a utility for additional unit testing.

## Objective
Extracts the `isParameterized` function into a utility to allow for better isolated testing.  The logic should be covered in a unit test to keep the component tests less complex.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
