### PR TITLE
fix: Fix post body for PR events

### DIFF
--- a/app/utils/pipeline/modal/request.js
+++ b/app/utils/pipeline/modal/request.js
@@ -7,7 +7,6 @@
  * @param parameters
  * @param isFrozen
  * @param reason
- * @param prNum
  * @returns {{causeMessage: string, pipelineId}}
  */
 export function buildPostBody( // eslint-disable-line import/prefer-default-export
@@ -17,8 +16,7 @@ export function buildPostBody( // eslint-disable-line import/prefer-default-expo
   event,
   parameters,
   isFrozen,
-  reason,
-  prNum
+  reason
 ) {
   const data = {
     pipelineId,
@@ -27,14 +25,16 @@ export function buildPostBody( // eslint-disable-line import/prefer-default-expo
 
   data.startFrom = job ? job.name : '~commit';
 
-  if (prNum) {
-    data.startFrom = '~pr';
-    data.prNum = prNum;
-  }
-
   if (event) {
     data.groupEventId = event.groupEventId;
     data.parentEventId = event.id;
+
+    const { prNum } = event;
+
+    if (prNum) {
+      data.prNum = prNum;
+      data.startFrom = job ? `PR-${prNum}:${job.name}` : '~pr';
+    }
   }
 
   if (parameters) {

--- a/tests/unit/utils/pipeline/modal/request-test.js
+++ b/tests/unit/utils/pipeline/modal/request-test.js
@@ -74,16 +74,37 @@ module('Unit | Utility | pipeline/modal/request', function () {
         'foobar',
         123,
         null,
-        { id: 9, groupEventId: 2 },
+        { id: 9, groupEventId: 2, prNum: 5 },
         null,
         false,
-        null,
-        5
+        null
       ),
       {
         pipelineId: 123,
         causeMessage: 'Manually started by foobar',
         startFrom: '~pr',
+        groupEventId: 2,
+        parentEventId: 9,
+        prNum: 5
+      }
+    );
+  });
+
+  test('buildPostBody sets correct values for starting from PR job', function (assert) {
+    assert.deepEqual(
+      buildPostBody(
+        'foobar',
+        123,
+        { name: 'job' },
+        { id: 9, groupEventId: 2, prNum: 5 },
+        null,
+        false,
+        null
+      ),
+      {
+        pipelineId: 123,
+        causeMessage: 'Manually started by foobar',
+        startFrom: 'PR-5:job',
         groupEventId: 2,
         parentEventId: 9,
         prNum: 5


### PR DESCRIPTION
## Context
When restarting a build for a PR job, the `startFrom` value needs to include the proper job prefix for the node, i.e. `PR-{pull request id}`

## Objective
Fix the post body for a pull request job to include the properly value

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
