### PR TITLE
fix(3238): Stages border is missing when visiting pipeline from Collection

### DIFF
--- a/app/pipeline/events/route.js
+++ b/app/pipeline/events/route.js
@@ -62,7 +62,7 @@ export default Route.extend({
 
     return RSVP.hash({
       jobs: this.get('pipeline.jobs'),
-      stages: this.get('pipeline.stages'),
+      stages: this.shuttle.fetchStages(pipelineId),
       events: this.store.query('event', {
         pipelineId,
         page: 1,


### PR DESCRIPTION
## Context

When a user navigates to a pipeline that has stages, the stages are being not rendered in the workflow graph.
After loading the pipeline model, EmberData fails to load its relationships/links (jobs, stages). Since the stage metadata is missing, the stages are not rendered in the workflow graph.
<img width="1721" alt="image" src="https://github.com/user-attachments/assets/fa051696-b14d-43a7-9e77-5152b1103431" />


## Objective

This PR fetches the stages for a pipeline by directly making the request to the backend without using EmberData.
<img width="1722" alt="image" src="https://github.com/user-attachments/assets/e9eb97d8-7732-4f3f-a7d5-c19c0d1ab3e5" />


## References

https://github.com/screwdriver-cd/screwdriver/issues/3238

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
