### PR TITLE
Refactor jobs to be injectable

### DIFF
--- a/app/components/pipeline/event/card/template.hbs
+++ b/app/components/pipeline/event/card/template.hbs
@@ -73,7 +73,6 @@
           {{#if this.showStartEventModal}}
             <Pipeline::Modal::StartEvent
               @pipeline={{@pipeline}}
-              @jobs={{@jobs}}
               @event={{@event}}
               @closeModal={{this.closeStartEventModal}}
             />
@@ -213,7 +212,6 @@
             {{#if this.showParametersModal}}
               <Pipeline::Modal::ShowParameters
                 @event={{@event}}
-                @jobs={{@jobs}}
                 @closeModal={{this.closeParametersModal}}
               />
             {{/if}}
@@ -238,7 +236,6 @@
             <Pipeline::Modal::EventGroupHistory
               @pipeline={{@pipeline}}
               @event={{@event}}
-              @jobs={{@jobs}}
               @userSettings={{@userSettings}}
               @isPR={{this.isPR}}
               @closeModal={{this.closeEventHistoryModal}}

--- a/app/components/pipeline/jobs/table/cell/actions/template.hbs
+++ b/app/components/pipeline/jobs/table/cell/actions/template.hbs
@@ -43,7 +43,6 @@
 
   {{#if this.showStartEventModal}}
     <Pipeline::Modal::StartEvent
-      @jobs={{@record.jobs}}
       @job={{@record.job}}
       @notice={{this.notice}}
       @closeModal={{this.closeStartEventModal}}
@@ -58,7 +57,6 @@
   {{#if this.showRestartJobModal}}
     <Pipeline::Modal::ConfirmAction
       @event={{this.latestEvent}}
-      @jobs={{@record.jobs}}
       @latestCommitEvent={{this.latestCommitEvent}}
       @job={{this.job}}
       @closeModal={{this.closeRestartJobModal}}

--- a/app/components/pipeline/modal/confirm-action/template.hbs
+++ b/app/components/pipeline/modal/confirm-action/template.hbs
@@ -55,7 +55,6 @@
         @action={{this.action}}
         @job={{@job}}
         @event={{@event}}
-        @jobs={{@jobs}}
         @onUpdateParameters={{this.onUpdateParameters}}
       />
     {{/if}}

--- a/app/components/pipeline/modal/event-group-history/template.hbs
+++ b/app/components/pipeline/modal/event-group-history/template.hbs
@@ -15,7 +15,6 @@
     >
       <Pipeline::Event::Card
         @event={{event}}
-        @jobs={{@jobs}}
         @userSettings={{@userSettings}}
         @queueName="eventGroupModal"
         @onClick={{fn @closeModal}}

--- a/app/components/pipeline/modal/search-event/template.hbs
+++ b/app/components/pipeline/modal/search-event/template.hbs
@@ -44,7 +44,6 @@
           <Pipeline::Event::Card
             @pipeline={{@pipeline}}
             @event={{event}}
-            @jobs={{@jobs}}
             @userSettings={{@userSettings}}
             @queueName="searchResults"
           />

--- a/app/components/pipeline/modal/show-parameters/template.hbs
+++ b/app/components/pipeline/modal/show-parameters/template.hbs
@@ -9,7 +9,6 @@
   <modal.body>
     <Pipeline::Parameters
       @event={{@event}}
-      @jobs={{@jobs}}
     />
   </modal.body>
 </BsModal>

--- a/app/components/pipeline/modal/start-event/component.js
+++ b/app/components/pipeline/modal/start-event/component.js
@@ -39,7 +39,9 @@ export default class PipelineModalStartEventComponent extends Component {
     this.defaultPipelineParameters = extractDefaultParameters(
       this.pipeline.parameters
     );
-    this.defaultJobParameters = extractDefaultJobParameters(this.args.jobs);
+    this.defaultJobParameters = extractDefaultJobParameters(
+      this.pipelinePageState.getJobs()
+    );
   }
 
   get isParameterized() {

--- a/app/components/pipeline/modal/start-event/template.hbs
+++ b/app/components/pipeline/modal/start-event/template.hbs
@@ -31,7 +31,6 @@
         @action="start"
         @pipelineParameters={{this.defaultPipelineParameters}}
         @jobParameters={{this.defaultJobParameters}}
-        @jobs={{@jobs}}
         @onUpdateParameters={{this.onUpdateParameters}}
       />
     {{else}}

--- a/app/components/pipeline/parameters/component.js
+++ b/app/components/pipeline/parameters/component.js
@@ -30,7 +30,7 @@ export default class PipelineParametersComponent extends Component {
       pipelineParameters,
       pipeline.parameters,
       jobParameters,
-      extractJobParameters(this.args.jobs),
+      extractJobParameters(this.pipelinePageState.getJobs()),
       this.args.job ? this.args.job.name : null
     );
 

--- a/app/components/pipeline/workflow/component.js
+++ b/app/components/pipeline/workflow/component.js
@@ -45,8 +45,6 @@ export default class PipelineWorkflowComponent extends Component {
 
   @tracked stageBuilds;
 
-  @tracked jobs;
-
   @tracked workflowGraphToDisplay;
 
   @tracked showGraph;
@@ -77,8 +75,6 @@ export default class PipelineWorkflowComponent extends Component {
     if (this.args.noEvents) {
       this.monitorForNewEvents();
     } else {
-      this.jobs = this.args.jobs;
-
       this.monitorForNewBuilds();
     }
 

--- a/app/components/pipeline/workflow/event-rail/template.hbs
+++ b/app/components/pipeline/workflow/event-rail/template.hbs
@@ -14,7 +14,6 @@
       <FaIcon @icon="magnifying-glass" />
       {{#if this.showSearchEventModal}}
         <Pipeline::Modal::SearchEvent
-          @jobs={{@jobs}}
           @userSettings={{@userSettings}}
           @closeModal={{this.closeSearchEventModal}}
         />
@@ -31,7 +30,6 @@
       />
       {{#if this.showStartEventModal}}
         <Pipeline::Modal::StartEvent
-          @jobs={{@jobs}}
           @closeModal={{this.closeStartEventModal}}
         />
       {{/if}}
@@ -49,7 +47,6 @@
     >
       <Pipeline::Event::Card
         @event={{event}}
-        @jobs={{@jobs}}
         @userSettings={{@userSettings}}
         @queueName="eventRail"
         @allowEventAction={{true}}

--- a/app/components/pipeline/workflow/graph/component.js
+++ b/app/components/pipeline/workflow/graph/component.js
@@ -52,7 +52,7 @@ export default class PipelineWorkflowGraphComponent extends Component {
       inputGraph: workflowGraph,
       builds,
       stageBuilds,
-      jobs: this.args.jobs.map(job => {
+      jobs: this.pipelinePageState.getJobs().map(job => {
         return { ...job, isDisabled: job.state === 'DISABLED' };
       }),
       start: event.startFrom,

--- a/app/components/pipeline/workflow/template.hbs
+++ b/app/components/pipeline/workflow/template.hbs
@@ -5,7 +5,6 @@
   <Pipeline::Workflow::EventRail
     @userSettings={{this.userSettings}}
     @event={{this.eventRailAnchor}}
-    @jobs={{this.jobs}}
     @prNums={{@prNums}}
     @reloadEvents={{@reloadEventRail}}
   />
@@ -92,7 +91,6 @@
           <Pipeline::Workflow::Graph
             @workflowGraph={{this.workflowGraphToDisplay}}
             @event={{this.event}}
-            @jobs={{this.jobs}}
             @builds={{this.builds}}
             @stageBuilds={{this.stageBuilds}}
             @chainPr={{this.pipeline.prChain}}
@@ -106,7 +104,6 @@
             <Pipeline::Workflow::Tooltip
               @d3Data={{this.d3Data}}
               @event={{this.event}}
-              @jobs={{this.jobs}}
               @builds={{this.builds}}
               @workflowGraph={{this.workflowGraphToDisplay}}
             />
@@ -115,7 +112,6 @@
             <Pipeline::Workflow::Tooltip::Stage
               @d3Data={{this.d3Data}}
               @event={{this.event}}
-              @jobs={{this.jobs}}
               @builds={{this.builds}}
               @workflowGraph={{this.workflowGraphToDisplay}}
             />
@@ -123,7 +119,6 @@
         {{else}}
           <Pipeline::Jobs::Table
             @event={{this.event}}
-            @jobs={{this.jobs}}
             @userSettings={{this.userSettings}}
             @numBuilds={{1}}
           />

--- a/app/components/pipeline/workflow/tooltip/component.js
+++ b/app/components/pipeline/workflow/tooltip/component.js
@@ -36,7 +36,7 @@ export default class PipelineWorkflowTooltipComponent extends Component {
     this.tooltipData = getTooltipData(
       this.args.d3Data.node,
       this.args.event,
-      this.args.jobs,
+      this.pipelinePageState.getJobs(),
       this.args.builds
     );
   }

--- a/app/components/pipeline/workflow/tooltip/stage/template.hbs
+++ b/app/components/pipeline/workflow/tooltip/stage/template.hbs
@@ -17,7 +17,6 @@
 {{#if this.showConfirmActionModal}}
   <Pipeline::Modal::ConfirmAction
     @event={{@event}}
-    @jobs={{@jobs}}
     @job={{this.job}}
     @stage={{@d3Data.stage}}
     @closeModal={{this.closeConfirmActionModal}}

--- a/app/components/pipeline/workflow/tooltip/template.hbs
+++ b/app/components/pipeline/workflow/tooltip/template.hbs
@@ -132,7 +132,6 @@
 {{#if this.showConfirmActionModal}}
   <Pipeline::Modal::ConfirmAction
     @event={{@event}}
-    @jobs={{@jobs}}
     @job={{this.tooltipData.job}}
     @closeModal={{this.closeConfirmActionModal}}
   />

--- a/app/pipeline-page-state/service.js
+++ b/app/pipeline-page-state/service.js
@@ -9,11 +9,14 @@ export default class PipelinePageStateService extends Service {
 
   stages;
 
+  jobs;
+
   clear() {
     this.pipeline = null;
     this.childPipelines = [];
     this.triggers = [];
     this.stages = [];
+    this.jobs = [];
   }
 
   setPipeline(pipeline) {
@@ -50,5 +53,13 @@ export default class PipelinePageStateService extends Service {
 
   getStages() {
     return this.stages;
+  }
+
+  setJobs(jobs) {
+    this.jobs = jobs;
+  }
+
+  getJobs() {
+    return this.jobs;
   }
 }

--- a/app/v2/pipeline/events/show/route.js
+++ b/app/v2/pipeline/events/show/route.js
@@ -41,10 +41,11 @@ export default class NewPipelineEventsShowRoute extends Route {
         });
     }
 
-    const jobs = await this.shuttle.fetchFromApi(
-      'get',
-      `/pipelines/${pipelineId}/jobs?type=pipeline`
-    );
+    await this.shuttle
+      .fetchFromApi('get', `/pipelines/${pipelineId}/jobs?type=pipeline`)
+      .then(jobs => {
+        this.pipelinePageState.setJobs(jobs);
+      });
 
     await this.shuttle
       .fetchFromApi('get', `/pipelines/${pipelineId}/stages`)
@@ -62,7 +63,6 @@ export default class NewPipelineEventsShowRoute extends Route {
       userSettings: model.userSettings,
       event,
       latestEvent,
-      jobs,
       invalidEvent: event === null
     };
   }

--- a/app/v2/pipeline/events/show/template.hbs
+++ b/app/v2/pipeline/events/show/template.hbs
@@ -1,7 +1,6 @@
 <Pipeline::Workflow
   @userSettings={{this.model.userSettings}}
   @event={{this.model.event}}
-  @jobs={{this.model.jobs}}
   @latestEvent={{this.model.latestEvent}}
   @invalidEvent={{this.model.invalidEvent}}
   @reloadEventRail={{this.model.reloadEventRail}}

--- a/app/v2/pipeline/jobs/route.js
+++ b/app/v2/pipeline/jobs/route.js
@@ -9,10 +9,11 @@ export default class NewPipelineJobsRoute extends Route {
   async model() {
     const pipelineId = this.pipelinePageState.getPipelineId();
 
-    const jobs = await this.shuttle.fetchFromApi(
-      'get',
-      `/pipelines/${pipelineId}/jobs?type=pipeline`
-    );
+    await this.shuttle
+      .fetchFromApi('get', `/pipelines/${pipelineId}/jobs?type=pipeline`)
+      .then(jobs => {
+        this.pipelinePageState.setJobs(jobs);
+      });
 
     const userSettings = await this.shuttle.fetchFromApi(
       'get',
@@ -20,7 +21,6 @@ export default class NewPipelineJobsRoute extends Route {
     );
 
     return {
-      jobs,
       userSettings
     };
   }

--- a/app/v2/pipeline/jobs/template.hbs
+++ b/app/v2/pipeline/jobs/template.hbs
@@ -3,6 +3,5 @@
 <Pipeline::Tab />
 
 <Pipeline::Jobs::Table
-  @jobs={{this.model.jobs}}
   @userSettings={{this.model.userSettings}}
 />

--- a/app/v2/pipeline/pulls/show/route.js
+++ b/app/v2/pipeline/pulls/show/route.js
@@ -75,9 +75,10 @@ export default class V2PipelinePullsShowRoute extends Route {
       }
     }
 
+    this.pipelinePageState.setJobs(jobs);
+
     return {
       ...model,
-      jobs,
       event,
       latestEvent,
       prNums: Array.from(prNums).sort((a, b) => a - b),

--- a/app/v2/pipeline/pulls/show/template.hbs
+++ b/app/v2/pipeline/pulls/show/template.hbs
@@ -1,7 +1,6 @@
 <Pipeline::Workflow
   @userSettings={{this.model.userSettings}}
   @event={{this.model.event}}
-  @jobs={{this.model.jobs}}
   @latestEvent={{this.model.latestEvent}}
   @prNums={{this.model.prNums}}
   @invalidEvent={{this.model.invalidEvent}}

--- a/tests/integration/components/pipeline/modal/confirm-action/component-test.js
+++ b/tests/integration/components/pipeline/modal/confirm-action/component-test.js
@@ -22,6 +22,7 @@ module(
         .returns({ sha: 'deadbeef0123456789' });
 
       sinon.stub(pipelinePageState, 'getPipeline').returns({ id: 987 });
+      sinon.stub(pipelinePageState, 'getJobs').returns([]);
     });
 
     test('it renders start action', async function (assert) {
@@ -30,14 +31,12 @@ module(
           commit: { message: 'commit message', url: 'http://foo.com' },
           sha: 'deadbeef0123456789'
         },
-        jobs: [],
         job: { name: 'main' },
         closeModal: () => {}
       });
       await render(
         hbs`<Pipeline::Modal::ConfirmAction
             @event={{this.event}}
-            @jobs={{this.jobs}}
             @job={{this.job}}
             @closeModal={{this.closeModal}}
         />`
@@ -59,14 +58,12 @@ module(
           commit: { message: 'commit message', url: 'http://foo.com' },
           sha: 'deadbeef0123456789'
         },
-        jobs: [],
         job: { name: 'main', status: 'SUCCESS' },
         closeModal: () => {}
       });
       await render(
         hbs`<Pipeline::Modal::ConfirmAction
             @event={{this.event}}
-            @jobs={{this.jobs}}
             @job={{this.job}}
             @closeModal={{this.closeModal}}
         />`
@@ -81,7 +78,6 @@ module(
           commit: { message: 'commit message', url: 'http://foo.com' },
           sha: 'deadbeef0123456789'
         },
-        jobs: [],
         job: { name: 'main' },
         stage: { name: 'stage' },
         closeModal: () => {}
@@ -89,7 +85,6 @@ module(
       await render(
         hbs`<Pipeline::Modal::ConfirmAction
             @event={{this.event}}
-            @jobs={{this.jobs}}
             @job={{this.job}}
             @stage={{this.stage}}
             @closeModal={{this.closeModal}}
@@ -107,14 +102,12 @@ module(
           commit: { message: 'commit message', url: 'http://foo.com' },
           sha: '0123456789deadbeef'
         },
-        jobs: [],
         job: { name: 'main' },
         closeModal: () => {}
       });
       await render(
         hbs`<Pipeline::Modal::ConfirmAction
             @event={{this.event}}
-            @jobs={{this.jobs}}
             @job={{this.job}}
             @closeModal={{this.closeModal}}
         />`
@@ -130,14 +123,12 @@ module(
           sha: 'deadbeef0123456789',
           type: 'pr'
         },
-        jobs: [],
         job: { name: 'main' },
         closeModal: () => {}
       });
       await render(
         hbs`<Pipeline::Modal::ConfirmAction
             @event={{this.event}}
-            @jobs={{this.jobs}}
             @job={{this.job}}
             @closeModal={{this.closeModal}}
         />`
@@ -152,14 +143,12 @@ module(
           commit: { message: 'commit message', url: 'http://foo.com' },
           sha: 'deadbeef0123456789'
         },
-        jobs: [],
         job: { name: 'main', status: 'FROZEN' },
         closeModal: () => {}
       });
       await render(
         hbs`<Pipeline::Modal::ConfirmAction
             @event={{this.event}}
-            @jobs={{this.jobs}}
             @job={{this.job}}
             @closeModal={{this.closeModal}}
         />`
@@ -181,14 +170,12 @@ module(
             }
           }
         },
-        jobs: [],
         job: { name: 'main' },
         closeModal: () => {}
       });
       await render(
         hbs`<Pipeline::Modal::ConfirmAction
             @event={{this.event}}
-            @jobs={{this.jobs}}
             @job={{this.job}}
             @closeModal={{this.closeModal}}
         />`
@@ -203,14 +190,12 @@ module(
           commit: { message: 'commit message', url: 'http://foo.com' },
           sha: 'deadbeef0123456789'
         },
-        jobs: [],
         job: { name: 'main', status: 'FROZEN' },
         closeModal: () => {}
       });
       await render(
         hbs`<Pipeline::Modal::ConfirmAction
             @event={{this.event}}
-            @jobs={{this.jobs}}
             @job={{this.job}}
             @closeModal={{this.closeModal}}
         />`
@@ -225,14 +210,12 @@ module(
           commit: { message: 'commit message', url: 'http://foo.com' },
           sha: 'deadbeef0123456789'
         },
-        jobs: [],
         job: { name: 'main', status: 'FROZEN' },
         closeModal: () => {}
       });
       await render(
         hbs`<Pipeline::Modal::ConfirmAction
             @event={{this.event}}
-            @jobs={{this.jobs}}
             @job={{this.job}}
             @closeModal={{this.closeModal}}
         />`
@@ -253,7 +236,6 @@ module(
           commit: { message: 'commit message', url: 'http://foo.com' },
           sha: 'deadbeef0123456789'
         },
-        jobs: [],
         job: { name: 'main' },
         closeModal: closeModalSpy
       });
@@ -261,7 +243,6 @@ module(
       await render(
         hbs`<Pipeline::Modal::ConfirmAction
             @event={{this.event}}
-            @jobs={{this.jobs}}
             @job={{this.job}}
             @closeModal={{this.closeModal}}
         />`
@@ -288,7 +269,6 @@ module(
           commit: { message: 'commit message', url: 'http://foo.com' },
           sha: 'deadbeef0123456789'
         },
-        jobs: [],
         job: { name: 'main' },
         closeModal: () => {}
       });
@@ -296,7 +276,6 @@ module(
       await render(
         hbs`<Pipeline::Modal::ConfirmAction
             @event={{this.event}}
-            @jobs={{this.jobs}}
             @job={{this.job}}
             @closeModal={{this.closeModal}}
         />`

--- a/tests/integration/components/pipeline/modal/event-group-history/component-test.js
+++ b/tests/integration/components/pipeline/modal/event-group-history/component-test.js
@@ -45,7 +45,6 @@ module(
 
       this.setProperties({
         event: { ...mockEvent, id: 1 },
-        jobs: {},
         userSettings: {},
         closeModal: () => {}
       });
@@ -53,7 +52,6 @@ module(
       await render(
         hbs`<Pipeline::Modal::EventGroupHistory
             @event={{this.event}}
-            @jobs={{this.jobs}}
             @userSettings={{this.userSettings}}
             @closeModal={{this.closeModal}}
         />`
@@ -80,7 +78,6 @@ module(
 
       this.setProperties({
         event: { ...mockEvent, id: 1 },
-        jobs: {},
         userSettings: {},
         closeModal: () => {}
       });
@@ -88,7 +85,6 @@ module(
       await render(
         hbs`<Pipeline::Modal::EventGroupHistory
             @event={{this.event}}
-            @jobs={{this.jobs}}
             @userSettings={{this.userSettings}}
             @isPR={{true}}
             @closeModal={{this.closeModal}}

--- a/tests/integration/components/pipeline/modal/search-event/component-test.js
+++ b/tests/integration/components/pipeline/modal/search-event/component-test.js
@@ -22,14 +22,12 @@ module(
 
     test('it renders', async function (assert) {
       this.setProperties({
-        jobs: [],
         userSettings: {},
         closeModal: () => {}
       });
 
       await render(
         hbs`<Pipeline::Modal::SearchEvent
-            @jobs={{this.jobs}}
             @userSettings={{this.userSettings}}
             @closeModal={{this.closeModal}}
         />`
@@ -51,14 +49,12 @@ module(
       sinon.stub(shuttle, 'fetchFromApi').resolves([]);
 
       this.setProperties({
-        jobs: [],
         userSettings: {},
         closeModal: () => {}
       });
 
       await render(
         hbs`<Pipeline::Modal::SearchEvent
-            @jobs={{this.jobs}}
             @userSettings={{this.userSettings}}
             @closeModal={{this.closeModal}}
         />`
@@ -82,15 +78,12 @@ module(
         .resolves([]);
 
       this.setProperties({
-        jobs: [],
         userSettings: {},
         closeModal: () => {}
       });
 
       await render(
         hbs`<Pipeline::Modal::SearchEvent
-            @pipeline={{this.pipeline}}
-            @jobs={{this.jobs}}
             @userSettings={{this.userSettings}}
             @closeModal={{this.closeModal}}
         />`
@@ -112,18 +105,15 @@ module(
 
     test('it handles invalid sha input', async function (assert) {
       const shuttle = this.owner.lookup('service:shuttle');
-
       const spyShuttle = sinon.spy(shuttle, 'fetchFromApi');
 
       this.setProperties({
-        jobs: [],
         userSettings: {},
         closeModal: () => {}
       });
 
       await render(
         hbs`<Pipeline::Modal::SearchEvent
-            @jobs={{this.jobs}}
             @userSettings={{this.userSettings}}
             @closeModal={{this.closeModal}}
         />`
@@ -147,15 +137,12 @@ module(
       sinon.stub(shuttle, 'fetchFromApi').resolves([]);
 
       this.setProperties({
-        pipeline: {},
-        jobs: [],
         userSettings: {},
         closeModal: () => {}
       });
 
       await render(
         hbs`<Pipeline::Modal::SearchEvent
-            @jobs={{this.jobs}}
             @userSettings={{this.userSettings}}
             @closeModal={{this.closeModal}}
         />`

--- a/tests/integration/components/pipeline/modal/show-parameters/component-test.js
+++ b/tests/integration/components/pipeline/modal/show-parameters/component-test.js
@@ -17,17 +17,16 @@ module(
       sinon.stub(pipelinePageState, 'getPipeline').returns({
         parameters: { foo: { value: 'foofoo' } }
       });
+      sinon.stub(pipelinePageState, 'getJobs').returns([]);
 
       this.setProperties({
         event: { meta: { parameters: { foo: { value: 'bar' } } } },
-        jobs: [],
         closeModal: () => {}
       });
 
       await render(
         hbs`<Pipeline::Modal::ShowParameters
             @event={{this.event}}
-            @jobs={{this.jobs}}
             @closeModal={{this.closeModal}}
         />`
       );

--- a/tests/integration/components/pipeline/modal/start-event/component-test.js
+++ b/tests/integration/components/pipeline/modal/start-event/component-test.js
@@ -9,20 +9,22 @@ module(
   function (hooks) {
     setupRenderingTest(hooks);
 
-    test('it renders when pipeline has no parameters', async function (assert) {
-      const pipelinePageState = this.owner.lookup(
-        'service:pipeline-page-state'
-      );
+    let pipelinePageState;
 
+    hooks.beforeEach(function () {
+      pipelinePageState = this.owner.lookup('service:pipeline-page-state');
+    });
+
+    test('it renders when pipeline has no parameters', async function (assert) {
       sinon.stub(pipelinePageState, 'getPipeline').returns({});
+      sinon.stub(pipelinePageState, 'getJobs').returns([]);
 
       this.setProperties({
-        jobs: [],
         closeModal: () => {}
       });
+
       await render(
         hbs`<Pipeline::Modal::StartEvent
-            @jobs={{this.jobs}}
             @closeModal={{this.closeModal}}
         />`
       );
@@ -31,26 +33,22 @@ module(
     });
 
     test('it renders when pipeline has parameters', async function (assert) {
-      const pipelinePageState = this.owner.lookup(
-        'service:pipeline-page-state'
-      );
-
       sinon
         .stub(pipelinePageState, 'getPipeline')
         .returns({ parameters: { p1: ['abc', '123'] } });
+      sinon.stub(pipelinePageState, 'getJobs').returns([
+        {
+          name: 'main',
+          permutations: [{ parameters: { j1: ['yes', 'no'] } }]
+        }
+      ]);
 
       this.setProperties({
-        jobs: [
-          {
-            name: 'main',
-            permutations: [{ parameters: { j1: ['yes', 'no'] } }]
-          }
-        ],
         closeModal: () => {}
       });
+
       await render(
         hbs`<Pipeline::Modal::StartEvent
-            @jobs={{this.jobs}}
             @closeModal={{this.closeModal}}
         />`
       );
@@ -60,19 +58,15 @@ module(
     });
 
     test('it renders optional notice', async function (assert) {
-      const pipelinePageState = this.owner.lookup(
-        'service:pipeline-page-state'
-      );
-
       sinon.stub(pipelinePageState, 'getPipeline').returns({});
+      sinon.stub(pipelinePageState, 'getJobs').returns([]);
 
       this.setProperties({
-        jobs: [],
         closeModal: () => {}
       });
+
       await render(
         hbs`<Pipeline::Modal::StartEvent
-            @jobs={{this.jobs}}
             @closeModal={{this.closeModal}}
             @notice="This is a notice to the user"
         />`
@@ -83,22 +77,18 @@ module(
 
     test('it closes modal on success', async function (assert) {
       const shuttle = this.owner.lookup('service:shuttle');
-      const pipelinePageState = this.owner.lookup(
-        'service:pipeline-page-state'
-      );
-
       const shuttleStub = sinon.stub(shuttle, 'fetchFromApi').resolves();
       const closeModalSpy = sinon.spy();
 
       sinon.stub(pipelinePageState, 'getPipeline').returns({});
+      sinon.stub(pipelinePageState, 'getJobs').returns([]);
 
       this.setProperties({
-        jobs: [],
         closeModal: closeModalSpy
       });
+
       await render(
         hbs`<Pipeline::Modal::StartEvent
-            @jobs={{this.jobs}}
             @closeModal={{this.closeModal}}
         />`
       );

--- a/tests/integration/components/pipeline/parameters/component-test.js
+++ b/tests/integration/components/pipeline/parameters/component-test.js
@@ -8,12 +8,24 @@ import sinon from 'sinon';
 module('Integration | Component | pipeline/parameters', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('it does not render title when no action is set', async function (assert) {
-    const pipelinePageState = this.owner.lookup('service:pipeline-page-state');
+  let pipelinePageState;
 
+  hooks.beforeEach(function () {
+    pipelinePageState = this.owner.lookup('service:pipeline-page-state');
+  });
+
+  test('it does not render title when no action is set', async function (assert) {
     sinon.stub(pipelinePageState, 'getPipeline').returns({
       parameters: { foo: { value: 'foofoo' } }
     });
+    sinon.stub(pipelinePageState, 'getJobs').returns([
+      {
+        name: 'job1',
+        permutations: [
+          { parameters: { p1: { value: 'p1' }, p2: { value: 'p2' } } }
+        ]
+      }
+    ]);
 
     this.setProperties({
       event: {
@@ -24,21 +36,13 @@ module('Integration | Component | pipeline/parameters', function (hooks) {
           }
         }
       },
-      job: { name: 'job1' },
-      jobs: [
-        {
-          name: 'job1',
-          permutations: [
-            { parameters: { p1: { value: 'p1' }, p2: { value: 'p2' } } }
-          ]
-        }
-      ]
+      job: { name: 'job1' }
     });
+
     await render(
       hbs`<Pipeline::Parameters
         @event={{this.event}}
         @job={{this.job}}
-        @jobs={{this.jobs}}
       />`
     );
 
@@ -46,13 +50,19 @@ module('Integration | Component | pipeline/parameters', function (hooks) {
   });
 
   test('it renders title with correct action', async function (assert) {
-    const pipelinePageState = this.owner.lookup('service:pipeline-page-state');
-
     sinon.stub(pipelinePageState, 'getPipeline').returns({
       parameters: {
         foo: { value: 'foofoo' }
       }
     });
+    sinon.stub(pipelinePageState, 'getJobs').returns([
+      {
+        name: 'job1',
+        permutations: [
+          { parameters: { p1: { value: 'p1' }, p2: { value: 'p2' } } }
+        ]
+      }
+    ]);
 
     this.setProperties({
       event: {
@@ -63,22 +73,14 @@ module('Integration | Component | pipeline/parameters', function (hooks) {
           }
         }
       },
-      job: { name: 'job1' },
-      jobs: [
-        {
-          name: 'job1',
-          permutations: [
-            { parameters: { p1: { value: 'p1' }, p2: { value: 'p2' } } }
-          ]
-        }
-      ]
+      job: { name: 'job1' }
     });
+
     await render(
       hbs`<Pipeline::Parameters
         @action="start"
         @event={{this.event}}
         @job={{this.job}}
-        @jobs={{this.jobs}}
       />`
     );
 
@@ -86,14 +88,20 @@ module('Integration | Component | pipeline/parameters', function (hooks) {
   });
 
   test('it renders parameters with shared group expanded from event', async function (assert) {
-    const pipelinePageState = this.owner.lookup('service:pipeline-page-state');
-
     sinon.stub(pipelinePageState, 'getPipeline').returns({
       parameters: {
         bar: ['barbar', 'bazbaz'],
         foo: { value: 'foo', description: 'awesome' }
       }
     });
+    sinon.stub(pipelinePageState, 'getJobs').returns([
+      {
+        name: 'job1',
+        permutations: [
+          { parameters: { p1: { value: 'p1' }, p2: { value: 'p2' } } }
+        ]
+      }
+    ]);
 
     this.setProperties({
       event: {
@@ -104,22 +112,13 @@ module('Integration | Component | pipeline/parameters', function (hooks) {
             job1: { p1: { value: 'abc' }, p2: { value: 'xyz' } }
           }
         }
-      },
-      jobs: [
-        {
-          name: 'job1',
-          permutations: [
-            { parameters: { p1: { value: 'p1' }, p2: { value: 'p2' } } }
-          ]
-        }
-      ]
+      }
     });
 
     await render(
       hbs`<Pipeline::Parameters
         @action="start"
         @event={{this.event}}
-        @jobs={{this.jobs}}
       />`
     );
 
@@ -143,14 +142,20 @@ module('Integration | Component | pipeline/parameters', function (hooks) {
   });
 
   test('it renders parameters job group expanded from event', async function (assert) {
-    const pipelinePageState = this.owner.lookup('service:pipeline-page-state');
-
     sinon.stub(pipelinePageState, 'getPipeline').returns({
       parameters: {
         bar: ['barbar', 'bazbaz'],
         foo: { value: 'foofoo' }
       }
     });
+    sinon.stub(pipelinePageState, 'getJobs').returns([
+      {
+        name: 'job1',
+        permutations: [
+          { parameters: { p1: { value: 'p1' }, p2: { value: 'p2' } } }
+        ]
+      }
+    ]);
 
     this.setProperties({
       event: {
@@ -162,14 +167,6 @@ module('Integration | Component | pipeline/parameters', function (hooks) {
           }
         }
       },
-      jobs: [
-        {
-          name: 'job1',
-          permutations: [
-            { parameters: { p1: { value: 'p1' }, p2: { value: 'p2' } } }
-          ]
-        }
-      ],
       job: { name: 'job1' }
     });
 
@@ -177,7 +174,6 @@ module('Integration | Component | pipeline/parameters', function (hooks) {
       hbs`<Pipeline::Parameters
         @action="start"
         @event={{this.event}}
-        @jobs={{this.jobs}}
         @job={{this.job}}
       />`
     );
@@ -201,25 +197,22 @@ module('Integration | Component | pipeline/parameters', function (hooks) {
   });
 
   test('it renders parameters with shared group expanded', async function (assert) {
-    const pipelinePageState = this.owner.lookup('service:pipeline-page-state');
-
     sinon.stub(pipelinePageState, 'getPipeline').returns({
       parameters: {
         bar: ['barbar', 'bazbaz'],
         foo: { value: 'foo', description: 'awesome' }
       }
     });
+    sinon.stub(pipelinePageState, 'getJobs').returns([{ name: 'job1' }]);
 
     this.setProperties({
-      pipelineParameters: { bar: { value: 'barbar' }, foo: { value: 'foo' } },
-      jobs: [{ name: 'job1' }]
+      pipelineParameters: { bar: { value: 'barbar' }, foo: { value: 'foo' } }
     });
 
     await render(
       hbs`<Pipeline::Parameters
         @action="start"
         @pipelineParameters={{this.pipelineParameters}}
-        @jobs={{this.jobs}}
       />`
     );
 
@@ -243,27 +236,24 @@ module('Integration | Component | pipeline/parameters', function (hooks) {
   });
 
   test('it renders parameters job group expanded', async function (assert) {
-    const pipelinePageState = this.owner.lookup('service:pipeline-page-state');
-
     sinon.stub(pipelinePageState, 'getPipeline').returns({});
+    sinon.stub(pipelinePageState, 'getJobs').returns([
+      {
+        name: 'job1',
+        permutations: [{ parameters: { p1: { value: 'p1' } } }]
+      }
+    ]);
 
     this.setProperties({
       jobParameters: {
         job1: { p1: { value: 'p1' } }
-      },
-      jobs: [
-        {
-          name: 'job1',
-          permutations: [{ parameters: { p1: { value: 'p1' } } }]
-        }
-      ]
+      }
     });
 
     await render(
       hbs`<Pipeline::Parameters
         @action="start"
         @jobParameters={{this.jobParameters}}
-        @jobs={{this.jobs}}
       />`
     );
 
@@ -276,8 +266,6 @@ module('Integration | Component | pipeline/parameters', function (hooks) {
   });
 
   test('it updates parameter value on input', async function (assert) {
-    const pipelinePageState = this.owner.lookup('service:pipeline-page-state');
-
     const onUpdateParameters = sinon.spy();
 
     sinon.stub(pipelinePageState, 'getPipeline').returns({
@@ -285,6 +273,12 @@ module('Integration | Component | pipeline/parameters', function (hooks) {
         foo: { value: 'foofoo' }
       }
     });
+    sinon.stub(pipelinePageState, 'getJobs').returns([
+      {
+        name: 'job1',
+        permutations: [{ parameters: { p1: { value: 'p1' } } }]
+      }
+    ]);
 
     this.setProperties({
       event: {
@@ -295,12 +289,6 @@ module('Integration | Component | pipeline/parameters', function (hooks) {
           }
         }
       },
-      jobs: [
-        {
-          name: 'job1',
-          permutations: [{ parameters: { p1: { value: 'p1' } } }]
-        }
-      ],
       onUpdateParameters
     });
 
@@ -308,7 +296,6 @@ module('Integration | Component | pipeline/parameters', function (hooks) {
       hbs`<Pipeline::Parameters
         @action="start"
         @event={{this.event}}
-        @jobs={{this.jobs}}
         @onUpdateParameters={{this.onUpdateParameters}}
       />`
     );
@@ -324,8 +311,6 @@ module('Integration | Component | pipeline/parameters', function (hooks) {
   });
 
   test('it updates job parameter value on input', async function (assert) {
-    const pipelinePageState = this.owner.lookup('service:pipeline-page-state');
-
     const onUpdateParameters = sinon.spy();
 
     sinon.stub(pipelinePageState, 'getPipeline').returns({
@@ -333,6 +318,12 @@ module('Integration | Component | pipeline/parameters', function (hooks) {
         foo: { value: 'foofoo' }
       }
     });
+    sinon.stub(pipelinePageState, 'getJobs').returns([
+      {
+        name: 'job1',
+        permutations: [{ parameters: { p1: { value: 'p1' } } }]
+      }
+    ]);
 
     this.setProperties({
       event: {
@@ -343,12 +334,6 @@ module('Integration | Component | pipeline/parameters', function (hooks) {
           }
         }
       },
-      jobs: [
-        {
-          name: 'job1',
-          permutations: [{ parameters: { p1: { value: 'p1' } } }]
-        }
-      ],
       job: { name: 'job1' },
       onUpdateParameters
     });
@@ -357,7 +342,6 @@ module('Integration | Component | pipeline/parameters', function (hooks) {
       hbs`<Pipeline::Parameters
         @action="start"
         @event={{this.event}}
-        @jobs={{this.jobs}}
         @job={{this.job}}
         @onUpdateParameters={{this.onUpdateParameters}}
       />`
@@ -374,8 +358,6 @@ module('Integration | Component | pipeline/parameters', function (hooks) {
   });
 
   test('it updates parameter value on selection', async function (assert) {
-    const pipelinePageState = this.owner.lookup('service:pipeline-page-state');
-
     const onUpdateParameters = sinon.spy();
 
     sinon.stub(pipelinePageState, 'getPipeline').returns({
@@ -383,6 +365,7 @@ module('Integration | Component | pipeline/parameters', function (hooks) {
         foo: ['foo', 'bar']
       }
     });
+    sinon.stub(pipelinePageState, 'getJobs').returns([]);
 
     this.setProperties({
       event: {
@@ -392,7 +375,6 @@ module('Integration | Component | pipeline/parameters', function (hooks) {
           }
         }
       },
-      jobs: [],
       onUpdateParameters
     });
 
@@ -400,7 +382,6 @@ module('Integration | Component | pipeline/parameters', function (hooks) {
       hbs`<Pipeline::Parameters
         @action="start"
         @event={{this.event}}
-        @jobs={{this.jobs}}
         @onUpdateParameters={{this.onUpdateParameters}}
       />`
     );
@@ -416,13 +397,12 @@ module('Integration | Component | pipeline/parameters', function (hooks) {
   });
 
   test('it adds icon when input is not equal to default value', async function (assert) {
-    const pipelinePageState = this.owner.lookup('service:pipeline-page-state');
-
     sinon.stub(pipelinePageState, 'getPipeline').returns({
       parameters: {
         foo: { value: 'foobar' }
       }
     });
+    sinon.stub(pipelinePageState, 'getJobs').returns([]);
 
     this.setProperties({
       event: {
@@ -432,7 +412,6 @@ module('Integration | Component | pipeline/parameters', function (hooks) {
           }
         }
       },
-      jobs: [],
       onUpdateParameters: () => {}
     });
 
@@ -440,7 +419,6 @@ module('Integration | Component | pipeline/parameters', function (hooks) {
       hbs`<Pipeline::Parameters
         @action="start"
         @event={{this.event}}
-        @jobs={{this.jobs}}
         @onUpdateParameters={{this.onUpdateParameters}}
       />`
     );
@@ -466,14 +444,13 @@ module('Integration | Component | pipeline/parameters', function (hooks) {
   });
 
   test('it renders inputs as read only when no action is set', async function (assert) {
-    const pipelinePageState = this.owner.lookup('service:pipeline-page-state');
-
     sinon.stub(pipelinePageState, 'getPipeline').returns({
       parameters: {
         bar: ['barbar', 'bazbaz'],
         foo: { value: 'foo', description: 'awesome' }
       }
     });
+    sinon.stub(pipelinePageState, 'getJobs').returns([{ name: 'job1' }]);
 
     this.setProperties({
       event: {
@@ -483,18 +460,12 @@ module('Integration | Component | pipeline/parameters', function (hooks) {
             foo: { value: 'foo' }
           }
         }
-      },
-      jobs: [
-        {
-          name: 'job1'
-        }
-      ]
+      }
     });
 
     await render(
       hbs`<Pipeline::Parameters
         @event={{this.event}}
-        @jobs={{this.jobs}}
       />`
     );
 

--- a/tests/integration/components/pipeline/workflow/component-test.js
+++ b/tests/integration/components/pipeline/workflow/component-test.js
@@ -22,6 +22,7 @@ module('Integration | Component | pipeline/workflow', function (hooks) {
     sinon.stub(pipelinePageState, 'getPipelineId').returns(pipelineId);
     sinon.stub(pipelinePageState, 'getTriggers').returns([]);
     sinon.stub(pipelinePageState, 'getStages').returns([]);
+    sinon.stub(pipelinePageState, 'getJobs').returns([]);
   });
 
   test('it renders for pipeline with no events', async function (assert) {
@@ -84,7 +85,6 @@ module('Integration | Component | pipeline/workflow', function (hooks) {
 
     this.setProperties({
       userSettings: {},
-      jobs: [],
       latestEvent: {
         id: 123,
         sha: 'abc123def456',
@@ -97,7 +97,6 @@ module('Integration | Component | pipeline/workflow', function (hooks) {
     await render(
       hbs`<Pipeline::Workflow
         @userSettings={{this.userSettings}}
-        @jobs={{this.jobs}}
         @latestEvent={{this.latestCommitEvent}}
         @invalidEvent={{true}}
       />`
@@ -121,14 +120,12 @@ module('Integration | Component | pipeline/workflow', function (hooks) {
     sinon.stub(shuttle, 'fetchFromApi').resolves([]);
 
     this.setProperties({
-      userSettings: {},
-      jobs: []
+      userSettings: {}
     });
 
     await render(
       hbs`<Pipeline::Workflow
         @userSettings={{this.userSettings}}
-        @jobs={{this.jobs}}
         @latestCommitEvent={{this.latestCommitEvent}}
         @invalidEvent={{true}}
       />`
@@ -166,7 +163,6 @@ module('Integration | Component | pipeline/workflow', function (hooks) {
 
     this.setProperties({
       userSettings: {},
-      jobs: [],
       latestEvent: event,
       event
     });
@@ -174,7 +170,6 @@ module('Integration | Component | pipeline/workflow', function (hooks) {
     await render(
       hbs`<Pipeline::Workflow
         @userSettings={{this.userSettings}}
-        @jobs={{this.jobs}}
         @stages={{this.stages}}
         @latestCommitEvent={{this.latestCommitEvent}}
         @event={{this.event}}
@@ -213,7 +208,6 @@ module('Integration | Component | pipeline/workflow', function (hooks) {
 
     this.setProperties({
       userSettings: {},
-      jobs: [],
       latestEvent: event,
       event,
       prNums: []
@@ -222,7 +216,6 @@ module('Integration | Component | pipeline/workflow', function (hooks) {
     await render(
       hbs`<Pipeline::Workflow
         @userSettings={{this.userSettings}}
-        @jobs={{this.jobs}}
         @latestCommitEvent={{this.latestCommitEvent}}
         @event={{this.event}}
         @prNums={{this.prNums}}
@@ -263,7 +256,6 @@ module('Integration | Component | pipeline/workflow', function (hooks) {
 
     this.setProperties({
       userSettings: {},
-      jobs: [],
       latestEvent: event,
       event,
       prNums: []
@@ -272,7 +264,6 @@ module('Integration | Component | pipeline/workflow', function (hooks) {
     await render(
       hbs`<Pipeline::Workflow
         @userSettings={{this.userSettings}}
-        @jobs={{this.jobs}}
         @latestCommitEvent={{this.latestCommitEvent}}
         @event={{this.event}}
         @prNums={{this.prNums}}

--- a/tests/integration/components/pipeline/workflow/graph/component-test.js
+++ b/tests/integration/components/pipeline/workflow/graph/component-test.js
@@ -8,12 +8,19 @@ module('Integration | Component | pipeline/workflow/graph', function (hooks) {
   setupRenderingTest(hooks);
 
   const stages = [];
+  const jobs = [];
 
   hooks.beforeEach(function () {
     const pipelinePageState = this.owner.lookup('service:pipeline-page-state');
 
-    stages.splice(0);
     sinon.stub(pipelinePageState, 'getStages').returns(stages);
+    sinon.stub(pipelinePageState, 'getJobs').returns(jobs);
+
+    jobs.push({ id: 1 });
+  });
+  hooks.afterEach(function () {
+    stages.splice(0);
+    jobs.splice(0);
   });
 
   test('it renders base graph', async function (assert) {
@@ -23,7 +30,6 @@ module('Integration | Component | pipeline/workflow/graph', function (hooks) {
         edges: [{ src: '~commit', dest: 'main' }]
       },
       event: { startFrom: '~commit' },
-      jobs: [{ id: 1 }],
       builds: [{ id: 1, jobId: 1, status: 'SUCCESS' }],
       displayJobNameLength: 20
     });
@@ -31,7 +37,6 @@ module('Integration | Component | pipeline/workflow/graph', function (hooks) {
       hbs`<Pipeline::Workflow::Graph
             @workflowGraph={{this.workflowGraph}}
             @event={{this.event}}
-            @jobs={{this.jobs}}
             @builds={{this.builds}}
             @chainPr={{false}}
             @displayJobNameLength={{this.displayJobNameLength}}
@@ -52,7 +57,6 @@ module('Integration | Component | pipeline/workflow/graph', function (hooks) {
         edges: [{ src: nodeNames[0], dest: nodeNames[1] }]
       },
       event: { startFrom: nodeNames[0] },
-      jobs: [{ id: 1 }],
       builds: [{ id: 1, jobId: 1, status: 'SUCCESS' }],
       displayJobNameLength: 25
     });
@@ -60,7 +64,6 @@ module('Integration | Component | pipeline/workflow/graph', function (hooks) {
       hbs`<Pipeline::Workflow::Graph
             @workflowGraph={{this.workflowGraph}}
             @event={{this.event}}
-            @jobs={{this.jobs}}
             @builds={{this.builds}}
             @chainPr={{false}}
             @displayJobNameLength={{this.displayJobNameLength}}
@@ -81,6 +84,13 @@ module('Integration | Component | pipeline/workflow/graph', function (hooks) {
 
   test('it renders virtual stage', async function (assert) {
     stages.push({ id: 10, name: 'test', jobIds: [1], setup: 11, teardown: 12 });
+    jobs.splice(0).push(
+      ...[
+        { id: 1, name: 'main' },
+        { id: 11, name: 'stage@test:setup' },
+        { id: 12, name: 'stage@test:teardown' }
+      ]
+    );
 
     this.setProperties({
       workflowGraph: {
@@ -107,11 +117,6 @@ module('Integration | Component | pipeline/workflow/graph', function (hooks) {
         ]
       },
       event: { startFrom: '~commit' },
-      jobs: [
-        { id: 1, name: 'main' },
-        { id: 11, name: 'stage@test:setup' },
-        { id: 12, name: 'stage@test:teardown' }
-      ],
       builds: [
         { id: 1, jobId: 11, status: 'SUCCESS' },
         { id: 2, jobId: 1, status: 'SUCCESS' },
@@ -123,7 +128,6 @@ module('Integration | Component | pipeline/workflow/graph', function (hooks) {
       hbs`<Pipeline::Workflow::Graph
             @workflowGraph={{this.workflowGraph}}
             @event={{this.event}}
-            @jobs={{this.jobs}}
             @builds={{this.builds}}
             @chainPr={{false}}
             @displayJobNameLength={{this.displayJobNameLength}}
@@ -137,6 +141,13 @@ module('Integration | Component | pipeline/workflow/graph', function (hooks) {
 
   test('it renders stage', async function (assert) {
     stages.push({ id: 10, name: 'test', jobIds: [1], setup: 11, teardown: 12 });
+    jobs.splice(0).push(
+      ...[
+        { id: 1, name: 'main' },
+        { id: 11, name: 'stage@test:setup' },
+        { id: 12, name: 'stage@test:teardown' }
+      ]
+    );
 
     this.setProperties({
       workflowGraph: {
@@ -161,11 +172,6 @@ module('Integration | Component | pipeline/workflow/graph', function (hooks) {
         ]
       },
       event: { startFrom: '~commit' },
-      jobs: [
-        { id: 1, name: 'main' },
-        { id: 11, name: 'stage@test:setup' },
-        { id: 12, name: 'stage@test:teardown' }
-      ],
       builds: [
         { id: 1, jobId: 11, status: 'SUCCESS' },
         { id: 2, jobId: 1, status: 'SUCCESS' },
@@ -177,7 +183,6 @@ module('Integration | Component | pipeline/workflow/graph', function (hooks) {
       hbs`<Pipeline::Workflow::Graph
             @workflowGraph={{this.workflowGraph}}
             @event={{this.event}}
-            @jobs={{this.jobs}}
             @builds={{this.builds}}
             @chainPr={{false}}
             @displayJobNameLength={{this.displayJobNameLength}}
@@ -199,7 +204,6 @@ module('Integration | Component | pipeline/workflow/graph', function (hooks) {
         ]
       },
       event: { startFrom: '~pr' },
-      jobs: [{ id: 1 }],
       builds: [{ id: 1, jobId: 1, status: 'SUCCESS' }],
       displayJobNameLength: 20
     });
@@ -207,7 +211,6 @@ module('Integration | Component | pipeline/workflow/graph', function (hooks) {
       hbs`<Pipeline::Workflow::Graph
             @workflowGraph={{this.workflowGraph}}
             @event={{this.event}}
-            @jobs={{this.jobs}}
             @builds={{this.builds}}
             @chainPr={{true}}
             @displayJobNameLength={{this.displayJobNameLength}}
@@ -238,7 +241,6 @@ module('Integration | Component | pipeline/workflow/graph', function (hooks) {
         edges: [{ src: '~commit', dest: 'main' }]
       },
       event: { startFrom: '~commit' },
-      jobs: [{ id: 1 }],
       builds: [{ id: 1, jobId: 1, status: 'SUCCESS' }],
       displayJobNameLength: 20
     });
@@ -246,7 +248,6 @@ module('Integration | Component | pipeline/workflow/graph', function (hooks) {
       hbs`<Pipeline::Workflow::Graph
             @workflowGraph={{this.workflowGraph}}
             @event={{this.event}}
-            @jobs={{this.jobs}}
             @builds={{this.builds}}
             @chainPr={{false}}
             @displayJobNameLength={{this.displayJobNameLength}}
@@ -262,13 +263,14 @@ module('Integration | Component | pipeline/workflow/graph', function (hooks) {
   });
 
   test('it re-renders graph when builds update', async function (assert) {
+    jobs.splice(0).push([{ id: 123 }]);
+
     this.setProperties({
       workflowGraph: {
         nodes: [{ name: '~commit' }, { name: 'main', id: 123 }],
         edges: [{ src: '~commit', dest: 'main' }]
       },
       event: { startFrom: '~commit' },
-      jobs: [{ id: 123 }],
       builds: [{ id: 1, jobId: 123, status: 'RUNNING' }],
       displayJobNameLength: 20
     });
@@ -276,7 +278,6 @@ module('Integration | Component | pipeline/workflow/graph', function (hooks) {
       hbs`<Pipeline::Workflow::Graph
             @workflowGraph={{this.workflowGraph}}
             @event={{this.event}}
-            @jobs={{this.jobs}}
             @builds={{this.builds}}
             @chainPr={{false}}
             @displayJobNameLength={{this.displayJobNameLength}}
@@ -295,6 +296,13 @@ module('Integration | Component | pipeline/workflow/graph', function (hooks) {
 
   test('it re-renders graph when stage builds update', async function (assert) {
     stages.push({ id: 10, name: 'test', jobIds: [1], setup: 11, teardown: 12 });
+    jobs.splice(0).push(
+      ...[
+        { id: 1, name: 'main' },
+        { id: 11, name: 'stage@test:setup' },
+        { id: 12, name: 'stage@test:teardown' }
+      ]
+    );
 
     this.setProperties({
       workflowGraph: {
@@ -319,11 +327,6 @@ module('Integration | Component | pipeline/workflow/graph', function (hooks) {
         ]
       },
       event: { startFrom: '~commit' },
-      jobs: [
-        { id: 1, name: 'main' },
-        { id: 11, name: 'stage@test:setup' },
-        { id: 12, name: 'stage@test:teardown' }
-      ],
       builds: [
         { id: 1, jobId: 11, status: 'SUCCESS' },
         { id: 2, jobId: 1, status: 'SUCCESS' },
@@ -336,7 +339,6 @@ module('Integration | Component | pipeline/workflow/graph', function (hooks) {
       hbs`<Pipeline::Workflow::Graph
             @workflowGraph={{this.workflowGraph}}
             @event={{this.event}}
-            @jobs={{this.jobs}}
             @builds={{this.builds}}
             @stageBuilds={{this.stageBuilds}}
             @chainPr={{false}}

--- a/tests/integration/components/pipeline/workflow/tooltip/component-test.js
+++ b/tests/integration/components/pipeline/workflow/tooltip/component-test.js
@@ -286,7 +286,6 @@ module('Integration | Component | pipeline/workflow/tooltip', function (hooks) {
         sizes: { ICON_SIZE: 0 }
       },
       event: {},
-      jobs: [],
       builds: []
     });
 
@@ -294,7 +293,6 @@ module('Integration | Component | pipeline/workflow/tooltip', function (hooks) {
       hbs`<Pipeline::Workflow::Tooltip
         @d3Data={{this.d3Data}}
         @event={{this.event}}
-        @jobs={{this.jobs}}
         @builds={{this.builds}}
       />`
     );

--- a/tests/integration/components/pipeline/workflow/tooltip/component-test.js
+++ b/tests/integration/components/pipeline/workflow/tooltip/component-test.js
@@ -14,6 +14,7 @@ module('Integration | Component | pipeline/workflow/tooltip', function (hooks) {
     sinon
       .stub(pipelinePageState, 'getPipeline')
       .returns({ id: 987, state: 'ACTIVE' });
+    sinon.stub(pipelinePageState, 'getJobs').returns([]);
   });
 
   test('it renders build detail and metrics links', async function (assert) {
@@ -26,7 +27,6 @@ module('Integration | Component | pipeline/workflow/tooltip', function (hooks) {
         sizes: { ICON_SIZE: 0 }
       },
       event: {},
-      jobs: [],
       builds: []
     });
 
@@ -34,7 +34,6 @@ module('Integration | Component | pipeline/workflow/tooltip', function (hooks) {
       hbs`<Pipeline::Workflow::Tooltip
         @d3Data={{this.d3Data}}
         @event={{this.event}}
-        @jobs={{this.jobs}}
         @builds={{this.builds}}
       />`
     );
@@ -55,7 +54,6 @@ module('Integration | Component | pipeline/workflow/tooltip', function (hooks) {
         sizes: { ICON_SIZE: 0 }
       },
       event: {},
-      jobs: [],
       builds: []
     });
 
@@ -63,7 +61,6 @@ module('Integration | Component | pipeline/workflow/tooltip', function (hooks) {
       hbs`<Pipeline::Workflow::Tooltip
         @d3Data={{this.d3Data}}
         @event={{this.event}}
-        @jobs={{this.jobs}}
         @builds={{this.builds}}
       />`
     );
@@ -82,7 +79,6 @@ module('Integration | Component | pipeline/workflow/tooltip', function (hooks) {
         sizes: { ICON_SIZE: 0 }
       },
       event: {},
-      jobs: [],
       builds: []
     });
 
@@ -90,7 +86,6 @@ module('Integration | Component | pipeline/workflow/tooltip', function (hooks) {
       hbs`<Pipeline::Workflow::Tooltip
         @d3Data={{this.d3Data}}
         @event={{this.event}}
-        @jobs={{this.jobs}}
         @builds={{this.builds}}
       />`
     );
@@ -109,7 +104,6 @@ module('Integration | Component | pipeline/workflow/tooltip', function (hooks) {
         sizes: { ICON_SIZE: 0 }
       },
       event: {},
-      jobs: [],
       builds: []
     });
 
@@ -117,7 +111,6 @@ module('Integration | Component | pipeline/workflow/tooltip', function (hooks) {
       hbs`<Pipeline::Workflow::Tooltip
         @d3Data={{this.d3Data}}
         @event={{this.event}}
-        @jobs={{this.jobs}}
         @builds={{this.builds}}
       />`
     );
@@ -137,7 +130,6 @@ module('Integration | Component | pipeline/workflow/tooltip', function (hooks) {
         sizes: { ICON_SIZE: 0 }
       },
       event: {},
-      jobs: [],
       builds: []
     });
 
@@ -145,7 +137,6 @@ module('Integration | Component | pipeline/workflow/tooltip', function (hooks) {
       hbs`<Pipeline::Workflow::Tooltip
         @d3Data={{this.d3Data}}
         @event={{this.event}}
-        @jobs={{this.jobs}}
         @builds={{this.builds}}
       />`
     );
@@ -167,7 +158,6 @@ module('Integration | Component | pipeline/workflow/tooltip', function (hooks) {
         sizes: { ICON_SIZE: 0 }
       },
       event: {},
-      jobs: [],
       builds: []
     });
 
@@ -175,7 +165,6 @@ module('Integration | Component | pipeline/workflow/tooltip', function (hooks) {
       hbs`<Pipeline::Workflow::Tooltip
         @d3Data={{this.d3Data}}
         @event={{this.event}}
-        @jobs={{this.jobs}}
         @builds={{this.builds}}
       />`
     );
@@ -195,7 +184,6 @@ module('Integration | Component | pipeline/workflow/tooltip', function (hooks) {
         sizes: { ICON_SIZE: 0 }
       },
       event: {},
-      jobs: [],
       builds: []
     });
 
@@ -203,7 +191,6 @@ module('Integration | Component | pipeline/workflow/tooltip', function (hooks) {
       hbs`<Pipeline::Workflow::Tooltip
         @d3Data={{this.d3Data}}
         @event={{this.event}}
-        @jobs={{this.jobs}}
         @builds={{this.builds}}
       />`
     );
@@ -222,7 +209,6 @@ module('Integration | Component | pipeline/workflow/tooltip', function (hooks) {
         sizes: { ICON_SIZE: 0 }
       },
       event: {},
-      jobs: [],
       builds: []
     });
 
@@ -230,7 +216,6 @@ module('Integration | Component | pipeline/workflow/tooltip', function (hooks) {
       hbs`<Pipeline::Workflow::Tooltip
         @d3Data={{this.d3Data}}
         @event={{this.event}}
-        @jobs={{this.jobs}}
         @builds={{this.builds}}
       />`
     );
@@ -249,7 +234,6 @@ module('Integration | Component | pipeline/workflow/tooltip', function (hooks) {
         sizes: { ICON_SIZE: 0 }
       },
       event: {},
-      jobs: [],
       builds: []
     });
 
@@ -257,7 +241,6 @@ module('Integration | Component | pipeline/workflow/tooltip', function (hooks) {
       hbs`<Pipeline::Workflow::Tooltip
         @d3Data={{this.d3Data}}
         @event={{this.event}}
-        @jobs={{this.jobs}}
         @builds={{this.builds}}
       />`
     );
@@ -276,7 +259,6 @@ module('Integration | Component | pipeline/workflow/tooltip', function (hooks) {
         sizes: { ICON_SIZE: 0 }
       },
       event: {},
-      jobs: [],
       builds: []
     });
 
@@ -284,7 +266,6 @@ module('Integration | Component | pipeline/workflow/tooltip', function (hooks) {
       hbs`<Pipeline::Workflow::Tooltip
         @d3Data={{this.d3Data}}
         @event={{this.event}}
-        @jobs={{this.jobs}}
         @builds={{this.builds}}
       />`
     );

--- a/tests/integration/components/pipeline/workflow/tooltip/stage/component-test.js
+++ b/tests/integration/components/pipeline/workflow/tooltip/stage/component-test.js
@@ -26,7 +26,6 @@ module(
           }
         },
         event: {},
-        jobs: [],
         builds: [],
         workflowGraph: {
           nodes: [],
@@ -38,7 +37,6 @@ module(
         hbs`<Pipeline::Workflow::Tooltip::Stage
             @d3Data={{this.d3Data}}
             @event={{this.event}}
-            @jobs={{this.jobs}}
             @builds={{this.builds}}
             @workflowGraph={{this.workflowGraph}}
         />`
@@ -66,7 +64,6 @@ module(
           }
         },
         event: {},
-        jobs: [],
         builds: [],
         workflowGraph: {
           nodes: [],
@@ -78,7 +75,6 @@ module(
         hbs`<Pipeline::Workflow::Tooltip::Stage
             @d3Data={{this.d3Data}}
             @event={{this.event}}
-            @jobs={{this.jobs}}
             @builds={{this.builds}}
             @workflowGraph={{this.workflowGraph}}
         />`
@@ -107,7 +103,6 @@ module(
           }
         },
         event: {},
-        jobs: [],
         workflowGraph: {
           nodes: [],
           edges: []
@@ -118,7 +113,6 @@ module(
         hbs`<Pipeline::Workflow::Tooltip::Stage
             @d3Data={{this.d3Data}}
             @event={{this.event}}
-            @jobs={{this.jobs}}
             @builds={{this.builds}}
             @workflowGraph={{this.workflowGraph}}
         />`


### PR DESCRIPTION
## Context
Jobs can be added to the injectable page state for use in the v2 UI. This will help reduce the amount of data being passed directly into the main component and any downstream components which may require the job data (i.e., the parameters component which is a few component layers down).


## Objective
Refactors the jobs data to be included in the injectable page state

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
