### PR TITLE
feat: Add support for filtering out skipped events

### DIFF
--- a/app/components/pipeline/event/card/component.js
+++ b/app/components/pipeline/event/card/component.js
@@ -28,6 +28,8 @@ export default class PipelineEventCardComponent extends Component {
 
   @service workflowDataReload;
 
+  @service pipelinePageState;
+
   @service selectedPrSha;
 
   @tracked event;
@@ -37,6 +39,8 @@ export default class PipelineEventCardComponent extends Component {
   @tracked latestCommitEvent;
 
   @tracked status;
+
+  @tracked hideCard;
 
   @tracked failureCount;
 
@@ -70,6 +74,7 @@ export default class PipelineEventCardComponent extends Component {
 
     this.showParametersModal = false;
     this.showAbortBuildModal = false;
+    this.hideCard = false;
   }
 
   willDestroy() {
@@ -162,6 +167,14 @@ export default class PipelineEventCardComponent extends Component {
 
     this.builds = builds;
     this.status = getStatus(this.event, builds);
+
+    if (this.args.handleFilter) {
+      const pipeline = this.pipelinePageState.getPipeline();
+
+      if (pipeline.settings?.filterEventsForNoBuilds) {
+        this.hideCard = !this.isHighlighted && this.status === 'SKIPPED';
+      }
+    }
 
     if (this.status !== 'COLLAPSED') {
       this.failureCount = getFailureCount(builds);

--- a/app/components/pipeline/event/card/styles.scss
+++ b/app/components/pipeline/event/card/styles.scss
@@ -6,7 +6,7 @@
   .event-card {
     display: flex;
     flex-direction: column;
-    margin: 1rem;
+    margin: 0 1rem 1rem;
     padding: 0.5rem;
     border-radius: 3px;
     border: 1px solid colors.$sd-light-gray;
@@ -18,6 +18,14 @@
 
     &.highlighted {
       background: rgba(colors.$sd-pale-purple, 0.5);
+    }
+
+    &.filtered {
+      visibility: hidden;
+      height: 0;
+      border: none;
+      margin-bottom: 0;
+      padding: 0;
     }
 
     .event-card-title {

--- a/app/components/pipeline/event/card/template.hbs
+++ b/app/components/pipeline/event/card/template.hbs
@@ -1,5 +1,5 @@
 <div
-  class="event-card{{if this.isHighlighted " highlighted"}}"
+  class="event-card{{if this.isHighlighted " highlighted"}}{{if this.hideCard " filtered"}}"
   title={{this.title}}
   {{did-insert this.initialize}}
   {{did-update this.update @event}}

--- a/app/components/pipeline/workflow/event-rail/styles.scss
+++ b/app/components/pipeline/workflow/event-rail/styles.scss
@@ -28,8 +28,10 @@
     }
 
     #event-cards-container {
-      height: calc(100% - $rail-actions-height);
+      $margin-bottom: 1rem;
+      height: calc(100% - $rail-actions-height - $margin-bottom);
       overflow: scroll;
+      margin-bottom: $margin-bottom;
     }
   }
 }

--- a/app/components/pipeline/workflow/event-rail/template.hbs
+++ b/app/components/pipeline/workflow/event-rail/template.hbs
@@ -55,6 +55,7 @@
         @showAbort={{true}}
         @showParameters={{true}}
         @showEventGroup={{true}}
+        @handleFilter={{true}}
       />
     </VerticalCollection>
   </div>


### PR DESCRIPTION
## Context
The pipeline has settings to filter out events that have been skipped and this filtering should be supported in the V2 UI.  The event cards are responsible for loading in their respective builds which allows the event cards to determine the state of the event.  Thus, the event cards are able to determine whether or not they should be displayed in the UI.

## Objective
Filters out the skipped events, if configured in the pipeline settings, by hiding them in the UI via CSS.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
