### PR TITLE
fix: Add overflow handling for long messages

### DIFF
--- a/app/components/pipeline/event/card/styles.scss
+++ b/app/components/pipeline/event/card/styles.scss
@@ -99,6 +99,7 @@
       .message {
         font-weight: variables.$weight-bold;
         font-size: 1rem;
+        overflow-x: auto;
       }
 
       .label {


### PR DESCRIPTION
## Context
Certain long messages may not break nicely and cause a bit of a text overflow in the event card.  For these instances, the overflowing text should be handled properly

## Objective
Adds horizontal overflow handling for event card messages

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
