### PR TITLE
feat(3065): Ability to collapse and expand stage in the UI

### DIFF
--- a/app/components/pipeline-workflow/component.js
+++ b/app/components/pipeline-workflow/component.js
@@ -52,6 +52,8 @@ export default Component.extend({
     }
   ),
 
+  collapsedStages: new Set([]),
+
   canRestartPipeline: computed('authenticated', 'pipeline.state', {
     get() {
       return this.authenticated && isActivePipeline(this.get('pipeline'));
@@ -230,6 +232,7 @@ export default Component.extend({
     // hide graph tooltip when event changes
     set(this, 'showTooltip', false);
     this.setStageBuilds();
+    set(this, 'collapsedStages', new Set([]));
   },
   actions: {
     graphClicked(job, mouseevent, sizes) {
@@ -405,6 +408,17 @@ export default Component.extend({
       };
 
       setProperties(this, properties);
+    },
+    onToggleStageView(stageName, isCollapsed) {
+      const collapsedStages = new Set(this.collapsedStages);
+
+      if (isCollapsed) {
+        collapsedStages.add(stageName);
+      } else {
+        collapsedStages.delete(stageName);
+      }
+
+      setProperties(this, { collapsedStages });
     },
     confirmStartBuild(newEventStartFromType) {
       setProperties(this, {

--- a/app/components/pipeline-workflow/template.hbs
+++ b/app/components/pipeline-workflow/template.hbs
@@ -16,9 +16,11 @@
     @causeMessage={{this.selectedEventObj.causeMessage}}
     @graphClicked={{action "graphClicked"}}
     @onShowStageActionsMenu={{action "onShowStageActionsMenu"}}
+    @onToggleStageView={{action "onToggleStageView"}}
     @isSkipped={{this.selectedEventObj.isSkipped}}
     @prChainEnabled={{this.prChainEnabled}}
     @stages={{this.stages}}
+    @collapsedStages={{this.collapsedStages}}
     @displayStageMenuHandle={{this.displayStageMenuHandle}}
   >
     <WorkflowTooltip

--- a/app/components/pipeline/workflow/component.js
+++ b/app/components/pipeline/workflow/component.js
@@ -51,6 +51,8 @@ export default class PipelineWorkflowComponent extends Component {
 
   @tracked showGraph;
 
+  @tracked collapsedStages = new Set([]);
+
   workflowGraph;
 
   workflowGraphWithDownstreamTriggers;
@@ -338,6 +340,19 @@ export default class PipelineWorkflowComponent extends Component {
     } else {
       this.d3Data = null;
     }
+  }
+
+  @action
+  toggleStageView(stageName, isCollapsed) {
+    const collapsedStages = new Set(this.collapsedStages);
+
+    if (isCollapsed) {
+      collapsedStages.add(stageName);
+    } else {
+      collapsedStages.delete(stageName);
+    }
+
+    this.collapsedStages = collapsedStages;
   }
 
   @action

--- a/app/components/pipeline/workflow/graph/component.js
+++ b/app/components/pipeline/workflow/graph/component.js
@@ -188,7 +188,7 @@ export default class PipelineWorkflowGraphComponent extends Component {
     if (
       this.event.id !== event.id ||
       this.decoratedGraph.nodes.length !== workflowGraph.nodes.length ||
-      this.collapsedStages.length !== collapsedStages.length
+      this.collapsedStages.size !== collapsedStages.size
     ) {
       if (this.event.id !== event.id) {
         this.event = event;

--- a/app/components/pipeline/workflow/graph/component.js
+++ b/app/components/pipeline/workflow/graph/component.js
@@ -134,7 +134,7 @@ export default class PipelineWorkflowGraphComponent extends Component {
         this.decoratedGraph,
         elementSizes,
         nodeWidth,
-        isSkipped,
+        isSkippedEvent,
         verticalDisplacements,
         horizontalDisplacements
       );

--- a/app/components/pipeline/workflow/graph/component.js
+++ b/app/components/pipeline/workflow/graph/component.js
@@ -31,6 +31,8 @@ export default class PipelineWorkflowGraphComponent extends Component {
 
   decoratedGraph;
 
+  collapsedStages;
+
   graphSvg;
 
   constructor() {
@@ -38,16 +40,24 @@ export default class PipelineWorkflowGraphComponent extends Component {
     this.event = this.args.event;
     this.builds = this.args.builds;
     this.stageBuilds = this.args.stageBuilds;
+    this.collapsedStages = this.args.collapsedStages;
 
     this.getDecoratedGraph(
       this.args.workflowGraph,
       this.args.builds,
       this.args.stageBuilds,
-      this.args.event
+      this.args.event,
+      this.args.collapsedStages
     );
   }
 
-  getDecoratedGraph(workflowGraph, builds, stageBuilds, event) {
+  getDecoratedGraph(
+    workflowGraph,
+    builds,
+    stageBuilds,
+    event,
+    collapsedStages
+  ) {
     this.decoratedGraph = decorateGraph({
       inputGraph: workflowGraph,
       builds,
@@ -58,7 +68,8 @@ export default class PipelineWorkflowGraphComponent extends Component {
       start: event.startFrom,
       chainPR: this.args.chainPr,
       prNum: event.prNum,
-      stages: this.pipelinePageState.getStages()
+      stages: this.pipelinePageState.getStages(),
+      collapsedStages
     });
   }
 
@@ -87,6 +98,10 @@ export default class PipelineWorkflowGraphComponent extends Component {
       this.args.setShowStageTooltip(true, stage, d3.event);
     };
 
+    const onClickStageViewToggle = (stageName, isCollapsed) => {
+      this.args.toggleStageView(stageName, isCollapsed);
+    };
+
     // Add the SVG element
     this.graphSvg = getGraphSvg(
       element,
@@ -106,7 +121,8 @@ export default class PipelineWorkflowGraphComponent extends Component {
           elementSizes,
           nodeWidth,
           onClickStageMenu,
-          this.args.displayStageTooltip
+          this.args.displayStageTooltip,
+          onClickStageViewToggle
         )
       : {};
 
@@ -157,7 +173,10 @@ export default class PipelineWorkflowGraphComponent extends Component {
   }
 
   @action
-  redraw(element, [workflowGraph, builds, stageBuilds, event]) {
+  redraw(
+    element,
+    [workflowGraph, builds, stageBuilds, event, collapsedStages]
+  ) {
     const elementSizes = getElementSizes();
     const maximumJobNameLength = getMaximumJobNameLength(
       this.decoratedGraph,
@@ -167,15 +186,23 @@ export default class PipelineWorkflowGraphComponent extends Component {
 
     if (
       this.event.id !== event.id ||
-      this.decoratedGraph.nodes.length !== workflowGraph.nodes.length
+      this.decoratedGraph.nodes.length !== workflowGraph.nodes.length ||
+      this.collapsedStages.length !== collapsedStages.length
     ) {
       if (this.event.id !== event.id) {
         this.event = event;
       }
       this.builds = builds;
       this.stageBuilds = stageBuilds;
+      this.collapsedStages = collapsedStages;
 
-      this.getDecoratedGraph(workflowGraph, builds, stageBuilds, event);
+      this.getDecoratedGraph(
+        workflowGraph,
+        builds,
+        stageBuilds,
+        event,
+        collapsedStages
+      );
       element.replaceChildren();
       this.draw(element);
 

--- a/app/components/pipeline/workflow/graph/component.js
+++ b/app/components/pipeline/workflow/graph/component.js
@@ -209,7 +209,13 @@ export default class PipelineWorkflowGraphComponent extends Component {
       return;
     }
 
-    this.getDecoratedGraph(workflowGraph, builds, stageBuilds, event);
+    this.getDecoratedGraph(
+      workflowGraph,
+      builds,
+      stageBuilds,
+      event,
+      collapsedStages
+    );
     updateEdgeStatuses(this.graphSvg, this.decoratedGraph);
     updateJobStatuses(
       this.graphSvg,

--- a/app/components/pipeline/workflow/graph/component.js
+++ b/app/components/pipeline/workflow/graph/component.js
@@ -16,7 +16,8 @@ import {
   getNodeWidth,
   updateEdgeStatuses,
   updateJobStatuses,
-  updateStageStatuses
+  updateStageStatuses,
+  updateStageEdgeStatuses
 } from 'screwdriver-ui/utils/pipeline/graph/d3-graph-util';
 import { nodeCanShowTooltip } from 'screwdriver-ui/utils/pipeline/graph/tooltip';
 
@@ -217,6 +218,7 @@ export default class PipelineWorkflowGraphComponent extends Component {
       collapsedStages
     );
     updateEdgeStatuses(this.graphSvg, this.decoratedGraph);
+    updateStageEdgeStatuses(this.graphSvg, this.decoratedGraph);
     updateJobStatuses(
       this.graphSvg,
       this.decoratedGraph,

--- a/app/components/pipeline/workflow/graph/styles.scss
+++ b/app/components/pipeline/workflow/graph/styles.scss
@@ -119,6 +119,19 @@
             line-height: 0.75rem;
           }
         }
+
+        .stage-view-toggle {
+          background-color: colors.$sd-black;
+          border-radius: 5px;
+          color: colors.$sd-white;
+          cursor: pointer;
+          font-family: monospace;
+          font-stretch: ultra-expanded;
+          font-weight: bold;
+          margin-right: 10px;
+          text-align: center;
+          width: 20px;
+        }
       }
 
       .stage-description {

--- a/app/components/pipeline/workflow/graph/styles.scss
+++ b/app/components/pipeline/workflow/graph/styles.scss
@@ -127,7 +127,7 @@
           cursor: pointer;
           font-family: monospace;
           font-stretch: ultra-expanded;
-          font-weight: bold;
+          font-weight: variables.$weight-bold;
           margin-right: 10px;
           text-align: center;
           width: 20px;

--- a/app/components/pipeline/workflow/graph/template.hbs
+++ b/app/components/pipeline/workflow/graph/template.hbs
@@ -1,4 +1,4 @@
 <div id="workflow-graph"
   {{did-insert this.draw}}
-  {{did-update this.redraw @workflowGraph @builds @stageBuilds @event}}
+  {{did-update this.redraw @workflowGraph @builds @stageBuilds @event @collapsedStages}}
 />

--- a/app/components/pipeline/workflow/template.hbs
+++ b/app/components/pipeline/workflow/template.hbs
@@ -95,11 +95,13 @@
             @jobs={{this.jobs}}
             @builds={{this.builds}}
             @stageBuilds={{this.stageBuilds}}
+            @collapsedStages={{this.collapsedStages}}
             @chainPr={{this.pipeline.prChain}}
             @displayJobNameLength={{this.displayJobNameLength}}
             @setShowTooltip={{this.setShowTooltip}}
             @displayStageTooltip={{true}}
             @setShowStageTooltip={{this.setShowStageTooltip}}
+            @toggleStageView={{this.toggleStageView}}
           />
 
           {{#if this.showTooltip}}

--- a/app/components/pipeline/workflow/tooltip/stage/component.js
+++ b/app/components/pipeline/workflow/tooltip/stage/component.js
@@ -24,11 +24,7 @@ export default class PipelineWorkflowTooltipStageComponent extends Component {
   }
 
   get stageStatus() {
-    const build = this.args.builds.find(
-      b => b.jobId === this.args.d3Data.stage.setup.id
-    );
-
-    return build ? build.status : null;
+    return this.args.d3Data.stage.status;
   }
 
   get job() {

--- a/app/components/pipeline/workflow/tooltip/template.hbs
+++ b/app/components/pipeline/workflow/tooltip/template.hbs
@@ -19,7 +19,7 @@
           Go to downstream pipeline {{t.triggerName}}
         </LinkTo>
     {{/each}}
-  {{else}}
+  {{else if (not-eq this.tooltipData.job.type "JOB_GROUP")}}
     <LinkTo
       id="build-link"
       @route="pipeline.build"
@@ -78,27 +78,31 @@
     {{/if}}
   {{/if}}
 
-  {{#if this.tooltipData.displayStop}}
-    <a
-      id="stop-build-link"
-      href="#"
-      {{on "click" (fn this.openStopBuildModal)}}
-    >
-      Stop build
-    </a>
-  {{/if}}
-  {{#if (eq this.tooltipData.job.status "FROZEN")}}
-    <a
-      id="stop-build-link"
-      href="#"
-      {{on "click" (fn this.openStopBuildModal)}}
-    >
-      Stop frozen build
-    </a>
+  {{#if (not-eq this.tooltipData.job.type "JOB_GROUP")}}
+    {{#if this.tooltipData.displayStop}}
+      <a
+        id="stop-build-link"
+        href="#"
+        {{on "click" (fn this.openStopBuildModal)}}
+      >
+        Stop build
+      </a>
+    {{/if}}
+    {{#if (eq this.tooltipData.job.status "FROZEN")}}
+      <a
+        id="stop-build-link"
+        href="#"
+        {{on "click" (fn this.openStopBuildModal)}}
+      >
+        Stop frozen build
+      </a>
+    {{/if}}
   {{/if}}
 
   {{#if this.tooltipData.job.description}}
-    <hr>
+    {{#if (not-eq this.tooltipData.job.type "JOB_GROUP")}}
+      <hr>
+    {{/if}}
     {{#if this.enableHiddenDescription}}
       <span
         id="hidden-tooltip-description"

--- a/app/components/workflow-graph-d3/styles.scss
+++ b/app/components/workflow-graph-d3/styles.scss
@@ -156,6 +156,19 @@ g {
         cursor: pointer;
       }
     }
+
+    .stage-view-toggle {
+      background-color: $sd-black;
+      border-radius: 5px;
+      color: $sd-white;
+      cursor: pointer;
+      font-family: monospace;
+      font-stretch: ultra-expanded;
+      font-weight: bold;
+      margin-right: 10px;
+      text-align: center;
+      width: 20px;
+    }
   }
 
   .stage-description {

--- a/app/components/workflow-stage-actions-menu/template.hbs
+++ b/app/components/workflow-stage-actions-menu/template.hbs
@@ -2,7 +2,7 @@
   {{#if this.canRestartPipeline}}
     {{#if (eq this.canStageStartFromView true)}}
       <a href="#" {{action this.confirmStartBuild 'STAGE'}}>
-        {{if this.menuData.stage.setup.status "Restart" "Start"}} pipeline from this stage
+        {{if this.menuData.stage.status "Restart" "Start"}} pipeline from this stage
       </a>
     {{/if}}
   {{/if}}

--- a/app/components/workflow-tooltip/template.hbs
+++ b/app/components/workflow-tooltip/template.hbs
@@ -10,60 +10,63 @@
       </LinkTo>
     {{/each}}
   {{else}}
+    {{#if (not-eq this.tooltipData.job.type "JOB_GROUP")}}
+      <LinkTo
+        @route="pipeline.build"
+        @model={{this.tooltipData.job.buildId}}
+        @disabled={{not (and this.tooltipData.job.buildId (not-eq this.tooltipData.job.status "CREATED"))}}
+      >
+        Go to build details
+      </LinkTo>
 
-    <LinkTo
-      @route="pipeline.build"
-      @model={{this.tooltipData.job.buildId}}
-      @disabled={{not (and this.tooltipData.job.buildId (not-eq this.tooltipData.job.status "CREATED"))}}
-    >
-      Go to build details
-    </LinkTo>
+      <LinkTo @route="pipeline.metrics" @query={{hash jobId=this.tooltipData.job.id}}>
+        Go to build metrics
+      </LinkTo>
 
-    <LinkTo @route="pipeline.metrics" @query={{hash jobId=this.tooltipData.job.id}}>
-      Go to build metrics
-    </LinkTo>
-
-    {{#if this.tooltipData.job.isDisabled}}
-      <p>
-        {{this.tooltipData.job.stateChangeMessage}}
-      </p>
-      <a href="#" {{action "toggleJob" this.tooltipData.job.name}}>
-        Enable this job
-      </a>
-    {{else}}
-      {{#if this.canRestartPipeline}}
-        {{#if this.tooltipData.job.manualStartDisabled}}
-          <p>
-            Disabled manually starting
-          </p>
-        {{else}}
-          {{#if (eq this.canJobStartFromView true)}}
-            <a href="#" {{action this.confirmStartBuild}}>
-              {{if this.tooltipData.job.status "Restart" "Start"}} pipeline from here
-            </a>
+      {{#if this.tooltipData.job.isDisabled}}
+        <p>
+          {{this.tooltipData.job.stateChangeMessage}}
+        </p>
+        <a href="#" {{action "toggleJob" this.tooltipData.job.name}}>
+          Enable this job
+        </a>
+      {{else}}
+        {{#if this.canRestartPipeline}}
+          {{#if this.tooltipData.job.manualStartDisabled}}
+            <p>
+              Disabled manually starting
+            </p>
+          {{else}}
+            {{#if (eq this.canJobStartFromView true)}}
+              <a href="#" {{action this.confirmStartBuild}}>
+                {{if this.tooltipData.job.status "Restart" "Start"}} pipeline from here
+              </a>
+            {{/if}}
           {{/if}}
         {{/if}}
+        {{#if (eq this.tooltipData.job.isDisabled false)}}
+          <a href="#" {{action "toggleJob" this.tooltipData.job.name}}>
+            Disable this job
+          </a>
+        {{/if}}
       {{/if}}
-      {{#if (eq this.tooltipData.job.isDisabled false)}}
-        <a href="#" {{action "toggleJob" this.tooltipData.job.name}}>
-          Disable this job
+
+      {{#if this.tooltipData.displayStop}}
+        <a href="#" {{action this.stopBuild this.tooltipData.selectedEvent this.tooltipData.job}}>
+          Stop build
+        </a>
+      {{/if}}
+      {{#if (eq this.tooltipData.job.status "FROZEN")}}
+        <a href="#" {{action this.stopBuild this.tooltipData.selectedEvent this.tooltipData.job}}>
+          Stop frozen build
         </a>
       {{/if}}
     {{/if}}
 
-    {{#if this.tooltipData.displayStop}}
-      <a href="#" {{action this.stopBuild this.tooltipData.selectedEvent this.tooltipData.job}}>
-        Stop build
-      </a>
-    {{/if}}
-    {{#if (eq this.tooltipData.job.status "FROZEN")}}
-      <a href="#" {{action this.stopBuild this.tooltipData.selectedEvent this.tooltipData.job}}>
-        Stop frozen build
-      </a>
-    {{/if}}
-
     {{#if this.tooltipData.job.description}}
-      <hr>
+      {{#if (not-eq this.tooltipData.job.type "JOB_GROUP")}}
+        <hr>
+      {{/if}}
       {{#if this.enableHiddenDescription}}
         <span class="text-nowrap" onClick={{action "clickDescription"}}>
           {{#if this.isDescriptionClicked}}
@@ -80,8 +83,6 @@
         </span>
       {{/if}}
     {{/if}}
-
-
   {{/if}}
   {{yield}}
 </div>

--- a/app/utils/graph-tools.js
+++ b/app/utils/graph-tools.js
@@ -959,7 +959,9 @@ const decorateGraph = ({
       return;
     }
 
-    if (srcNode.status && srcNode.status !== 'RUNNING') {
+    if (srcStage) {
+      e.status = srcStage.status;
+    } else if (srcNode.status && srcNode.status !== 'RUNNING') {
       if (prTriggeredNodes && node(prTriggeredNodes, srcNode.name)) {
         // For non-chain PR pipelines, PR triggered jobs do not need outbound edges to have a status as they are the last node in the chain.
       } else {

--- a/app/utils/graph-tools.js
+++ b/app/utils/graph-tools.js
@@ -830,11 +830,37 @@ const decorateGraph = ({
     return s;
   });
 
+  // Decorate stages with status
+  graph.stages.forEach(s => {
+    // Get build information
+    if (stageBuildsAvailable) {
+      const stage = findStage(pipelineStages, s.name);
+      const stageBuild = findStageBuild(stageBuilds, stage.id);
+
+      s.id = stage.id;
+
+      if (stageBuild) {
+        s.status = stageBuild.status;
+        s.stageBuildId = stageBuild.id;
+      }
+    }
+  });
+
   // Decorate nodes with position
   positionGraphNodes(graph);
 
   // Decorate nodes with status
   nodes.forEach(n => {
+    if (n.type === 'JOB_GROUP') {
+      const stage = findStage(graph.stages, n.stageName);
+
+      if (stage && stage.status) {
+        n.status = stage.status;
+      }
+
+      return;
+    }
+
     // Get job information
     let jobId = n.id;
 
@@ -907,22 +933,6 @@ const decorateGraph = ({
           graphNode => graphNode.name !== '~pr'
         )
       : null;
-
-  // Decorate stages with status
-  graph.stages.forEach(s => {
-    // Get build information
-    if (stageBuildsAvailable) {
-      const stage = findStage(pipelineStages, s.name);
-      const stageBuild = findStageBuild(stageBuilds, stage.id);
-
-      s.id = stage.id;
-
-      if (stageBuild) {
-        s.status = stageBuild.status;
-        s.stageBuildId = stageBuild.id;
-      }
-    }
-  });
 
   // Decorate edges with positions and status
   edges.forEach(e => {

--- a/app/utils/graph-tools.js
+++ b/app/utils/graph-tools.js
@@ -187,8 +187,8 @@ const collapseStageNodesAndEdges = (stage, originalNodes, originalEdges) => {
     }
   });
 
-  stageJobNames.push(`stage@${stageName}:setup`);
-  stageJobNames.push(`stage@${stageName}:teardown`);
+  stageJobNames.push(stage.setup.name);
+  stageJobNames.push(stage.teardown.name);
 
   originalEdges.forEach(e => {
     const isSrcInStage = stageJobNames.includes(e.src);
@@ -211,8 +211,6 @@ const collapseStageNodesAndEdges = (stage, originalNodes, originalEdges) => {
   });
 
   stage.jobs = [stageNodeGroup];
-  delete stage.setup;
-  delete stage.teardown;
 
   return {
     stage,

--- a/app/utils/pipeline-workflow.js
+++ b/app/utils/pipeline-workflow.js
@@ -50,5 +50,5 @@ export function canStageStart(activeTab, pipelineGraph, stage) {
     return false;
   }
 
-  return canJobStart(activeTab, pipelineGraph, stage.setup.name);
+  return canJobStart(activeTab, pipelineGraph, `stage@${stage.name}:setup`);
 }

--- a/app/utils/pipeline-workflow.js
+++ b/app/utils/pipeline-workflow.js
@@ -50,5 +50,5 @@ export function canStageStart(activeTab, pipelineGraph, stage) {
     return false;
   }
 
-  return canJobStart(activeTab, pipelineGraph, `stage@${stage.name}:setup`);
+  return canJobStart(activeTab, pipelineGraph, stage.setup.name);
 }

--- a/app/utils/pipeline/graph/d3-graph-util.js
+++ b/app/utils/pipeline/graph/d3-graph-util.js
@@ -427,7 +427,8 @@ export function addStages(
   sizes,
   nodeWidth,
   onStageMenuHandleClick,
-  displayStageMenuHandle
+  displayStageMenuHandle,
+  onStageViewToggleClick
 ) {
   const { TITLE_SIZE } = sizes;
 
@@ -478,6 +479,22 @@ export function addStages(
       .append('div')
       .attr('class', 'stage-title')
       .style('font-size', `${TITLE_SIZE}px`);
+
+    const isStageCollapsed = stage.isCollapsed;
+
+    // stage expand/collapse toggle button
+    stageTitle
+      .append('span')
+      .html(isStageCollapsed ? '+' : '-')
+      .attr(
+        'title',
+        isStageCollapsed ? 'Expand the stage' : 'Collapse the stage'
+      )
+      .attr('class', 'stage-view-toggle')
+      .style('font-size', `${TITLE_SIZE}px`)
+      .on('click', () => {
+        onStageViewToggleClick(stage.name, !isStageCollapsed);
+      });
 
     // stage info - name
     stageTitle
@@ -734,6 +751,7 @@ export function addStageEdges( // eslint-disable-line max-params
  * @param sizes
  * @param nodeWidth
  * @param verticalDisplacements
+ * @param horizontalDisplacements
  * @param isSkipped
  * @param onClick
  */

--- a/app/utils/pipeline/graph/d3-graph-util.js
+++ b/app/utils/pipeline/graph/d3-graph-util.js
@@ -618,8 +618,10 @@ export function addEdges( // eslint-disable-line max-params
     .append('path')
     .attr('class', d =>
       isSkipped
-        ? 'graph-edge build-skipped'
-        : `graph-edge ${d.status ? `build-${d.status.toLowerCase()}` : ''}`
+        ? 'graph-edge node-edge build-skipped'
+        : `graph-edge node-edge ${
+            d.status ? `build-${d.status.toLowerCase()}` : ''
+          }`
     )
     .attr('stroke-dasharray', d => (!d.status || isSkipped ? 5 : 0))
     .attr('stroke-width', 2)
@@ -934,11 +936,31 @@ export function updateJobStatuses(svg, data, sizes, nodeWidth) {
  */
 export function updateEdgeStatuses(svg, data) {
   svg
-    .selectAll('.graph-edge')
+    .selectAll('.graph-edge.node-edge')
     .data(data.edges)
     .join()
     .attr('class', edge => {
-      return `graph-edge ${
+      return `graph-edge node-edge ${
+        edge.status ? `build-${edge.status.toLowerCase()}` : ''
+      }`;
+    })
+    .attr('stroke-dasharray', edge => {
+      return !edge.status ? 5 : 0;
+    });
+}
+
+/**
+ * Updates the edge statuses in the existing graph SVG
+ * @param svg
+ * @param data
+ */
+export function updateStageEdgeStatuses(svg, data) {
+  svg
+    .selectAll('.graph-edge.stage-edge')
+    .data(data.stageEdges)
+    .join()
+    .attr('class', edge => {
+      return `graph-edge stage-edge ${
         edge.status ? `build-${edge.status.toLowerCase()}` : ''
       }`;
     })

--- a/tests/integration/components/pipeline/workflow/graph/component-test.js
+++ b/tests/integration/components/pipeline/workflow/graph/component-test.js
@@ -344,6 +344,7 @@ module('Integration | Component | pipeline/workflow/graph', function (hooks) {
         { id: 3, jobId: 12, status: 'RUNNING' }
       ],
       stageBuilds: [{ id: 1, stageId: 10, status: 'RUNNING' }],
+      collapsedStages: new Set([]),
       displayJobNameLength: 20
     });
     await render(
@@ -353,6 +354,7 @@ module('Integration | Component | pipeline/workflow/graph', function (hooks) {
             @jobs={{this.jobs}}
             @builds={{this.builds}}
             @stageBuilds={{this.stageBuilds}}
+            @collapsedStages={{this.collapsedStages}}
             @chainPr={{false}}
             @displayJobNameLength={{this.displayJobNameLength}}
       />`

--- a/tests/integration/components/pipeline/workflow/graph/component-test.js
+++ b/tests/integration/components/pipeline/workflow/graph/component-test.js
@@ -25,6 +25,7 @@ module('Integration | Component | pipeline/workflow/graph', function (hooks) {
       event: { startFrom: '~commit' },
       jobs: [{ id: 1 }],
       builds: [{ id: 1, jobId: 1, status: 'SUCCESS' }],
+      collapsedStages: new Set([]),
       displayJobNameLength: 20
     });
     await render(
@@ -33,6 +34,7 @@ module('Integration | Component | pipeline/workflow/graph', function (hooks) {
             @event={{this.event}}
             @jobs={{this.jobs}}
             @builds={{this.builds}}
+            @collapsedStages={{this.collapsedStages}}
             @chainPr={{false}}
             @displayJobNameLength={{this.displayJobNameLength}}
       />`
@@ -54,6 +56,7 @@ module('Integration | Component | pipeline/workflow/graph', function (hooks) {
       event: { startFrom: nodeNames[0] },
       jobs: [{ id: 1 }],
       builds: [{ id: 1, jobId: 1, status: 'SUCCESS' }],
+      collapsedStages: new Set([]),
       displayJobNameLength: 25
     });
     await render(
@@ -62,6 +65,7 @@ module('Integration | Component | pipeline/workflow/graph', function (hooks) {
             @event={{this.event}}
             @jobs={{this.jobs}}
             @builds={{this.builds}}
+            @collapsedStages={{this.collapsedStages}}
             @chainPr={{false}}
             @displayJobNameLength={{this.displayJobNameLength}}
       />`
@@ -117,6 +121,7 @@ module('Integration | Component | pipeline/workflow/graph', function (hooks) {
         { id: 2, jobId: 1, status: 'SUCCESS' },
         { id: 3, jobId: 12, status: 'SUCCESS' }
       ],
+      collapsedStages: new Set([]),
       displayJobNameLength: 20
     });
     await render(
@@ -125,6 +130,7 @@ module('Integration | Component | pipeline/workflow/graph', function (hooks) {
             @event={{this.event}}
             @jobs={{this.jobs}}
             @builds={{this.builds}}
+            @collapsedStages={{this.collapsedStages}}
             @chainPr={{false}}
             @displayJobNameLength={{this.displayJobNameLength}}
       />`
@@ -171,6 +177,7 @@ module('Integration | Component | pipeline/workflow/graph', function (hooks) {
         { id: 2, jobId: 1, status: 'SUCCESS' },
         { id: 3, jobId: 12, status: 'SUCCESS' }
       ],
+      collapsedStages: new Set([]),
       displayJobNameLength: 20
     });
     await render(
@@ -179,6 +186,7 @@ module('Integration | Component | pipeline/workflow/graph', function (hooks) {
             @event={{this.event}}
             @jobs={{this.jobs}}
             @builds={{this.builds}}
+            @collapsedStages={{this.collapsedStages}}
             @chainPr={{false}}
             @displayJobNameLength={{this.displayJobNameLength}}
       />`
@@ -201,6 +209,7 @@ module('Integration | Component | pipeline/workflow/graph', function (hooks) {
       event: { startFrom: '~pr' },
       jobs: [{ id: 1 }],
       builds: [{ id: 1, jobId: 1, status: 'SUCCESS' }],
+      collapsedStages: new Set([]),
       displayJobNameLength: 20
     });
     await render(
@@ -209,6 +218,7 @@ module('Integration | Component | pipeline/workflow/graph', function (hooks) {
             @event={{this.event}}
             @jobs={{this.jobs}}
             @builds={{this.builds}}
+            @collapsedStages={{this.collapsedStages}}
             @chainPr={{true}}
             @displayJobNameLength={{this.displayJobNameLength}}
       />`
@@ -240,6 +250,7 @@ module('Integration | Component | pipeline/workflow/graph', function (hooks) {
       event: { startFrom: '~commit' },
       jobs: [{ id: 1 }],
       builds: [{ id: 1, jobId: 1, status: 'SUCCESS' }],
+      collapsedStages: new Set([]),
       displayJobNameLength: 20
     });
     await render(
@@ -248,6 +259,7 @@ module('Integration | Component | pipeline/workflow/graph', function (hooks) {
             @event={{this.event}}
             @jobs={{this.jobs}}
             @builds={{this.builds}}
+            @collapsedStages={{this.collapsedStages}}
             @chainPr={{false}}
             @displayJobNameLength={{this.displayJobNameLength}}
       />`
@@ -270,6 +282,7 @@ module('Integration | Component | pipeline/workflow/graph', function (hooks) {
       event: { startFrom: '~commit' },
       jobs: [{ id: 123 }],
       builds: [{ id: 1, jobId: 123, status: 'RUNNING' }],
+      collapsedStages: new Set([]),
       displayJobNameLength: 20
     });
     await render(
@@ -278,6 +291,7 @@ module('Integration | Component | pipeline/workflow/graph', function (hooks) {
             @event={{this.event}}
             @jobs={{this.jobs}}
             @builds={{this.builds}}
+            @collapsedStages={{this.collapsedStages}}
             @chainPr={{false}}
             @displayJobNameLength={{this.displayJobNameLength}}
       />`

--- a/tests/integration/components/pipeline/workflow/tooltip/component-test.js
+++ b/tests/integration/components/pipeline/workflow/tooltip/component-test.js
@@ -291,4 +291,44 @@ module('Integration | Component | pipeline/workflow/tooltip', function (hooks) {
 
     assert.dom('#hidden-tooltip-description').exists({ count: 1 });
   });
+
+  test('it does not render actionable menu options when the node represents stage jobs group', async function (assert) {
+    this.setProperties({
+      d3Data: {
+        node: {
+          name: 'stage@production jobs(3)',
+          description:
+            'This job group includes the following jobs: prod-deploy, prod-test, prod-certify',
+          type: 'JOB_GROUP'
+        },
+        d3Event: { clientX: 0, clientY: 0 },
+        sizes: { ICON_SIZE: 0 }
+      },
+      event: {},
+      jobs: [],
+      builds: []
+    });
+
+    await render(
+      hbs`<Pipeline::Workflow::Tooltip
+        @d3Data={{this.d3Data}}
+        @event={{this.event}}
+        @jobs={{this.jobs}}
+        @builds={{this.builds}}
+      />`
+    );
+
+    assert.dom('#remote-pipeline-link').doesNotExist();
+    assert.dom('.downstream-pipeline-link').doesNotExist();
+    assert.dom('#build-link').doesNotExist();
+    assert.dom('#metrics-link').doesNotExist();
+    assert.dom('#toggle-job-link').doesNotExist();
+    assert.dom('#stop-build-link').doesNotExist();
+
+    // assert.dom('#tooltip-description').exists({ count: 1 });
+    assert.dom('#hidden-tooltip-description').exists({ count: 1 });
+    assert
+      .dom('#hidden-tooltip-description')
+      .hasText('Description: This job group includes t...');
+  });
 });

--- a/tests/integration/components/pipeline/workflow/tooltip/component-test.js
+++ b/tests/integration/components/pipeline/workflow/tooltip/component-test.js
@@ -325,7 +325,6 @@ module('Integration | Component | pipeline/workflow/tooltip', function (hooks) {
     assert.dom('#toggle-job-link').doesNotExist();
     assert.dom('#stop-build-link').doesNotExist();
 
-    // assert.dom('#tooltip-description').exists({ count: 1 });
     assert.dom('#hidden-tooltip-description').exists({ count: 1 });
     assert
       .dom('#hidden-tooltip-description')

--- a/tests/integration/components/pipeline/workflow/tooltip/stage/component-test.js
+++ b/tests/integration/components/pipeline/workflow/tooltip/stage/component-test.js
@@ -88,7 +88,7 @@ module(
       assert.dom('#start-job-link').hasText('Start pipeline from this stage');
     });
 
-    test('it renders an stage tooltip to start', async function (assert) {
+    test('it renders an stage tooltip to restart', async function (assert) {
       const router = this.owner.lookup('service:router');
 
       sinon.stub(router, 'currentRoute').value({
@@ -102,12 +102,12 @@ module(
             setup: {
               id: 123,
               name: 'setup'
-            }
+            },
+            status: 'SUCCESS'
           }
         },
         event: {},
         jobs: [],
-        builds: [{ jobId: 123, status: 'SUCCESS' }],
         workflowGraph: {
           nodes: [],
           edges: []

--- a/tests/integration/components/workflow-stage-actions-menu/component-test.js
+++ b/tests/integration/components/workflow-stage-actions-menu/component-test.js
@@ -61,9 +61,9 @@ module(
           name: 'integration',
           setup: {
             id: 777,
-            name: 'stage@integration:setup',
-            status: 'RUNNING'
-          }
+            name: 'stage@integration:setup'
+          },
+          status: 'RUNNING'
         }
       };
 

--- a/tests/integration/components/workflow-tooltip/component-test.js
+++ b/tests/integration/components/workflow-tooltip/component-test.js
@@ -561,4 +561,34 @@ module('Integration | Component | workflow tooltip', function (hooks) {
 
     assert.dom('span').hasText(`Description: ${fullDescription}`);
   });
+
+  test('it does not render actionable menu options when the node represents stage jobs group', async function (assert) {
+    const data = {
+      job: {
+        name: 'stage@production jobs(3)',
+        description:
+          'This job group includes the following jobs: prod-deploy, prod-test, prod-certify',
+        type: 'JOB_GROUP'
+      }
+    };
+
+    this.set('data', data);
+    this.set('confirmStartBuild', () => {});
+    this.set('canJobStartFromView', true);
+
+    await render(hbs`<WorkflowTooltip
+        @tooltipData={{this.data}}
+        @canRestartPipeline={{true}}
+        @confirmStartBuild={{this.confirmStartBuild}}
+        @canJobStartFromView={{this.canJobStartFromView}}
+      />`);
+
+    assert.dom('.content a').doesNotExist();
+    assert.dom('.content span').exists({ count: 1 });
+    assert
+      .dom('.content span')
+      .hasText(
+        'Description: This job group includes the following jobs: prod-deploy, prod-test, prod-certify'
+      );
+  });
 });

--- a/tests/unit/utils/graph-tools-test.js
+++ b/tests/unit/utils/graph-tools-test.js
@@ -1069,7 +1069,8 @@ module('Unit | Utility | graph tools', function () {
         hidden: true,
         src: 'stage@integration:teardown',
         srcStageName: 'integration',
-        to: expectedOutput.stages[1]
+        to: expectedOutput.stages[1],
+        status: undefined
       }
     ];
 
@@ -1403,6 +1404,16 @@ module('Unit | Utility | graph tools', function () {
           x: 6,
           y: 0
         },
+        setup: {
+          name: 'stage@production:setup',
+          id: 38,
+          stageName: 'production'
+        },
+        teardown: {
+          name: 'stage@production:teardown',
+          id: 39,
+          stageName: 'production'
+        },
         isCollapsed: true
       }
     ];
@@ -1423,7 +1434,8 @@ module('Unit | Utility | graph tools', function () {
         hidden: true,
         src: 'stage@integration:teardown',
         srcStageName: 'integration',
-        to: expectedOutput.stages[1]
+        to: expectedOutput.stages[1],
+        status: undefined
       }
     ];
 

--- a/tests/unit/utils/graph-tools-test.js
+++ b/tests/unit/utils/graph-tools-test.js
@@ -691,6 +691,8 @@ module('Unit | Utility | graph tools', function () {
       }
     ];
 
+    const COLLAPSED_STAGES = new Set([]);
+
     const JOBS = [
       { id: 1, name: 'component', virtualJob: false },
       { id: 2, name: 'publish', virtualJob: false },
@@ -1002,7 +1004,8 @@ module('Unit | Utility | graph tools', function () {
           name: 'stage@integration:teardown',
           stageName: 'integration',
           virtual: true
-        }
+        },
+        isCollapsed: false
       },
       {
         description: undefined,
@@ -1045,7 +1048,8 @@ module('Unit | Utility | graph tools', function () {
           id: 39,
           name: 'stage@production:teardown',
           stageName: 'production'
-        }
+        },
+        isCollapsed: false
       }
     ];
 
@@ -1072,6 +1076,361 @@ module('Unit | Utility | graph tools', function () {
     const result = decorateGraph({
       inputGraph: GRAPH,
       stages: STAGES,
+      collapsedStages: COLLAPSED_STAGES,
+      jobs: JOBS
+    });
+
+    assert.deepEqual(result, expectedOutput);
+  });
+
+  test('it processes graph with collapsed stages', function (assert) {
+    const GRAPH = {
+      nodes: [
+        { name: '~pr' },
+        { name: '~commit' },
+        { name: 'component', id: 1 },
+        { name: 'publish', id: 2 },
+        {
+          name: 'stage@integration:setup',
+          id: 28,
+          stageName: 'integration',
+          virtual: true
+        },
+        { name: 'ci-deploy', id: 21, stageName: 'integration' },
+        { name: 'ci-test', id: 22, stageName: 'integration' },
+        { name: 'ci-certify', id: 23, stageName: 'integration' },
+        {
+          name: 'stage@integration:teardown',
+          id: 29,
+          stageName: 'integration',
+          virtual: true
+        },
+        { name: 'stage@production:setup', id: 38, stageName: 'production' },
+        { name: 'prod-deploy', id: 31, stageName: 'production' },
+        { name: 'prod-test', id: 32, stageName: 'production' },
+        { name: 'prod-certify', id: 33, stageName: 'production' },
+        {
+          name: 'stage@production:teardown',
+          id: 39,
+          stageName: 'production'
+        }
+      ],
+      edges: [
+        { src: '~pr', dest: 'component' },
+        { src: '~commit', dest: 'component' },
+        { src: 'component', dest: 'publish' },
+        { src: 'publish', dest: 'stage@integration:setup' },
+        { src: 'stage@integration:setup', dest: 'ci-deploy' },
+        { src: 'ci-deploy', dest: 'ci-test' },
+        { src: 'ci-test', dest: 'ci-certify' },
+        { src: 'ci-certify', dest: 'stage@integration:teardown' },
+        { src: 'stage@integration:teardown', dest: 'stage@production:setup' },
+        { src: 'stage@production:setup', dest: 'prod-deploy' },
+        { src: 'prod-deploy', dest: 'prod-test' },
+        { src: 'prod-test', dest: 'prod-certify' },
+        { src: 'prod-certify', dest: 'stage@production:teardown' }
+      ]
+    };
+
+    const STAGES = [
+      {
+        id: 7,
+        name: 'integration',
+        jobIds: [21, 22, 23, 24],
+        setup: 28,
+        teardown: 29
+      },
+      {
+        id: 8,
+        name: 'production',
+        jobs: [31, 32],
+        setup: 38,
+        teardown: 39
+      },
+      {
+        id: 9,
+        name: 'canary',
+        jobs: [41, 42],
+        setup: 48,
+        teardown: 49
+      }
+    ];
+
+    const COLLAPSED_STAGES = new Set(['production']);
+
+    const JOBS = [
+      { id: 1, name: 'component', virtualJob: false },
+      { id: 2, name: 'publish', virtualJob: false },
+      { id: 21, name: 'ci-deploy', virtualJob: false },
+      { id: 22, name: 'ci-test', virtualJob: false },
+      { id: 23, name: 'ci-certify', virtualJob: false },
+      { id: 28, name: 'stage@integration:setup', virtualJob: true },
+      { id: 29, name: 'stage@integration:teardown', virtualJob: true },
+      { id: 31, name: 'prod-deploy', virtualJob: false },
+      { id: 32, name: 'prod-test', virtualJob: false },
+      { id: 33, name: 'prod-certify', virtualJob: false },
+      { id: 38, name: 'stage@production:setup', virtualJob: false },
+      { id: 39, name: 'stage@production:teardown', virtualJob: false }
+    ];
+
+    const expectedOutput = {
+      edges: [
+        {
+          dest: 'component',
+          from: {
+            x: 0,
+            y: 0
+          },
+          src: '~pr',
+          to: {
+            x: 1,
+            y: 0
+          }
+        },
+        {
+          dest: 'component',
+          from: {
+            x: 0,
+            y: 1
+          },
+          src: '~commit',
+          to: {
+            x: 1,
+            y: 0
+          }
+        },
+        {
+          dest: 'publish',
+          from: {
+            x: 1,
+            y: 0
+          },
+          src: 'component',
+          to: {
+            x: 2,
+            y: 0
+          }
+        },
+        {
+          dest: 'ci-test',
+          from: {
+            x: 3,
+            y: 0
+          },
+          src: 'ci-deploy',
+          to: {
+            x: 4,
+            y: 0
+          }
+        },
+        {
+          dest: 'ci-certify',
+          from: {
+            x: 4,
+            y: 0
+          },
+          src: 'ci-test',
+          to: {
+            x: 5,
+            y: 0
+          }
+        },
+        {
+          dest: 'ci-deploy',
+          from: {
+            x: 2,
+            y: 0
+          },
+          hidden: true,
+          src: 'publish',
+          to: {
+            x: 3,
+            y: 0
+          }
+        },
+        {
+          dest: 'stage@production jobs (3)',
+          from: {
+            x: 5,
+            y: 0
+          },
+          hidden: true,
+          src: 'ci-certify',
+          to: {
+            x: 6,
+            y: 0
+          }
+        }
+      ],
+      meta: {
+        height: 2,
+        width: 7
+      },
+      nodes: [
+        {
+          isDisabled: false,
+          name: '~pr',
+          pos: {
+            x: 0,
+            y: 0
+          }
+        },
+        {
+          isDisabled: false,
+          name: '~commit',
+          pos: {
+            x: 0,
+            y: 1
+          }
+        },
+        {
+          id: 1,
+          isDisabled: false,
+          name: 'component',
+          pos: {
+            x: 1,
+            y: 0
+          }
+        },
+        {
+          id: 2,
+          isDisabled: false,
+          name: 'publish',
+          pos: {
+            x: 2,
+            y: 0
+          }
+        },
+        {
+          id: 21,
+          isDisabled: false,
+          name: 'ci-deploy',
+          pos: {
+            x: 3,
+            y: 0
+          },
+          stageName: 'integration'
+        },
+        {
+          id: 22,
+          isDisabled: false,
+          name: 'ci-test',
+          pos: {
+            x: 4,
+            y: 0
+          },
+          stageName: 'integration'
+        },
+        {
+          id: 23,
+          isDisabled: false,
+          name: 'ci-certify',
+          pos: {
+            x: 5,
+            y: 0
+          },
+          stageName: 'integration'
+        },
+        {
+          description:
+            'This job group includes the following jobs: prod-deploy, prod-test, prod-certify',
+          isDisabled: false,
+          name: 'stage@production jobs (3)',
+          pos: {
+            x: 6,
+            y: 0
+          },
+          stageName: 'production',
+          type: 'JOB_GROUP'
+        }
+      ]
+    };
+
+    expectedOutput.stages = [
+      {
+        description: undefined,
+        graph: {
+          edges: [expectedOutput.edges[3], expectedOutput.edges[4]],
+          meta: {
+            height: 1,
+            width: 3
+          },
+          nodes: [
+            expectedOutput.nodes[4],
+            expectedOutput.nodes[5],
+            expectedOutput.nodes[6]
+          ]
+        },
+        id: 7,
+        jobs: [
+          { id: 21, name: 'ci-deploy', stageName: 'integration' },
+          { id: 22, name: 'ci-test', stageName: 'integration' },
+          { id: 23, name: 'ci-certify', stageName: 'integration' }
+        ],
+        name: 'integration',
+        pos: {
+          x: 3,
+          y: 0
+        },
+        setup: {
+          id: 28,
+          name: 'stage@integration:setup',
+          stageName: 'integration',
+          virtual: true
+        },
+        teardown: {
+          id: 29,
+          name: 'stage@integration:teardown',
+          stageName: 'integration',
+          virtual: true
+        },
+        isCollapsed: false
+      },
+      {
+        description: undefined,
+        graph: {
+          edges: [],
+          meta: {
+            height: 1,
+            width: 1
+          },
+          nodes: [expectedOutput.nodes[7]]
+        },
+        id: 8,
+        jobs: [expectedOutput.nodes[7]],
+        name: 'production',
+        pos: {
+          x: 6,
+          y: 0
+        },
+        isCollapsed: true
+      }
+    ];
+
+    expectedOutput.stageEdges = [
+      {
+        dest: 'stage@integration:setup',
+        destStageName: 'integration',
+        from: expectedOutput.nodes[3],
+        hidden: true,
+        src: 'publish',
+        to: expectedOutput.stages[0]
+      },
+      {
+        dest: 'stage@production jobs (3)',
+        destStageName: 'production',
+        from: expectedOutput.stages[0],
+        hidden: true,
+        src: 'stage@integration:teardown',
+        srcStageName: 'integration',
+        to: expectedOutput.stages[1]
+      }
+    ];
+
+    const result = decorateGraph({
+      inputGraph: GRAPH,
+      stages: STAGES,
+      collapsedStages: COLLAPSED_STAGES,
       jobs: JOBS
     });
 
@@ -1441,6 +1800,8 @@ module('Unit | Utility | graph tools', function () {
       }
     ];
 
+    const COLLAPSED_STAGES = new Set([]);
+
     const JOBS = [
       { id: 1, name: 'triggering-stage', virtualJob: false },
       {
@@ -1472,6 +1833,7 @@ module('Unit | Utility | graph tools', function () {
     const result = decorateGraph({
       inputGraph: GRAPH,
       stages: STAGES,
+      collapsedStages: COLLAPSED_STAGES,
       jobs: JOBS
     });
 

--- a/tests/unit/utils/graph-tools-test.js
+++ b/tests/unit/utils/graph-tools-test.js
@@ -1335,7 +1335,6 @@ module('Unit | Utility | graph tools', function () {
         {
           description:
             'This job group includes the following jobs: prod-deploy, prod-test, prod-certify',
-          isDisabled: false,
           name: 'stage@production jobs (3)',
           pos: {
             x: 6,


### PR DESCRIPTION
## Context

Right now stage visualization default behavior is expanded.

<img width="1288" alt="image" src="https://github.com/user-attachments/assets/7952a396-c9f4-48b0-b465-42480d408eed" />


## Objective

Should have a way to collapse and expand a stage so it can minimize the real estate take in workflow graph.

**When Expanded**
<img width="1298" alt="image" src="https://github.com/user-attachments/assets/991ab811-b53e-4ab6-81d6-785b2b0729d1" />


**When Collapsed**
<img width="1293" alt="image" src="https://github.com/user-attachments/assets/d63b23f4-5943-4cc9-a8f0-7debb42a4988" />




## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
