### PR TITLE
fix: Fix logic for displaying job start/restart tooltip

### DIFF
--- a/app/components/pipeline/workflow/tooltip/component.js
+++ b/app/components/pipeline/workflow/tooltip/component.js
@@ -49,10 +49,7 @@ export default class PipelineWorkflowTooltipComponent extends Component {
   }
 
   get displayRestartButton() {
-    const canRestartPipeline =
-      this.session.isAuthenticated && isActivePipeline(this.pipeline);
-
-    return canRestartPipeline && !this.tooltipData.job.stageName;
+    return this.session.isAuthenticated && isActivePipeline(this.pipeline);
   }
 
   get canJobStartFromView() {


### PR DESCRIPTION
## Context
There's some aggressive logic in the v2 UI that prevents jobs that are included in a stage to have the tooltip option to start/restart.  This logic should be relaxed to allow those jobs to have the ability to start/restart if needed.

## Objective
Removes the check that a job can not be part of a stage in order to be started/restarted

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
