### PR TITLE
fix(3193): use remoteName instead of displayName to show remote trigger's pipeline name as title [2]

### DIFF
--- a/app/utils/pipeline/graph/d3-graph-util.js
+++ b/app/utils/pipeline/graph/d3-graph-util.js
@@ -66,14 +66,7 @@ export function getElementSizes(isMinified = false) {
 export function getMaximumJobNameLength(data, displayJobNameLength) {
   return Math.min(
     data.nodes.reduce(
-      (max, cur) =>
-        Math.max(
-          (!/sd@/.test(cur.name) && cur.displayName
-            ? cur.displayName
-            : cur.name
-          ).length,
-          max
-        ),
+      (max, cur) => Math.max((cur.displayName || cur.name).length, max),
       0
     ),
     displayJobNameLength
@@ -804,11 +797,9 @@ export function addJobIcons( // eslint-disable-line max-params
     );
 
   nodeGroups.append('title').text(d => {
-    if (/sd@/.test(d.name) && d.displayName !== undefined) {
-      return d.displayName;
-    }
+    const name = d.remoteName !== undefined ? d.remoteName : d.name;
 
-    return d.status ? `${d.name} - ${d.status}` : d.name;
+    return d.status ? `${name} - ${d.status}` : name;
   });
 }
 
@@ -838,10 +829,7 @@ export function addJobNames(
     .enter()
     .append('text')
     .text(d => {
-      const displayName =
-        !/sd@/.test(d.name) && d.displayName !== undefined
-          ? d.displayName
-          : d.name;
+      const displayName = d.displayName !== undefined ? d.displayName : d.name;
 
       return displayName.length > maximumJobNameLength
         ? `${displayName.substring(0, 8)}...${displayName.slice(-8)}`
@@ -871,11 +859,7 @@ export function addJobNames(
     )
     .insert('title')
     .text(d => {
-      if (/sd@/.test(d.name) && d.displayName !== undefined) {
-        return d.displayName;
-      }
-
-      return d.name;
+      return d.remoteName !== undefined ? d.remoteName : d.name;
     });
 }
 

--- a/tests/integration/components/workflow-graph-d3/component-test.js
+++ b/tests/integration/components/workflow-graph-d3/component-test.js
@@ -92,7 +92,7 @@ module('Integration | Component | workflow graph d3', function (hooks) {
       nodes: [
         { name: '~pr' },
         { name: '~commit' },
-        { name: '~sd@123:main', displayName: 'foo/bar@main' },
+        { name: '~sd@123:main', remoteName: 'foo/bar@main' },
         { name: '~sd@456:main' },
         { name: 'foo', displayName: 'bar' },
         { name: 'baz' }

--- a/tests/unit/utils/pipeline/graph/d3-graph-util-test.js
+++ b/tests/unit/utils/pipeline/graph/d3-graph-util-test.js
@@ -55,7 +55,7 @@ module('Unit | Utility | pipeline-graph | d3-graph-util', function () {
         { name: 'job1' },
         { name: 'job2', displayName: '0123456789' },
         { name: 'job3' },
-        { name: '~sd@1:foo', displayName: '0123456789/0123456789' }
+        { name: '~sd@1:foo', remotename: '0123456789/0123456789' }
       ]
     };
 

--- a/tests/unit/utils/pipeline/graph/d3-graph-util-test.js
+++ b/tests/unit/utils/pipeline/graph/d3-graph-util-test.js
@@ -55,7 +55,7 @@ module('Unit | Utility | pipeline-graph | d3-graph-util', function () {
         { name: 'job1' },
         { name: 'job2', displayName: '0123456789' },
         { name: 'job3' },
-        { name: '~sd@1:foo', remotename: '0123456789/0123456789' }
+        { name: '~sd@1:foo', remoteName: '0123456789/0123456789' }
       ]
     };
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Follow up https://github.com/screwdriver-cd/ui/pull/1152

`displayName` is used to show the name of upstream pipeline but it is also used to label the normal job.
Hence we should check whether the `displayName` is from remote trigger or not.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Use `remoteName` insteadOf `displayName` to show remote trigger's pipeline name.

https://github.com/screwdriver-cd/models/pull/643

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

- Issue: https://github.com/screwdriver-cd/screwdriver/issues/3193
- PR: https://github.com/screwdriver-cd/models/pull/643

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
