### PR TITLE
feat: Glimmer component for delete token modal

### DIFF
--- a/app/components/tokens/modal/delete/component.js
+++ b/app/components/tokens/modal/delete/component.js
@@ -1,0 +1,58 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+
+export default class TokensModalDeleteComponent extends Component {
+  @service shuttle;
+
+  @service pipelinePageState;
+
+  @tracked errorMessage;
+
+  @tracked isAwaitingResponse;
+
+  @tracked wasActionSuccessful;
+
+  @tracked tokenName;
+
+  constructor() {
+    super(...arguments);
+
+    this.isAwaitingResponse = false;
+    this.wasActionSuccessful = false;
+  }
+
+  get isSubmitButtonDisabled() {
+    if (this.wasActionSuccessful || this.isAwaitingResponse) {
+      return true;
+    }
+
+    return this.tokenName !== this.args.token.name;
+  }
+
+  @action
+  async deleteToken() {
+    this.isAwaitingResponse = true;
+
+    const deleteUrl = `/tokens/${this.args.token.id}`;
+    const url =
+      this.args.type === 'pipeline'
+        ? `/pipelines/${this.pipelinePageState.getPipelineId()}${deleteUrl}`
+        : deleteUrl;
+
+    return this.shuttle
+      .fetchFromApi('delete', url)
+      .then(() => {
+        this.wasActionSuccessful = true;
+        this.args.closeModal(this.args.token);
+      })
+      .catch(err => {
+        this.wasActionSuccessful = false;
+        this.errorMessage = err.message;
+      })
+      .finally(() => {
+        this.isAwaitingResponse = false;
+      });
+  }
+}

--- a/app/components/tokens/modal/delete/styles.scss
+++ b/app/components/tokens/modal/delete/styles.scss
@@ -1,0 +1,15 @@
+@use 'screwdriver-colors' as colors;
+
+@mixin styles {
+  #delete-token-modal {
+    &.modal {
+      .modal-dialog {
+        .modal-body {
+          .delete-token-message-warning {
+            color: colors.$sd-warn-bg;
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/components/tokens/modal/delete/template.hbs
+++ b/app/components/tokens/modal/delete/template.hbs
@@ -1,0 +1,46 @@
+<BsModal
+  id="delete-token-modal"
+  @onHide={{fn @closeModal}}
+  as |modal|
+>
+  <modal.header>
+    Delete a {{@type}} token
+  </modal.header>
+  <modal.body>
+    {{#if this.errorMessage}}
+      <InfoMessage
+        id="error-message"
+        @message={{this.errorMessage}}
+        @type="warning"
+        @icon="triangle-exclamation"
+      />
+    {{/if}}
+
+    <div class="delete-token-message">
+      <div class="delete-token-message-warning">
+        <FaIcon @icon="triangle-exclamation" />
+        <b>Deleting this token is permanent!</b>
+      </div>
+      <br />
+      <div>
+        If you are sure you want to delete this token, enter the name of the token (<b>{{@token.name}}</b>) below
+      </div>
+    </div>
+    <Input
+      @type="text"
+      @value={{this.tokenName}}
+      autofocus={{true}}
+    />
+  </modal.body>
+  <modal.footer>
+    <BsButton
+      id="submit-delete"
+      class="confirm"
+      disabled={{this.isSubmitButtonDisabled}}
+      @defaultText="Delete token"
+      @pendingText="Deleting token..."
+      @type="primary"
+      @onClick={{fn this.deleteToken}}
+    />
+  </modal.footer>
+</BsModal>

--- a/tests/integration/components/tokens/modal/delete/component-test.js
+++ b/tests/integration/components/tokens/modal/delete/component-test.js
@@ -1,0 +1,116 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
+import { click, fillIn, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+
+module('Integration | Component | tokens/modal/delete', function (hooks) {
+  setupRenderingTest(hooks);
+
+  let shuttle;
+
+  hooks.beforeEach(function () {
+    const pipelinePageState = this.owner.lookup('service:pipeline-page-state');
+
+    shuttle = this.owner.lookup('service:shuttle');
+
+    sinon.stub(pipelinePageState, 'getPipelineId').returns(123);
+  });
+
+  test('it renders', async function (assert) {
+    this.setProperties({
+      token: {
+        name: 'test-token'
+      },
+      closeModal: () => {}
+    });
+
+    await render(
+      hbs`<Tokens::Modal::Delete
+        @type="pipeline"
+        @token={{this.token}}
+        @closeModal={{this.closeModal}}
+      />`
+    );
+
+    assert.dom('.delete-token-message').exists({ count: 1 });
+    assert.dom('.delete-token-message-warning').exists({ count: 1 });
+    assert.dom('input').exists({ count: 1 });
+    assert.dom('#submit-delete').isDisabled();
+  });
+
+  test('it enables the submit button when the token name is correct', async function (assert) {
+    this.setProperties({
+      token: {
+        name: 'test-token'
+      },
+      closeModal: () => {}
+    });
+
+    await render(
+      hbs`<Tokens::Modal::Delete
+        @type="pipeline"
+        @token={{this.token}}
+        @closeModal={{this.closeModal}}
+      />`
+    );
+
+    await fillIn('input', 'test');
+    assert.dom('#submit-delete').isDisabled();
+
+    await fillIn('input', 'test-token');
+    assert.dom('#submit-delete').isEnabled();
+  });
+
+  test('it displays error message correctly', async function (assert) {
+    sinon.stub(shuttle, 'fetchFromApi').rejects({ message: 'Error message' });
+
+    this.setProperties({
+      token: {
+        name: 'test-token'
+      },
+      closeModal: () => {}
+    });
+
+    await render(
+      hbs`<Tokens::Modal::Delete
+        @type="pipeline"
+        @token={{this.token}}
+        @closeModal={{this.closeModal}}
+      />`
+    );
+    await fillIn('input', 'test-token');
+    await click('#submit-delete');
+
+    assert.dom('#submit-delete').isEnabled();
+    assert.dom('#error-message').exists({ count: 1 });
+  });
+
+  test('it autocloses the modal when the token is deleted', async function (assert) {
+    sinon.stub(shuttle, 'fetchFromApi').resolves();
+
+    const token = {
+      name: 'test-token'
+    };
+    const closeModalSpy = sinon.spy();
+
+    this.setProperties({
+      token,
+      closeModal: closeModalSpy
+    });
+
+    await render(
+      hbs`<Tokens::Modal::Delete
+        @type="pipeline"
+        @token={{this.token}}
+        @closeModal={{this.closeModal}}
+      />`
+    );
+    await fillIn('input', 'test-token');
+    await click('#submit-delete');
+
+    assert.dom('#submit-delete').isDisabled();
+    assert.true(closeModalSpy.calledOnce, true);
+    assert.true(closeModalSpy.calledWith(token), true);
+  });
+});


### PR DESCRIPTION
## Context
Updating the V2 UI for pipeline secrets requires a new set of components to handle management of tokens. This modal provides a new user experience that is in line with the rest of the V2 user experience leveraging modals more heavily for user interactions.

## Objective
Creates a new modal for facilitating deletion of API tokens

![Screenshot 2025-04-03 at 16-37-14 minghay_various Secrets](https://github.com/user-attachments/assets/cb5010ff-ae44-4328-8fe1-0c206c4c0c6c)

![Screenshot 2025-04-03 at 16-37-24 minghay_various Secrets](https://github.com/user-attachments/assets/adaf4d37-d761-46b1-a435-99fe6dcf8074)

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
