### PR TITLE
feat: Child pipeline route

### DIFF
--- a/app/components/pipeline/nav/component.js
+++ b/app/components/pipeline/nav/component.js
@@ -1,0 +1,10 @@
+import Component from '@glimmer/component';
+import { service } from '@ember/service';
+
+export default class PipelineNavComponent extends Component {
+  @service pipelinePageState;
+
+  get hasChildPipelines() {
+    return !!this.pipelinePageState.getPipeline().childPipelines;
+  }
+}

--- a/app/components/pipeline/nav/template.hbs
+++ b/app/components/pipeline/nav/template.hbs
@@ -2,6 +2,11 @@
   <LinkTo @route="v2.pipeline.events" title="Events">
     <FaIcon @icon="cubes" @size="16x" />
   </LinkTo>
+  {{#if this.hasChildPipelines}}
+    <LinkTo @route="v2.pipeline.child-pipelines" title="Child pipelines">
+      <FaIcon @icon="sitemap" @size="16x" />
+    </LinkTo>
+  {{/if}}
   <LinkTo @route="v2.pipeline.secrets" title="Secrets">
     <FaIcon @icon="key" @size="16x" />
   </LinkTo>

--- a/app/router.js
+++ b/app/router.js
@@ -134,7 +134,7 @@ Router.map(function route() {
         this.route('secrets');
         this.route('options');
         this.route('metrics');
-
+        this.route('child-pipelines');
         this.route('events', function eventsRoute() {
           this.route('show', { path: '/:event_id' });
         });

--- a/app/v2/pipeline/child-pipelines/route.js
+++ b/app/v2/pipeline/child-pipelines/route.js
@@ -1,0 +1,26 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class V2PipelineChildPipelinesRoute extends Route {
+  @service shuttle;
+
+  @service pipelinePageState;
+
+  beforeModel() {
+    const pipeline = this.pipelinePageState.getPipeline();
+
+    if (!pipeline.childPipelines) {
+      this.replaceWith('v2.pipeline.events.index');
+    }
+  }
+
+  async model() {
+    const pipelineId = this.pipelinePageState.getPipelineId();
+
+    await this.shuttle
+      .fetchFromApi('get', `/pipelines?configPipelineId=${pipelineId}`)
+      .then(pipelines => {
+        this.pipelinePageState.setChildPipelines(pipelines);
+      });
+  }
+}

--- a/app/v2/pipeline/child-pipelines/template.hbs
+++ b/app/v2/pipeline/child-pipelines/template.hbs
@@ -1,0 +1,3 @@
+{{page-title "Child pipelines"}}
+
+<Pipeline::Children />

--- a/app/v2/pipeline/index/route.js
+++ b/app/v2/pipeline/index/route.js
@@ -4,13 +4,7 @@ import { service } from '@ember/service';
 export default class NewPipelineIndexRoute extends Route {
   @service router;
 
-  @service pipelinePageState;
-
   beforeModel() {
-    if (this.pipelinePageState.getPipeline().childPipelines) {
-      this.router.replaceWith('pipeline.child-pipelines');
-    } else {
-      this.router.replaceWith('v2.pipeline.events');
-    }
+    this.router.replaceWith('v2.pipeline.events');
   }
 }

--- a/tests/integration/components/pipeline/nav/component-test.js
+++ b/tests/integration/components/pipeline/nav/component-test.js
@@ -2,13 +2,30 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
 
 module('Integration | Component | pipeline/nav', function (hooks) {
   setupRenderingTest(hooks);
 
   test('it renders', async function (assert) {
+    const pipelinePageState = this.owner.lookup('service:pipeline-page-state');
+
+    sinon.stub(pipelinePageState, 'getPipeline').returns({});
+
     await render(hbs`<Pipeline::Nav />`);
 
     assert.dom('#pipeline-nav a').exists({ count: 4 });
+  });
+
+  test('it renders link to child pipelines', async function (assert) {
+    const pipelinePageState = this.owner.lookup('service:pipeline-page-state');
+
+    sinon
+      .stub(pipelinePageState, 'getPipeline')
+      .returns({ childPipelines: [{ id: 1 }] });
+
+    await render(hbs`<Pipeline::Nav />`);
+
+    assert.dom('#pipeline-nav a').exists({ count: 5 });
   });
 });

--- a/tests/unit/v2/pipeline/child-pipelines/route-test.js
+++ b/tests/unit/v2/pipeline/child-pipelines/route-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
+
+module('Unit | Route | v2/pipeline/children', function (hooks) {
+  setupTest(hooks);
+
+  test('it exists', function (assert) {
+    let route = this.owner.lookup('route:v2/pipeline/child-pipelines');
+
+    assert.ok(route);
+  });
+});


### PR DESCRIPTION
## Context
Adds in the proper V2 route for child pipelines.  

**Requires the glimmer component from https://github.com/screwdriver-cd/ui/pull/1360 and therefore should be merged after https://github.com/screwdriver-cd/ui/pull/1360**

## Objective
1. Adds the proper route for the v2 child pipeline page
2. Adds a navigation icon to the left-side navbar to the child pipeline page if the pipeline is a parent pipeline
![Screenshot 2025-03-05 at 17-25-24 screwdriver cd](https://github.com/user-attachments/assets/8a258cab-4ab2-4f09-9368-18f3dea6d2b0)

## References
https://github.com/screwdriver-cd/ui/pull/1360
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
