### PR TITLE
feat(3284): Find sibling pipelines by scmUri search [2]

### DIFF
--- a/app/components/pipeline/header/component.js
+++ b/app/components/pipeline/header/component.js
@@ -57,25 +57,17 @@ export default class PipelineHeaderComponent extends Component {
 
   @action
   async getPipelinesWithSameRepo() {
-    const pipelineId = this.pipeline.id;
-
     if (this.pipeline.scmRepo && this.pipeline.scmUri) {
-      const [scm, repositoryId] = this.pipeline.scmUri.split(':');
+      const { scmUri } = this.pipeline;
 
       this.sameRepoPipeline = await this.shuttle
         .fetchFromApi(
           'get',
-          `/pipelines?search=${this.pipeline.scmRepo.name}&sortBy=name&sort=ascending`
+          `/pipelines?scmUri=${scmUri}&sortBy=scmUri&sort=ascending`
         )
         .then(pipelines =>
           pipelines
-            .filter(pipeline => {
-              const [s, r] = pipeline.scmUri.split(':');
-
-              return (
-                pipeline.id !== pipelineId && scm === s && repositoryId === r
-              );
-            })
+            .filter(pipeline => pipeline.scmUri !== scmUri)
             .map(pipeline => ({
               url: `/v2/pipelines/${pipeline.id}`,
               branchAndRootDir: pipeline.scmRepo.rootDir

--- a/app/pipeline/service.js
+++ b/app/pipeline/service.js
@@ -11,12 +11,12 @@ export default Service.extend({
     this.set('buildsLink', buildsLink);
   },
 
-  getSiblingPipeline(scmRepo, page) {
+  getSiblingPipeline(scmUri, page) {
     const pipelineListConfig = {
       page,
       count: ENV.APP.NUM_PIPELINES_LISTED,
-      search: scmRepo,
-      sortBy: 'name',
+      scmUri,
+      sortBy: 'scmUri',
       sort: 'ascending'
     };
 

--- a/tests/integration/components/pipeline-header/component-test.js
+++ b/tests/integration/components/pipeline-header/component-test.js
@@ -85,13 +85,6 @@ module('Integration | Component | pipeline header', function (hooks) {
           rootDir: 'aaa'
         },
         scmUri: 'github.com:123456:abc:aaa'
-      },
-      {
-        id: 6,
-        scmRepo: {
-          branch: 'abc'
-        },
-        scmUri: 'github.com:654321:abc'
       }
     ];
 
@@ -121,10 +114,11 @@ module('Integration | Component | pipeline header', function (hooks) {
   });
 
   test('it renders branch-move when API returns multiple pages', async function (assert) {
+    const baseScmUri = 'github.com:123456';
     const pipelineMock = EmberObject.create({
       id: 1,
       scmContext: 'github:github.com',
-      scmUri: 'github.com:123456:master',
+      scmUri: `${baseScmUri}:master`,
       scmRepo: {
         name: 'batman/batmobile'
       }
@@ -137,7 +131,7 @@ module('Integration | Component | pipeline header', function (hooks) {
           name: pipelineMock.scmRepo.name,
           branch: `branch-${id}`
         },
-        scmUri: pipelineMock.scmUri
+        scmUri: `${baseScmUri}:branch-${id}`
       };
     };
 
@@ -177,157 +171,6 @@ module('Integration | Component | pipeline header', function (hooks) {
 
     await click('span.branch');
     assert.dom('li.branch-item').exists({ count: 5 });
-    assert.deepEqual(loadPages, [1, 2, 3]);
-  });
-
-  test('it renders branch-move when API returns multiple pages with other name pipeline', async function (assert) {
-    const pipelineMock = EmberObject.create({
-      id: 1,
-      scmContext: 'github:github.com',
-      scmUri: 'github.com:123456:master',
-      scmRepo: {
-        name: 'batman/batmobile'
-      }
-    });
-
-    const createSiblingPipelineMock = id => {
-      return {
-        id,
-        scmRepo: {
-          name: pipelineMock.scmRepo.name,
-          branch: `branch-${id}`
-        },
-        scmUri: pipelineMock.scmUri
-      };
-    };
-
-    // In test, NUM_PIPELINES_LISTED is 3
-    const firstPageSiblingPipelines = [
-      pipelineMock,
-      createSiblingPipelineMock(2),
-      createSiblingPipelineMock(3)
-    ];
-    const secondPageSiblingPipelines = [
-      createSiblingPipelineMock(4),
-      createSiblingPipelineMock(5),
-      {
-        id: 6,
-        scmRepo: {
-          name: 'batman/batmobile-other',
-          branch: `main`
-        },
-        scmUri: 'github.com:789:master'
-      }
-    ];
-
-    const loadPages = [];
-
-    const pipelineStub = Service.extend({
-      getSiblingPipeline(_, page) {
-        loadPages.push(page);
-
-        if (page === 1) return Promise.resolve(firstPageSiblingPipelines);
-        if (page === 2) return Promise.resolve(secondPageSiblingPipelines);
-
-        return assert.fails('This line should not run.');
-      }
-    });
-
-    this.owner.unregister('service:pipeline');
-    this.owner.register('service:pipeline', pipelineStub);
-
-    injectScmServiceStub(this);
-
-    this.set('pipelineMock', pipelineMock);
-    await render(hbs`<PipelineHeader @pipeline={{this.pipelineMock}} />`);
-
-    await click('span.branch');
-    assert.dom('li.branch-item').exists({ count: 4 });
-    assert.deepEqual(loadPages, [1, 2]);
-  });
-
-  test('it renders branch-move when API returns multiple pages with multiple scm', async function (assert) {
-    const pipelineMock = EmberObject.create({
-      id: 1,
-      scmContext: 'github:github.com',
-      scmUri: 'github.com:123456:master',
-      scmRepo: {
-        name: 'batman/batmobile'
-      }
-    });
-
-    const createSiblingPipelineMock = id => {
-      return {
-        id,
-        scmRepo: {
-          name: pipelineMock.scmRepo.name,
-          branch: `branch-${id}`
-        },
-        scmUri: pipelineMock.scmUri
-      };
-    };
-
-    // In test, NUM_PIPELINES_LISTED is 3
-    const firstPageSiblingPipelines = [
-      pipelineMock,
-      createSiblingPipelineMock(2),
-      createSiblingPipelineMock(3),
-      {
-        id: 4,
-        scmRepo: {
-          name: 'batman/batmobile-other',
-          branch: `main`
-        },
-        scmUri: 'example.com:123456:master'
-      }
-    ];
-    const secondPageSiblingPipelines = [
-      createSiblingPipelineMock(5),
-      createSiblingPipelineMock(6),
-      {
-        id: 7,
-        scmRepo: {
-          name: 'batman/batmobile',
-          branch: `main`
-        },
-        scmUri: 'example.com:789:master'
-      }
-    ];
-    const thirdPageSiblingPipelines = [
-      {
-        id: 8,
-        scmRepo: {
-          name: 'batman/batmobile',
-          branch: `main`
-        },
-        scmUri: 'example.com:789:master'
-      }
-    ];
-
-    const loadPages = [];
-
-    const pipelineStub = Service.extend({
-      getSiblingPipeline(_, page) {
-        loadPages.push(page);
-
-        if (page === 1) return Promise.resolve(firstPageSiblingPipelines);
-        if (page === 2) return Promise.resolve(secondPageSiblingPipelines);
-        if (page === 3) return Promise.resolve(thirdPageSiblingPipelines);
-
-        return assert.fails('This line should not run.');
-      }
-    });
-
-    this.owner.unregister('service:pipeline');
-    this.owner.register('service:pipeline', pipelineStub);
-
-    injectScmServiceStub(this);
-
-    this.set('pipelineMock', pipelineMock);
-    await render(hbs`<PipelineHeader @pipeline={{this.pipelineMock}} />`);
-
-    await click('span.branch');
-    assert.dom('li.branch-item').exists({ count: 4 });
     assert.deepEqual(loadPages, [1, 2, 3]);
   });
 

--- a/tests/integration/components/pipeline/header/component-test.js
+++ b/tests/integration/components/pipeline/header/component-test.js
@@ -82,28 +82,23 @@ module('Integration | Component | pipeline/header', function (hooks) {
     sinon.stub(shuttle, 'fetchFromApi').resolves([
       {
         id: 123,
-        scmUri: 'git.github.com:9876',
+        scmUri: 'git.github.com:9876:abc',
         scmRepo: { branch: 'abc' }
       },
       {
         id: 124,
-        scmUri: 'git.github.com:9876',
+        scmUri: 'git.github.com:9876:def',
         scmRepo: { branch: 'def' }
       },
       {
         id: 125,
-        scmUri: 'git.github.com:9876',
+        scmUri: 'git.github.com:9876:ghi',
         scmRepo: { branch: 'ghi' }
-      },
-      {
-        id: 321,
-        scmUri: 'git.not.com:9876',
-        scmRepo: { branch: 'abc' }
       }
     ]);
     sinon.stub(pipelinePageState, 'getPipeline').returns({
       id: 123,
-      scmUri: 'git.github.com:9876',
+      scmUri: 'git.github.com:9876:abc',
       scmRepo: { url: 'https://gihub.com/test' },
       annotations: {}
     });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

We are using `name` param to find sibling pipelines, but it has an issue.
After https://github.com/screwdriver-cd/screwdriver/pull/3285 , we will be able to find them by `scmUri` param.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Use `scmUri` param to find sibling pipelines.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

- Issue: https://github.com/screwdriver-cd/screwdriver/issues/3284
- PR: https://github.com/screwdriver-cd/screwdriver/pull/3285

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
