### PR TITLE
feat: Include truncated sha in tooltip

### DIFF
--- a/app/components/pipeline/jobs/table/cell/history/component.js
+++ b/app/components/pipeline/jobs/table/cell/history/component.js
@@ -21,4 +21,8 @@ export default class PipelineJobsTableCellHistoryComponent extends Component {
 
     this.args.record.onDestroy(this.args.record.job);
   }
+
+  truncateSha(build) {
+    return build.meta.build.sha.slice(0, 7);
+  }
 }

--- a/app/components/pipeline/jobs/table/cell/history/template.hbs
+++ b/app/components/pipeline/jobs/table/cell/history/template.hbs
@@ -20,6 +20,7 @@
               class="tooltip"
             >
               <p>Build# {{build.id}}</p>
+              <p>SHA - {{this.truncateSha build}}</p>
               {{#if build.startTime}}
                 <p>Start - {{moment-format build.startTime "MM/DD/YYYY HH:mmA"}}</p>
               {{/if}}

--- a/tests/integration/components/pipeline/jobs/table/cell/history/component-test.js
+++ b/tests/integration/components/pipeline/jobs/table/cell/history/component-test.js
@@ -85,7 +85,12 @@ module(
           id: 999,
           status: 'SUCCESS',
           startTime: '2024-07-14T17:25:57.671Z',
-          endTime: '2024-07-14T17:26:55.202Z'
+          endTime: '2024-07-14T17:26:55.202Z',
+          meta: {
+            build: {
+              sha: 'abcdefgh0123456789'
+            }
+          }
         }
       ];
 


### PR DESCRIPTION
## Context
The tooltip for the job history could be improved by also including the commit SHA to help further differentiate the builds

## Objective
Adds in the commit SHA into the tooltip in the build history of the jobs table
<img width="1979" alt="Screenshot 2025-03-17 at 2 04 57 PM" src="https://github.com/user-attachments/assets/1cc575f2-21b7-422e-b8c3-7d1af95ef454" />

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
