### PR TITLE
feat: Event status filter

### DIFF
--- a/app/components/pipeline/jobs/table/cell/history/styles.scss
+++ b/app/components/pipeline/jobs/table/cell/history/styles.scss
@@ -1,7 +1,7 @@
 @mixin styles {
   .history-cell {
     display: flex;
-    max-width: 9rem;
+    margin-right: 1rem;
     overflow: scroll;
 
     .build-history-container {

--- a/app/components/pipeline/jobs/table/cell/job/styles.scss
+++ b/app/components/pipeline/jobs/table/cell/job/styles.scss
@@ -1,7 +1,6 @@
 @mixin styles {
   .job-cell {
     display: flex;
-    max-width: 50rem;
     padding-right: 2.5rem;
 
     .job-status {
@@ -21,6 +20,7 @@
 
     .job-name {
       padding: 1rem 0;
+      text-wrap: nowrap;
       overflow: scroll;
     }
   }

--- a/app/components/pipeline/jobs/table/cell/status/component.js
+++ b/app/components/pipeline/jobs/table/cell/status/component.js
@@ -1,0 +1,25 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+export default class PipelineJobsTableCellStatusComponent extends Component {
+  @tracked build;
+
+  constructor() {
+    super(...arguments);
+
+    const { job } = this.args.record;
+
+    this.args.record.onCreate(job, builds => {
+      if (builds.length > 0) {
+        this.build = builds[0];
+        this.args.record.status = this.build.status;
+      }
+    });
+  }
+
+  willDestroy() {
+    super.willDestroy();
+
+    this.args.record.onDestroy(this.args.record.job);
+  }
+}

--- a/app/components/pipeline/jobs/table/cell/status/styles.scss
+++ b/app/components/pipeline/jobs/table/cell/status/styles.scss
@@ -1,6 +1,7 @@
 @mixin styles {
   .status-cell {
     display: flex;
+    justify-content: center;
 
     .build-status-container {
       padding: 1rem 0;

--- a/app/components/pipeline/jobs/table/cell/status/styles.scss
+++ b/app/components/pipeline/jobs/table/cell/status/styles.scss
@@ -1,0 +1,25 @@
+@mixin styles {
+  .status-cell {
+    display: flex;
+
+    .build-status-container {
+      padding: 1rem 0;
+
+      a,
+      .created {
+        display: flex;
+
+        svg {
+          margin: auto;
+        }
+      }
+
+      .tooltip {
+        p {
+          text-align: left;
+          margin: 0;
+        }
+      }
+    }
+  }
+}

--- a/app/components/pipeline/jobs/table/cell/status/template.hbs
+++ b/app/components/pipeline/jobs/table/cell/status/template.hbs
@@ -1,0 +1,40 @@
+<div class="status-cell">
+  {{#if this.build}}
+    <span class="build-status-container">
+      {{#if (not-eq this.build.status "CREATED")}}
+        <LinkTo
+          @route="pipeline.build"
+          @models={{array @record.job.pipelineId this.build.id}}
+          @title={{this.build.id}}
+        >
+              <FaIcon
+                @icon="circle"
+                @fixedWidth="true"
+                class={{this.build.status}}
+              />
+            </LinkTo>
+            <BsTooltip
+              @placement="bottom"
+              @renderInPlace={{true}}
+              class="tooltip"
+            >
+              <p>Build# {{this.build.id}}</p>
+              {{#if this.build.startTime}}
+                <p>Start - {{moment-format this.build.startTime "MM/DD/YYYY HH:mmA"}}</p>
+              {{/if}}
+              {{#if this.build.endTime}}
+                <p>End - {{moment-format this.build.endTime "MM/DD/YYYY HH:mmA"}}</p>
+              {{/if}}
+            </BsTooltip>
+      {{else}}
+        <div class="created">
+            <FaIcon
+              @icon="circle"
+              @fixedWidth="true"
+              class={{this.build.status}}
+            />
+          </div>
+      {{/if}}
+    </span>
+  {{/if}}
+</div>

--- a/app/components/pipeline/jobs/table/component.js
+++ b/app/components/pipeline/jobs/table/component.js
@@ -210,8 +210,10 @@ export default class PipelineJobsTableComponent extends Component {
       data.currentPageNumber
     );
 
-    this.dataReloader
-      .fetchBuildsForJobs(this.dataReloader.newJobIds())
-      .then(() => {});
+    if (!this.event) {
+      this.dataReloader
+        .fetchBuildsForJobs(this.dataReloader.newJobIds())
+        .then(() => {});
+    }
   }
 }

--- a/app/components/pipeline/jobs/table/component.js
+++ b/app/components/pipeline/jobs/table/component.js
@@ -57,8 +57,18 @@ export default class PipelineJobsTableComponent extends Component {
           // eslint-disable-next-line ember/no-string-prototype-extensions
           .map(status => _.capitalize(status))
           .sort(),
-        filterFunction: (val, filterVal) => {
-          return val.toLowerCase() === filterVal.toLowerCase();
+        filterFunction: (val, filterVal, row) => {
+          const filterValue = filterVal.toLowerCase();
+
+          if (val !== 'undefined') {
+            return val.toLowerCase() === filterValue;
+          }
+
+          const build = this.workflowDataReload
+            .getBuildsForEvent(this.event.id)
+            .filter(b => b.jobId === row.job.id)[0];
+
+          return build?.status.toLowerCase() === filterValue;
         }
       };
     } else {

--- a/app/components/pipeline/jobs/table/component.js
+++ b/app/components/pipeline/jobs/table/component.js
@@ -3,6 +3,8 @@ import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { dom } from '@fortawesome/fontawesome-svg-core';
+import _ from 'lodash';
+import { statuses } from 'screwdriver-ui/utils/build';
 import DataReloader from './dataReloader';
 import getDisplayName from './util';
 
@@ -42,27 +44,34 @@ export default class PipelineJobsTableComponent extends Component {
   }
 
   setColumnData() {
-    const historyColumnConfiguration = {
-      title: this.args.historyColumnName
-        ? this.args.historyColumnName.toUpperCase()
-        : 'HISTORY',
-      className: 'history-column',
-      component: 'historyCell'
-    };
+    let historyColumnConfiguration;
 
-    if (!this.event) {
-      historyColumnConfiguration.propertyName = 'history';
-      historyColumnConfiguration.filterWithSelect = true;
-      historyColumnConfiguration.predefinedFilterOptions = [
-        '5',
-        '10',
-        '15',
-        '20',
-        '25',
-        '30'
-      ];
-      historyColumnConfiguration.filterFunction = async (_, filterVal) => {
-        await this.dataReloader.setNumBuilds(filterVal);
+    if (this.event) {
+      historyColumnConfiguration = {
+        title: 'STATUS',
+        className: 'status-column',
+        component: 'statusCell',
+        propertyName: 'status',
+        filterWithSelect: true,
+        predefinedFilterOptions: [...statuses, 'WARNING']
+          // eslint-disable-next-line ember/no-string-prototype-extensions
+          .map(status => _.capitalize(status))
+          .sort(),
+        filterFunction: (val, filterVal) => {
+          return val.toLowerCase() === filterVal.toLowerCase();
+        }
+      };
+    } else {
+      historyColumnConfiguration = {
+        title: 'HISTORY',
+        className: 'history-column',
+        component: 'historyCell',
+        propertyName: 'history',
+        filterWithSelect: true,
+        predefinedFilterOptions: [5, 10, 15, 20, 25, 30],
+        filterFunction: async (_val, filterVal) => {
+          await this.dataReloader.setNumBuilds(filterVal);
+        }
       };
     }
 

--- a/app/components/pipeline/jobs/table/component.js
+++ b/app/components/pipeline/jobs/table/component.js
@@ -68,7 +68,7 @@ export default class PipelineJobsTableComponent extends Component {
         component: 'historyCell',
         propertyName: 'history',
         filterWithSelect: true,
-        predefinedFilterOptions: [5, 10, 15, 20, 25, 30],
+        predefinedFilterOptions: ['5', '10', '15', '20', '25', '30'],
         filterFunction: async (_val, filterVal) => {
           await this.dataReloader.setNumBuilds(filterVal);
         }

--- a/app/components/pipeline/jobs/table/styles.scss
+++ b/app/components/pipeline/jobs/table/styles.scss
@@ -21,29 +21,37 @@
 
     .table-main {
       max-height: calc(100% - $table-footer-height);
+      margin-top: 0;
       overflow: scroll;
 
       table {
+        table-layout: fixed;
+        $column-width: 10rem;
+        $start-column-width: 15rem;
+        min-width: calc(7 * $column-width + $start-column-width);
+        width: 100%;
+
+        .start-time-column {
+          width: $start-column-width;
+        }
+
+        .status-column,
+        .duration-column,
+        .coverage-column,
+        .stage-column,
+        .metrics-column,
+        .actions-column {
+          width: $column-width;
+        }
+
         thead {
+          position: sticky;
+          top: 0;
+          background: colors.$sd-white;
+          z-index: 1;
+
           th {
-            &.history-column {
-              width: 15rem;
-            }
-            &.status-column {
-              width: 10rem;
-            }
-
-            &.duration-column,
-            &.start-time-column {
-              width: 20rem;
-            }
-
-            &.coverage-column,
-            &.stage-column,
-            &.metrics-column,
-            &.actions-column {
-              width: 10rem;
-            }
+            border: none;
           }
         }
 

--- a/app/components/pipeline/jobs/table/styles.scss
+++ b/app/components/pipeline/jobs/table/styles.scss
@@ -29,6 +29,9 @@
             &.history-column {
               width: 15rem;
             }
+            &.status-column {
+              width: 10rem;
+            }
 
             &.duration-column,
             &.start-time-column {

--- a/app/components/pipeline/jobs/table/styles.scss
+++ b/app/components/pipeline/jobs/table/styles.scss
@@ -1,30 +1,30 @@
 @use 'screwdriver-colors' as colors;
+@use 'ember-models-table';
 
 @use 'cell/actions/styles' as actions;
 @use 'cell/history/styles' as history;
 @use 'cell/job/styles' as job;
 @use 'cell/metrics/styles' as metrics;
+@use 'cell/status/styles' as status;
 
 @mixin styles {
   #pipeline-jobs {
+    @include ember-models-table.styles;
+
     padding: 1rem;
 
     display: flex;
     flex-direction: column;
     height: 100%;
 
-    $searchbar-height: 2rem;
     $table-footer-height: 2.5rem;
 
-    #jobs-table {
-      margin: 2rem 0;
-      max-height: calc(100% - $searchbar-height - $table-footer-height);
+    .table-main {
+      max-height: calc(100% - $table-footer-height);
       overflow: scroll;
 
       table {
         thead {
-          color: colors.$sd-text-med;
-
           th {
             &.history-column {
               width: 15rem;
@@ -49,20 +49,7 @@
           @include history.styles;
           @include job.styles;
           @include metrics.styles;
-
-          tr {
-            color: colors.$sd-text;
-            height: 4rem;
-
-            &:hover {
-              color: colors.$sd-text;
-              background-color: rgba(colors.$sd-running, 0.1);
-            }
-          }
-
-          td {
-            vertical-align: middle;
-          }
+          @include status.styles;
 
           svg {
             &.SUCCESS {
@@ -96,74 +83,8 @@
       }
     }
 
-    #jobs-table-footer {
+    .table-footer {
       height: $table-footer-height;
-      display: flex;
-      color: colors.$sd-text-med;
-
-      #table-summary {
-        display: flex;
-        margin: auto;
-      }
-
-      #select-pagination-size {
-        display: flex;
-        margin: auto;
-
-        label {
-          background-color: transparent;
-          border: none;
-          color: colors.$sd-text-med;
-        }
-
-        select {
-          border-radius: 0.25rem;
-        }
-      }
-
-      #page-navigation {
-        display: flex;
-
-        button {
-          background-color: transparent;
-          border: none;
-
-          svg {
-            color: colors.$sd-text;
-          }
-
-          &:disabled {
-            svg {
-              color: rgba(colors.$sd-text, 0.5);
-            }
-          }
-        }
-      }
-
-      #pagination-controls {
-        display: flex;
-        justify-content: flex-end;
-        margin: auto;
-
-        #page-select {
-          display: flex;
-          width: 10rem;
-          margin-right: 2.5rem;
-
-          label {
-            background-color: transparent;
-            border: none;
-            color: colors.$sd-text-med;
-          }
-
-          select {
-            display: flex;
-            align-items: center;
-            padding: 0.375rem 0.75rem;
-            margin-bottom: 0;
-          }
-        }
-      }
     }
   }
 }

--- a/app/components/pipeline/jobs/table/template.hbs
+++ b/app/components/pipeline/jobs/table/template.hbs
@@ -1,74 +1,72 @@
-<div
-  id="pipeline-jobs-container"
+<ModelsTable
+  id="pipeline-jobs"
+  @data={{this.data}}
+  @columns={{this.columns}}
+  @columnComponents={{hash
+    jobCell=(component "pipeline/jobs/table/cell/job")
+    historyCell=(component "pipeline/jobs/table/cell/history")
+    statusCell=(component "pipeline/jobs/table/cell/status")
+    durationCell=(component "pipeline/jobs/table/cell/duration")
+    startTimeCell=(component "pipeline/jobs/table/cell/start-time")
+    coverageCell=(component "pipeline/jobs/table/cell/coverage")
+    stageCell=(component "pipeline/jobs/table/cell/stage")
+    metricsCell=(component "pipeline/jobs/table/cell/metrics")
+    actionsCell=(component "pipeline/jobs/table/cell/actions")
+  }}
+  @themeInstance={{this.theme}}
+  @onDisplayDataChanged={{this.onDisplayDataChanged}}
+
   {{did-insert this.initialize}}
   {{did-update this.update @event}}
+
+  as |MT|
 >
-  <ModelsTable
-    id="pipeline-jobs"
-    @data={{this.data}}
-    @columns={{this.columns}}
-    @columnComponents={{hash
-      jobCell=(component "pipeline/jobs/table/cell/job")
-      historyCell=(component "pipeline/jobs/table/cell/history")
-      statusCell=(component "pipeline/jobs/table/cell/status")
-      durationCell=(component "pipeline/jobs/table/cell/duration")
-      startTimeCell=(component "pipeline/jobs/table/cell/start-time")
-      coverageCell=(component "pipeline/jobs/table/cell/coverage")
-      stageCell=(component "pipeline/jobs/table/cell/stage")
-      metricsCell=(component "pipeline/jobs/table/cell/metrics")
-      actionsCell=(component "pipeline/jobs/table/cell/actions")
-    }}
-    @themeInstance={{this.theme}}
-    @onDisplayDataChanged={{this.onDisplayDataChanged}}
-    as |MT|
-  >
-    <div class="table-main">
-      <MT.Table />
-    </div>
+  <div class="table-main">
+    <MT.Table />
+  </div>
 
-    <div class="table-footer">
-      <MT.Summary
-        class="table-summary"
-        as |Summary|
-      >
-        {{Summary.summary}}
-      </MT.Summary>
+  <div class="table-footer">
+    <MT.Summary
+      class="entry-summary"
+      as |Summary|
+    >
+      {{Summary.summary}}
+    </MT.Summary>
 
-      <MT.PageSizeSelect class="select-pagination-size"/>
+    <MT.PageSizeSelect class="select-pagination-size"/>
 
-      <MT.PaginationSimple class="pagination-controls" as |PS|>
-        <div class="page-navigation">
-          <BsButton
-            disabled={{if PS.goToBackEnabled false true}}
-            @onClick={{fn PS.goToFirst}}
-          >
-            <FaIcon @icon="angle-double-left"/>
-          </BsButton>
-          <BsButton
-            disabled={{if PS.goToBackEnabled false true}}
-            @onClick={{fn PS.goToPrev}}
-          >
-            <FaIcon @icon="angle-left"/>
-          </BsButton>
-          <BsButton
-            disabled={{if PS.goToForwardEnabled false true}}
-            @onClick={{fn PS.goToNext}}
-          >
-            <FaIcon @icon="angle-right"/>
-          </BsButton>
-          <BsButton
-            disabled={{if PS.goToForwardEnabled false true}}
-            @onClick={{fn PS.goToLast}}
-          >
-            <FaIcon @icon="angle-double-right"/>
-          </BsButton>
-        </div>
+    <MT.PaginationSimple class="pagination-controls" as |PS|>
+      <div class="page-navigation">
+        <BsButton
+          disabled={{if PS.goToBackEnabled false true}}
+          @onClick={{fn PS.goToFirst}}
+        >
+          <FaIcon @icon="angle-double-left"/>
+        </BsButton>
+        <BsButton
+          disabled={{if PS.goToBackEnabled false true}}
+          @onClick={{fn PS.goToPrev}}
+        >
+          <FaIcon @icon="angle-left"/>
+        </BsButton>
+        <BsButton
+          disabled={{if PS.goToForwardEnabled false true}}
+          @onClick={{fn PS.goToNext}}
+        >
+          <FaIcon @icon="angle-right"/>
+        </BsButton>
+        <BsButton
+          disabled={{if PS.goToForwardEnabled false true}}
+          @onClick={{fn PS.goToLast}}
+        >
+          <FaIcon @icon="angle-double-right"/>
+        </BsButton>
+      </div>
 
-        <div class="page-select">
-          <label class="input-group-text">Page:</label>
-          <PS.PageNumberSelect/>
-        </div>
-      </MT.PaginationSimple>
-    </div>
-  </ModelsTable>
-</div>
+      <div class="page-select">
+        <label class="input-group-text">Page:</label>
+        <PS.PageNumberSelect/>
+      </div>
+    </MT.PaginationSimple>
+  </div>
+</ModelsTable>

--- a/app/components/pipeline/jobs/table/template.hbs
+++ b/app/components/pipeline/jobs/table/template.hbs
@@ -10,6 +10,7 @@
     @columnComponents={{hash
       jobCell=(component "pipeline/jobs/table/cell/job")
       historyCell=(component "pipeline/jobs/table/cell/history")
+      statusCell=(component "pipeline/jobs/table/cell/status")
       durationCell=(component "pipeline/jobs/table/cell/duration")
       startTimeCell=(component "pipeline/jobs/table/cell/start-time")
       coverageCell=(component "pipeline/jobs/table/cell/coverage")

--- a/app/components/pipeline/jobs/table/template.hbs
+++ b/app/components/pipeline/jobs/table/template.hbs
@@ -21,22 +21,22 @@
     @onDisplayDataChanged={{this.onDisplayDataChanged}}
     as |MT|
   >
-    <div id="jobs-table">
+    <div class="table-main">
       <MT.Table />
     </div>
 
-    <div id="jobs-table-footer">
+    <div class="table-footer">
       <MT.Summary
-        id="table-summary"
+        class="table-summary"
         as |Summary|
       >
         {{Summary.summary}}
       </MT.Summary>
 
-      <MT.PageSizeSelect id="select-pagination-size"/>
+      <MT.PageSizeSelect class="select-pagination-size"/>
 
-      <MT.PaginationSimple id="pagination-controls" as |PS|>
-        <div id="page-navigation">
+      <MT.PaginationSimple class="pagination-controls" as |PS|>
+        <div class="page-navigation">
           <BsButton
             disabled={{if PS.goToBackEnabled false true}}
             @onClick={{fn PS.goToFirst}}
@@ -63,7 +63,7 @@
           </BsButton>
         </div>
 
-        <div id="page-select">
+        <div class="page-select">
           <label class="input-group-text">Page:</label>
           <PS.PageNumberSelect/>
         </div>

--- a/app/components/pipeline/workflow/template.hbs
+++ b/app/components/pipeline/workflow/template.hbs
@@ -125,7 +125,6 @@
             @event={{this.event}}
             @jobs={{this.jobs}}
             @userSettings={{this.userSettings}}
-            @historyColumnName={{"status"}}
             @numBuilds={{1}}
           />
         {{/if}}

--- a/app/styles/ember-models-table.scss
+++ b/app/styles/ember-models-table.scss
@@ -35,6 +35,10 @@
                 color: #0056b3;
               }
             }
+
+            select + button {
+              display: none;
+            }
           }
         }
       }

--- a/app/styles/ember-models-table.scss
+++ b/app/styles/ember-models-table.scss
@@ -36,8 +36,16 @@
               }
             }
 
-            select + button {
-              display: none;
+            select {
+              border: none;
+
+              + button {
+                display: none;
+              }
+            }
+
+            .form-control {
+              background-color: transparent;
             }
           }
         }
@@ -65,14 +73,15 @@
     display: flex;
     color: colors.$sd-text-med;
 
-    .table-summary {
-      display: flex;
-      margin: auto;
+    .entry-summary {
+      margin: auto 0;
+      min-width: 15rem;
     }
 
     .select-pagination-size {
       display: flex;
       margin: auto;
+      min-width: 12rem;
 
       label {
         background-color: transparent;
@@ -85,29 +94,31 @@
       }
     }
 
-    .page-navigation {
-      display: flex;
-
-      button {
-        background-color: transparent;
-        border: none;
-
-        svg {
-          color: colors.$sd-text;
-        }
-
-        &:disabled {
-          svg {
-            color: rgba(colors.$sd-text, 0.5);
-          }
-        }
-      }
-    }
-
     .pagination-controls {
       display: flex;
       justify-content: flex-end;
       margin: auto;
+      flex: 0;
+      min-width: 25rem;
+
+      .page-navigation {
+        display: flex;
+
+        button {
+          background-color: transparent;
+          border: none;
+
+          svg {
+            color: colors.$sd-text;
+          }
+
+          &:disabled {
+            svg {
+              color: rgba(colors.$sd-text, 0.5);
+            }
+          }
+        }
+      }
 
       .page-select {
         display: flex;

--- a/package-lock.json
+++ b/package-lock.json
@@ -88,6 +88,7 @@
         "jwt-decode": "^4.0.0",
         "lint-staged": "^15.2.2",
         "loader.js": "^4.7.0",
+        "lodash": "^4.17.21",
         "lodash.groupby": "^4.6.0",
         "lodash.isequal": "^4.5.0",
         "lodash.uniqby": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
     "jwt-decode": "^4.0.0",
     "lint-staged": "^15.2.2",
     "loader.js": "^4.7.0",
+    "lodash": "^4.17.21",
     "lodash.groupby": "^4.6.0",
     "lodash.isequal": "^4.5.0",
     "lodash.uniqby": "^4.7.0",

--- a/tests/integration/components/pipeline/jobs/table/cell/status/component-test.js
+++ b/tests/integration/components/pipeline/jobs/table/cell/status/component-test.js
@@ -1,0 +1,103 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
+import { clearRender, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+
+module(
+  'Integration | Component | pipeline/jobs/table/cell/status',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test('it renders', async function (assert) {
+      const job = { id: 123, name: 'main' };
+
+      this.setProperties({
+        record: {
+          job,
+          onCreate: () => {},
+          onDestroy: () => {}
+        }
+      });
+      await render(
+        hbs`<Pipeline::Jobs::Table::Cell::Status
+            @record={{this.record}}
+        />`
+      );
+
+      assert.dom('a').doesNotExist();
+    });
+
+    test('it calls onCreate', async function (assert) {
+      const onCreate = sinon.spy();
+      const job = { id: 123, name: 'main' };
+
+      this.setProperties({
+        record: {
+          job,
+          onCreate,
+          onDestroy: () => {}
+        }
+      });
+      await render(
+        hbs`<Pipeline::Jobs::Table::Cell::Status
+            @record={{this.record}}
+        />`
+      );
+
+      assert.equal(onCreate.calledOnce, true);
+      assert.equal(onCreate.calledWith(job), true);
+    });
+
+    test('it calls onDestroy', async function (assert) {
+      const onDestroy = sinon.spy();
+      const job = { id: 123, name: 'main' };
+
+      this.setProperties({
+        record: {
+          job,
+          onCreate: () => {},
+          onDestroy
+        }
+      });
+      await render(
+        hbs`<Pipeline::Jobs::Table::Cell::Status
+            @record={{this.record}}
+        />`
+      );
+      await clearRender();
+
+      assert.equal(onDestroy.calledOnce, true);
+      assert.equal(onDestroy.calledWith(job), true);
+    });
+
+    test('it renders build status', async function (assert) {
+      const job = { id: 123, name: 'main' };
+      const build = {
+        id: 999,
+        status: 'SUCCESS',
+        startTime: '2024-07-14T17:25:57.671Z',
+        endTime: '2024-07-14T17:26:55.202Z'
+      };
+
+      this.setProperties({
+        record: {
+          job,
+          onCreate: (j, cb) => {
+            cb([build]);
+          },
+          onDestroy: () => {}
+        }
+      });
+
+      await render(
+        hbs`<Pipeline::Jobs::Table::Cell::Status
+            @record={{this.record}}
+        />`
+      );
+
+      assert.dom('svg.SUCCESS').exists({ count: 1 });
+      assert.dom('.build-status-container a').exists({ count: 1 });
+    });
+  }
+);


### PR DESCRIPTION
## Context
The events table view shows all the job build status for an event.  For pipelines that are large, having the ability to filter out the table to just particular build statuses is helpful for getting to particular builds of interest.

## Objective
1. Creates a new component for displaying the job build status rather than leveraging the existing build history component.
![Screenshot 2025-02-28 at 12-13-49 Events](https://github.com/user-attachments/assets/e7660523-df2e-4183-adf1-bd9b483e5f47)
![Screenshot 2025-02-28 at 12-14-11 Events](https://github.com/user-attachments/assets/0516867a-7b3e-4c62-9b64-d721a28e3f6a)
2. Updates the table component to use the shared table style extracted in #1349 
3. Fixes a bug where table display changes populates incorrect build data back into the table for the event/pr event job view
 
## References
https://github.com/screwdriver-cd/screwdriver/issues/3200
https://github.com/screwdriver-cd/ui/pull/1349

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
