### PR TITLE
feat: V2 opt in

### DIFF
--- a/app/components/app-header/component.js
+++ b/app/components/app-header/component.js
@@ -61,8 +61,10 @@ export default Component.extend({
         if (targetURL.includes('pulls')) {
           targetURL = `${targetURL.split('pulls/')[0]}pulls`;
         }
+        localStorage.removeItem('newUI');
       } else {
         targetURL = `/v2${currentURL}`;
+        localStorage.setItem('newUI', 'true');
       }
 
       this.router.transitionTo(targetURL);

--- a/app/components/app-header/component.js
+++ b/app/components/app-header/component.js
@@ -2,11 +2,11 @@ import Component from '@ember/component';
 import ENV from 'screwdriver-ui/config/environment';
 import { computed, get } from '@ember/object';
 import { inject as service } from '@ember/service';
-import { getOwner } from '@ember/application';
 
 export default Component.extend({
   router: service(),
   session: service(),
+  optInRouteMapping: service(),
   tagName: 'header',
   showSearch: false,
   docUrl: ENV.APP.SDDOC_URL,
@@ -17,23 +17,20 @@ export default Component.extend({
     get() {
       const currentURL = get(this, 'router.currentURL');
 
-      return currentURL.includes('/v2/');
+      return currentURL.startsWith('/v2');
     }
   }),
-  hasAlternativeRoute: computed('isNewUI', 'router.currentRouteName', {
-    get() {
-      const routeName = this.router.currentRouteName;
+  hasAlternativeRoute: computed(
+    'router.currentRouteName',
+    'optInRouteMapping.routeMappings',
+    {
+      get() {
+        const routeName = this.router.currentRouteName;
 
-      let alterRouteName = `v2.${this.router.currentRouteName}`;
-
-      if (this.isNewUI) {
-        // to remove v2. prefix
-        alterRouteName = routeName.slice(3);
+        return this.optInRouteMapping.routeMappings.has(routeName);
       }
-
-      return getOwner(this).lookup(`route:${alterRouteName}`);
     }
-  }),
+  ),
   actions: {
     invalidateSession() {
       this.onInvalidate();
@@ -56,10 +53,16 @@ export default Component.extend({
     switchUI() {
       const currentURL = get(this, 'router.currentURL');
 
-      let targetURL = `/v2${currentURL}`;
+      let targetURL = currentURL;
 
       if (this.isNewUI) {
-        targetURL = currentURL.split('/v2/').join('/');
+        targetURL = currentURL.replace('/v2/', '/');
+
+        if (targetURL.includes('pulls')) {
+          targetURL = `${targetURL.split('pulls/')[0]}pulls`;
+        }
+      } else {
+        targetURL = `/v2${currentURL}`;
       }
 
       this.router.transitionTo(targetURL);

--- a/app/opt-in-route-mapping/service.js
+++ b/app/opt-in-route-mapping/service.js
@@ -1,0 +1,28 @@
+import Service from '@ember/service';
+
+export default class OptInRouteMappingService extends Service {
+  routeMappings;
+
+  constructor() {
+    super(...arguments);
+
+    this.routeMappings = new Map();
+
+    this.routeMappings.set(
+      'pipeline.child-pipelines',
+      'v2.pipeline.child-pipelines'
+    );
+    this.routeMappings.set(
+      'v2.pipeline.child-pipelines',
+      'pipeline.child-pipelines'
+    );
+    this.routeMappings.set('pipeline.jobs.index', 'v2.pipeline.jobs');
+    this.routeMappings.set('v2.pipeline.jobs', 'pipeline.jobs.index');
+
+    this.routeMappings.set('pipeline.events.show', 'v2.pipeline.events.show');
+    this.routeMappings.set('v2.pipeline.events.show', 'pipeline.events.show');
+
+    this.routeMappings.set('pipeline.pulls', 'v2.pipeline.pulls.show');
+    this.routeMappings.set('v2.pipeline.pulls.show', 'pipeline.pulls');
+  }
+}

--- a/app/pipeline/child-pipelines/route.js
+++ b/app/pipeline/child-pipelines/route.js
@@ -7,6 +7,13 @@ export default Route.extend({
   router: service(),
   store: service(),
   routeAfterAuthentication: 'pipeline.child-pipelines',
+  beforeModel() {
+    const { pipeline } = this.modelFor('pipeline');
+
+    if (localStorage.getItem('newUI') === 'true') {
+      this.router.transitionTo('v2.pipeline.child-pipelines', pipeline.id);
+    }
+  },
   model() {
     // Guests should not access this page
     if (get(this, 'session.data.authenticated.isGuest')) {

--- a/app/pipeline/events/route.js
+++ b/app/pipeline/events/route.js
@@ -13,8 +13,18 @@ export default Route.extend({
   routeAfterAuthentication: 'pipeline.events',
   pipelineService: service('pipeline'),
   userSettings: service(),
-  beforeModel() {
-    this.set('pipeline', this.modelFor('pipeline').pipeline);
+  beforeModel(transition) {
+    const { pipeline } = this.modelFor('pipeline');
+
+    if (localStorage.getItem('newUI') === 'true') {
+      if (transition.intent.URL) {
+        this.transitionTo(`/v2${transition.intent.URL}`);
+      } else {
+        this.transitionTo('v2.pipeline.events', pipeline.id);
+      }
+    } else {
+      this.set('pipeline', pipeline);
+    }
   },
   setupController(controller, model = {}) {
     this._super(controller, model);

--- a/app/pipeline/jobs/index/route.js
+++ b/app/pipeline/jobs/index/route.js
@@ -12,7 +12,13 @@ export default Route.extend(AuthenticatedRouteMixin, {
   routeAfterAuthentication: 'pipeline.jobs.index',
   pipelineService: service('pipeline'),
   beforeModel() {
-    this.set('pipeline', this.modelFor('pipeline').pipeline);
+    const { pipeline } = this.modelFor('pipeline');
+
+    if (localStorage.getItem('newUI') === 'true') {
+      this.transitionTo('v2.pipeline.jobs', pipeline.id);
+    } else {
+      this.set('pipeline', pipeline);
+    }
   },
   setupController(controller, model) {
     this._super(controller, model);

--- a/app/pipeline/pulls/route.js
+++ b/app/pipeline/pulls/route.js
@@ -15,6 +15,15 @@ export default EventsRoute.extend({
     });
     this.pipelineService.setBuildsLink('pipeline.pulls');
   },
+  beforeModel() {
+    if (localStorage.getItem('newUI') === 'true') {
+      this.transitionTo('v2.pipeline.pulls', this.get('pipeline.id'));
+    } else {
+      const { pipeline } = this.modelFor('pipeline');
+
+      this.set('pipeline', pipeline);
+    }
+  },
   async model() {
     const pipelineId = this.get('pipeline.id');
     const pipelineEventsController = this.controllerFor('pipeline.events');

--- a/tests/unit/opt-in-route-mapping/service-test.js
+++ b/tests/unit/opt-in-route-mapping/service-test.js
@@ -1,0 +1,13 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
+
+module('Unit | Service | optInRouteMapping', function (hooks) {
+  setupTest(hooks);
+
+  // TODO: Replace this with your real tests.
+  test('it exists', function (assert) {
+    let service = this.owner.lookup('service:opt-in-route-mapping');
+
+    assert.ok(service);
+  });
+});


### PR DESCRIPTION
## Context
The new V2 UI should have the ability to be opt in so that users will always hit the V2 UI.  As part of an opt-in flow, all of the existing routes that have a V2 UI should be redirected to the respective destinations.  When a user decides to opt-out of the V2 UI, then the existing routes should be made available (as well as all of the V2 pages if the user goes directly to those pages).

## Objective
1. Creates a route mapping going between the different UI routes.  Since there are some differences in the actual routes, this mapping will be manually maintained until the old routes are fully retired.
2. Leverage local storage to keep the state of the user's opt-in of the V2 UI.  While this will mean users need to reconfigure the UI setting per browser/device, this should be fine in the interim as most users should be using a single browser on a single device.  Additionally, this is mostly a temporary solution while the remaining V2 UI components and pages are introduced.
3. Sets up the needed beforeModel hooks to direct users to the V2 pages if they have opted-in

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
