### PR TITLE
feat: Banners component

### DIFF
--- a/app/components/banners/component.js
+++ b/app/components/banners/component.js
@@ -1,0 +1,50 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+
+export default class BannersComponent extends Component {
+  @service banners;
+
+  @tracked bannersForDisplay;
+
+  @tracked displayingBanner;
+
+  @tracked bannerIndex = 0;
+
+  @action
+  async initializeBanners() {
+    this.banners.registerCallback(this.onBannersUpdated);
+
+    await this.banners.getGlobalBanners();
+  }
+
+  @action
+  getDisplayIndex() {
+    return this.bannerIndex + 1;
+  }
+
+  @action
+  onBannersUpdated(banners) {
+    this.bannersForDisplay = banners;
+    this.displayingBanner = banners[0];
+  }
+
+  @action
+  previousBanner() {
+    this.bannerIndex =
+      this.bannerIndex === 0
+        ? this.bannersForDisplay.length - 1
+        : this.bannerIndex - 1;
+    this.displayingBanner = this.bannersForDisplay[this.bannerIndex];
+  }
+
+  @action
+  nextBanner() {
+    this.bannerIndex =
+      this.bannerIndex === this.bannersForDisplay.length - 1
+        ? 0
+        : this.bannerIndex + 1;
+    this.displayingBanner = this.bannersForDisplay[this.bannerIndex];
+  }
+}

--- a/app/components/banners/styles.scss
+++ b/app/components/banners/styles.scss
@@ -1,0 +1,61 @@
+@use 'screwdriver-colors' as colors;
+@use 'variables';
+@use 'bootstrap-alert' as alert;
+@use 'screwdriver-button' as sdButton;
+
+@mixin styles {
+  #banners {
+    @include alert.styles;
+
+    .alert {
+      height: variables.$banners-height;
+      display: flex;
+      flex-direction: column;
+      margin: 0;
+      border: none;
+      border-radius: 0;
+
+      #banner {
+        display: flex;
+
+        svg {
+          margin-top: 0.175rem;
+          margin-right: 0.25rem;
+        }
+
+        .message {
+          height: 2.25rem;
+          overflow: auto;
+          padding-right: 5rem;
+        }
+      }
+
+      #banner-controls {
+        display: flex;
+        flex-direction: row-reverse;
+        font-size: 0.75rem;
+        height: 1rem;
+
+        @include sdButton.styles;
+
+        #next-banner,
+        #previous-banner {
+          display: flex;
+          width: 1rem;
+          border: none;
+          padding: 0;
+          color: colors.$sd-info-fg;
+
+          &:hover {
+            color: rgba(colors.$sd-info-fg, 0.75);
+            background-color: transparent;
+          }
+
+          svg {
+            margin: auto;
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/components/banners/template.hbs
+++ b/app/components/banners/template.hbs
@@ -1,0 +1,42 @@
+<div
+  id="banners"
+  {{did-insert this.initializeBanners}}
+>
+  {{#if this.displayingBanner}}
+    <BsAlert
+      @type="info"
+      @dismissible={{false}}
+    >
+      <div id="banner">
+        <FaIcon @icon="circle-info" />
+        <div class="message">
+          {{{input-sanitizer this.displayingBanner.message}}}
+        </div>
+      </div>
+
+      <div id="banner-controls">
+        <div id="banner-count">
+          {{this.getDisplayIndex}} of {{this.bannersForDisplay.length}}
+        </div>
+        {{#if (gt this.bannersForDisplay.length 1)}}
+          <BsButton
+            id="next-banner"
+            @type="primary"
+            @outline={{true}}
+            {{on "click" this.nextBanner}}
+          >
+            <FaIcon @icon="caret-right"/>
+          </BsButton>
+          <BsButton
+            id="previous-banner"
+            @type="primary"
+            @outline={{true}}
+            {{on "click" this.previousBanner}}
+          >
+            <FaIcon @icon="caret-left"/>
+          </BsButton>
+        {{/if}}
+      </div>
+    </BsAlert>
+  {{/if}}
+</div>

--- a/app/styles/bootstrap-alert.scss
+++ b/app/styles/bootstrap-alert.scss
@@ -1,0 +1,10 @@
+@use 'screwdriver-colors' as colors;
+
+@mixin styles {
+  .alert {
+    &.alert-info {
+      color: colors.$sd-info-fg;
+      background-color: colors.$sd-info-bg;
+    }
+  }
+}

--- a/tests/integration/components/banners/component-test.js
+++ b/tests/integration/components/banners/component-test.js
@@ -1,0 +1,115 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
+import { click, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | banners', function (hooks) {
+  setupRenderingTest(hooks);
+
+  let bannersService;
+
+  hooks.beforeEach(function () {
+    bannersService = this.owner.lookup('service:banners');
+  });
+
+  test('it renders', async function (assert) {
+    bannersService.globalBanners = [];
+
+    await render(hbs`<Banners />`);
+
+    assert.dom('#banners').exists({ count: 1 });
+    assert.dom('#banner').doesNotExist();
+  });
+
+  test('it renders single banner', async function (assert) {
+    bannersService.globalBanners = [{ message: 'abc' }];
+
+    await render(hbs`<Banners />`);
+
+    assert.dom('#banner').hasText('abc');
+    assert.dom('#banner-count').exists({ count: 1 });
+    assert.dom('#banner-count').hasText('1 of 1');
+  });
+
+  test('it renders banners', async function (assert) {
+    bannersService.globalBanners = [
+      {
+        message: 'abc'
+      },
+      {
+        message: '123'
+      }
+    ];
+
+    await render(hbs`<Banners />`);
+
+    assert.dom('#banner').hasText('abc');
+    assert.dom('#banner-count').exists({ count: 1 });
+    assert.dom('#banner-count').hasText('1 of 2');
+    assert.dom('#next-banner').exists({ count: 1 });
+    assert.dom('#previous-banner').exists({ count: 1 });
+  });
+
+  test('it cycles banners', async function (assert) {
+    const message1 = 'abc';
+    const message2 = '123';
+
+    bannersService.globalBanners = [
+      {
+        message: message1
+      },
+      {
+        message: message2
+      }
+    ];
+
+    await render(hbs`<Banners />`);
+    assert.dom('#banner').hasText(message1);
+    assert.dom('#banner-count').hasText('1 of 2');
+
+    await click('#next-banner');
+    assert.dom('#banner').hasText(message2);
+    assert.dom('#banner-count').hasText('2 of 2');
+
+    await click('#next-banner');
+    assert.dom('#banner').hasText(message1);
+    assert.dom('#banner-count').hasText('1 of 2');
+
+    await click('#previous-banner');
+    assert.dom('#banner').hasText(message2);
+    assert.dom('#banner-count').hasText('2 of 2');
+
+    await click('#previous-banner');
+    assert.dom('#banner').hasText(message1);
+    assert.dom('#banner-count').hasText('1 of 2');
+  });
+
+  test('it renders banner with image tag', async function (assert) {
+    bannersService.globalBanners = [
+      {
+        message: `Image tag: <img src="#notanimage" onerror="alert('unsafe script injection from warning!')" />`
+      }
+    ];
+
+    await render(hbs`<Banners />`);
+
+    assert.dom('.message').hasText('Image tag:');
+  });
+
+  test('it renders with link', async function (assert) {
+    bannersService.globalBanners = [
+      {
+        message: `test - <a href="https://docs.screwdriver.cd/" onclick="alert('xss test');">screwdriver docs</a>`
+      }
+    ];
+
+    await render(hbs`<Banners />`);
+
+    assert.dom('.message').hasText('test - screwdriver docs');
+    assert
+      .dom('.message > a')
+      .hasAttribute('href', 'https://docs.screwdriver.cd/');
+    assert.dom('.message > a').hasNoAttribute('rel');
+    assert.dom('.message > a').hasNoAttribute('onclick');
+  });
+});


### PR DESCRIPTION
## Context
Expanding on #1373, creates the actual Glimmer component for the banners that will be displayed below the page header.

Banners will now take up a little bit more vertical height, but will have a banner count at the bottom right corner.  Note that banners are no longer dismissible.  Dismissibility of the banners can be revisited in the future to properly design out the actual experience.
![Screenshot 2025-03-19 at 17-27-11 Dashboard](https://github.com/user-attachments/assets/f1dda47f-c30b-4159-ba03-ba2daee673e1)

When there are multiple banners, the bottom right will surface left and right arrows to allow users to switch through the available banner messages.
![Screenshot 2025-03-19 at 15-33-03](https://github.com/user-attachments/assets/7ffa2a33-c1ed-4267-8b2d-dacae3fd85c2)

For banner messages that are large, vertical scrolling is configured.  This is the other reason why the banners now take up additional vertical space.
![Screenshot 2025-03-19 at 15-33-19](https://github.com/user-attachments/assets/bbe17735-d8ef-48f5-a85a-034fd89b75f5)

## Objective
1. Creates a shared stylesheet that is super barebones for shared styles to theme bootstrap alert components with the right color palette.
2. Creates the Glimmer component for the new banners experience.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
