### PR TITLE
fix: Drop query parameter for now

### DIFF
--- a/app/v2/pipeline/events/index/route.js
+++ b/app/v2/pipeline/events/index/route.js
@@ -11,7 +11,8 @@ export default class NewPipelineEventsIndexRoute extends Route {
     const pipelineId = this.pipelinePageState.getPipelineId();
 
     const latestEvent = await this.shuttle
-      .fetchFromApi('get', `/pipelines/${pipelineId}/events?count=1`)
+      // TODO: Add the count=1 query parameter back in when the API bug is resolved -> https://github.com/screwdriver-cd/screwdriver/issues/3308
+      .fetchFromApi('get', `/pipelines/${pipelineId}/events`)
       .then(events => {
         return events[0];
       });


### PR DESCRIPTION
## Context
There's a bug with the pipeline events API that causes the endpoint to be slow/unresponsive when the `count` query parameter is set: https://github.com/screwdriver-cd/screwdriver/issues/3308

The API is fine when the `count` query parameter is not set, so temporarily it will be a better trade-off to have a larger response payload for the quick API response.

## Objective
Remove the `count` query parameter due to the API issue.  Add in a TODO item to add the query parameter back in when the API issue is fixed.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3308

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
