### PR TITLE
feat: Creates an injectable service for banners

### DIFF
--- a/app/banners/service.js
+++ b/app/banners/service.js
@@ -1,0 +1,57 @@
+import Service, { service } from '@ember/service';
+
+export default class BannersService extends Service {
+  @service shuttle;
+
+  globalBanners;
+
+  pipelineBanners;
+
+  displayingBanners;
+
+  bannerCallback;
+
+  constructor() {
+    super(...arguments);
+
+    this.pipelineBanners = new Map();
+  }
+
+  registerCallback(callback) {
+    this.bannerCallback = callback;
+  }
+
+  async getGlobalBanners() {
+    if (!this.globalBanners) {
+      await this.shuttle
+        .fetchFromApi('get', '/banners?isActive=true&scope=GLOBAL')
+        .then(banners => {
+          this.globalBanners = banners;
+          this.displayingBanners = banners;
+        });
+    }
+    if (!this.displayingBanners) {
+      this.displayingBanners = this.globalBanners;
+    }
+
+    this.bannerCallback(this.displayingBanners);
+  }
+
+  async getPipelineBanners(pipelineId) {
+    const pipelineBanners = this.pipelineBanners.has(pipelineId)
+      ? this.pipelineBanners.get(pipelineId)
+      : await this.shuttle
+          .fetchFromApi(
+            'get',
+            `/banners?isActive=true&scope=PIPELINE&scopeId=${pipelineId}`
+          )
+          .then(banners => {
+            this.pipelineBanners.set(pipelineId, banners);
+
+            return banners;
+          });
+
+    this.displayingBanners = pipelineBanners.concat(this.globalBanners);
+    this.bannerCallback(this.displayingBanners);
+  }
+}

--- a/tests/unit/banners/service-test.js
+++ b/tests/unit/banners/service-test.js
@@ -1,0 +1,108 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
+import sinon from 'sinon';
+
+module('Unit | Service | banners', function (hooks) {
+  setupTest(hooks);
+
+  let shuttle;
+
+  let service;
+
+  let spyCallback;
+
+  hooks.beforeEach(function () {
+    shuttle = this.owner.lookup('service:shuttle');
+    service = this.owner.lookup('service:banners');
+    spyCallback = sinon.spy();
+
+    service.registerCallback(spyCallback);
+  });
+
+  test('it exists', function (assert) {
+    assert.ok(service);
+  });
+
+  test('it sets callback correct', async function (assert) {
+    assert.equal(service.bannerCallback, spyCallback);
+  });
+
+  test('it gets global banners and returns them in the callback', async function (assert) {
+    const mockBanners = [
+      {
+        message: 'test message'
+      }
+    ];
+
+    sinon.stub(shuttle, 'fetchFromApi').resolves(mockBanners);
+
+    await service.getGlobalBanners();
+
+    assert.equal(service.globalBanners, mockBanners);
+    assert.equal(service.displayingBanners, mockBanners);
+    assert.equal(spyCallback.calledOnce, true);
+    assert.equal(spyCallback.calledWith(service.displayingBanners), true);
+  });
+
+  test('it returns global banners without re-fetching them in the callback', async function (assert) {
+    const mockBanners = [
+      {
+        message: 'test message'
+      }
+    ];
+
+    service.globalBanners = mockBanners;
+    await service.getGlobalBanners();
+
+    assert.equal(service.globalBanners, mockBanners);
+    assert.equal(service.displayingBanners, mockBanners);
+    assert.equal(spyCallback.calledOnce, true);
+    assert.equal(spyCallback.calledWith(service.displayingBanners), true);
+  });
+
+  test('it gets pipeline banners and returns them in the callback', async function (assert) {
+    const pipelineId = 123;
+    const mockBanners = [
+      {
+        message: 'test message'
+      }
+    ];
+
+    sinon.stub(shuttle, 'fetchFromApi').resolves(mockBanners);
+    service.globalBanners = [];
+
+    await service.getPipelineBanners(pipelineId);
+
+    const { displayingBanners } = service;
+
+    assert.equal(spyCallback.calledOnce, true);
+    assert.equal(spyCallback.calledWith(displayingBanners), true);
+    assert.equal(service.pipelineBanners.get(pipelineId), mockBanners);
+    assert.equal(service.displayingBanners.length, 1);
+  });
+
+  test('it returns pipeline banners and global banners in the callback', async function (assert) {
+    const pipelineId = 123;
+    const mockBanners = [
+      {
+        message: 'test message'
+      }
+    ];
+
+    sinon.stub(shuttle, 'fetchFromApi').resolves(mockBanners);
+    service.globalBanners = [
+      {
+        message: 'global banner'
+      }
+    ];
+
+    await service.getPipelineBanners(pipelineId);
+
+    const { displayingBanners } = service;
+
+    assert.equal(spyCallback.calledOnce, true);
+    assert.equal(spyCallback.calledWith(displayingBanners), true);
+    assert.equal(service.displayingBanners.length, 2);
+    assert.equal(service.displayingBanners[0].message, mockBanners[0].message);
+  });
+});


### PR DESCRIPTION
## Context
Banners exist in 2 flavors, global and pipeline.  The location of all banners exists under the page navigation header, but the current implementations leaves a lot to be desired due to not being able to handle multiple banners nicely (they are currently stacked one on top of another and takes up valuable page space.  The improve upon the existing banner design, a new injectable service for capturing all of the banners that should be displayed on a given page needs to be created so that the banner UI component can properly display the relevant banners in a user-friendly manner.  The end result will look as follows:
![Screenshot 2025-03-19 at 15-33-03](https://github.com/user-attachments/assets/1a69d320-f86b-42f6-b0f5-1b83d46fc8e2)
![Screenshot 2025-03-19 at 15-33-19](https://github.com/user-attachments/assets/895f4fa9-699c-468e-9af2-8e61eba80105)


## Objective
Creates an injectable service for fetching and caching banners relevant to the given page.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
