### PR TITLE
feat: Modal component to refresh tokens

### DIFF
--- a/app/components/tokens/modal/refresh/component.js
+++ b/app/components/tokens/modal/refresh/component.js
@@ -1,0 +1,76 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+
+export default class TokensModalRefreshComponent extends Component {
+  @service shuttle;
+
+  @service pipelinePageState;
+
+  @tracked errorMessage;
+
+  @tracked isAwaitingResponse;
+
+  @tracked wasActionSuccessful;
+
+  @tracked isCopyButtonDisabled;
+
+  @tracked tokenValue;
+
+  token;
+
+  constructor() {
+    super(...arguments);
+
+    this.isAwaitingResponse = false;
+    this.wasActionSuccessful = false;
+    this.isCopyButtonDisabled = false;
+
+    this.token = this.args.token;
+  }
+
+  get tokenType() {
+    return this.token.type;
+  }
+
+  get isSubmitButtonDisabled() {
+    return !!(this.wasActionSuccessful || this.isAwaitingResponse);
+  }
+
+  get tokenValue() {
+    return this.token?.value;
+  }
+
+  @action
+  copyTokenValue() {
+    navigator.clipboard.writeText(this.tokenValue).then(() => {
+      this.isCopyButtonDisabled = true;
+    });
+  }
+
+  @action
+  async refreshToken() {
+    this.isAwaitingResponse = true;
+
+    const refreshUrl = `/tokens/${this.token.id}/refresh`;
+    const url =
+      this.token.type === 'pipeline'
+        ? `/pipelines/${this.pipelinePageState.getPipelineId()}${refreshUrl}`
+        : refreshUrl;
+
+    return this.shuttle
+      .fetchFromApi('put', url)
+      .then(response => {
+        this.tokenValue = response.value;
+        this.wasActionSuccessful = true;
+      })
+      .catch(err => {
+        this.wasActionSuccessful = false;
+        this.errorMessage = err.message;
+      })
+      .finally(() => {
+        this.isAwaitingResponse = false;
+      });
+  }
+}

--- a/app/components/tokens/modal/refresh/styles.scss
+++ b/app/components/tokens/modal/refresh/styles.scss
@@ -1,0 +1,21 @@
+@use 'screwdriver-colors' as colors;
+
+@mixin styles {
+  #refresh-token-modal {
+    &.modal {
+      .modal-dialog {
+        .modal-body {
+          .token-value-container {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+
+            .token-value {
+              margin-left: 5rem;
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/components/tokens/modal/refresh/template.hbs
+++ b/app/components/tokens/modal/refresh/template.hbs
@@ -1,0 +1,65 @@
+<BsModal
+  id="refresh-token-modal"
+  @onHide={{fn @closeModal}}
+  as |modal|
+>
+  <modal.header>
+    Refresh {{this.tokenType}} token
+  </modal.header>
+  <modal.body>
+    <div>
+      The current token for <b>"{{this.token.name}}"</b> will be invalidated and a new one will be generated.
+    </div>
+    <br />
+    <div>
+      Are you sure you want to refresh this token?
+    </div>
+
+    {{#if this.errorMessage}}
+      <InfoMessage
+        id="error-message"
+        @message={{this.errorMessage}}
+        @type="warning"
+        @icon="triangle-exclamation"
+      />
+    {{/if}}
+    {{#if this.tokenValue}}
+      <BsAlert
+        id="success-container"
+        @dismissible={{false}}
+        @type="success"
+      >
+        <FaIcon @icon="circle-check" />
+        You can only see this value once, so remember to copy it!
+
+        <div class="token-value-container">
+          <div class="token-value">
+            {{this.tokenValue}}
+          </div>
+          <BsButton
+            @type="success"
+            @outline={{true}}
+            @onClick={{fn this.copyTokenValue}}
+            disabled={{this.isCopyButtonDisabled}}
+          >
+            <FaIcon
+              @icon="copy"
+            />
+          </BsButton>
+        </div>
+      </BsAlert>
+    {{/if}}
+  </modal.body>
+  <modal.footer>
+    <BsButton
+      id="refresh-token"
+      class="confirm"
+      disabled={{this.isSubmitButtonDisabled}}
+      @defaultText="Refresh token"
+      @pendingText="Refreshing token..."
+      @fulfilledText="Token refreshed"
+      @type="primary"
+      @onClick={{fn this.refreshToken}}
+    />
+  </modal.footer>
+</BsModal>

--- a/tests/integration/components/tokens/modal/refresh/component-test.js
+++ b/tests/integration/components/tokens/modal/refresh/component-test.js
@@ -1,0 +1,86 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
+import { click, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+
+module('Integration | Component | tokens/modal/refresh', function (hooks) {
+  setupRenderingTest(hooks);
+
+  let shuttle;
+
+  hooks.beforeEach(function () {
+    const pipelinePageState = this.owner.lookup('service:pipelinePageState');
+
+    shuttle = this.owner.lookup('service:shuttle');
+
+    sinon.stub(pipelinePageState, 'getPipelineId').returns(1);
+  });
+
+  test('it renders', async function (assert) {
+    this.setProperties({
+      token: { name: 'test', type: 'pipeline' },
+      closeModal: () => {}
+    });
+
+    await render(
+      hbs`<Tokens::Modal::Refresh
+        @token={{this.token}}
+        @closeModal={{this.closeModal}}
+      />`
+    );
+
+    assert.dom('.modal-header').hasText('Refresh pipeline token ×');
+    assert.dom('#error-message').doesNotExist();
+    assert.dom('#success-container').doesNotExist();
+    assert.dom('#refresh-token').exists({ count: 1 });
+    assert.dom('#refresh-token').isEnabled();
+  });
+
+  test('it displays error message on error', async function (assert) {
+    const errorMessage = 'Error refreshing token';
+
+    sinon.stub(shuttle, 'fetchFromApi').rejects({ message: errorMessage });
+
+    this.setProperties({
+      token: { name: 'test', type: 'pipeline' },
+      closeModal: () => {}
+    });
+
+    await render(
+      hbs`<Tokens::Modal::Refresh
+        @token={{this.token}}
+        @closeModal={{this.closeModal}}
+      />`
+    );
+    await click('#refresh-token');
+
+    assert.dom('#error-message').exists({ count: 1 });
+    assert.dom('#error-message').hasText(`× ${errorMessage}`);
+    assert.dom('#refresh-token').isEnabled();
+  });
+
+  test('it refreshes token on success', async function (assert) {
+    const tokenValue = 'new-value';
+    const newToken = { value: tokenValue };
+
+    sinon.stub(shuttle, 'fetchFromApi').resolves(newToken);
+
+    this.setProperties({
+      token: { name: 'test', type: 'pipeline' },
+      closeModal: () => {}
+    });
+
+    await render(
+      hbs`<Tokens::Modal::Refresh
+        @token={{this.token}}
+        @closeModal={{this.closeModal}}
+      />`
+    );
+    await click('#refresh-token');
+
+    assert.dom('#success-container').exists({ count: 1 });
+    assert.dom('#success-container .token-value').hasText(tokenValue);
+    assert.dom('#refresh-token').isDisabled();
+  });
+});


### PR DESCRIPTION
## Context
Updating the V2 UI for pipeline secrets requires a new set of components to handle management of tokens. This modal provides a new user experience that is in line with the rest of the V2 user experience leveraging modals more heavily for user interactions.

## Objective
Creates a new modal for facilitating refreshing of new API tokens

![Screenshot 2025-04-01 at 15-58-12 minghay_various Secrets](https://github.com/user-attachments/assets/54f0749e-be6e-4e9d-903c-3c06b3b6afe2)
![Screenshot 2025-04-01 at 16-03-25 minghay_various Secrets](https://github.com/user-attachments/assets/fad06bd0-0d53-4d70-82c3-045783f6e346)
![Screenshot 2025-04-01 at 16-03-54 minghay_various Secrets](https://github.com/user-attachments/assets/01ba3fd6-4b8e-477c-b155-23730e35cffe)

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
