### PR TITLE
Refactor stages to be injectable

### DIFF
--- a/app/components/pipeline/workflow/component.js
+++ b/app/components/pipeline/workflow/component.js
@@ -47,8 +47,6 @@ export default class PipelineWorkflowComponent extends Component {
 
   @tracked jobs;
 
-  @tracked stages;
-
   @tracked workflowGraphToDisplay;
 
   @tracked showGraph;
@@ -80,7 +78,6 @@ export default class PipelineWorkflowComponent extends Component {
       this.monitorForNewEvents();
     } else {
       this.jobs = this.args.jobs;
-      this.stages = this.args.stages;
 
       this.monitorForNewBuilds();
     }

--- a/app/components/pipeline/workflow/graph/component.js
+++ b/app/components/pipeline/workflow/graph/component.js
@@ -1,6 +1,7 @@
 /* global d3 */
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
+import { service } from '@ember/service';
 import { isSkipped } from 'screwdriver-ui/utils/pipeline/event';
 import { decorateGraph } from 'screwdriver-ui/utils/graph-tools';
 import {
@@ -20,6 +21,8 @@ import {
 import { nodeCanShowTooltip } from 'screwdriver-ui/utils/pipeline/graph/tooltip';
 
 export default class PipelineWorkflowGraphComponent extends Component {
+  @service pipelinePageState;
+
   event;
 
   builds;
@@ -55,7 +58,7 @@ export default class PipelineWorkflowGraphComponent extends Component {
       start: event.startFrom,
       chainPR: this.args.chainPr,
       prNum: event.prNum,
-      stages: this.args.stages
+      stages: this.pipelinePageState.getStages()
     });
   }
 
@@ -93,7 +96,7 @@ export default class PipelineWorkflowGraphComponent extends Component {
       onClickGraph
     );
 
-    const hasStages = this.args.stages.length > 0;
+    const hasStages = this.pipelinePageState.getStages().length > 0;
 
     // stages
     const { verticalDisplacements, horizontalDisplacements } = hasStages

--- a/app/components/pipeline/workflow/template.hbs
+++ b/app/components/pipeline/workflow/template.hbs
@@ -95,7 +95,6 @@
             @jobs={{this.jobs}}
             @builds={{this.builds}}
             @stageBuilds={{this.stageBuilds}}
-            @stages={{this.stages}}
             @chainPr={{this.pipeline.prChain}}
             @displayJobNameLength={{this.displayJobNameLength}}
             @setShowTooltip={{this.setShowTooltip}}

--- a/app/pipeline-page-state/service.js
+++ b/app/pipeline-page-state/service.js
@@ -7,10 +7,13 @@ export default class PipelinePageStateService extends Service {
 
   triggers;
 
+  stages;
+
   clear() {
     this.pipeline = null;
     this.childPipelines = [];
     this.triggers = [];
+    this.stages = [];
   }
 
   setPipeline(pipeline) {
@@ -39,5 +42,13 @@ export default class PipelinePageStateService extends Service {
 
   getTriggers() {
     return this.triggers;
+  }
+
+  setStages(stages) {
+    this.stages = stages;
+  }
+
+  getStages() {
+    return this.stages;
   }
 }

--- a/app/v2/pipeline/events/show/route.js
+++ b/app/v2/pipeline/events/show/route.js
@@ -46,10 +46,11 @@ export default class NewPipelineEventsShowRoute extends Route {
       `/pipelines/${pipelineId}/jobs?type=pipeline`
     );
 
-    const stages = await this.shuttle.fetchFromApi(
-      'get',
-      `/pipelines/${pipelineId}/stages`
-    );
+    await this.shuttle
+      .fetchFromApi('get', `/pipelines/${pipelineId}/stages`)
+      .then(stages => {
+        this.pipelinePageState.setStages(stages);
+      });
 
     await this.shuttle
       .fetchFromApi('get', `/pipelines/${pipelineId}/triggers`)
@@ -62,7 +63,6 @@ export default class NewPipelineEventsShowRoute extends Route {
       event,
       latestEvent,
       jobs,
-      stages,
       invalidEvent: event === null
     };
   }

--- a/app/v2/pipeline/events/show/template.hbs
+++ b/app/v2/pipeline/events/show/template.hbs
@@ -2,7 +2,6 @@
   @userSettings={{this.model.userSettings}}
   @event={{this.model.event}}
   @jobs={{this.model.jobs}}
-  @stages={{this.model.stages}}
   @latestEvent={{this.model.latestEvent}}
   @invalidEvent={{this.model.invalidEvent}}
   @reloadEventRail={{this.model.reloadEventRail}}

--- a/app/v2/pipeline/pulls/route.js
+++ b/app/v2/pipeline/pulls/route.js
@@ -14,10 +14,11 @@ export default class NewPipelinePullsRoute extends Route {
       '/users/settings'
     );
 
-    const stages = await this.shuttle.fetchFromApi(
-      'get',
-      `/pipelines/${pipelineId}/stages`
-    );
+    await this.shuttle
+      .fetchFromApi('get', `/pipelines/${pipelineId}/stages`)
+      .then(stages => {
+        this.pipelinePageState.setStages(stages);
+      });
 
     await this.shuttle
       .fetchFromApi('get', `/pipelines/${pipelineId}/triggers`)
@@ -32,7 +33,6 @@ export default class NewPipelinePullsRoute extends Route {
 
     return {
       userSettings,
-      stages,
       pullRequestJobs
     };
   }

--- a/app/v2/pipeline/pulls/show/template.hbs
+++ b/app/v2/pipeline/pulls/show/template.hbs
@@ -2,7 +2,6 @@
   @userSettings={{this.model.userSettings}}
   @event={{this.model.event}}
   @jobs={{this.model.jobs}}
-  @stages={{this.model.stages}}
   @latestEvent={{this.model.latestEvent}}
   @prNums={{this.model.prNums}}
   @invalidEvent={{this.model.invalidEvent}}

--- a/tests/integration/components/pipeline/workflow/graph/component-test.js
+++ b/tests/integration/components/pipeline/workflow/graph/component-test.js
@@ -2,9 +2,19 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render, rerender } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
 
 module('Integration | Component | pipeline/workflow/graph', function (hooks) {
   setupRenderingTest(hooks);
+
+  const stages = [];
+
+  hooks.beforeEach(function () {
+    const pipelinePageState = this.owner.lookup('service:pipeline-page-state');
+
+    stages.splice(0);
+    sinon.stub(pipelinePageState, 'getStages').returns(stages);
+  });
 
   test('it renders base graph', async function (assert) {
     this.setProperties({
@@ -15,7 +25,6 @@ module('Integration | Component | pipeline/workflow/graph', function (hooks) {
       event: { startFrom: '~commit' },
       jobs: [{ id: 1 }],
       builds: [{ id: 1, jobId: 1, status: 'SUCCESS' }],
-      stages: [],
       displayJobNameLength: 20
     });
     await render(
@@ -24,7 +33,6 @@ module('Integration | Component | pipeline/workflow/graph', function (hooks) {
             @event={{this.event}}
             @jobs={{this.jobs}}
             @builds={{this.builds}}
-            @stages={{this.stages}}
             @chainPr={{false}}
             @displayJobNameLength={{this.displayJobNameLength}}
       />`
@@ -46,7 +54,6 @@ module('Integration | Component | pipeline/workflow/graph', function (hooks) {
       event: { startFrom: nodeNames[0] },
       jobs: [{ id: 1 }],
       builds: [{ id: 1, jobId: 1, status: 'SUCCESS' }],
-      stages: [],
       displayJobNameLength: 25
     });
     await render(
@@ -55,7 +62,6 @@ module('Integration | Component | pipeline/workflow/graph', function (hooks) {
             @event={{this.event}}
             @jobs={{this.jobs}}
             @builds={{this.builds}}
-            @stages={{this.stages}}
             @chainPr={{false}}
             @displayJobNameLength={{this.displayJobNameLength}}
       />`
@@ -74,6 +80,8 @@ module('Integration | Component | pipeline/workflow/graph', function (hooks) {
   });
 
   test('it renders virtual stage', async function (assert) {
+    stages.push({ id: 10, name: 'test', jobIds: [1], setup: 11, teardown: 12 });
+
     this.setProperties({
       workflowGraph: {
         nodes: [
@@ -109,7 +117,6 @@ module('Integration | Component | pipeline/workflow/graph', function (hooks) {
         { id: 2, jobId: 1, status: 'SUCCESS' },
         { id: 3, jobId: 12, status: 'SUCCESS' }
       ],
-      stages: [{ id: 10, name: 'test', jobIds: [1], setup: 11, teardown: 12 }],
       displayJobNameLength: 20
     });
     await render(
@@ -118,7 +125,6 @@ module('Integration | Component | pipeline/workflow/graph', function (hooks) {
             @event={{this.event}}
             @jobs={{this.jobs}}
             @builds={{this.builds}}
-            @stages={{this.stages}}
             @chainPr={{false}}
             @displayJobNameLength={{this.displayJobNameLength}}
       />`
@@ -130,6 +136,8 @@ module('Integration | Component | pipeline/workflow/graph', function (hooks) {
   });
 
   test('it renders stage', async function (assert) {
+    stages.push({ id: 10, name: 'test', jobIds: [1], setup: 11, teardown: 12 });
+
     this.setProperties({
       workflowGraph: {
         nodes: [
@@ -163,7 +171,6 @@ module('Integration | Component | pipeline/workflow/graph', function (hooks) {
         { id: 2, jobId: 1, status: 'SUCCESS' },
         { id: 3, jobId: 12, status: 'SUCCESS' }
       ],
-      stages: [{ id: 10, name: 'test', jobIds: [1], setup: 11, teardown: 12 }],
       displayJobNameLength: 20
     });
     await render(
@@ -172,7 +179,6 @@ module('Integration | Component | pipeline/workflow/graph', function (hooks) {
             @event={{this.event}}
             @jobs={{this.jobs}}
             @builds={{this.builds}}
-            @stages={{this.stages}}
             @chainPr={{false}}
             @displayJobNameLength={{this.displayJobNameLength}}
       />`
@@ -195,7 +201,6 @@ module('Integration | Component | pipeline/workflow/graph', function (hooks) {
       event: { startFrom: '~pr' },
       jobs: [{ id: 1 }],
       builds: [{ id: 1, jobId: 1, status: 'SUCCESS' }],
-      stages: [],
       displayJobNameLength: 20
     });
     await render(
@@ -204,7 +209,6 @@ module('Integration | Component | pipeline/workflow/graph', function (hooks) {
             @event={{this.event}}
             @jobs={{this.jobs}}
             @builds={{this.builds}}
-            @stages={{this.stages}}
             @chainPr={{true}}
             @displayJobNameLength={{this.displayJobNameLength}}
       />`
@@ -236,7 +240,6 @@ module('Integration | Component | pipeline/workflow/graph', function (hooks) {
       event: { startFrom: '~commit' },
       jobs: [{ id: 1 }],
       builds: [{ id: 1, jobId: 1, status: 'SUCCESS' }],
-      stages: [],
       displayJobNameLength: 20
     });
     await render(
@@ -245,7 +248,6 @@ module('Integration | Component | pipeline/workflow/graph', function (hooks) {
             @event={{this.event}}
             @jobs={{this.jobs}}
             @builds={{this.builds}}
-            @stages={{this.stages}}
             @chainPr={{false}}
             @displayJobNameLength={{this.displayJobNameLength}}
       />`
@@ -268,7 +270,6 @@ module('Integration | Component | pipeline/workflow/graph', function (hooks) {
       event: { startFrom: '~commit' },
       jobs: [{ id: 123 }],
       builds: [{ id: 1, jobId: 123, status: 'RUNNING' }],
-      stages: [],
       displayJobNameLength: 20
     });
     await render(
@@ -277,7 +278,6 @@ module('Integration | Component | pipeline/workflow/graph', function (hooks) {
             @event={{this.event}}
             @jobs={{this.jobs}}
             @builds={{this.builds}}
-            @stages={{this.stages}}
             @chainPr={{false}}
             @displayJobNameLength={{this.displayJobNameLength}}
       />`
@@ -294,6 +294,8 @@ module('Integration | Component | pipeline/workflow/graph', function (hooks) {
   });
 
   test('it re-renders graph when stage builds update', async function (assert) {
+    stages.push({ id: 10, name: 'test', jobIds: [1], setup: 11, teardown: 12 });
+
     this.setProperties({
       workflowGraph: {
         nodes: [
@@ -328,7 +330,6 @@ module('Integration | Component | pipeline/workflow/graph', function (hooks) {
         { id: 3, jobId: 12, status: 'RUNNING' }
       ],
       stageBuilds: [{ id: 1, stageId: 10, status: 'RUNNING' }],
-      stages: [{ id: 10, name: 'test', jobIds: [1], setup: 11, teardown: 12 }],
       displayJobNameLength: 20
     });
     await render(
@@ -338,7 +339,6 @@ module('Integration | Component | pipeline/workflow/graph', function (hooks) {
             @jobs={{this.jobs}}
             @builds={{this.builds}}
             @stageBuilds={{this.stageBuilds}}
-            @stages={{this.stages}}
             @chainPr={{false}}
             @displayJobNameLength={{this.displayJobNameLength}}
       />`


### PR DESCRIPTION
## Context
Stages can be added to the injectable page state for use in the v2 UI. This will help reduce the amount of data being passed directly into the main component and any downstream components which may require the stage data (i.e., the workflow graph component).

## Objective
Refactor stages into the injectable page state

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
