### PR TITLE
feat: Add pipeline children to injectable service

### DIFF
--- a/app/pipeline-page-state/service.js
+++ b/app/pipeline-page-state/service.js
@@ -3,8 +3,11 @@ import Service from '@ember/service';
 export default class PipelinePageStateService extends Service {
   pipeline;
 
+  childPipelines;
+
   clear() {
     this.pipeline = null;
+    this.childPipelines = [];
   }
 
   setPipeline(pipeline) {
@@ -17,5 +20,13 @@ export default class PipelinePageStateService extends Service {
 
   getPipelineId() {
     return this.pipeline.id;
+  }
+
+  setChildPipelines(pipelines) {
+    this.childPipelines = pipelines;
+  }
+
+  getChildPipelines() {
+    return this.childPipelines;
   }
 }


### PR DESCRIPTION
## Context
The pipeline children V2 page needs to be able to operate off of the list of child pipelines.

## Objective
Adds pipeline children data to the injectable pipeline page state service.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
