### PR TITLE
feat: Update event status

### DIFF
--- a/app/components/pipeline/event/card/component.js
+++ b/app/components/pipeline/event/card/component.js
@@ -40,6 +40,8 @@ export default class PipelineEventCardComponent extends Component {
 
   @tracked status;
 
+  @tracked aggregateStatus;
+
   @tracked hideCard;
 
   @tracked failureCount;
@@ -169,6 +171,7 @@ export default class PipelineEventCardComponent extends Component {
 
     this.builds = builds;
     this.status = getStatus(this.event, builds);
+    this.aggregateStatus = this.status;
 
     if (this.args.handleFilter) {
       const pipeline = this.pipelinePageState.getPipeline();
@@ -182,6 +185,12 @@ export default class PipelineEventCardComponent extends Component {
       this.failureCount = getFailureCount(builds);
       this.warningCount = getWarningCount(builds);
       this.successCount = getSuccessCount(builds);
+
+      if (this.warningCount > 0) {
+        this.aggregateStatus = 'WARNING';
+      } else if (this.failureCount > 0) {
+        this.aggregateStatus = 'FAILURE';
+      }
     }
 
     if (!this.durationIntervalId && !isEventComplete) {

--- a/app/components/pipeline/event/card/template.hbs
+++ b/app/components/pipeline/event/card/template.hbs
@@ -6,7 +6,7 @@
   {{on "click" this.goToEvent}}
 >
   <div class="event-card-title">
-    <div class="event-status {{this.status}}">
+    <div class="event-status {{this.aggregateStatus}}">
       <FaIcon
         @icon={{this.icon.name}}
         @fixedWidth="true"

--- a/app/utils/pipeline/event.js
+++ b/app/utils/pipeline/event.js
@@ -26,15 +26,19 @@ export const isComplete = builds => {
     return false;
   }
 
-  return builds.every(build => {
-    const { status } = build;
+  const filteredBuilds = builds.filter(build => build.status !== 'CREATED');
 
-    if (status === 'UNSTABLE') {
-      return build.endTime !== undefined;
-    }
+  return filteredBuilds.length === 0
+    ? false
+    : filteredBuilds.every(build => {
+        const { status } = build;
 
-    return !unfinishedStatuses.includes(status);
-  });
+        if (status === 'UNSTABLE') {
+          return build.endTime !== undefined;
+        }
+
+        return !unfinishedStatuses.includes(status);
+      });
 };
 
 /**
@@ -53,9 +57,15 @@ export const getStatus = (event, builds) => {
   }
 
   if (isComplete(builds)) {
-    return builds.filter(build => build.status === 'WARNING').length > 0
+    const filteredBuilds = builds.filter(build => build.status !== 'CREATED');
+
+    if (filteredBuilds.length === 0) {
+      return 'RUNNING';
+    }
+
+    return filteredBuilds.filter(build => build.status === 'WARNING').length > 0
       ? 'WARNING'
-      : builds[0].status;
+      : filteredBuilds[0].status;
   }
 
   return builds[0].status === 'FROZEN' ? 'FROZEN' : 'RUNNING';

--- a/tests/unit/utils/pipeline/event-test.js
+++ b/tests/unit/utils/pipeline/event-test.js
@@ -55,6 +55,11 @@ module('Unit | Utility | Pipeline | event', function () {
     );
     assert.equal(isComplete([{ status: 'SUCCESS' }]), true);
     assert.equal(isComplete([{ status: 'QUEUED' }]), false);
+    assert.equal(isComplete([{ status: 'CREATED' }]), false);
+    assert.equal(
+      isComplete([{ status: 'CREATED' }, { status: 'SUCCESS' }]),
+      true
+    );
   });
 
   test('getStatus returns correct value', function (assert) {
@@ -68,5 +73,10 @@ module('Unit | Utility | Pipeline | event', function () {
     assert.equal(getStatus({}, [{ status: 'FROZEN' }]), 'FROZEN');
     assert.equal(getStatus({}, [{ status: 'CREATED' }]), 'RUNNING');
     assert.equal(getStatus({}, [{ status: 'WARNING' }]), 'WARNING');
+    assert.equal(getStatus({}, [{ status: 'CREATED' }]), 'RUNNING');
+    assert.equal(
+      getStatus({}, [{ status: 'CREATED' }, { status: 'SUCCESS' }]),
+      'SUCCESS'
+    );
   });
 });


### PR DESCRIPTION
## Context
Builds with the created status should typically be ignored as it's a state that's primarily used by the backend.  If there is only a single build with the created status, the build status can be used directly as there is no other upstream job dependencies to account for

## Objective
1. Adds in additional handling for builds with a created status to properly ignore those statuses
2. Detaches the event card status icon from the style so that long pipelines can have a running status icon but styled/colored to better highlight any builds that may require attention.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
