### PR TITLE
feat: Inject pipeline data into search event modal

### DIFF
--- a/app/components/pipeline/modal/search-event/component.js
+++ b/app/components/pipeline/modal/search-event/component.js
@@ -8,6 +8,8 @@ export default class PipelineModalSearchEventComponent extends Component {
 
   @service shuttle;
 
+  @service pipelinePageState;
+
   @tracked searchField = 'message';
 
   @tracked searchInput = null;
@@ -46,7 +48,7 @@ export default class PipelineModalSearchEventComponent extends Component {
     }
 
     // Construct search URL with proper query parameters
-    const baseUrl = `/pipelines/${this.args.pipeline.id}/events?${
+    const baseUrl = `/pipelines/${this.pipelinePageState.getPipelineId()}/events?${
       this.searchField
     }=${encodeURIComponent(inputValue)}`;
     const url = `${baseUrl}&type=${this.isPr ? 'pr' : 'pipeline'}`;

--- a/app/components/pipeline/workflow/event-rail/template.hbs
+++ b/app/components/pipeline/workflow/event-rail/template.hbs
@@ -14,7 +14,6 @@
       <FaIcon @icon="magnifying-glass" />
       {{#if this.showSearchEventModal}}
         <Pipeline::Modal::SearchEvent
-          @pipeline={{@pipeline}}
           @jobs={{@jobs}}
           @userSettings={{@userSettings}}
           @closeModal={{this.closeSearchEventModal}}

--- a/tests/integration/components/pipeline/modal/search-event/component-test.js
+++ b/tests/integration/components/pipeline/modal/search-event/component-test.js
@@ -10,13 +10,18 @@ module(
   function (hooks) {
     setupRenderingTest(hooks);
 
-    test('it renders', async function (assert) {
+    hooks.beforeEach(function () {
       const router = this.owner.lookup('service:router');
+      const pipelinePageState = this.owner.lookup(
+        'service:pipeline-page-state'
+      );
 
       sinon.stub(router, 'currentRouteName').value('pipeline');
+      sinon.stub(pipelinePageState, 'getPipelineId').returns(123);
+    });
 
+    test('it renders', async function (assert) {
       this.setProperties({
-        pipeline: {},
         jobs: [],
         userSettings: {},
         closeModal: () => {}
@@ -24,7 +29,6 @@ module(
 
       await render(
         hbs`<Pipeline::Modal::SearchEvent
-            @pipeline={{this.pipeline}}
             @jobs={{this.jobs}}
             @userSettings={{this.userSettings}}
             @closeModal={{this.closeModal}}
@@ -42,14 +46,11 @@ module(
     });
 
     test('it makes API call for valid input with default searchField', async function (assert) {
-      const router = this.owner.lookup('service:router');
       const shuttle = this.owner.lookup('service:shuttle');
 
-      sinon.stub(router, 'currentRouteName').value('pipeline');
       sinon.stub(shuttle, 'fetchFromApi').resolves([]);
 
       this.setProperties({
-        pipeline: {},
         jobs: [],
         userSettings: {},
         closeModal: () => {}
@@ -57,7 +58,6 @@ module(
 
       await render(
         hbs`<Pipeline::Modal::SearchEvent
-            @pipeline={{this.pipeline}}
             @jobs={{this.jobs}}
             @userSettings={{this.userSettings}}
             @closeModal={{this.closeModal}}
@@ -72,10 +72,8 @@ module(
     });
 
     test('it makes API call for valid input with selected searchField', async function (assert) {
-      const router = this.owner.lookup('service:router');
       const shuttle = this.owner.lookup('service:shuttle');
 
-      sinon.stub(router, 'currentRouteName').value('pipeline');
       sinon
         .stub(shuttle, 'fetchFromApi')
         .onCall(0)
@@ -84,7 +82,6 @@ module(
         .resolves([]);
 
       this.setProperties({
-        pipeline: {},
         jobs: [],
         userSettings: {},
         closeModal: () => {}
@@ -114,14 +111,11 @@ module(
     });
 
     test('it handles invalid sha input', async function (assert) {
-      const router = this.owner.lookup('service:router');
       const shuttle = this.owner.lookup('service:shuttle');
 
-      sinon.stub(router, 'currentRouteName').value('pipeline');
       const spyShuttle = sinon.spy(shuttle, 'fetchFromApi');
 
       this.setProperties({
-        pipeline: {},
         jobs: [],
         userSettings: {},
         closeModal: () => {}
@@ -129,7 +123,6 @@ module(
 
       await render(
         hbs`<Pipeline::Modal::SearchEvent
-            @pipeline={{this.pipeline}}
             @jobs={{this.jobs}}
             @userSettings={{this.userSettings}}
             @closeModal={{this.closeModal}}
@@ -149,10 +142,8 @@ module(
     });
 
     test('it clears input and search results when escape key is pressed', async function (assert) {
-      const router = this.owner.lookup('service:router');
       const shuttle = this.owner.lookup('service:shuttle');
 
-      sinon.stub(router, 'currentRouteName').value('pipeline');
       sinon.stub(shuttle, 'fetchFromApi').resolves([]);
 
       this.setProperties({
@@ -164,7 +155,6 @@ module(
 
       await render(
         hbs`<Pipeline::Modal::SearchEvent
-            @pipeline={{this.pipeline}}
             @jobs={{this.jobs}}
             @userSettings={{this.userSettings}}
             @closeModal={{this.closeModal}}


### PR DESCRIPTION
## Context
Refactor the search event modal to use injected pipeline data.

## Objective
Refactor the search event modal to use injected pipeline data instead of having it passed into the component.

## References
https://github.com/screwdriver-cd/ui/pull/1331
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
