### PR TITLE
feat: Glimmer component for editing a token modal

### DIFF
--- a/app/components/tokens/modal/edit/component.js
+++ b/app/components/tokens/modal/edit/component.js
@@ -1,0 +1,77 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+
+export default class TokensModalEditComponent extends Component {
+  @service shuttle;
+
+  @service pipelinePageState;
+
+  @tracked errorMessage;
+
+  @tracked tokenName;
+
+  @tracked tokenDescription;
+
+  @tracked isAwaitingResponse;
+
+  @tracked wasActionSuccessful;
+
+  constructor() {
+    super(...arguments);
+
+    this.isAwaitingResponse = false;
+    this.wasActionSuccessful = false;
+    this.tokenNames = this.args.token.tokens.map(token => token.name);
+  }
+
+  isTokenNameInvalid() {
+    return this.tokenNames.includes(this.tokenName);
+  }
+
+  get inputClass() {
+    return this.isTokenNameInvalid() ? 'invalid' : null;
+  }
+
+  get isSubmitButtonDisabled() {
+    if (this.wasActionSuccessful || this.isAwaitingResponse) {
+      return true;
+    }
+
+    return (
+      this.isTokenNameInvalid() || (!this.tokenName && !this.tokenDescription)
+    );
+  }
+
+  @action
+  async createToken() {
+    const { id, type } = this.args.token;
+
+    this.isAwaitingResponse = true;
+
+    const updateUrl = `/tokens/${id}`;
+    const url =
+      type === 'pipeline'
+        ? `/pipelines/${this.pipelinePageState.getPipelineId()}${updateUrl}`
+        : updateUrl;
+
+    return this.shuttle
+      .fetchFromApi('put', url, {
+        name: this.tokenName,
+        description: this.tokenDescription
+      })
+      .then(response => {
+        this.wasActionSuccessful = true;
+
+        this.args.closeModal(response);
+      })
+      .catch(err => {
+        this.wasActionSuccessful = false;
+        this.errorMessage = err.message;
+      })
+      .finally(() => {
+        this.isAwaitingResponse = false;
+      });
+  }
+}

--- a/app/components/tokens/modal/edit/styles.scss
+++ b/app/components/tokens/modal/edit/styles.scss
@@ -1,0 +1,36 @@
+@use 'screwdriver-colors' as colors;
+
+@mixin styles {
+  #edit-token-modal {
+    &.modal {
+      .modal-dialog {
+        .modal-body {
+          .edit-token {
+            display: flex;
+            flex-direction: column;
+
+            label {
+              display: flex;
+              align-items: center;
+
+              div {
+                width: 6rem;
+              }
+
+              input {
+                flex: 1;
+
+                &.invalid {
+                  color: colors.$sd-warn-bg;
+                  outline: 2px solid colors.$sd-warn-bg;
+                  border-radius: 3px;
+                  border: none;
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/components/tokens/modal/edit/template.hbs
+++ b/app/components/tokens/modal/edit/template.hbs
@@ -1,0 +1,55 @@
+<BsModal
+  id="edit-token-modal"
+  @onHide={{fn @closeModal}}
+  as |modal|
+>
+  <modal.header>
+    Edit a {{@token.type}} token
+  </modal.header>
+  <modal.body>
+    {{#if this.errorMessage}}
+      <InfoMessage
+        id="error-message"
+        @message={{this.errorMessage}}
+        @type="warning"
+        @icon="triangle-exclamation"
+      />
+    {{/if}}
+
+    <div class="edit-token">
+      <label>
+        <div>Name:</div>
+        <Input
+          id="token-name-input"
+          @type="text"
+          @value={{this.tokenName}}
+          placeholder={{@token.name}}
+          class={{this.inputClass}}
+          disabled={{this.inputDisabled}}
+          autofocus={{true}}
+        />
+      </label>
+      <label>
+        <div>Description:</div>
+        <Input
+          id="token-description-input"
+          @type="text"
+          @value={{this.tokenDescription}}
+          placeholder={{@token.description}}
+          disabled={{this.inputDisabled}}
+        />
+      </label>
+    </div>
+  </modal.body>
+  <modal.footer>
+    <BsButton
+      id="submit-token"
+      class="confirm"
+      disabled={{this.isSubmitButtonDisabled}}
+      @defaultText="Update token"
+      @pendingText="Updating token..."
+      @type="primary"
+      @onClick={{fn this.createToken}}
+    />
+  </modal.footer>
+</BsModal>

--- a/tests/integration/components/tokens/modal/edit/component-test.js
+++ b/tests/integration/components/tokens/modal/edit/component-test.js
@@ -1,0 +1,105 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
+import { click, fillIn, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+
+module('Integration | Component | tokens/modal/edit', function (hooks) {
+  setupRenderingTest(hooks);
+
+  let shuttle;
+
+  hooks.beforeEach(function () {
+    const pipelinePageState = this.owner.lookup('service:pipelinePageState');
+
+    shuttle = this.owner.lookup('service:shuttle');
+
+    sinon.stub(pipelinePageState, 'getPipelineId').returns(1);
+
+    this.setProperties({
+      token: {
+        name: 'test',
+        type: 'pipeline',
+        tokens: [{ name: 'exists' }]
+      },
+      closeModal: () => {}
+    });
+  });
+
+  test('it renders', async function (assert) {
+    await render(
+      hbs`<Tokens::Modal::Edit
+        @token={{this.token}}
+        @closeModal={{this.closeModal}}
+      />`
+    );
+
+    assert.dom('.modal-header').hasText('Edit a pipeline token ×');
+    assert.dom('#error-message').doesNotExist();
+    assert.dom('#submit-token').exists({ count: 1 });
+    assert.dom('#submit-token').isDisabled();
+  });
+
+  test('it enables submit button correctly', async function (assert) {
+    await render(
+      hbs`<Tokens::Modal::Edit
+        @token={{this.token}}
+        @closeModal={{this.closeModal}}
+      />`
+    );
+
+    assert.dom('#submit-token').isDisabled();
+
+    await fillIn('#token-name-input', 'updated');
+    assert.dom('#submit-token').isEnabled();
+
+    await fillIn('#token-name-input', 'exists');
+    assert.dom('#token-name-input').hasClass('invalid');
+    assert.dom('#submit-token').isDisabled();
+
+    await fillIn('#token-name-input', '');
+    await fillIn('#token-description-input', 'description');
+    assert.dom('#submit-token').isEnabled();
+  });
+
+  test('it handles API error', async function (assert) {
+    sinon.stub(shuttle, 'fetchFromApi').rejects({ message: 'error' });
+
+    await render(
+      hbs`<Tokens::Modal::Edit
+        @token={{this.token}}
+        @closeModal={{this.closeModal}}
+      />`
+    );
+    await fillIn('#token-name-input', 'updated');
+    await click('#submit-token');
+
+    assert.dom('#error-message').exists({ count: 1 });
+    assert.dom('#submit-token').isEnabled();
+  });
+
+  test('it handles API success', async function (assert) {
+    const closeModalSpy = sinon.spy();
+    const updatedName = 'updated';
+    const updatedToken = { name: updatedName };
+
+    sinon.stub(shuttle, 'fetchFromApi').resolves(updatedToken);
+
+    this.setProperties({
+      closeModal: closeModalSpy
+    });
+
+    await render(
+      hbs`<Tokens::Modal::Edit
+        @token={{this.token}}
+        @closeModal={{this.closeModal}}
+      />`
+    );
+    await fillIn('#token-name-input', updatedName);
+    await click('#submit-token');
+
+    assert.dom('#submit-token').isDisabled();
+    assert.true(closeModalSpy.calledOnce);
+    assert.equal(closeModalSpy.calledWith(updatedToken), true);
+  });
+});


### PR DESCRIPTION
## Context
Updating the V2 UI for pipeline secrets requires a new set of components to handle management of tokens. This modal provides a new user experience that is in line with the rest of the V2 user experience leveraging modals more heavily for user interactions.

## Objective
Creates a new modal for facilitating updating of API tokens

![Screenshot 2025-04-04 at 13-42-52 minghay_various Secrets](https://github.com/user-attachments/assets/bf3d6819-8494-4658-92a1-0be75b975ca0)

![Screenshot 2025-04-04 at 13-43-50 minghay_various Secrets](https://github.com/user-attachments/assets/8d6fc97d-9d39-420c-9283-96b2ac357a77)

![Screenshot 2025-04-04 at 13-43-32 minghay_various Secrets](https://github.com/user-attachments/assets/f5a613c2-18b0-4335-a9f2-fa296c2fe41e)

![Screenshot 2025-04-04 at 13-43-02 minghay_various Secrets](https://github.com/user-attachments/assets/f81b53c9-cb46-4d29-b8a1-6aa450ad9008)

![Screenshot 2025-04-04 at 13-43-16 minghay_various Secrets](https://github.com/user-attachments/assets/44c939ca-6e95-41c0-924e-4ac77ce98b69)

![Screenshot 2025-04-04 at 13-44-29 minghay_various Secrets](https://github.com/user-attachments/assets/ddfab8b5-8597-4f79-8994-bfe7aeb14bdb)

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
