### PR TITLE
fix: Deep inspect for warning

### DIFF
--- a/app/components/pipeline/event/card/util.js
+++ b/app/components/pipeline/event/card/util.js
@@ -115,7 +115,9 @@ export const getFailureCount = builds => {
 };
 
 export const getWarningCount = builds => {
-  return builds.filter(build => build.status === 'UNSTABLE').length;
+  return builds.filter(
+    build => build.status === 'WARNING' || build.status === 'UNSTABLE'
+  ).length;
 };
 
 export const getSuccessCount = builds => {

--- a/app/utils/pipeline/build.js
+++ b/app/utils/pipeline/build.js
@@ -10,7 +10,7 @@ export const hasWarning = build => {
       return build.meta.build.warning;
     }
 
-    return !!build.meta.build.warning.message;
+    return !!build.meta.build.warning;
   }
 
   return false;

--- a/tests/unit/components/pipeline/event/card/util-test.js
+++ b/tests/unit/components/pipeline/event/card/util-test.js
@@ -199,9 +199,10 @@ module('Unit | Component | pipeline/event/card/util', function () {
       getWarningCount([
         { status: 'SUCCESS' },
         { status: 'UNSTABLE' },
-        { status: 'ABORTED' }
+        { status: 'ABORTED' },
+        { status: 'WARNING' }
       ]),
-      1
+      2
     );
   });
 

--- a/tests/unit/utils/pipeline/build-test.js
+++ b/tests/unit/utils/pipeline/build-test.js
@@ -12,25 +12,15 @@ module('Unit | Utility | Pipeline | build', function () {
     assert.equal(hasWarning({ meta: { build: {} } }), false);
     assert.equal(hasWarning({ meta: { build: { warning: false } } }), false);
     assert.equal(hasWarning({ meta: { build: { warning: true } } }), true);
-    assert.equal(hasWarning({ meta: { build: { warning: {} } } }), false);
-    assert.equal(
-      hasWarning({ meta: { build: { warning: { message: '' } } } }),
-      false
-    );
-    assert.equal(
-      hasWarning({
-        meta: { build: { warning: { message: 'This is a warning message' } } }
-      }),
-      true
-    );
+    assert.equal(hasWarning({ meta: { build: { warning: {} } } }), true);
   });
 
   test('setBuildStatus sets correct values for builds', function (assert) {
     const builds = [
       { status: 'SUCCESS' },
       { status: 'FAILED' },
-      { status: 'FAILED', meta: { build: { warning: 'No effect' } } },
-      { status: 'SUCCESS', meta: { build: { warning: { message: '' } } } },
+      { status: 'FAILED', meta: { build: { warning: false } } },
+      { status: 'SUCCESS', meta: { build: { warning: true } } },
       {
         status: 'SUCCESS',
         meta: { build: { warning: { message: 'Changed status' } } }
@@ -44,7 +34,7 @@ module('Unit | Utility | Pipeline | build', function () {
     assert.equal(builds[0].status, 'SUCCESS');
     assert.equal(builds[1].status, 'FAILED');
     assert.equal(builds[2].status, 'FAILED');
-    assert.equal(builds[3].status, 'SUCCESS');
+    assert.equal(builds[3].status, 'WARNING');
     assert.equal(builds[4].status, 'WARNING');
   });
 });


### PR DESCRIPTION
## Context
The API returns the build meta warning object in various structural forms.  Relaxing to check for only the existence of of the key is a better option while retaining the check for a boolean value.

## Objective
1. Relaxes the build meta warning object check for determining a build status.
2. Updates the event card warning count to also include warning statuses

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
