### PR TITLE
feat: Add style for success button

### DIFF
--- a/app/styles/screwdriver-button.scss
+++ b/app/styles/screwdriver-button.scss
@@ -40,4 +40,24 @@
       background-color: rgba(colors.$sd-warn-bg, 0.1);
     }
   }
+
+  .btn-success {
+    color: colors.$sd-white;
+    background-color: colors.$sd-success;
+    border-color: colors.$sd-success;
+
+    &:hover:not(:disabled) {
+      background-color: rgba(colors.$sd-success, 0.75);
+      border-color: transparent;
+    }
+  }
+
+  .btn-outline-success {
+    color: colors.$sd-success;
+    border-color: colors.$sd-success;
+
+    &:hover:not(:disabled) {
+      background-color: rgba(colors.$sd-success, 0.1);
+    }
+  }
 }


### PR DESCRIPTION
## Context
The shared bootstrap button styles only has styling set for the `primary` and `danger` button types.  Adding a new style for `success` button type will provide another option for use

## Objective
Creates a new shared style for the success button type

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
