### PR TITLE
fix: Fix cacheKey being incorrectly removed

### DIFF
--- a/app/workflow-data-reload/dataReloader.js
+++ b/app/workflow-data-reload/dataReloader.js
@@ -45,7 +45,6 @@ export default class DataReloader {
       clearInterval(this.intervalId);
       this.intervalId = null;
 
-      this.cacheKey = null;
       this.responseCache.clear();
       this.callbacks.clear();
       this.queueNames.clear();


### PR DESCRIPTION
## Context
The pipeline workflow data reloading gets unloaded when navigating to a view that does not require the background data loading.  As part of the unloading process, the cached data is cleared out and will be reset when the UI requires the background data loading again.  There's an issue where the latest commit SHA is unable to correctly get reset.

## Objective
Fixes the issue where a data reloader's static `cacheKey` property gets incorrectly invalidated.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
