### PR TITLE
feat: V2 child pipeline table

### DIFF
--- a/app/components/pipeline/children/table/cell/account/styles.scss
+++ b/app/components/pipeline/children/table/cell/account/styles.scss
@@ -1,0 +1,11 @@
+@mixin styles {
+  .account-cell {
+    display: flex;
+
+    svg {
+      margin-top: auto;
+      margin-bottom: auto;
+      margin-right: 0.25rem;
+    }
+  }
+}

--- a/app/components/pipeline/children/table/cell/account/template.hbs
+++ b/app/components/pipeline/children/table/cell/account/template.hbs
@@ -1,0 +1,7 @@
+<div class="account-cell">
+  <FaIcon
+    @icon={{@record.scmIcon}}
+    @prefix="fab"
+  />
+  {{@record.scmName}}
+</div>

--- a/app/components/pipeline/children/table/cell/actions/component.js
+++ b/app/components/pipeline/children/table/cell/actions/component.js
@@ -1,0 +1,27 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+export default class PipelineChildrenTableCellActionsComponent extends Component {
+  @tracked isDeletePipelineModalOpen;
+
+  constructor() {
+    super(...arguments);
+
+    this.isDeletePipelineModalOpen = false;
+  }
+
+  @action
+  showDeletePipelineModal() {
+    this.isDeletePipelineModalOpen = true;
+  }
+
+  @action
+  closeDeletePipelineModal(deletedPipeline) {
+    this.isDeletePipelineModalOpen = false;
+
+    if (deletedPipeline) {
+      this.args.record.onPipelineDeleted(this.args.record.id);
+    }
+  }
+}

--- a/app/components/pipeline/children/table/cell/actions/template.hbs
+++ b/app/components/pipeline/children/table/cell/actions/template.hbs
@@ -1,0 +1,18 @@
+<div class="actions-cell">
+  <BsButton
+    @type="primary"
+    @outline={{true}}
+    @onClick={{this.showDeletePipelineModal}}
+  >
+    <FaIcon
+      @icon="trash"
+    />
+
+    {{#if this.isDeletePipelineModalOpen}}
+      <Pipeline::Modal::DeletePipeline
+        @pipeline={{@record.pipeline}}
+        @closeModal={{this.closeDeletePipelineModal}}
+      />
+    {{/if}}
+  </BsButton>
+</div>

--- a/app/components/pipeline/children/table/cell/branch/styles.scss
+++ b/app/components/pipeline/children/table/cell/branch/styles.scss
@@ -1,0 +1,20 @@
+@mixin styles {
+  .branch-cell {
+    max-width: 90%;
+
+    a {
+      display: flex;
+
+      svg {
+        margin-top: auto;
+        margin-bottom: auto;
+        margin-right: 0.25rem;
+      }
+
+      .branch-name {
+        padding: 1rem 0;
+        overflow: auto;
+      }
+    }
+  }
+}

--- a/app/components/pipeline/children/table/cell/branch/template.hbs
+++ b/app/components/pipeline/children/table/cell/branch/template.hbs
@@ -1,0 +1,11 @@
+<div class="branch-cell">
+  <a
+    href={{@record.scmRepo.url}}
+    target="_blank"
+  >
+    <FaIcon @icon="code-branch" />
+    <div class="branch-name">
+      {{@record.branchName}}
+    </div>
+  </a>
+</div>

--- a/app/components/pipeline/children/table/cell/pipeline/styles.scss
+++ b/app/components/pipeline/children/table/cell/pipeline/styles.scss
@@ -1,0 +1,15 @@
+@mixin styles {
+  .pipeline-cell {
+    max-width: 90%;
+
+    a {
+      display: block;
+      white-space: nowrap;
+
+      .pipeline-name {
+        padding: 1rem 0;
+        overflow: auto;
+      }
+    }
+  }
+}

--- a/app/components/pipeline/children/table/cell/pipeline/template.hbs
+++ b/app/components/pipeline/children/table/cell/pipeline/template.hbs
@@ -2,6 +2,7 @@
   <LinkTo
     @route="v2.pipeline"
     @model={{@record.id}}
+    target="_blank"
   >
     <div class="pipeline-name">
       {{@record.name}}

--- a/app/components/pipeline/children/table/cell/pipeline/template.hbs
+++ b/app/components/pipeline/children/table/cell/pipeline/template.hbs
@@ -1,0 +1,10 @@
+<div class="pipeline-cell">
+  <LinkTo
+    @route="v2.pipeline"
+    @model={{@record.id}}
+  >
+    <div class="pipeline-name">
+      {{@record.name}}
+    </div>
+  </LinkTo>
+</div>

--- a/app/components/pipeline/children/table/cell/status/component.js
+++ b/app/components/pipeline/children/table/cell/status/component.js
@@ -1,0 +1,18 @@
+import Component from '@glimmer/component';
+import _ from 'lodash';
+import { getStateIcon } from 'screwdriver-ui/utils/pipeline';
+
+export default class PipelineChildrenTableCellStatusComponent extends Component {
+  icon;
+
+  state;
+
+  constructor() {
+    super(...arguments);
+
+    this.icon = getStateIcon(this.args.record.state);
+
+    // eslint-disable-next-line ember/no-string-prototype-extensions
+    this.state = _.capitalize(this.args.record.state);
+  }
+}

--- a/app/components/pipeline/children/table/cell/status/styles.scss
+++ b/app/components/pipeline/children/table/cell/status/styles.scss
@@ -1,0 +1,14 @@
+@use 'screwdriver-colors' as colors;
+
+@mixin styles {
+  .status-cell {
+    svg {
+      &.fa-circle-check {
+        color: colors.$sd-success;
+      }
+      &.fa-circle-xmark {
+        color: colors.$sd-failure;
+      }
+    }
+  }
+}

--- a/app/components/pipeline/children/table/cell/status/template.hbs
+++ b/app/components/pipeline/children/table/cell/status/template.hbs
@@ -1,0 +1,4 @@
+<div class="status-cell">
+  <FaIcon @icon={{this.icon}} />
+  {{this.state}}
+</div>

--- a/app/components/pipeline/children/table/component.js
+++ b/app/components/pipeline/children/table/component.js
@@ -18,26 +18,29 @@ export default class PipelineChildrenTableComponent extends Component {
   constructor() {
     super(...arguments);
 
-    this.data = this.pipelinePageState
-      .getChildPipelines()
-      .slice(0, 3)
-      .map(pipeline => {
-        const scm = this.scm.getScm(pipeline.scmContext);
+    this.data = this.pipelinePageState.getChildPipelines().map(pipeline => {
+      const scm = this.scm.getScm(pipeline.scmContext);
 
-        return {
-          pipeline,
-          id: pipeline.id,
-          name: pipeline.name,
-          branchName: pipeline.scmRepo.branch,
-          scmRepo: pipeline.scmRepo,
-          scmIcon: scm.iconType,
-          scmName: scm.displayName,
-          state: pipeline.state,
-          onPipelineDeleted: pipelineId => {
-            this.data = this.data.filter(d => d.id !== pipelineId);
-          }
-        };
-      });
+      return {
+        pipeline,
+        id: pipeline.id,
+        name: pipeline.name,
+        branchName: pipeline.scmRepo.branch,
+        scmRepo: pipeline.scmRepo,
+        scmIcon: scm.iconType,
+        scmName: scm.displayName,
+        state: pipeline.state,
+        onPipelineDeleted: pipelineId => {
+          this.data = this.data.filter(d => d.id !== pipelineId);
+
+          const updatedChildPipelines = this.pipelinePageState
+            .getChildPipelines()
+            .filter(p => p.id !== pipelineId);
+
+          this.pipelinePageState.setChildPipelines(updatedChildPipelines);
+        }
+      };
+    });
   }
 
   get theme() {

--- a/app/components/pipeline/children/table/component.js
+++ b/app/components/pipeline/children/table/component.js
@@ -1,0 +1,96 @@
+import Component from '@glimmer/component';
+import { service } from '@ember/service';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import { dom } from '@fortawesome/fontawesome-svg-core';
+
+export default class PipelineChildrenTableComponent extends Component {
+  @service scm;
+
+  @service shuttle;
+
+  @service pipelinePageState;
+
+  @service('emt-themes/ember-bootstrap-v5') emberModelTableBootstrapTheme;
+
+  @tracked data;
+
+  constructor() {
+    super(...arguments);
+
+    this.data = this.pipelinePageState
+      .getChildPipelines()
+      .slice(0, 3)
+      .map(pipeline => {
+        const scm = this.scm.getScm(pipeline.scmContext);
+
+        return {
+          pipeline,
+          id: pipeline.id,
+          name: pipeline.name,
+          branchName: pipeline.scmRepo.branch,
+          scmRepo: pipeline.scmRepo,
+          scmIcon: scm.iconType,
+          scmName: scm.displayName,
+          state: pipeline.state,
+          onPipelineDeleted: pipelineId => {
+            this.data = this.data.filter(d => d.id !== pipelineId);
+          }
+        };
+      });
+  }
+
+  get theme() {
+    const theme = this.emberModelTableBootstrapTheme;
+
+    theme.table = 'table table-condensed table-hover table-sm';
+
+    return theme;
+  }
+
+  get columns() {
+    return [
+      {
+        title: 'NAME',
+        propertyName: 'name',
+        component: 'pipelineCell',
+        className: 'pipeline-column'
+      },
+      {
+        title: 'BRANCH',
+        propertyName: 'branchName',
+        component: 'branchCell',
+        className: 'branch-column',
+        filterFunction: this.data.map(d => d.branchName)
+      },
+      {
+        title: 'ACCOUNT',
+        propertyName: 'scmName',
+        component: 'accountCell',
+        className: 'account-column',
+        filterWithSelect: true
+      },
+      {
+        title: 'STATUS',
+        propertyName: 'state',
+        component: 'statusCell',
+        className: 'status-column',
+        filterWithSelect: true,
+        predefinedFilterOptions: ['Active', 'Inactive'],
+        filterFunction(val, filterVal) {
+          return val.toLowerCase() === filterVal.toLowerCase();
+        }
+      },
+      {
+        title: 'ACTIONS',
+        component: 'actionsCell',
+        className: 'actions-column'
+      }
+    ];
+  }
+
+  @action
+  initialize(element) {
+    dom.i2svg({ node: element });
+  }
+}

--- a/app/components/pipeline/children/table/styles.scss
+++ b/app/components/pipeline/children/table/styles.scss
@@ -1,0 +1,43 @@
+@use 'ember-models-table';
+
+@use 'cell/account/styles' as account;
+@use 'cell/branch/styles' as branch;
+@use 'cell/pipeline/styles' as pipeline;
+@use 'cell/status/styles' as status;
+
+@mixin styles {
+  #child-pipelines {
+    @include ember-models-table.styles;
+
+    table {
+      table-layout: fixed;
+      width: 100%;
+
+      thead {
+        th {
+          &.pipeline-column,
+          &.branch-column {
+            min-width: 20rem;
+            width: 40%;
+          }
+          &.account-column {
+            width: 20rem;
+          }
+          &.status-column {
+            width: 10rem;
+          }
+          &.actions-column {
+            width: 7.5rem;
+          }
+        }
+      }
+
+      tbody {
+        @include account.styles;
+        @include branch.styles;
+        @include pipeline.styles;
+        @include status.styles;
+      }
+    }
+  }
+}

--- a/app/components/pipeline/children/table/template.hbs
+++ b/app/components/pipeline/children/table/template.hbs
@@ -1,0 +1,67 @@
+<ModelsTable
+  id="child-pipelines"
+  @data={{this.data}}
+  @columns={{this.columns}}
+  @columnComponents={{hash
+    pipelineCell=(component "pipeline/children/table/cell/pipeline")
+    branchCell=(component "pipeline/children/table/cell/branch")
+    accountCell=(component "pipeline/children/table/cell/account")
+    statusCell=(component "pipeline/children/table/cell/status")
+    actionsCell=(component "pipeline/children/table/cell/actions")
+  }}
+  @themeInstance={{this.theme}}
+  @onDisplayDataChanged={{this.onDisplayDataChanged}}
+
+  {{did-insert this.initialize}}
+
+  as |MT|
+>
+  <div class="table-main">
+    <MT.Table />
+  </div>
+
+  <div class="table-footer">
+    <MT.Summary
+      class="table-summary"
+      as |Summary|
+    >
+      {{Summary.summary}}
+    </MT.Summary>
+
+    <MT.PageSizeSelect class="select-pagination-size"/>
+
+    <MT.PaginationSimple class="pagination-controls" as |PS|>
+      <div class="page-navigation">
+        <BsButton
+          disabled={{if PS.goToBackEnabled false true}}
+          @onClick={{fn PS.goToFirst}}
+        >
+          <FaIcon @icon="angle-double-left"/>
+        </BsButton>
+        <BsButton
+          disabled={{if PS.goToBackEnabled false true}}
+          @onClick={{fn PS.goToPrev}}
+        >
+          <FaIcon @icon="angle-left"/>
+        </BsButton>
+        <BsButton
+          disabled={{if PS.goToForwardEnabled false true}}
+          @onClick={{fn PS.goToNext}}
+        >
+          <FaIcon @icon="angle-right"/>
+        </BsButton>
+        <BsButton
+          disabled={{if PS.goToForwardEnabled false true}}
+          @onClick={{fn PS.goToLast}}
+        >
+          <FaIcon @icon="angle-double-right"/>
+        </BsButton>
+      </div>
+
+      <div class="page-select">
+        <label class="input-group-text">Page:</label>
+        <PS.PageNumberSelect/>
+      </div>
+    </MT.PaginationSimple>
+  </div>
+</ModelsTable>

--- a/tests/integration/components/pipeline/children/table/cell/account/component-test.js
+++ b/tests/integration/components/pipeline/children/table/cell/account/component-test.js
@@ -1,0 +1,29 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module(
+  'Integration | Component | pipeline/children/table/cell/account',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test('it renders', async function (assert) {
+      this.setProperties({
+        record: {
+          scmIcon: 'github',
+          scmName: 'github'
+        }
+      });
+
+      await render(
+        hbs`<Pipeline::Children::Table::Cell::Account
+            @record={{this.record}}
+        />`
+      );
+
+      assert.dom('svg').exists({ count: 1 });
+      assert.dom(this.element).hasText('github');
+    });
+  }
+);

--- a/tests/integration/components/pipeline/children/table/cell/actions/component-test.js
+++ b/tests/integration/components/pipeline/children/table/cell/actions/component-test.js
@@ -1,0 +1,21 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module(
+  'Integration | Component | pipeline/children/table/cell/actions',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test('it renders', async function (assert) {
+      this.setProperties({
+        record: {}
+      });
+
+      await render(hbs`<Pipeline::Children::Table::Cell::Actions />`);
+
+      assert.dom('svg').exists({ count: 1 });
+    });
+  }
+);

--- a/tests/integration/components/pipeline/children/table/cell/branch/component-test.js
+++ b/tests/integration/components/pipeline/children/table/cell/branch/component-test.js
@@ -1,0 +1,24 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module(
+  'Integration | Component | pipeline/children/table/cell/branch',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test('it renders', async function (assert) {
+      this.setProperties({
+        record: {
+          scmRepo: { url: 'http://test.com' },
+          branchName: 'main'
+        }
+      });
+
+      await render(hbs`<Pipeline::Children::Table::Cell::Branch />`);
+
+      assert.dom('a').exists({ count: 1 });
+    });
+  }
+);

--- a/tests/integration/components/pipeline/children/table/cell/pipeline/component-test.js
+++ b/tests/integration/components/pipeline/children/table/cell/pipeline/component-test.js
@@ -1,0 +1,24 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module(
+  'Integration | Component | pipeline/children/table/cell/pipeline',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test('it renders', async function (assert) {
+      this.setProperties({
+        record: {
+          id: 123,
+          name: 'myPipeline'
+        }
+      });
+
+      await render(hbs`<Pipeline::Children::Table::Cell::Pipeline />`);
+
+      assert.dom('a').exists({ count: 1 });
+    });
+  }
+);

--- a/tests/integration/components/pipeline/children/table/cell/status/component-test.js
+++ b/tests/integration/components/pipeline/children/table/cell/status/component-test.js
@@ -1,0 +1,28 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module(
+  'Integration | Component | pipeline/children/table/cell/status',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test('it renders', async function (assert) {
+      this.setProperties({
+        record: {
+          state: 'ACTIVE'
+        }
+      });
+
+      await render(
+        hbs`<Pipeline::Children::Table::Cell::Status
+            @record={{this.record}}
+        />`
+      );
+
+      assert.dom('svg').exists({ count: 1 });
+      assert.dom(this.element).hasText('Active');
+    });
+  }
+);


### PR DESCRIPTION
## Context
The child pipeline's route for the V2 UI requires having a table glimmer component.

## Objective
Creates a glimmer component to handle the child pipelines table in the V2 UI.

![Screenshot 2025-02-25 at 13-52-41 ChildPipelines](https://github.com/user-attachments/assets/ecc39ce8-aae0-42f5-9c1b-fd1fb91a97fb)

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
