### PR TITLE
fix: Sets links to open in new tab/window

### DIFF
--- a/app/components/pipeline/header/template.hbs
+++ b/app/components/pipeline/header/template.hbs
@@ -15,6 +15,7 @@
         class="header-item"
         @route="v2.pipeline"
         @model={{this.pipeline.configPipelineId}}
+        target="_blank"
       >
         <FaIcon @icon="gear" />
         Parent Pipeline
@@ -38,6 +39,7 @@
       id="scm-link"
       href="{{branch-url-encode this.pipeline.scmRepo.url}}"
       class="header-item scm"
+      target="_blank"
     >
       <FaIcon @icon={{this.scmContext.scmIcon}} @prefix="fab" />
       {{this.scmContext.scm}}


### PR DESCRIPTION
## Context
The links in the pipeline header component should open in a new tab/window rather than using the same window.  There's a link to sonarqube already that opens in a new tab/window so keeping the same expectations for the other links makes the most sense.

## Objective
Sets the target on the header links to open in a new tab/window

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
