### PR TITLE
feat: Inject pipeline data into job coverage cell

### DIFF
--- a/app/components/pipeline/jobs/table/cell/coverage/component.js
+++ b/app/components/pipeline/jobs/table/cell/coverage/component.js
@@ -5,6 +5,8 @@ import { service } from '@ember/service';
 export default class PipelineJobsTableCellCoverageComponent extends Component {
   @service shuttle;
 
+  @service pipelinePageState;
+
   @tracked latestBuild;
 
   @tracked coverage;
@@ -13,11 +15,11 @@ export default class PipelineJobsTableCellCoverageComponent extends Component {
     super(...arguments);
 
     const { job } = this.args.record;
+    const pipeline = this.pipelinePageState.getPipeline();
 
     this.args.record.onCreate(job, builds => {
       if (builds.length > 0) {
         this.latestBuild = builds[builds.length - 1];
-        const { pipeline } = this.args.record;
 
         this.shuttle
           .fetchFromApi('get', '/coverage/info', {

--- a/tests/integration/components/pipeline/jobs/table/cell/coverage/component-test.js
+++ b/tests/integration/components/pipeline/jobs/table/cell/coverage/component-test.js
@@ -9,13 +9,21 @@ module(
   function (hooks) {
     setupRenderingTest(hooks);
 
+    hooks.beforeEach(function () {
+      const pipelinePageState = this.owner.lookup(
+        'service:pipeline-page-state'
+      );
+
+      sinon
+        .stub(pipelinePageState, 'getPipeline')
+        .returns({ id: 123, name: 'myPipeline' });
+    });
+
     test('it renders', async function (assert) {
-      const pipeline = { id: 123, name: 'myPipeline' };
       const job = { id: 123, name: 'main' };
 
       this.setProperties({
         record: {
-          pipeline,
           job,
           onCreate: () => {},
           onDestroy: () => {}
@@ -77,7 +85,6 @@ module(
     });
 
     test('it renders coverage value', async function (assert) {
-      const pipeline = { id: 123, name: 'myPipeline' };
       const job = { id: 123, name: 'main' };
       const builds = [
         {
@@ -93,7 +100,6 @@ module(
 
       this.setProperties({
         record: {
-          pipeline,
           job,
           onCreate: (j, cb) => {
             return cb(builds);
@@ -112,7 +118,6 @@ module(
     });
 
     test('it renders when no coverage available', async function (assert) {
-      const pipeline = { id: 123, name: 'myPipeline' };
       const job = { id: 123, name: 'main' };
       const builds = [
         {
@@ -128,7 +133,6 @@ module(
 
       this.setProperties({
         record: {
-          pipeline,
           job,
           onCreate: (j, cb) => {
             return cb(builds);


### PR DESCRIPTION
## Context
Refactor the job coverage table cell to use the injected pipeline data

## Objective
Refactors the job coverage table cell to not depend on pipeline data being passed into the component

## References
https://github.com/screwdriver-cd/ui/pull/1331
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
