### PR TITLE
fix: Add mapping for core event route

### DIFF
--- a/app/opt-in-route-mapping/service.js
+++ b/app/opt-in-route-mapping/service.js
@@ -22,6 +22,9 @@ export default class OptInRouteMappingService extends Service {
     this.routeMappings.set('pipeline.events.show', 'v2.pipeline.events.show');
     this.routeMappings.set('v2.pipeline.events.show', 'pipeline.events.show');
 
+    this.routeMappings.set('pipeline.events.index', 'v2.pipeline.events.index');
+    this.routeMappings.set('v2.pipeline.events.index', 'pipeline.events.index');
+
     this.routeMappings.set('pipeline.pulls', 'v2.pipeline.pulls.show');
     this.routeMappings.set('v2.pipeline.pulls.show', 'pipeline.pulls');
   }


### PR DESCRIPTION
## Context
When a pipeline does not have any events, the event index route is used and needs to be mapped for the v2 UI opt-in.

## Objective
Adds the missing event index route mapping for v2 UI opt-in

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
