### PR TITLE
feat: Create modal for starting all child pipelines

### DIFF
--- a/app/components/pipeline/modal/start-children/component.js
+++ b/app/components/pipeline/modal/start-children/component.js
@@ -28,7 +28,7 @@ export default class PipelineModalStartChildrenComponent extends Component {
         `/pipelines/${this.pipelinePageState.getPipelineId()}/startall`
       )
       .then(() => {
-        this.args.closeModal();
+        this.args.closeModal(true);
         this.wasActionSuccessful = true;
       })
       .catch(err => {

--- a/app/components/pipeline/modal/start-children/component.js
+++ b/app/components/pipeline/modal/start-children/component.js
@@ -1,0 +1,42 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+
+export default class PipelineModalStartChildrenComponent extends Component {
+  @service shuttle;
+
+  @service pipelinePageState;
+
+  @tracked errorMessage = null;
+
+  @tracked isAwaitingResponse = false;
+
+  @tracked wasActionSuccessful = false;
+
+  get isStartAllButtonDisabled() {
+    return this.wasActionSuccessful || this.isAwaitingResponse;
+  }
+
+  @action
+  async startChildren() {
+    this.isAwaitingResponse = true;
+
+    await this.shuttle
+      .fetchFromApi(
+        'post',
+        `/pipelines/${this.pipelinePageState.getPipelineId()}/startall`
+      )
+      .then(() => {
+        this.args.closeModal();
+        this.wasActionSuccessful = true;
+      })
+      .catch(err => {
+        this.wasActionSuccessful = false;
+        this.errorMessage = err.message;
+      })
+      .finally(() => {
+        this.isAwaitingResponse = false;
+      });
+  }
+}

--- a/app/components/pipeline/modal/start-children/template.hbs
+++ b/app/components/pipeline/modal/start-children/template.hbs
@@ -1,0 +1,30 @@
+<BsModal
+  id="start-all-children-modal"
+  @onHide={{fn @closeModal}}
+  as |modal|
+>
+  <modal.header>
+    <div class="modal-title">Are you sure you want to start all child pipelines?</div>
+  </modal.header>
+  {{#if this.errorMessage}}
+    <modal.body>
+      <InfoMessage
+        @message={{this.errorMessage}}
+        @type="warning"
+        @icon="triangle-exclamation"
+        @dismissible={{false}}
+      />
+    </modal.body>
+  {{/if}}
+  <modal.footer>
+    <BsButton
+      id="start-all-button"
+      disabled={{this.isStartAllButtonDisabled}}
+      @type="primary"
+      @defaultText="Yes"
+      @pendingText="Starting"
+      @fulfilledText="Started"
+      @onClick={{fn this.startChildren}}
+    />
+  </modal.footer>
+</BsModal>

--- a/tests/integration/components/pipeline/modal/start-children/component-test.js
+++ b/tests/integration/components/pipeline/modal/start-children/component-test.js
@@ -51,7 +51,7 @@ module(
       assert.dom('.alert').exists({ count: 1 });
     });
 
-    test('it closes modal on successful start', async function (assert) {
+    test('it closes modal with correct value on successful start', async function (assert) {
       const shuttle = this.owner.lookup('service:shuttle');
       const pipelinePageState = this.owner.lookup(
         'service:pipeline-page-state'
@@ -73,6 +73,7 @@ module(
 
       await click('#start-all-button');
       assert.equal(closeModalSpy.calledOnce, true);
+      assert.equal(closeModalSpy.calledWith(true), true);
     });
   }
 );

--- a/tests/integration/components/pipeline/modal/start-children/component-test.js
+++ b/tests/integration/components/pipeline/modal/start-children/component-test.js
@@ -1,0 +1,54 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
+import { click, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+
+module(
+  'Integration | Component | pipeline/modal/start-children',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test('it renders', async function (assert) {
+      this.setProperties({
+        closeModal: () => {}
+      });
+
+      await render(
+        hbs`<Pipeline::Modal::StartChildren
+            @closeModal={{this.closeModal}}
+        />`
+      );
+
+      assert.dom('.modal-header').exists({ count: 1 });
+      assert.dom('.alert').doesNotExist();
+      assert.dom('.modal-title').exists({ count: 1 });
+      assert.dom('.modal-footer').exists({ count: 1 });
+      assert.dom('#start-all-button').exists({ count: 1 });
+      assert.dom('#start-all-button').isEnabled();
+    });
+
+    test('it sets error message when starting child pipelines fails', async function (assert) {
+      const shuttle = this.owner.lookup('service:shuttle');
+      const pipelinePageState = this.owner.lookup(
+        'service:pipeline-page-state'
+      );
+
+      sinon.stub(pipelinePageState, 'getPipelineId').returns(123);
+      sinon.stub(shuttle, 'fetchFromApi').rejects();
+
+      this.setProperties({
+        closeModal: () => {}
+      });
+
+      await render(
+        hbs`<Pipeline::Modal::StartChildren
+            @closeModal={{this.closeModal}}
+        />`
+      );
+
+      await click('#start-all-button');
+      assert.dom('.alert').exists({ count: 1 });
+    });
+  }
+);

--- a/tests/integration/components/pipeline/modal/start-children/component-test.js
+++ b/tests/integration/components/pipeline/modal/start-children/component-test.js
@@ -50,5 +50,29 @@ module(
       await click('#start-all-button');
       assert.dom('.alert').exists({ count: 1 });
     });
+
+    test('it closes modal on successful start', async function (assert) {
+      const shuttle = this.owner.lookup('service:shuttle');
+      const pipelinePageState = this.owner.lookup(
+        'service:pipeline-page-state'
+      );
+      const closeModalSpy = sinon.spy();
+
+      sinon.stub(pipelinePageState, 'getPipelineId').returns(123);
+      sinon.stub(shuttle, 'fetchFromApi').resolves();
+
+      this.setProperties({
+        closeModal: closeModalSpy
+      });
+
+      await render(
+        hbs`<Pipeline::Modal::StartChildren
+            @closeModal={{this.closeModal}}
+        />`
+      );
+
+      await click('#start-all-button');
+      assert.equal(closeModalSpy.calledOnce, true);
+    });
   }
 );


### PR DESCRIPTION
## Context
The child pipeline page in the V2 UI needs a modal to confirm starting all child pipelines

## Objective
Creates a glimmer modal component for staring all child pipelines

![Screenshot 2025-02-27 at 11-46-30 ChildPipelines](https://github.com/user-attachments/assets/01a58457-1801-49c4-96ae-472a4b884a68)

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
