### PR TITLE
fix: Handle 201 for start all children

### DIFF
--- a/app/components/pipeline/modal/start-children/component.js
+++ b/app/components/pipeline/modal/start-children/component.js
@@ -25,15 +25,22 @@ export default class PipelineModalStartChildrenComponent extends Component {
     await this.shuttle
       .fetchFromApi(
         'post',
-        `/pipelines/${this.pipelinePageState.getPipelineId()}/startall`
+        `/pipelines/${this.pipelinePageState.getPipelineId()}/startall`,
+        null,
+        true
       )
       .then(() => {
         this.args.closeModal(true);
         this.wasActionSuccessful = true;
       })
       .catch(err => {
-        this.wasActionSuccessful = false;
-        this.errorMessage = err.message;
+        if (err.jqXHR.status === 201) {
+          this.args.closeModal(true);
+          this.wasActionSuccessful = true;
+        } else {
+          this.wasActionSuccessful = false;
+          this.errorMessage = err.response.message;
+        }
       })
       .finally(() => {
         this.isAwaitingResponse = false;

--- a/app/components/pipeline/modal/start-children/component.js
+++ b/app/components/pipeline/modal/start-children/component.js
@@ -34,7 +34,7 @@ export default class PipelineModalStartChildrenComponent extends Component {
         this.wasActionSuccessful = true;
       })
       .catch(err => {
-        if (err.jqXHR.status === 201) {
+        if (err.jqXHR.status >= 200 && err.jqXHR.status < 300) {
           this.args.closeModal(true);
           this.wasActionSuccessful = true;
         } else {

--- a/tests/integration/components/pipeline/modal/start-children/component-test.js
+++ b/tests/integration/components/pipeline/modal/start-children/component-test.js
@@ -35,7 +35,9 @@ module(
       );
 
       sinon.stub(pipelinePageState, 'getPipelineId').returns(123);
-      sinon.stub(shuttle, 'fetchFromApi').rejects();
+      sinon
+        .stub(shuttle, 'fetchFromApi')
+        .rejects({ jqXHR: { status: 500 }, response: { message: 'error' } });
 
       this.setProperties({
         closeModal: () => {}


### PR DESCRIPTION
## Context
The shuttle service configures the ajax client to expect JSON response bodies.  The API may return a 201 without a body causing the ajax client to attempt to parse invalid JSON.  This is what is currently happening on the `v4/postV4PipelinesIdStartall` API call.

## Objective
Updates the start all children pipelines API call to request the whole error object to be returned so that further introspection can be done on the actual API call and the returned status code.

## References
https://github.com/screwdriver-cd/ui/pull/1354
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
