### PR TITLE
feat: Inject pipeline state into pipeline header

### DIFF
--- a/app/components/pipeline/header/component.js
+++ b/app/components/pipeline/header/component.js
@@ -8,30 +8,38 @@ export default class PipelineHeaderComponent extends Component {
 
   @service shuttle;
 
+  @service pipelinePageState;
+
   @tracked addToCollectionModalOpen = false;
 
   @tracked errorMessage;
 
   @tracked collections = null;
 
+  pipeline;
+
   sameRepoPipeline = [];
 
+  constructor() {
+    super(...arguments);
+
+    this.pipeline = this.pipelinePageState.getPipeline();
+  }
+
   get pipelineDescription() {
-    return this.args.pipeline.annotations['screwdriver.cd/pipelineDescription'];
+    return this.pipeline.annotations['screwdriver.cd/pipelineDescription'];
   }
 
   get sonarBadgeUri() {
     return (
-      this.args.pipeline.badges.sonar.uri ||
-      this.args.pipeline.badges.sonar.defaultUri
+      this.pipeline.badges.sonar.uri || this.pipeline.badges.sonar.defaultUri
     );
   }
 
   get sonarBadgeDescription() {
     const sonarBadgeDescription = 'SonarQube project';
     const sonarBadgeName =
-      this.args.pipeline.badges.sonar.name ||
-      this.args.pipeline.badges.sonar.defaultName;
+      this.pipeline.badges.sonar.name || this.pipeline.badges.sonar.defaultName;
 
     return sonarBadgeName
       ? `SonarQube project: ${sonarBadgeName}`
@@ -39,7 +47,7 @@ export default class PipelineHeaderComponent extends Component {
   }
 
   get scmContext() {
-    const scm = this.scm.getScm(this.args.pipeline.scmContext);
+    const scm = this.scm.getScm(this.pipeline.scmContext);
 
     return {
       scm: scm.displayName,
@@ -49,15 +57,15 @@ export default class PipelineHeaderComponent extends Component {
 
   @action
   async getPipelinesWithSameRepo() {
-    const pipelineId = this.args.pipeline.id;
+    const pipelineId = this.pipeline.id;
 
-    if (this.args.pipeline.scmRepo && this.args.pipeline.scmUri) {
-      const [scm, repositoryId] = this.args.pipeline.scmUri.split(':');
+    if (this.pipeline.scmRepo && this.pipeline.scmUri) {
+      const [scm, repositoryId] = this.pipeline.scmUri.split(':');
 
       this.sameRepoPipeline = await this.shuttle
         .fetchFromApi(
           'get',
-          `/pipelines?search=${this.args.pipeline.scmRepo.name}&sortBy=name&sort=ascending`
+          `/pipelines?search=${this.pipeline.scmRepo.name}&sortBy=name&sort=ascending`
         )
         .then(pipelines =>
           pipelines

--- a/app/components/pipeline/header/template.hbs
+++ b/app/components/pipeline/header/template.hbs
@@ -4,24 +4,24 @@
       id="pipeline-link"
       class="header-item pipeline-name"
       @route="v2.pipeline"
-      @model={{@pipeline.id}}
+      @model={{this.pipeline.id}}
     >
-      {{@pipeline.scmRepo.name}}
+      {{this.pipeline.scmRepo.name}}
     </LinkTo>
 
-    {{#if @pipeline.configPipelineId}}
+    {{#if this.pipeline.configPipelineId}}
       <LinkTo
         id="parent-pipeline-link"
         class="header-item"
         @route="v2.pipeline"
-        @model={{@pipeline.configPipelineId}}
+        @model={{this.pipeline.configPipelineId}}
       >
         <FaIcon @icon="gear" />
         Parent Pipeline
       </LinkTo>
     {{/if}}
 
-    {{#if @pipeline.badges.sonar}}
+    {{#if this.pipeline.badges.sonar}}
       <a
         id="sonarqube-link"
         class="header-item"
@@ -36,7 +36,7 @@
 
     <a
       id="scm-link"
-      href="{{branch-url-encode @pipeline.scmRepo.url}}"
+      href="{{branch-url-encode this.pipeline.scmRepo.url}}"
       class="header-item scm"
     >
       <FaIcon @icon={{this.scmContext.scmIcon}} @prefix="fab" />
@@ -47,7 +47,7 @@
       <dd.toggle>
         <FaIcon @icon="code-branch" @title="Source code" />
         <span class="branch">
-          {{@pipeline.scmRepo.branch}}
+          {{this.pipeline.scmRepo.branch}}
         </span>
         <BsTooltip @placement="bottom" @renderInPlace={{false}} @triggerEvents="hover" class="tooltip">
           Switch to another Pipeline with the same repository
@@ -78,7 +78,7 @@
     >
       {{#if this.addToCollectionModalOpen}}
         <Pipeline::Modal::AddToCollection
-          @pipeline={{@pipeline}}
+          @pipeline={{this.pipeline}}
           @collections={{this.collections}}
           @errorMessage={{this.errorMessage}}
           @closeModal={{this.closeAddToCollectionModal}}

--- a/app/v2/pipeline/template.hbs
+++ b/app/v2/pipeline/template.hbs
@@ -2,12 +2,7 @@
 
 <div id="pipeline-page-contents">
   <Pipeline::Nav />
-
-  <Pipeline::Header
-    @pipeline={{this.model.pipeline}}
-    @collections={{this.model.collections}}
-  />
-
+  <Pipeline::Header />
   <div
     id="pipeline-main"
     class="{{this.routeClasses}}"

--- a/tests/integration/components/pipeline/header/component-test.js
+++ b/tests/integration/components/pipeline/header/component-test.js
@@ -8,86 +8,75 @@ module('Integration | Component | pipeline/header', function (hooks) {
   setupRenderingTest(hooks);
 
   test('it renders core items', async function (assert) {
-    this.setProperties({
-      pipeline: {
-        id: 123,
-        scmContext: 'github:github.com',
-        scmRepo: { url: 'https://gihub.com/test' },
-        annotations: {}
-      }
+    const pipelinePageState = this.owner.lookup('service:pipeline-page-state');
+    const id = 123;
+    const url = 'https://gihub.com/test';
+
+    sinon.stub(pipelinePageState, 'getPipeline').returns({
+      id,
+      scmContext: 'github:github.com',
+      scmRepo: { url },
+      annotations: {}
     });
 
-    await render(hbs`<Pipeline::Header
-      @pipeline={{this.pipeline}}
-      @collections={{this.collections}}
-    />`);
+    await render(hbs`<Pipeline::Header />`);
 
-    assert
-      .dom('#pipeline-link')
-      .hasAttribute('href', `/v2/pipelines/${this.pipeline.id}`);
+    assert.dom('#pipeline-link').hasAttribute('href', `/v2/pipelines/${id}`);
     assert.dom('#parent-pipeline-link').doesNotExist();
     assert.dom('#sonarqube-link').doesNotExist();
-    assert
-      .dom('#scm-link')
-      .hasAttribute('href', `${this.pipeline.scmRepo.url}`);
+    assert.dom('#scm-link').hasAttribute('href', `${url}`);
     assert.dom('#repo-pipelines').exists({ count: 1 });
     assert.dom('#add-to-collection').exists({ count: 1 });
   });
 
   test('it renders link to parent pipeline', async function (assert) {
-    this.setProperties({
-      pipeline: { configPipelineId: 999, annotations: {} }
+    const pipelinePageState = this.owner.lookup('service:pipeline-page-state');
+    const configPipelineId = 999;
+
+    sinon.stub(pipelinePageState, 'getPipeline').returns({
+      configPipelineId,
+      annotations: {}
     });
 
-    await render(hbs`<Pipeline::Header
-      @pipeline={{this.pipeline}}
-      @collections={{this.collections}}
-    />`);
+    await render(hbs`<Pipeline::Header />`);
 
     assert
       .dom('#parent-pipeline-link')
-      .hasAttribute('href', `/v2/pipelines/${this.pipeline.configPipelineId}`);
+      .hasAttribute('href', `/v2/pipelines/${configPipelineId}`);
   });
 
   test('it renders link to sonarqube project', async function (assert) {
-    this.setProperties({
-      pipeline: {
-        badges: { sonar: { uri: 'https://sonarqube.com/test' } },
-        annotations: {}
-      }
+    const pipelinePageState = this.owner.lookup('service:pipeline-page-state');
+    const uri = 'https://sonarqube.com/test';
+
+    sinon.stub(pipelinePageState, 'getPipeline').returns({
+      badges: { sonar: { uri } },
+      annotations: {}
     });
 
-    await render(hbs`<Pipeline::Header
-      @pipeline={{this.pipeline}}
-      @collections={{this.collections}}
-    />`);
+    await render(hbs`<Pipeline::Header />`);
 
-    assert
-      .dom('#sonarqube-link')
-      .hasAttribute('href', `${this.pipeline.badges.sonar.uri}`);
+    assert.dom('#sonarqube-link').hasAttribute('href', `${uri}`);
   });
 
   test('it renders link to sonarqube', async function (assert) {
-    this.setProperties({
-      pipeline: {
-        badges: {
-          sonar: { defaultUri: 'https://sonarqube.com' }
-        },
-        annotations: {}
-      }
+    const pipelinePageState = this.owner.lookup('service:pipeline-page-state');
+    const defaultUri = 'https://sonarqube.com';
+
+    sinon.stub(pipelinePageState, 'getPipeline').returns({
+      badges: {
+        sonar: { defaultUri }
+      },
+      annotations: {}
     });
 
-    await render(hbs`<Pipeline::Header
-      @pipeline={{this.pipeline}}
-      @collections={{this.collections}}
-    />`);
+    await render(hbs`<Pipeline::Header />`);
 
-    assert
-      .dom('#sonarqube-link')
-      .hasAttribute('href', `${this.pipeline.badges.sonar.defaultUri}`);
+    assert.dom('#sonarqube-link').hasAttribute('href', `${defaultUri}`);
   });
 
   test('it renders dropdown to other pipelines', async function (assert) {
+    const pipelinePageState = this.owner.lookup('service:pipeline-page-state');
     const shuttle = this.owner.lookup('service:shuttle');
 
     sinon.stub(shuttle, 'fetchFromApi').resolves([
@@ -112,20 +101,14 @@ module('Integration | Component | pipeline/header', function (hooks) {
         scmRepo: { branch: 'abc' }
       }
     ]);
-
-    this.setProperties({
-      pipeline: {
-        id: 123,
-        scmUri: 'git.github.com:9876',
-        scmRepo: { url: 'https://gihub.com/test' },
-        annotations: {}
-      }
+    sinon.stub(pipelinePageState, 'getPipeline').returns({
+      id: 123,
+      scmUri: 'git.github.com:9876',
+      scmRepo: { url: 'https://gihub.com/test' },
+      annotations: {}
     });
 
-    await render(hbs`<Pipeline::Header
-      @pipeline={{this.pipeline}}
-      @collections={{this.collections}}
-    />`);
+    await render(hbs`<Pipeline::Header />`);
 
     assert.dom('#repo-pipelines .dropdown-menu').doesNotExist();
     await click('#repo-pipelines > a.dropdown-toggle');
@@ -135,23 +118,19 @@ module('Integration | Component | pipeline/header', function (hooks) {
   });
 
   test('it renders pipeline description', async function (assert) {
+    const pipelinePageState = this.owner.lookup('service:pipeline-page-state');
     const pipelineDescription = 'This is a test pipeline';
 
-    this.setProperties({
-      pipeline: {
-        id: 123,
-        scmContext: 'github:github.com',
-        scmRepo: { url: 'https://gihub.com/test' },
-        annotations: {
-          'screwdriver.cd/pipelineDescription': pipelineDescription
-        }
+    sinon.stub(pipelinePageState, 'getPipeline').returns({
+      id: 123,
+      scmContext: 'github:github.com',
+      scmRepo: { url: 'https://gihub.com/test' },
+      annotations: {
+        'screwdriver.cd/pipelineDescription': pipelineDescription
       }
     });
 
-    await render(hbs`<Pipeline::Header
-      @pipeline={{this.pipeline}}
-      @collections={{this.collections}}
-    />`);
+    await render(hbs`<Pipeline::Header />`);
 
     assert
       .dom('#pipeline-header .pipeline-description')


### PR DESCRIPTION
## Context
Refactor the pipeline header component to use the injectable pipeline data rather than having that data passed into the component.

## Objective
Refactor the pipeline header component.  Also removes the `collection` component argument as it was not actually used.

## References
https://github.com/screwdriver-cd/ui/pull/1331
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
