### PR TITLE
fix: Remove pipeline from route models

### DIFF
--- a/app/v2/pipeline/events/index/route.js
+++ b/app/v2/pipeline/events/index/route.js
@@ -4,9 +4,11 @@ import { service } from '@ember/service';
 export default class NewPipelineEventsIndexRoute extends Route {
   @service shuttle;
 
+  @service pipelinePageState;
+
   async model() {
     const model = this.modelFor('v2.pipeline.events');
-    const pipelineId = model.pipeline.id;
+    const pipelineId = this.pipelinePageState.getPipelineId();
 
     const latestEvent = await this.shuttle
       .fetchFromApi('get', `/pipelines/${pipelineId}/events?count=1`)
@@ -14,7 +16,10 @@ export default class NewPipelineEventsIndexRoute extends Route {
         return events[0];
       });
 
-    return { ...model, latestEvent };
+    return {
+      userSettings: model.userSettings,
+      latestEvent
+    };
   }
 
   afterModel(model) {

--- a/app/v2/pipeline/events/index/template.hbs
+++ b/app/v2/pipeline/events/index/template.hbs
@@ -1,5 +1,4 @@
 <Pipeline::Workflow
-  @pipeline={{this.model.pipeline}}
   @userSettings={{this.model.userSettings}}
   @noEvents={{true}}
 />

--- a/app/v2/pipeline/events/route.js
+++ b/app/v2/pipeline/events/route.js
@@ -5,15 +5,12 @@ export default class NewPipelineEventsRoute extends Route {
   @service shuttle;
 
   async model() {
-    const model = this.modelFor('v2.pipeline');
-
     const userSettings = await this.shuttle.fetchFromApi(
       'get',
       '/users/settings'
     );
 
     return {
-      ...model,
       userSettings
     };
   }

--- a/app/v2/pipeline/events/show/route.js
+++ b/app/v2/pipeline/events/show/route.js
@@ -5,10 +5,12 @@ import { NotFoundError } from 'ember-ajax/errors';
 export default class NewPipelineEventsShowRoute extends Route {
   @service shuttle;
 
+  @service pipelinePageState;
+
   async model(params, transition) {
     const eventId = params.event_id;
     const model = this.modelFor('v2.pipeline.events');
-    const pipelineId = model.pipeline.id;
+    const pipelineId = this.pipelinePageState.getPipelineId();
 
     let latestEvent;
 
@@ -51,7 +53,7 @@ export default class NewPipelineEventsShowRoute extends Route {
     );
 
     return {
-      ...model,
+      userSettings: model.userSettings,
       event,
       latestEvent,
       jobs,

--- a/app/v2/pipeline/events/show/template.hbs
+++ b/app/v2/pipeline/events/show/template.hbs
@@ -1,5 +1,4 @@
 <Pipeline::Workflow
-  @pipeline={{this.model.pipeline}}
   @userSettings={{this.model.userSettings}}
   @event={{this.model.event}}
   @jobs={{this.model.jobs}}

--- a/app/v2/pipeline/index/route.js
+++ b/app/v2/pipeline/index/route.js
@@ -4,10 +4,10 @@ import { service } from '@ember/service';
 export default class NewPipelineIndexRoute extends Route {
   @service router;
 
-  beforeModel() {
-    const { pipeline } = this.modelFor('v2.pipeline');
+  @service pipelinePageState;
 
-    if (pipeline.childPipelines) {
+  beforeModel() {
+    if (this.pipelinePageState.getPipeline().childPipelines) {
       this.router.replaceWith('pipeline.child-pipelines');
     } else {
       this.router.replaceWith('v2.pipeline.events');

--- a/app/v2/pipeline/index/template.hbs
+++ b/app/v2/pipeline/index/template.hbs
@@ -1,3 +1,0 @@
-{{page-title "Index"}}
-> pipeline index
-{{outlet}}

--- a/app/v2/pipeline/jobs/route.js
+++ b/app/v2/pipeline/jobs/route.js
@@ -4,9 +4,10 @@ import { service } from '@ember/service';
 export default class NewPipelineJobsRoute extends Route {
   @service shuttle;
 
+  @service pipelinePageState;
+
   async model() {
-    const { pipeline } = this.modelFor('v2.pipeline');
-    const pipelineId = pipeline.id;
+    const pipelineId = this.pipelinePageState.getPipelineId();
 
     const jobs = await this.shuttle.fetchFromApi(
       'get',
@@ -19,7 +20,6 @@ export default class NewPipelineJobsRoute extends Route {
     );
 
     return {
-      pipeline,
       jobs,
       userSettings
     };

--- a/app/v2/pipeline/jobs/template.hbs
+++ b/app/v2/pipeline/jobs/template.hbs
@@ -3,7 +3,6 @@
 <Pipeline::Tab />
 
 <Pipeline::Jobs::Table
-  @pipeline={{this.model.pipeline}}
   @jobs={{this.model.jobs}}
   @userSettings={{this.model.userSettings}}
 />

--- a/app/v2/pipeline/options/route.js
+++ b/app/v2/pipeline/options/route.js
@@ -1,6 +1,5 @@
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
-import { get } from '@ember/object';
 
 export default class PipelineOptionsRoute extends Route {
   @service session;
@@ -9,10 +8,12 @@ export default class PipelineOptionsRoute extends Route {
 
   @service shuttle;
 
+  @service pipelinePageState;
+
   beforeModel() {
     // Guests should not access this page
-    if (get(this, 'session.data.authenticated.isGuest')) {
-      this.router.transitionTo('v2.pipeline');
+    if (this.session.data.authenticated.isGuest) {
+      this.replaceWith('v2.pipeline');
     }
 
     // Reset error message when switching pages
@@ -26,7 +27,7 @@ export default class PipelineOptionsRoute extends Route {
   }
 
   async model() {
-    const { pipeline } = this.modelFor('v2.pipeline');
+    const pipeline = this.pipelinePageState.getPipeline();
     const pipelineId = pipeline.id;
 
     const jobs = await this.shuttle.fetchJobs(pipelineId).catch(e => {

--- a/app/v2/pipeline/pulls/index/template.hbs
+++ b/app/v2/pipeline/pulls/index/template.hbs
@@ -1,5 +1,4 @@
 <Pipeline::Workflow
-  @pipeline={{this.model.pipeline}}
   @userSettings={{this.model.userSettings}}
   @noEvents={{true}}
 />

--- a/app/v2/pipeline/pulls/route.js
+++ b/app/v2/pipeline/pulls/route.js
@@ -4,9 +4,10 @@ import { service } from '@ember/service';
 export default class NewPipelinePullsRoute extends Route {
   @service shuttle;
 
+  @service pipelinePageState;
+
   async model() {
-    const model = this.modelFor('v2.pipeline');
-    const pipelineId = model.pipeline.id;
+    const pipelineId = this.pipelinePageState.getPipelineId();
 
     const userSettings = await this.shuttle.fetchFromApi(
       'get',
@@ -29,7 +30,6 @@ export default class NewPipelinePullsRoute extends Route {
     );
 
     return {
-      ...model,
       userSettings,
       stages,
       triggers,

--- a/app/v2/pipeline/pulls/show/route.js
+++ b/app/v2/pipeline/pulls/show/route.js
@@ -9,6 +9,8 @@ import {
 export default class V2PipelinePullsShowRoute extends Route {
   @service shuttle;
 
+  @service pipelinePageState;
+
   @service selectedPrSha;
 
   queryParams = {
@@ -19,7 +21,7 @@ export default class V2PipelinePullsShowRoute extends Route {
 
   async model(params, transition) {
     const model = this.modelFor('v2.pipeline.pulls');
-    const { pipeline } = model;
+    const pipeline = this.pipelinePageState.getPipeline();
     const pipelineId = pipeline.id;
     const prNums = transition.data.prNums
       ? new Set(transition.data.prNums)

--- a/app/v2/pipeline/pulls/show/template.hbs
+++ b/app/v2/pipeline/pulls/show/template.hbs
@@ -1,5 +1,4 @@
 <Pipeline::Workflow
-  @pipeline={{this.model.pipeline}}
   @userSettings={{this.model.userSettings}}
   @event={{this.model.event}}
   @jobs={{this.model.jobs}}

--- a/app/v2/pipeline/route.js
+++ b/app/v2/pipeline/route.js
@@ -2,33 +2,37 @@ import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 
 export default class NewPipelineRoute extends Route {
-  @service router;
-
   @service shuttle;
 
   @service pipelinePageState;
 
   async model(params) {
+    const pipelineId = params.pipeline_id;
+
     this.pipelinePageState.clear();
 
-    const [pipeline, banners] = await Promise.all([
-      this.shuttle
-        .fetchFromApi('get', `/pipelines/${params.pipeline_id}`)
-        .catch(() => null),
-      this.shuttle.fetchBanners('PIPELINE', params.pipeline_id).catch(() => [])
-    ]);
+    const pipeline = await this.shuttle
+      .fetchFromApi('get', `/pipelines/${pipelineId}`)
+      .then(response => {
+        this.pipelinePageState.setPipeline(response);
+      })
+      .catch(() => {
+        this.replaceWith('/404');
 
-    this.pipelinePageState.setPipeline(pipeline);
+        return null;
+      });
+
+    if (!pipeline) {
+      return null;
+    }
+
+    const banners = await this.shuttle
+      .fetchBanners('PIPELINE', pipelineId)
+      .catch(() => []);
 
     return {
-      pipeline,
+      pipelineName: pipeline.name,
       banners
     };
-  }
-
-  afterModel(model) {
-    if (!model.pipeline) {
-      this.router.replaceWith('/404');
-    }
   }
 }

--- a/app/v2/pipeline/secrets/route.js
+++ b/app/v2/pipeline/secrets/route.js
@@ -8,10 +8,12 @@ export default class NewPipelineSecretsRoute extends Route {
 
   @service shuttle;
 
+  @service pipelinePageState;
+
   async beforeModel() {
     // Guests should not access this page
     if (this.session.data.authenticated.isGuest) {
-      this.router.transitionTo('v2.pipeline');
+      this.router.replaceWith('v2.pipeline');
     }
   }
 
@@ -19,7 +21,7 @@ export default class NewPipelineSecretsRoute extends Route {
     // Refresh error message
     this.controllerFor('v2.pipeline.secrets').set('errorMessage', '');
 
-    const { pipeline } = this.modelFor('v2.pipeline');
+    const pipeline = this.pipelinePageState.getPipeline();
     const pipelineId = pipeline.id;
 
     const secrets = await this.shuttle

--- a/app/v2/pipeline/template.hbs
+++ b/app/v2/pipeline/template.hbs
@@ -1,6 +1,6 @@
-<Banner @banners={{this.model.banners}}/>
+{{page-title this.model.pipelineName}}
 
-{{page-title this.model.pipeline.name}}
+<Banner @banners={{this.model.banners}}/>
 
 <div id="pipeline-page-contents">
   <Pipeline::Nav />


### PR DESCRIPTION
## Context
Removes the pipeline data from the route models since https://github.com/screwdriver-cd/ui/pull/1331 allows for injecting the pipeline data directly into the components that require the data.

## Objective
1. Refactor the pipeline routes to not include the pipeline data in the model since it was only being passed down the chain of routes.  
2. Removes an unused template for the pipeline index route
3. Cleans up a few redirects within the routes

## References
https://github.com/screwdriver-cd/ui/pull/1331
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
