### PR TITLE
fix: Fix event status determination

### DIFF
--- a/app/components/pipeline/workflow/component.js
+++ b/app/components/pipeline/workflow/component.js
@@ -161,7 +161,7 @@ export default class PipelineWorkflowComponent extends Component {
       this.event.id
     );
 
-    if (!this.isEventComplete(event, builds)) {
+    if (!this.isEventComplete(builds)) {
       this.workflowDataReload.registerBuildsCallback(
         BUILD_QUEUE_NAME,
         event.id,
@@ -193,7 +193,7 @@ export default class PipelineWorkflowComponent extends Component {
   buildsCallback(builds) {
     this.builds = builds;
 
-    if (this.isEventComplete(this.event, builds)) {
+    if (this.isEventComplete(builds)) {
       this.workflowDataReload.removeBuildsCallback(
         BUILD_QUEUE_NAME,
         this.event.id
@@ -201,8 +201,8 @@ export default class PipelineWorkflowComponent extends Component {
     }
   }
 
-  isEventComplete(event, builds) {
-    return !!(isSkipped(this.event, builds) || isComplete(builds));
+  isEventComplete(builds) {
+    return isSkipped(this.event, builds) || isComplete(builds);
   }
 
   get isPR() {

--- a/app/utils/pipeline/event.js
+++ b/app/utils/pipeline/event.js
@@ -13,7 +13,7 @@ export const isSkipped = (event, builds) => {
 
   return builds?.length > 0
     ? false
-    : !!event?.commit?.message.match(/\[(skip ci|ci skip)\]/);
+    : !!event.commit?.message.match(/\[(skip ci|ci skip)\]/);
 };
 
 /**
@@ -23,7 +23,7 @@ export const isSkipped = (event, builds) => {
  */
 export const isComplete = builds => {
   if (!builds || builds.length === 0) {
-    return true;
+    return false;
   }
 
   return builds.every(build => {
@@ -48,11 +48,11 @@ export const getStatus = (event, builds) => {
     return 'SKIPPED';
   }
 
-  if (isComplete(builds)) {
-    if (!builds || builds.length === 0) {
-      return 'UNKNOWN';
-    }
+  if (!builds || builds.length === 0) {
+    return 'UNKNOWN';
+  }
 
+  if (isComplete(builds)) {
     return builds.filter(build => build.status === 'WARNING').length > 0
       ? 'WARNING'
       : builds[0].status;

--- a/tests/unit/utils/pipeline/event-test.js
+++ b/tests/unit/utils/pipeline/event-test.js
@@ -46,8 +46,8 @@ module('Unit | Utility | Pipeline | event', function () {
   });
 
   test('isComplete returns correct value', function (assert) {
-    assert.equal(isComplete(null), true);
-    assert.equal(isComplete([]), true);
+    assert.equal(isComplete(null), false);
+    assert.equal(isComplete([]), false);
     assert.equal(isComplete([{ status: 'UNSTABLE' }]), false);
     assert.equal(
       isComplete([{ status: 'UNSTABLE', endTime: '2024-04-01T00:00:00.000Z' }]),


### PR DESCRIPTION
## Context
When starting a new event, the v2 UI does not properly reload the workflow graph

## Objective
Fixes the event status determination that was not properly calculating the status of a newly started event as there are no builds queued up on the initial page update.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
