### PR TITLE
fix: Update API fetch to ignore scheduler events

### DIFF
--- a/app/components/pipeline/workflow/event-rail/component.js
+++ b/app/components/pipeline/workflow/event-rail/component.js
@@ -81,7 +81,7 @@ export default class PipelineWorkflowEventRailComponent extends Component {
   }
 
   async fetchEvents(event, direction) {
-    const pipelineId = this.pipelinePageState.getPipelineId();
+    const pipeline = this.pipelinePageState.getPipeline();
 
     if (this.isPR) {
       if (!this.prNums || this.prNums.length === 0) {
@@ -97,7 +97,7 @@ export default class PipelineWorkflowEventRailComponent extends Component {
         return this.shuttle
           .fetchFromApi(
             'get',
-            `/pipelines/${pipelineId}/events?type=${this.eventType}&prNum=${prNumToFetch}`
+            `/pipelines/${pipeline.id}/events?type=${this.eventType}&prNum=${prNumToFetch}`
           )
           .then(events => {
             return events[0];
@@ -110,15 +110,14 @@ export default class PipelineWorkflowEventRailComponent extends Component {
     }
 
     const sort = direction === 'gt' ? 'ascending' : 'descending';
+    const baseUrl = `/pipelines/${pipeline.id}/events?count=${EVENT_BATCH_SIZE}&type=${this.eventType}&id=${direction}:${event.id}&sort=${sort}`;
+    const url = pipeline.settings?.filterSchedulerEvents
+      ? `${baseUrl}&creator=ne:sd:scheduler`
+      : baseUrl;
 
-    return this.shuttle
-      .fetchFromApi(
-        'get',
-        `/pipelines/${pipelineId}/events?count=${EVENT_BATCH_SIZE}&type=${this.eventType}&id=${direction}:${event.id}&sort=${sort}`
-      )
-      .then(events => {
-        return events;
-      });
+    return this.shuttle.fetchFromApi('get', url).then(events => {
+      return events;
+    });
   }
 
   @action


### PR DESCRIPTION
## Context
If the scheduler filter is configured for a pipeline, the events should be filtered from the event rail.

## Objective
Adds in support to the API call for filtering events created by the scheduler.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
