### PR TITLE
fix: Remove fulfilled text

### DIFF
--- a/app/components/pipeline/modal/add-to-collection/template.hbs
+++ b/app/components/pipeline/modal/add-to-collection/template.hbs
@@ -73,7 +73,6 @@
       disabled={{this.isSubmitButtonDisabled}}
       @defaultText="Add to collection(s)"
       @pendingText="Adding to collection(s)..."
-      @fulfilledText="Added to collection(s)"
       @type="primary"
       @onClick={{fn this.submitCollections}}
     />

--- a/app/components/pipeline/modal/confirm-action/component.js
+++ b/app/components/pipeline/modal/confirm-action/component.js
@@ -89,12 +89,6 @@ export default class PipelineModalConfirmActionComponent extends Component {
     return `${capitalizeFirstLetter(this.action)}ing...`;
   }
 
-  get completedAction() {
-    return this.wasActionSuccessful
-      ? `${capitalizeFirstLetter(this.action)}ed`
-      : 'Yes';
-  }
-
   @action
   onUpdateParameters(parameters) {
     this.parameters = parameters;

--- a/app/components/pipeline/modal/confirm-action/template.hbs
+++ b/app/components/pipeline/modal/confirm-action/template.hbs
@@ -67,7 +67,6 @@
       @type="primary"
       @defaultText="Yes"
       @pendingText={{this.pendingAction}}
-      @fulfilledText={{this.completedAction}}
       @onClick={{fn this.startBuild}}
     />
   </modal.footer>

--- a/app/components/pipeline/modal/delete-pipeline/template.hbs
+++ b/app/components/pipeline/modal/delete-pipeline/template.hbs
@@ -51,7 +51,6 @@
       @type="primary"
       @defaultText="Yes"
       @pendingText="Deleting"
-      @fulfilledText="Deleted"
       @onClick={{fn this.deletePipeline}}
     />
   </modal.footer>

--- a/app/components/pipeline/modal/start-children/template.hbs
+++ b/app/components/pipeline/modal/start-children/template.hbs
@@ -23,7 +23,6 @@
       @type="primary"
       @defaultText="Yes"
       @pendingText="Starting"
-      @fulfilledText="Started"
       @onClick={{fn this.startChildren}}
     />
   </modal.footer>

--- a/app/components/pipeline/modal/start-event/template.hbs
+++ b/app/components/pipeline/modal/start-event/template.hbs
@@ -47,7 +47,6 @@
       @type="primary"
       @defaultText="Yes"
       @pendingText="Starting"
-      @fulfilledText="Started"
       @onClick={{fn this.startBuild}}
     />
   </modal.footer>

--- a/app/components/pipeline/modal/stop-build/template.hbs
+++ b/app/components/pipeline/modal/stop-build/template.hbs
@@ -25,7 +25,6 @@
       @type="primary"
       @defaultText="Yes"
       @pendingText="Stopping"
-      @fulfilledText="Stopped"
       @onClick={{fn this.stopBuild}}
     />
   </modal.footer>

--- a/app/components/pipeline/modal/toggle-job/template.hbs
+++ b/app/components/pipeline/modal/toggle-job/template.hbs
@@ -40,7 +40,6 @@
       @type="primary"
       @defaultText="Save"
       @pendingText="Saving"
-      @fulfilledText="Saved"
       @onClick={{fn this.updateJob}}
       disabled={{this.isDisabled}}
     />


### PR DESCRIPTION
## Context
The bootstrap ember components for buttons supports the use of a fulfilled text that will replace the button text when the async click action rejects; however, there's no good way to have that set unless the code rejects or throws an error which is then not compatible with the current testing setup.  As such, it's mostly dead end code and should just be removed.

## Objective
Removes fulfilled text option on the bootstrap button components

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
