### PR TITLE
fix(3294): Fix - The edges from stages to upstreams are not properly drawn

### DIFF
--- a/app/utils/pipeline/graph/d3-graph-util.js
+++ b/app/utils/pipeline/graph/d3-graph-util.js
@@ -390,14 +390,14 @@ export function getVerticalDisplacements(
  * @returns {{stageVerticalDisplacements: {}, verticalDisplacements: {}}}
  */
 export function getHorizontalDisplacements(data, sizes) {
-  const stagesGroupedByStartRowPosition = groupBy(data.stages, 'pos.y');
+  const stagesGroupedByStartColumnPosition = groupBy(data.stages, 'pos.x');
 
   const columnsToBeDisplaced = {};
 
   data.stages.forEach(s => {
     const stageEndPosX = s.pos.x + s.graph.meta.width - 1;
 
-    if (stagesGroupedByStartRowPosition[stageEndPosX + 1]) {
+    if (stagesGroupedByStartColumnPosition[stageEndPosX + 1]) {
       columnsToBeDisplaced[stageEndPosX + 1] = true;
     }
   });


### PR DESCRIPTION
## Context

There is not enough horizontal spacing between the stages. Due to this, the edges originating from a stage is not properly drawn.

**Before**
![image](https://github.com/user-attachments/assets/41046e60-92dd-4d53-ab75-13fa393f52f5)


## Objective
Provide sufficient spacing between the stages to properly render the edges.

**After**
![image](https://github.com/user-attachments/assets/920ca59b-c969-40a5-8bd0-64937b82d43e)


## References

https://github.com/screwdriver-cd/screwdriver/issues/3294

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
