### PR TITLE
feat: Modal for creating tokens

### DIFF
--- a/app/components/tokens/modal/create/component.js
+++ b/app/components/tokens/modal/create/component.js
@@ -1,0 +1,93 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+
+export default class TokensModalCreateComponent extends Component {
+  @service shuttle;
+
+  @service pipelinePageState;
+
+  @tracked errorMessage;
+
+  @tracked tokenName;
+
+  @tracked tokenDescription;
+
+  @tracked isAwaitingResponse;
+
+  @tracked wasActionSuccessful;
+
+  @tracked isCopyButtonDisabled;
+
+  @tracked newToken;
+
+  tokenNames;
+
+  constructor() {
+    super(...arguments);
+
+    this.isAwaitingResponse = false;
+    this.wasActionSuccessful = false;
+    this.isCopyButtonDisabled = false;
+    this.tokenNames = this.args.tokens.map(token => token.name);
+  }
+
+  isTokenNameInvalid() {
+    return this.tokenNames.includes(this.tokenName);
+  }
+
+  get inputClass() {
+    return this.isTokenNameInvalid() ? 'invalid' : null;
+  }
+
+  get isSubmitButtonDisabled() {
+    if (this.wasActionSuccessful || this.isAwaitingResponse) {
+      return true;
+    }
+
+    return !this.tokenName || this.isTokenNameInvalid();
+  }
+
+  get inputDisabled() {
+    return !!this.tokenValue;
+  }
+
+  get tokenValue() {
+    return this.newToken?.value;
+  }
+
+  @action
+  copyTokenValue() {
+    navigator.clipboard.writeText(this.tokenValue).then(() => {
+      this.isCopyButtonDisabled = true;
+    });
+  }
+
+  @action
+  async createToken() {
+    this.isAwaitingResponse = true;
+
+    const url =
+      this.args.type === 'pipeline'
+        ? `/pipelines/${this.pipelinePageState.getPipelineId()}/tokens`
+        : '/tokens';
+
+    return this.shuttle
+      .fetchFromApi('post', url, {
+        name: this.tokenName,
+        description: this.tokenDescription
+      })
+      .then(response => {
+        this.newToken = response;
+        this.wasActionSuccessful = true;
+      })
+      .catch(err => {
+        this.wasActionSuccessful = false;
+        this.errorMessage = err.message;
+      })
+      .finally(() => {
+        this.isAwaitingResponse = false;
+      });
+  }
+}

--- a/app/components/tokens/modal/create/styles.scss
+++ b/app/components/tokens/modal/create/styles.scss
@@ -1,0 +1,46 @@
+@use 'screwdriver-colors' as colors;
+
+@mixin styles {
+  #create-token-modal {
+    &.modal {
+      .modal-dialog {
+        .modal-body {
+          .token-value-container {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+
+            .token-value {
+              margin-left: 5rem;
+            }
+          }
+
+          .create-new-token {
+            display: flex;
+            flex-direction: column;
+
+            label {
+              display: flex;
+              align-items: center;
+
+              div {
+                width: 6rem;
+              }
+
+              input {
+                flex: 1;
+
+                &.invalid {
+                  color: colors.$sd-warn-bg;
+                  outline: 2px solid colors.$sd-warn-bg;
+                  border-radius: 3px;
+                  border: none;
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/components/tokens/modal/create/template.hbs
+++ b/app/components/tokens/modal/create/template.hbs
@@ -1,0 +1,79 @@
+<BsModal
+  id="create-token-modal"
+  @onHide={{fn @closeModal this.newToken}}
+  as |modal|
+>
+  <modal.header>
+    Create a new {{@type}} token
+  </modal.header>
+  <modal.body>
+    {{#if this.errorMessage}}
+      <InfoMessage
+        id="error-message"
+        @message={{this.errorMessage}}
+        @type="warning"
+        @icon="triangle-exclamation"
+      />
+    {{/if}}
+    {{#if this.tokenValue}}
+      <BsAlert
+        id="success-container"
+        @dismissible={{false}}
+        @type="success"
+      >
+        <FaIcon @icon="circle-check" />
+        You can only see this value once, so remember to copy it!
+
+        <div class="token-value-container">
+          <div class="token-value">
+            {{this.tokenValue}}
+          </div>
+          <BsButton
+            @type="success"
+            @outline={{true}}
+            @onClick={{fn this.copyTokenValue}}
+            disabled={{this.isCopyButtonDisabled}}
+          >
+            <FaIcon
+              @icon="copy"
+            />
+          </BsButton>
+        </div>
+      </BsAlert>
+    {{/if}}
+
+    <div class="create-new-token">
+      <label>
+        <div>Name:</div>
+        <Input
+          id="token-name-input"
+          @type="text"
+          @value={{this.tokenName}}
+          autofocus={{true}}
+          class={{this.inputClass}}
+          disabled={{this.inputDisabled}}
+        />
+      </label>
+      <label>
+        <div>Description:</div>
+        <Input
+          @type="text"
+          @value={{this.tokenDescription}}
+          placeholder="Optional"
+          disabled={{this.inputDisabled}}
+        />
+      </label>
+    </div>
+  </modal.body>
+  <modal.footer>
+    <BsButton
+      id="submit-token"
+      class="confirm"
+      disabled={{this.isSubmitButtonDisabled}}
+      @defaultText="Create token"
+      @pendingText="Creating token..."
+      @type="primary"
+      @onClick={{fn this.createToken}}
+    />
+  </modal.footer>
+</BsModal>

--- a/tests/integration/components/tokens/modal/create/component-test.js
+++ b/tests/integration/components/tokens/modal/create/component-test.js
@@ -1,0 +1,147 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
+import { click, fillIn, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+
+module('Integration | Component | tokens/modal/create', function (hooks) {
+  setupRenderingTest(hooks);
+
+  let shuttle;
+
+  hooks.beforeEach(function () {
+    const pipelinePageState = this.owner.lookup('service:pipelinePageState');
+
+    shuttle = this.owner.lookup('service:shuttle');
+
+    sinon.stub(pipelinePageState, 'getPipelineId').returns(1);
+  });
+
+  test('it renders', async function (assert) {
+    this.setProperties({
+      tokens: [],
+      closeModal: () => {}
+    });
+
+    await render(
+      hbs`<Tokens::Modal::Create
+        @type="pipeline"
+        @tokens={{this.tokens}}
+        @closeModal={{this.closeModal}}
+      />`
+    );
+
+    assert.dom('.modal-header').hasText('Create a new pipeline token ×');
+    assert.dom('#error-message').doesNotExist();
+    assert.dom('#success-container').doesNotExist();
+    assert.dom('.create-new-token').exists({ count: 1 });
+    assert.dom('.create-new-token input').exists({ count: 2 });
+    assert.dom('#token-name-input').exists({ count: 1 });
+    assert.dom('#submit-token').exists({ count: 1 });
+    assert.dom('#submit-token').isDisabled();
+
+    await render(
+      hbs`<Tokens::Modal::Create
+        @type="user"
+        @tokens={{this.tokens}}
+        @closeModal={{this.closeModal}}
+      />`
+    );
+
+    assert.dom('.modal-header').hasText('Create a new user token ×');
+  });
+
+  test('it sets invalid class on invalid input', async function (assert) {
+    this.setProperties({
+      tokens: [{ name: 'test' }],
+      closeModal: () => {}
+    });
+
+    await render(
+      hbs`<Tokens::Modal::Create
+        @type="pipeline"
+        @tokens={{this.tokens}}
+        @closeModal={{this.closeModal}}
+      />`
+    );
+    assert.dom('#token-name-input').hasNoClass('invalid');
+
+    await fillIn('#token-name-input', 'test');
+    assert.dom('#token-name-input').hasClass('invalid');
+  });
+
+  test('it enables submit button when token name is valid', async function (assert) {
+    this.setProperties({
+      tokens: [{ name: 'test' }],
+      closeModal: () => {}
+    });
+
+    await render(
+      hbs`<Tokens::Modal::Create
+        @type="pipeline"
+        @tokens={{this.tokens}}
+        @closeModal={{this.closeModal}}
+      />`
+    );
+    assert.dom('#submit-token').isDisabled();
+
+    await fillIn('#token-name-input', 'new-token');
+    assert.dom('#submit-token').isNotDisabled();
+  });
+
+  test('it handles API error correctly', async function (assert) {
+    sinon.stub(shuttle, 'fetchFromApi').rejects({ message: 'error' });
+
+    this.setProperties({
+      tokens: [],
+      closeModal: () => {}
+    });
+
+    await render(
+      hbs`<Tokens::Modal::Create
+        @type="pipeline"
+        @tokens={{this.tokens}}
+        @closeModal={{this.closeModal}}
+      />`
+    );
+    await fillIn('#token-name-input', 'new-token');
+    await click('#submit-token');
+
+    assert.dom('#error-message').exists({ count: 1 });
+    assert.dom('#error-message').hasText('× error');
+    assert.dom('#submit-token').isNotDisabled();
+  });
+
+  test('it handles API success correctly', async function (assert) {
+    const closeModalSpy = sinon.spy();
+    const newToken = {
+      value: 'token-value'
+    };
+
+    sinon.stub(shuttle, 'fetchFromApi').resolves(newToken);
+
+    this.setProperties({
+      tokens: [],
+      closeModal: closeModalSpy
+    });
+
+    await render(
+      hbs`<Tokens::Modal::Create
+        @type="pipeline"
+        @tokens={{this.tokens}}
+        @closeModal={{this.closeModal}}
+      />`
+    );
+    await fillIn('#token-name-input', 'new-token');
+    await click('#submit-token');
+
+    assert.dom('#submit-token').isDisabled();
+    assert.dom('#error-message').doesNotExist();
+    assert.dom('#success-container').exists({ count: 1 });
+    assert.dom('#success-container .token-value').hasText(newToken.value);
+
+    await click('.modal-header .close');
+    assert.true(closeModalSpy.calledOnce);
+    assert.true(closeModalSpy.calledWith(newToken));
+  });
+});


### PR DESCRIPTION
## Context
Updating the V2 UI for pipeline secrets requires a new set of components to handle management of tokens.  This modal provides a new user experience that is in line with the rest of the V2 user experience leveraging modals more heavily for user interactions.

## Objective
Creates a new modal for facilitating creation of new API tokens

New modal look and feel
![Screenshot 2025-04-01 at 11-42-31 minghay_various Secrets](https://github.com/user-attachments/assets/7e3f99ac-b1cc-428e-821a-f7b96f8efd81)


![Screenshot 2025-04-01 at 11-43-23 minghay_various Secrets](https://github.com/user-attachments/assets/1976032a-b46e-4fe9-8605-9d51952ce730)

In modal validation of the required token value.  Note that the submit button is disabled when a token name is invalid
![Screenshot 2025-04-01 at 11-43-05 minghay_various Secrets](https://github.com/user-attachments/assets/fb7706db-f112-4420-ad41-b05889ba6167)

![Screenshot 2025-04-01 at 11-43-50 minghay_various Secrets](https://github.com/user-attachments/assets/e5cb1e24-9f2b-4582-b76a-3e01ff1fa8c5)

Successful token creation provides the token value in the message area.  This new message area is no longer dismissible but has a new addition with a copy button that copies the token value to the user's clipboard (can only be clicked once with the current implementation.  This restriction can be removed if deemed too restrictive).  Also note that the submit button is disabled as there is no support for creating multiple tokens in the same modal flow.
![Screenshot 2025-04-01 at 11-45-03 minghay_various Secrets](https://github.com/user-attachments/assets/d53259fd-cffb-4486-9799-2b7cda4c6966)

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
