### PR TITLE
fix: Drop router injection

### DIFF
--- a/app/v2/pipeline/index/route.js
+++ b/app/v2/pipeline/index/route.js
@@ -1,10 +1,7 @@
 import Route from '@ember/routing/route';
-import { service } from '@ember/service';
 
 export default class NewPipelineIndexRoute extends Route {
-  @service router;
-
   beforeModel() {
-    this.router.replaceWith('v2.pipeline.events');
+    this.replaceWith('v2.pipeline.events');
   }
 }


### PR DESCRIPTION
## Context
The router injection can be dropped on the route as the route class has a needed functionality to handle redirects.

## Objective
Removes the unnecessary injection of the router service.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
