### PR TITLE
fix: Set query parameters for event API request

### DIFF
--- a/app/v2/pipeline/events/index/route.js
+++ b/app/v2/pipeline/events/index/route.js
@@ -11,8 +11,8 @@ export default class NewPipelineEventsIndexRoute extends Route {
     const pipelineId = this.pipelinePageState.getPipelineId();
 
     const latestEvent = await this.shuttle
-      // TODO: Add the count=1 query parameter back in when the API bug is resolved -> https://github.com/screwdriver-cd/screwdriver/issues/3308
-      .fetchFromApi('get', `/pipelines/${pipelineId}/events`)
+      // TODO: Change back to count=1 when the API bug is resolved -> https://github.com/screwdriver-cd/screwdriver/issues/3308
+      .fetchFromApi('get', `/pipelines/${pipelineId}/events?page=1&count=2`)
       .then(events => {
         return events[0];
       });

--- a/app/v2/pipeline/events/show/route.js
+++ b/app/v2/pipeline/events/show/route.js
@@ -25,7 +25,11 @@ export default class NewPipelineEventsShowRoute extends Route {
         .catch(async err => {
           if (err instanceof NotFoundError) {
             latestEvent = await this.shuttle
-              .fetchFromApi('get', `/pipelines/${pipelineId}/events?count=1`)
+              // TODO: Change back to count=1 when the API bug is resolved -> https://github.com/screwdriver-cd/screwdriver/issues/3308
+              .fetchFromApi(
+                'get',
+                `/pipelines/${pipelineId}/events?page=1&count=2`
+              )
               .then(events => {
                 return events[0];
               });


### PR DESCRIPTION
## Context
[Due to this issue with the event API](https://github.com/screwdriver-cd/screwdriver/issues/3308), setting a count value that isn't 1 doesn't have the same performance impact; thus, it would be better to set the query parameters to minimize the payload size while still having the API performance.

## Objective
Sets query parameters to avoid the API performance issue while minimizing the response payload.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3308

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
