### PR TITLE
feat: Glimmer component for child pipelines

### DIFF
--- a/app/components/pipeline/children/component.js
+++ b/app/components/pipeline/children/component.js
@@ -1,0 +1,23 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+export default class PipelineChildrenComponent extends Component {
+  @tracked isStartAllChildrenModalOpen;
+
+  @tracked childrenPipelineStarted = false;
+
+  @action
+  showStartAllChildrenModal() {
+    this.isStartAllChildrenModalOpen = true;
+  }
+
+  @action
+  closeStartAllChildrenModal(childrenPipelineStarted) {
+    this.isStartAllChildrenModalOpen = false;
+
+    if (childrenPipelineStarted) {
+      this.childrenPipelineStarted = true;
+    }
+  }
+}

--- a/app/components/pipeline/children/styles.scss
+++ b/app/components/pipeline/children/styles.scss
@@ -1,0 +1,24 @@
+@use 'table/styles' as table;
+
+@mixin styles {
+  #child-pipelines-container {
+    $margin: 1rem;
+    $start-children-button-container-height: 2.5rem;
+
+    margin: $margin;
+    height: calc(100% - 2 * $margin);
+
+    #start-all-button-container {
+      display: flex;
+      flex-direction: row-reverse;
+      margin-bottom: $margin;
+      height: $start-children-button-container-height;
+    }
+
+    #child-pipeline-table-container {
+      height: calc(100% - $start-children-button-container-height - $margin);
+
+      @include table.styles;
+    }
+  }
+}

--- a/app/components/pipeline/children/table/styles.scss
+++ b/app/components/pipeline/children/table/styles.scss
@@ -1,3 +1,4 @@
+@use 'screwdriver-colors' as colors;
 @use 'ember-models-table';
 
 @use 'cell/account/styles' as account;
@@ -9,35 +10,57 @@
   #child-pipelines {
     @include ember-models-table.styles;
 
-    table {
-      table-layout: fixed;
-      width: 100%;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
 
-      thead {
-        th {
-          &.pipeline-column,
-          &.branch-column {
-            min-width: 20rem;
-            width: 40%;
-          }
-          &.account-column {
-            width: 20rem;
-          }
-          &.status-column {
-            width: 10rem;
-          }
-          &.actions-column {
-            width: 7.5rem;
+    $table-footer-height: 2.5rem;
+
+    .table-main {
+      max-height: calc(100% - $table-footer-height);
+      margin-top: 0;
+      overflow: scroll;
+
+      table {
+        table-layout: fixed;
+        width: 100%;
+
+        thead {
+          position: sticky;
+          top: 0;
+          background: colors.$sd-white;
+
+          th {
+            border: none;
+
+            &.pipeline-column,
+            &.branch-column {
+              min-width: 20rem;
+              width: 40%;
+            }
+            &.account-column {
+              width: 20rem;
+            }
+            &.status-column {
+              width: 10rem;
+            }
+            &.actions-column {
+              width: 7.5rem;
+            }
           }
         }
-      }
 
-      tbody {
-        @include account.styles;
-        @include branch.styles;
-        @include pipeline.styles;
-        @include status.styles;
+        tbody {
+          @include account.styles;
+          @include branch.styles;
+          @include pipeline.styles;
+          @include status.styles;
+        }
       }
+    }
+
+    .table-footer {
+      height: $table-footer-height;
     }
   }
 }

--- a/app/components/pipeline/children/template.hbs
+++ b/app/components/pipeline/children/template.hbs
@@ -1,0 +1,22 @@
+<div id="child-pipelines-container">
+  <div id="start-all-button-container">
+    <BsButton
+      id="start-all-button"
+      @type="primary"
+      @outline={{true}}
+      @disabled={{this.childrenPipelineStarted}}
+      @onClick={{this.showStartAllChildrenModal}}
+    >
+      Start all child pipelines
+      {{#if this.isStartAllChildrenModalOpen}}
+        <Pipeline::Modal::StartChildren
+          @closeModal={{this.closeStartAllChildrenModal}}
+        />
+      {{/if}}
+    </BsButton>
+  </div>
+
+  <div id="child-pipeline-table-container">
+    <Pipeline::Children::Table />
+  </div>
+</div>

--- a/app/components/pipeline/modal/delete-pipeline/component.js
+++ b/app/components/pipeline/modal/delete-pipeline/component.js
@@ -32,7 +32,7 @@ export default class PipelineModalDeletePipelineComponent extends Component {
     this.isAwaitingResponse = true;
 
     await this.shuttle
-      .fetchFromApi('delete', `/pipelines/${this.args.pipelineId}`)
+      .fetchFromApi('delete', `/pipelines/${this.args.pipeline.id}`)
       .then(() => {
         this.args.closeModal(true);
       })

--- a/app/components/pipeline/styles.scss
+++ b/app/components/pipeline/styles.scss
@@ -1,3 +1,4 @@
+@use 'children/styles' as children;
 @use 'event/styles' as event;
 @use 'header/styles' as header;
 @use 'jobs/styles' as jobs;
@@ -8,6 +9,7 @@
 @use 'workflow/styles' as workflow;
 
 @mixin styles {
+  @include children.styles;
   @include event.styles;
   @include header.styles;
   @include jobs.styles;

--- a/tests/integration/components/pipeline/children/component-test.js
+++ b/tests/integration/components/pipeline/children/component-test.js
@@ -1,0 +1,31 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+
+module('Integration | Component | pipeline/children', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    const pipelinePageState = this.owner.lookup('service:pipeline-page-state');
+
+    sinon.stub(pipelinePageState, 'getChildPipelines').returns([
+      {
+        id: 123,
+        name: 'child123',
+        scmRepo: {
+          branch: 'main',
+          url: 'https://github.com/test'
+        },
+        scmContext: 'github:github.com',
+        state: 'ACTIVE'
+      }
+    ]);
+
+    await render(hbs`<Pipeline::Children />`);
+
+    assert.dom('#start-all-button-container').exists({ count: 1 });
+    assert.dom('#child-pipeline-table-container').exists({ count: 1 });
+  });
+});


### PR DESCRIPTION
## Context
Creating a glimmer component to house the child pipelines table and the button to start all child pipelines.

## Objective
1. Creates a glimmer component that can be used directly within the route template to display the whole child pipeline view
![Screenshot 2025-03-05 at 16-08-56 Child pipelines](https://github.com/user-attachments/assets/1e1ba347-e311-4284-82c6-6fdd1325884a)
![Screenshot 2025-03-05 at 16-09-17 Child pipelines](https://github.com/user-attachments/assets/9b7c006f-7376-4101-ac6a-c810d2ce1a9f)

2. Updates the child pipeline table style to handle various viewport heights with the proper scrolling and sticky table header

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
