### PR TITLE
Redirect to v1 for secrets and options

### DIFF
--- a/app/v2/pipeline/options/route.js
+++ b/app/v2/pipeline/options/route.js
@@ -10,10 +10,15 @@ export default class PipelineOptionsRoute extends Route {
 
   @service pipelinePageState;
 
-  beforeModel() {
+  beforeModel(transition) {
     // Guests should not access this page
     if (this.session.data.authenticated.isGuest) {
       this.replaceWith('v2.pipeline');
+    } else {
+      this.replaceWith(
+        'pipeline.options',
+        transition.to.parent.params.pipeline_id
+      );
     }
 
     // Reset error message when switching pages

--- a/app/v2/pipeline/secrets/route.js
+++ b/app/v2/pipeline/secrets/route.js
@@ -10,10 +10,15 @@ export default class NewPipelineSecretsRoute extends Route {
 
   @service pipelinePageState;
 
-  async beforeModel() {
+  async beforeModel(transition) {
     // Guests should not access this page
     if (this.session.data.authenticated.isGuest) {
       this.router.replaceWith('v2.pipeline');
+    } else {
+      this.replaceWith(
+        'pipeline.secrets',
+        transition.to.parent.params.pipeline_id
+      );
     }
   }
 


### PR DESCRIPTION
## Context
The V2 UI for the pipeline secrets and options are leveraging the old non-glimmer components using ember data.  Those components still need to be rebuilt, until then, these routes should just redirect back to the old pages.

## Objective
Redirect the pipeline options and secrets pages back to the V1 route until the proper V2 versions are ready.

## References
https://github.com/screwdriver-cd/ui/pull/1072
https://github.com/screwdriver-cd/ui/pull/1078
https://github.com/screwdriver-cd/ui/pull/1080
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
