### PR TITLE
fix: apply css to modal button in build detail page

### DIFF
--- a/app/components/build-banner/template.hbs
+++ b/app/components/build-banner/template.hbs
@@ -214,12 +214,12 @@
         {{/if}}
       <div class="row confirm-button">
         <div class="col-6">
-          <button class="build-action-yes" {{action "buildActionButtonClick"}}>
+          <button class="d-button is-primary build-action-yes" {{action "buildActionButtonClick"}}>
             Yes
           </button>
         </div>
         <div class="col-6 right">
-          <button class="build-action-no" {{action "closeBuildActionModal"}}>
+          <button class="d-button is-secondary build-action-no" {{action "closeBuildActionModal"}}>
             No
           </button>
         </div>


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Follow up #1363 
To apply css to the button in the build detail page modal, add classes to the button.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Apply the same css as the workflow graph tooltip start modal.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
