### PR TITLE
feat: Extract toggle styles to shared stylesheet

### DIFF
--- a/app/components/pipeline/workflow/styles.scss
+++ b/app/components/pipeline/workflow/styles.scss
@@ -1,6 +1,7 @@
 @use 'variables';
 @use 'screwdriver-colors' as colors;
 @use 'screwdriver-button' as button;
+@use 'screwdriver-toggle' as toggle;
 
 @use 'event-rail/styles' as event-rail;
 @use 'graph/styles' as graph;
@@ -64,28 +65,7 @@
           margin-left: 1rem;
           display: flex;
 
-          .x-toggle-component {
-            &.x-toggle-focused .x-toggle-btn:not(.x-toggle-disabled)::after,
-            &.x-toggle-focused .x-toggle-btn:not(.x-toggle-disabled)::before {
-              box-shadow: 0 0 2px 3px colors.$sd-running;
-            }
-
-            .x-toggle-light.x-toggle-btn {
-              background: colors.$sd-text-light;
-            }
-
-            .x-toggle:checked + label > .x-toggle-light.x-toggle-btn {
-              background: colors.$sd-pale-purple;
-            }
-
-            label {
-              margin-bottom: 0;
-
-              &.off-label {
-                padding-right: 0;
-              }
-            }
-          }
+          @include toggle.styles;
         }
       }
 

--- a/app/styles/screwdriver-toggle.scss
+++ b/app/styles/screwdriver-toggle.scss
@@ -1,0 +1,26 @@
+@use 'screwdriver-colors' as colors;
+
+@mixin styles {
+  .x-toggle-component {
+    &.x-toggle-focused .x-toggle-btn:not(.x-toggle-disabled)::after,
+    &.x-toggle-focused .x-toggle-btn:not(.x-toggle-disabled)::before {
+      box-shadow: 0 0 2px 3px colors.$sd-running;
+    }
+
+    .x-toggle-light.x-toggle-btn {
+      background: colors.$sd-text-light;
+    }
+
+    .x-toggle:checked + label > .x-toggle-light.x-toggle-btn {
+      background: colors.$sd-pale-purple;
+    }
+
+    label {
+      margin-bottom: 0;
+
+      &.off-label {
+        padding-right: 0;
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Context
The toggle styles should be extracted into a shared stylesheet for better reuse in other components.

## Objective
Extracts the toggle style into a sharable stylesheet

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
