### PR TITLE
feat: Inject pipeline

### DIFF
--- a/app/pipeline-page-state/service.js
+++ b/app/pipeline-page-state/service.js
@@ -1,0 +1,21 @@
+import Service from '@ember/service';
+
+export default class PipelinePageStateService extends Service {
+  pipeline;
+
+  clear() {
+    this.pipeline = null;
+  }
+
+  setPipeline(pipeline) {
+    this.pipeline = pipeline;
+  }
+
+  getPipeline() {
+    return this.pipeline;
+  }
+
+  getPipelineId() {
+    return this.pipeline.id;
+  }
+}

--- a/app/v2/pipeline/route.js
+++ b/app/v2/pipeline/route.js
@@ -6,10 +6,16 @@ export default class NewPipelineRoute extends Route {
 
   @service shuttle;
 
+  @service pipelinePageState;
+
   async model(params) {
+    this.pipelinePageState.clear();
+
     const pipeline = await this.shuttle
       .fetchFromApi('get', `/pipelines/${params.pipeline_id}`)
       .catch(() => null);
+
+    this.pipelinePageState.setPipeline(pipeline);
 
     return {
       pipeline

--- a/tests/unit/pipeline-page-state/service-test.js
+++ b/tests/unit/pipeline-page-state/service-test.js
@@ -1,0 +1,13 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
+
+module('Unit | Service | pipelinePageState', function (hooks) {
+  setupTest(hooks);
+
+  // TODO: Replace this with your real tests.
+  test('it exists', function (assert) {
+    let service = this.owner.lookup('service:pipeline-page-state');
+
+    assert.ok(service);
+  });
+});


### PR DESCRIPTION
## Context
The pipeline page has a lot of static data that is being passed through many layers of glimmer components.  This static data can be injected into the components as necessary.  For this initial change, only the pipeline data will be set up, but future changes will start incorporating additional pieces of data.

## Objective
Sets up an injectable ember service for capturing static data starting with the pipeline data. 

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
