### PR TITLE
fix: truncate long branch names on the search page

### DIFF
--- a/app/components/search-list/styles.scss
+++ b/app/components/search-list/styles.scss
@@ -12,11 +12,23 @@
   .appId {
     text-align: left;
     width: 45%;
+    max-width: 250px;
+    a {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
   }
 
   .branch {
     width: 25%;
     text-align: right;
+    max-width: 200px;
+    a {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
   }
 
   .account {

--- a/app/components/search-list/template.hbs
+++ b/app/components/search-list/template.hbs
@@ -43,13 +43,13 @@
       <tr>
         <td class="appId">
           {{!-- {{#highlight-terms query}} --}}
-          <LinkTo @route="pipeline" @model={{pipeline.id}}>
+          <LinkTo @route="pipeline" @model={{pipeline.id}} title="{{pipeline.appId}}">
             {{pipeline.appId}}
           </LinkTo>
           {{!-- {{/highlight-terms}} --}}
         </td>
         <td class="branch">
-          <a href={{branch-url-encode pipeline.hubUrl}}>
+          <a href={{branch-url-encode pipeline.hubUrl}} title="{{pipeline.branch}}">
             <FaIcon @icon="code-branch" />{{pipeline.branch}}
           </a>
         </td>

--- a/tests/integration/components/search-list/component-test.js
+++ b/tests/integration/components/search-list/component-test.js
@@ -94,10 +94,22 @@ module('Integration | Component | search list', function (hooks) {
     );
 
     assert.dom('tbody tr:first-child td.appId').hasText('batman/tumbler');
+    assert
+      .dom('tbody tr:first-child td.appId a')
+      .hasAttribute('title', 'batman/tumbler');
     assert.dom('tbody tr:first-child td.branch').hasText('waynecorp');
+    assert
+      .dom('tbody tr:first-child td.branch a')
+      .hasAttribute('title', 'waynecorp');
     assert.dom('tbody tr:first-child td.account').hasText('bitbucket.org');
     assert.dom('tbody tr:nth-child(2) td.appId').hasText('foo/bar');
+    assert
+      .dom('tbody tr:nth-child(2) td.appId a')
+      .hasAttribute('title', 'foo/bar');
     assert.dom('tbody tr:nth-child(2) td.branch').hasText('master');
+    assert
+      .dom('tbody tr:nth-child(2) td.branch a')
+      .hasAttribute('title', 'master');
     assert.dom('tbody tr:nth-child(2) td.account').hasText('github.com');
     assert.dom('.add-to-collection').exists({ count: 2 });
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

The long branch name overflow on the pipeline search page.

<img width="986" alt="before" src="https://github.com/user-attachments/assets/f1545f43-53c1-4110-a45e-fcfa3feb6726" />

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Omit long branch name as in the [collection pages](https://github.com/screwdriver-cd/ui/blob/4b69d942d3af1307589b5a15282eb5191602bd38/app/components/collection-table-row/styles.scss#L26-L30).

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
