### PR TITLE
feat: Create modal for restart/stop build in build detail page

### DIFF
--- a/app/components/build-banner/component.js
+++ b/app/components/build-banner/component.js
@@ -20,6 +20,7 @@ export default Component.extend({
   classNames: ['build-banner', 'grid'],
   classNameBindings: ['buildStatus'],
   shouldSkipNextNotify: false,
+  showBuildActionModal: false,
   coverage: service(),
   coverageInfo: {},
   coverageStep: computed('buildSteps', {
@@ -321,12 +322,21 @@ export default Component.extend({
       this.changeBuild(targetPr.event.pipelineId, targetPr.build.id);
     },
 
-    buildButtonClick() {
+    buildActionButtonClick() {
+      this.set('showBuildActionModal', false);
       if (this.buildAction === 'Stop') {
         this.onStop();
       } else {
         this.onStart();
       }
+    },
+
+    openBuildActionModal() {
+      this.set('showBuildActionModal', true);
+    },
+
+    closeBuildActionModal() {
+      this.set('showBuildActionModal', false);
     }
   }
 });

--- a/app/components/build-banner/template.hbs
+++ b/app/components/build-banner/template.hbs
@@ -219,7 +219,7 @@
           </button>
         </div>
         <div class="col-6 right">
-           <button class="build-action-no" {{action "closeBuildActionModal"}}>
+          <button class="build-action-no" {{action "closeBuildActionModal"}}>
             No
           </button>
         </div>

--- a/app/components/build-banner/template.hbs
+++ b/app/components/build-banner/template.hbs
@@ -178,12 +178,54 @@
   <li class="call-to-action button-right">
     {{#if this.isAuthenticated}}
       <BsButton
-        @onClick={{action "buildButtonClick"}}
+        @onClick={{action "openBuildActionModal"}}
         @outline={{true}}
         disabled={{or (await this.isButtonDisabled) (not this.isButtonDisabledLoaded)}}
       >
         {{this.buildAction}}
       </BsButton>
+      {{#if this.showBuildActionModal}}
+      <ModalDialog
+        @targetAttachment="center"
+        @translucentOverlay={{true}}
+        @containerClass="detached-confirm-dialog"
+      >
+        <h3>
+          Are you sure to {{this.buildAction}}?
+        </h3>
+        {{#if (eq this.buildAction 'Restart')}}
+        <div class="job-info">
+          <p>
+            Job:
+            <code>
+              {{this.jobName}}
+            </code>
+          <br />
+            Commit:
+            <code>
+              {{this.event.truncatedMessage}}
+            </code>
+            <a href={{this.event.commit.url}}>
+              #{{this.event.truncatedSha}}
+            </a>
+          <br />
+          </p>
+        </div>
+        {{/if}}
+      <div class="row confirm-button">
+        <div class="col-6">
+          <button class="build-action-yes" {{action "buildActionButtonClick"}}>
+            Yes
+          </button>
+        </div>
+        <div class="col-6 right">
+           <button class="build-action-no" {{action "closeBuildActionModal"}}>
+            No
+          </button>
+        </div>
+      </div>
+      </ModalDialog>
+      {{/if}}
     {{/if}}
   </li>
 </ul> 

--- a/tests/integration/components/build-banner/component-test.js
+++ b/tests/integration/components/build-banner/component-test.js
@@ -399,7 +399,7 @@ module('Integration | Component | build banner', function (hooks) {
   });
 
   test('it renders a stop button for running job when authenticated', async function (assert) {
-    assert.expect(9);
+    assert.expect(10);
     this.set('willRender', () => {
       console.log('will render');
       assert.ok(true);
@@ -438,7 +438,7 @@ module('Integration | Component | build banner', function (hooks) {
   });
 
   test('it renders a stop button for running disabled job when authenticated', async function (assert) {
-    assert.expect(10);
+    assert.expect(11);
     this.set('willRender', () => {
       assert.ok(true);
     });
@@ -477,7 +477,7 @@ module('Integration | Component | build banner', function (hooks) {
   });
 
   test('it renders a stop button for blocked job when authenticated', async function (assert) {
-    assert.expect(9);
+    assert.expect(10);
     this.set('willRender', () => {
       assert.ok(true);
     });

--- a/tests/integration/components/build-banner/component-test.js
+++ b/tests/integration/components/build-banner/component-test.js
@@ -324,7 +324,7 @@ module('Integration | Component | build banner', function (hooks) {
   });
 
   test('it renders a restart button for completed jobs when authenticated', async function (assert) {
-    assert.expect(4);
+    assert.expect(7);
 
     const reloadBuildSpy = sinon.spy();
 
@@ -357,6 +357,10 @@ module('Integration | Component | build banner', function (hooks) {
     assert.dom('.clicks-disabled').doesNotExist();
     assert.notOk(reloadBuildSpy.called);
     await click('button');
+    assert.dom('.ember-modal-dialog').exists({ count: 1 });
+    assert.dom('.job-info').hasText('Job: PR-671 Commit: Merge it #abcdef1');
+    await click('button.build-action-yes');
+    assert.dom('.ember-modal-dialog').doesNotExist();
   });
 
   test('it renders a disabled restart button for completed disabled jobs when authenticated', async function (assert) {
@@ -395,7 +399,7 @@ module('Integration | Component | build banner', function (hooks) {
   });
 
   test('it renders a stop button for running job when authenticated', async function (assert) {
-    assert.expect(6);
+    assert.expect(9);
     this.set('willRender', () => {
       console.log('will render');
       assert.ok(true);
@@ -427,10 +431,14 @@ module('Integration | Component | build banner', function (hooks) {
 
     assert.dom('button').hasText('Stop');
     await click('button');
+    assert.dom('.ember-modal-dialog').exists({ count: 1 });
+    assert.dom('.job-info').doesNotExist();
+    await click('button.build-action-yes');
+    assert.dom('.ember-modal-dialog').doesNotExist();
   });
 
   test('it renders a stop button for running disabled job when authenticated', async function (assert) {
-    assert.expect(7);
+    assert.expect(10);
     this.set('willRender', () => {
       assert.ok(true);
     });
@@ -462,10 +470,14 @@ module('Integration | Component | build banner', function (hooks) {
     assert.dom('button').hasText('Stop');
     assert.dom('.clicks-disabled').doesNotExist();
     await click('button');
+    assert.dom('.ember-modal-dialog').exists({ count: 1 });
+    assert.dom('.job-info').doesNotExist();
+    await click('button.build-action-yes');
+    assert.dom('.ember-modal-dialog').doesNotExist();
   });
 
   test('it renders a stop button for blocked job when authenticated', async function (assert) {
-    assert.expect(6);
+    assert.expect(9);
     this.set('willRender', () => {
       assert.ok(true);
     });
@@ -496,6 +508,10 @@ module('Integration | Component | build banner', function (hooks) {
 
     assert.dom('button').hasText('Stop');
     await click('button');
+    assert.dom('.ember-modal-dialog').exists({ count: 1 });
+    assert.dom('.job-info').doesNotExist();
+    await click('button.build-action-yes');
+    assert.dom('.ember-modal-dialog').doesNotExist();
   });
 
   test('it renders coverage info if coverage step finished', async function (assert) {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Users want to confirm restart/stop build when clicking button in the build detail page.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Add modal to confirm restart/stop build in the build detail page.
![modal](https://github.com/user-attachments/assets/5a9ffd9c-edb0-4750-bc2d-06deb8d6176f)


## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
