### PR TITLE
Refactor event type to be injectable

### DIFF
--- a/app/components/pipeline/modal/search-event/component.js
+++ b/app/components/pipeline/modal/search-event/component.js
@@ -4,8 +4,6 @@ import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 export default class PipelineModalSearchEventComponent extends Component {
-  @service router;
-
   @service shuttle;
 
   @service pipelinePageState;
@@ -17,8 +15,6 @@ export default class PipelineModalSearchEventComponent extends Component {
   @tracked searchResults = [];
 
   @tracked invalidSha = false;
-
-  isPr = this.router.currentRouteName.includes('pulls');
 
   searchFieldOptions = ['message', 'sha', 'creator', 'author'];
 
@@ -51,7 +47,9 @@ export default class PipelineModalSearchEventComponent extends Component {
     const baseUrl = `/pipelines/${this.pipelinePageState.getPipelineId()}/events?${
       this.searchField
     }=${encodeURIComponent(inputValue)}`;
-    const url = `${baseUrl}&type=${this.isPr ? 'pr' : 'pipeline'}`;
+    const url = `${baseUrl}&type=${
+      this.pipelinePageState.getIsPr() ? 'pr' : 'pipeline'
+    }`;
 
     this.shuttle.fetchFromApi('get', url).then(events => {
       this.searchResults = events;

--- a/app/components/pipeline/workflow/component.js
+++ b/app/components/pipeline/workflow/component.js
@@ -6,8 +6,6 @@ import { isComplete, isSkipped } from 'screwdriver-ui/utils/pipeline/event';
 import { getDisplayJobNameLength, getWorkflowGraph } from './util';
 import { extractEventStages } from '../../../utils/graph-tools';
 
-const PIPELINE_EVENT = 'pipeline';
-const PR_EVENT = 'pr';
 const BUILD_QUEUE_NAME = 'graph';
 const STAGE_BUILD_QUEUE_NAME = 'stageBuilds';
 const LATEST_COMMIT_EVENT_QUEUE_NAME = 'latestCommitEvent';
@@ -55,8 +53,6 @@ export default class PipelineWorkflowComponent extends Component {
 
   workflowGraphWithDownstreamTriggers;
 
-  eventType;
-
   dataReloadId;
 
   constructor() {
@@ -65,13 +61,9 @@ export default class PipelineWorkflowComponent extends Component {
     this.pipeline = this.pipelinePageState.getPipeline();
     this.userSettings = this.args.userSettings;
     this.latestEvent = this.args.latestEvent;
-    this.eventType = this.router.currentRouteName.includes('events')
-      ? PIPELINE_EVENT
-      : PR_EVENT;
-
     this.dataReloadId = this.workflowDataReload.start(
       this.pipeline.id,
-      this.eventType === PR_EVENT
+      this.pipelinePageState.getIsPr()
     );
 
     if (this.args.noEvents) {
@@ -86,7 +78,7 @@ export default class PipelineWorkflowComponent extends Component {
   monitorForNewEvents() {
     const pipelineId = this.pipeline.id;
 
-    if (this.eventType === PR_EVENT) {
+    if (this.pipelinePageState.getIsPr()) {
       this.workflowDataReload.registerOpenPrsCallback(
         OPEN_PRS_QUEUE_NAME,
         pipelineId,
@@ -252,7 +244,7 @@ export default class PipelineWorkflowComponent extends Component {
   }
 
   get isPR() {
-    return this.eventType === PR_EVENT;
+    return this.pipelinePageState.getIsPr();
   }
 
   get eventRailAnchor() {

--- a/app/components/pipeline/workflow/event-rail/component.js
+++ b/app/components/pipeline/workflow/event-rail/component.js
@@ -4,14 +4,10 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import ENV from 'screwdriver-ui/config/environment';
 
-const PIPELINE_EVENT = 'pipeline';
-const PR_EVENT = 'pr';
 const EVENT_BATCH_SIZE = 10;
 
 export default class PipelineWorkflowEventRailComponent extends Component {
   @service shuttle;
-
-  @service router;
 
   @service workflowDataReload;
 
@@ -25,8 +21,6 @@ export default class PipelineWorkflowEventRailComponent extends Component {
 
   @tracked firstItemId;
 
-  eventType;
-
   prNums;
 
   newestEvent = null;
@@ -38,9 +32,6 @@ export default class PipelineWorkflowEventRailComponent extends Component {
   constructor() {
     super(...arguments);
 
-    this.eventType = this.router.currentRouteName.includes('events')
-      ? PIPELINE_EVENT
-      : PR_EVENT;
     this.prNums = this.args.prNums;
 
     const { event } = this.args;
@@ -62,7 +53,11 @@ export default class PipelineWorkflowEventRailComponent extends Component {
   }
 
   get isPR() {
-    return this.eventType === PR_EVENT;
+    return this.pipelinePageState.getIsPr();
+  }
+
+  get eventType() {
+    return this.isPR ? 'pr' : 'pipeline';
   }
 
   @action

--- a/app/pipeline-page-state/service.js
+++ b/app/pipeline-page-state/service.js
@@ -11,12 +11,15 @@ export default class PipelinePageStateService extends Service {
 
   jobs;
 
+  isPr;
+
   clear() {
     this.pipeline = null;
     this.childPipelines = [];
     this.triggers = [];
     this.stages = [];
     this.jobs = [];
+    this.isPr = false;
   }
 
   setPipeline(pipeline) {
@@ -61,5 +64,13 @@ export default class PipelinePageStateService extends Service {
 
   getJobs() {
     return this.jobs;
+  }
+
+  setIsPr(isPr) {
+    this.isPr = isPr;
+  }
+
+  getIsPr() {
+    return this.isPr;
   }
 }

--- a/app/v2/pipeline/pulls/route.js
+++ b/app/v2/pipeline/pulls/route.js
@@ -6,6 +6,14 @@ export default class NewPipelinePullsRoute extends Route {
 
   @service pipelinePageState;
 
+  activate() {
+    this.pipelinePageState.setIsPr(true);
+  }
+
+  deactivate() {
+    this.pipelinePageState.setIsPr(false);
+  }
+
   async model() {
     const pipelineId = this.pipelinePageState.getPipelineId();
 

--- a/tests/integration/components/pipeline/modal/search-event/component-test.js
+++ b/tests/integration/components/pipeline/modal/search-event/component-test.js
@@ -11,13 +11,12 @@ module(
     setupRenderingTest(hooks);
 
     hooks.beforeEach(function () {
-      const router = this.owner.lookup('service:router');
       const pipelinePageState = this.owner.lookup(
         'service:pipeline-page-state'
       );
 
-      sinon.stub(router, 'currentRouteName').value('pipeline');
       sinon.stub(pipelinePageState, 'getPipelineId').returns(123);
+      sinon.stub(pipelinePageState, 'getIsPr').returns(false);
     });
 
     test('it renders', async function (assert) {

--- a/tests/integration/components/pipeline/workflow/component-test.js
+++ b/tests/integration/components/pipeline/workflow/component-test.js
@@ -7,6 +7,7 @@ import sinon from 'sinon';
 module('Integration | Component | pipeline/workflow', function (hooks) {
   setupRenderingTest(hooks);
 
+  let pipelinePageState;
   const pipelineId = 1234;
   const pipeline = { id: pipelineId };
 
@@ -14,7 +15,8 @@ module('Integration | Component | pipeline/workflow', function (hooks) {
     const workflowDataReload = this.owner.lookup(
       'service:workflow-data-reload'
     );
-    const pipelinePageState = this.owner.lookup('service:pipeline-page-state');
+
+    pipelinePageState = this.owner.lookup('service:pipeline-page-state');
 
     sinon.stub(workflowDataReload, 'start').callsFake(() => {});
 
@@ -26,9 +28,7 @@ module('Integration | Component | pipeline/workflow', function (hooks) {
   });
 
   test('it renders for pipeline with no events', async function (assert) {
-    const router = this.owner.lookup('service:router');
-
-    sinon.stub(router, 'currentRouteName').value('events');
+    sinon.stub(pipelinePageState, 'getIsPr').returns(false);
 
     this.setProperties({
       userSettings: {}
@@ -49,10 +49,9 @@ module('Integration | Component | pipeline/workflow', function (hooks) {
   });
 
   test('it renders for pipeline with no PRs', async function (assert) {
-    const router = this.owner.lookup('service:router');
     const shuttle = this.owner.lookup('service:shuttle');
 
-    sinon.stub(router, 'currentRouteName').value('pulls');
+    sinon.stub(pipelinePageState, 'getIsPr').returns(true);
     sinon.stub(shuttle, 'fetchFromApi').resolves([]);
 
     this.setProperties({
@@ -79,7 +78,7 @@ module('Integration | Component | pipeline/workflow', function (hooks) {
     const router = this.owner.lookup('service:router');
     const shuttle = this.owner.lookup('service:shuttle');
 
-    sinon.stub(router, 'currentRouteName').value('events');
+    sinon.stub(pipelinePageState, 'getIsPr').returns(false);
     sinon.stub(router, 'currentURL').value('/v2/pipelines/1/events/11');
     sinon.stub(shuttle, 'fetchFromApi').resolves([]);
 
@@ -115,7 +114,7 @@ module('Integration | Component | pipeline/workflow', function (hooks) {
     const router = this.owner.lookup('service:router');
     const shuttle = this.owner.lookup('service:shuttle');
 
-    sinon.stub(router, 'currentRouteName').value('pulls');
+    sinon.stub(pipelinePageState, 'getIsPr').returns(true);
     sinon.stub(router, 'currentURL').value('/v2/pipelines/1/pulls/11');
     sinon.stub(shuttle, 'fetchFromApi').resolves([]);
 
@@ -145,7 +144,7 @@ module('Integration | Component | pipeline/workflow', function (hooks) {
     const shuttle = this.owner.lookup('service:shuttle');
     const eventId = 123;
 
-    sinon.stub(router, 'currentRouteName').value('events');
+    sinon.stub(pipelinePageState, 'getIsPr').returns(false);
     sinon.stub(router, 'currentURL').value(`/v2/pipelines/1/events/${eventId}`);
     sinon.stub(shuttle, 'fetchFromApi').resolves([]);
 
@@ -188,7 +187,7 @@ module('Integration | Component | pipeline/workflow', function (hooks) {
     const eventId = 123;
     const prNum = 4;
 
-    sinon.stub(router, 'currentRouteName').value('pulls');
+    sinon.stub(pipelinePageState, 'getIsPr').returns(true);
     sinon.stub(router, 'currentURL').value(`/v2/pipelines/1/pulls/${prNum}`);
     sinon.stub(shuttle, 'fetchFromApi').resolves([]);
 
@@ -236,7 +235,7 @@ module('Integration | Component | pipeline/workflow', function (hooks) {
 
     pipeline.annotations = { 'screwdriver.cd/restrictPR': 'all' };
 
-    sinon.stub(router, 'currentRouteName').value('pulls');
+    sinon.stub(pipelinePageState, 'getIsPr').returns(true);
     sinon.stub(router, 'currentURL').value(`/v2/pipelines/1/pulls/${prNum}`);
     sinon.stub(shuttle, 'fetchFromApi').resolves([]);
 

--- a/tests/integration/components/pipeline/workflow/event/rail/component-test.js
+++ b/tests/integration/components/pipeline/workflow/event/rail/component-test.js
@@ -10,9 +10,11 @@ module(
     setupRenderingTest(hooks);
 
     test('it renders', async function (assert) {
-      const router = this.owner.lookup('service:router');
+      const pipelinePageState = this.owner.lookup(
+        'service:pipeline-page-state'
+      );
 
-      sinon.stub(router, 'currentRouteName').value('events');
+      sinon.stub(pipelinePageState, 'getIsPr').returns(false);
 
       await render(hbs`<Pipeline::Workflow::EventRail/>`);
 
@@ -24,9 +26,11 @@ module(
     });
 
     test('it renders for pull requests', async function (assert) {
-      const router = this.owner.lookup('service:router');
+      const pipelinePageState = this.owner.lookup(
+        'service:pipeline-page-state'
+      );
 
-      sinon.stub(router, 'currentRouteName').value('pulls');
+      sinon.stub(pipelinePageState, 'getIsPr').returns(true);
 
       await render(hbs`<Pipeline::Workflow::EventRail/>`);
 


### PR DESCRIPTION
## Context
The event type can be added to the injectable page state for use in the v2 UI. This will help reduce the need for downstream components to query the url path and extract the needed information.

## Objective
Refactors the event type to be injectable and set on the PR route accordingly.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
