### PR TITLE
fix: Change column name to status for event job display

### DIFF
--- a/app/components/pipeline/jobs/table/component.js
+++ b/app/components/pipeline/jobs/table/component.js
@@ -43,7 +43,9 @@ export default class PipelineJobsTableComponent extends Component {
 
   setColumnData() {
     const historyColumnConfiguration = {
-      title: 'HISTORY',
+      title: this.args.historyColumnName
+        ? this.args.historyColumnName.toUpperCase()
+        : 'HISTORY',
       className: 'history-column',
       component: 'historyCell'
     };

--- a/app/components/pipeline/workflow/template.hbs
+++ b/app/components/pipeline/workflow/template.hbs
@@ -99,6 +99,7 @@
             @event={{this.event}}
             @jobs={{this.jobs}}
             @userSettings={{this.userSettings}}
+            @historyColumnName={{"status"}}
             @numBuilds={{1}}
           />
         {{/if}}


### PR DESCRIPTION
## Context
The job view in the V2 UI for an event displays the build history column name as `HISTORY`.  As the event only has one build status per job, history doesn't accurately capture the column contents and should be renamed to `STATUS` instead.
![Screenshot 2025-02-18 at 15-12-23 Events](https://github.com/user-attachments/assets/3ec39ba0-172f-4b52-a77c-ece862f564e6)

## Objective
Renames the `HISTORY` column to `STATUS`
![Screenshot 2025-02-18 at 15-11-23 Events](https://github.com/user-attachments/assets/da69f45e-b32c-4fc6-8cca-cdc23be08da3)

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
