### PR TITLE
feat: Glimmer modal component for deleting secrets

### DIFF
--- a/app/components/pipeline/secrets-and-tokens/secrets/modal/delete/component.js
+++ b/app/components/pipeline/secrets-and-tokens/secrets/modal/delete/component.js
@@ -1,0 +1,50 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+
+export default class PipelineSecretsAndTokensModalDeleteComponent extends Component {
+  @service shuttle;
+
+  @tracked errorMessage;
+
+  @tracked isAwaitingResponse;
+
+  @tracked wasActionSuccessful;
+
+  @tracked secretName;
+
+  constructor() {
+    super(...arguments);
+
+    this.isAwaitingResponse = false;
+    this.wasActionSuccessful = false;
+  }
+
+  get isSubmitButtonDisabled() {
+    if (this.wasActionSuccessful || this.isAwaitingResponse) {
+      return true;
+    }
+
+    return this.secretName !== this.args.secret.name;
+  }
+
+  @action
+  async deleteSecret() {
+    this.isAwaitingResponse = true;
+
+    return this.shuttle
+      .fetchFromApi('delete', `/secrets/${this.args.secret.id}`)
+      .then(() => {
+        this.wasActionSuccessful = true;
+        this.args.closeModal(this.args.secret);
+      })
+      .catch(err => {
+        this.wasActionSuccessful = false;
+        this.errorMessage = err.message;
+      })
+      .finally(() => {
+        this.isAwaitingResponse = false;
+      });
+  }
+}

--- a/app/components/pipeline/secrets-and-tokens/secrets/modal/delete/styles.scss
+++ b/app/components/pipeline/secrets-and-tokens/secrets/modal/delete/styles.scss
@@ -1,0 +1,15 @@
+@use 'screwdriver-colors' as colors;
+
+@mixin styles {
+  #delete-secret-modal {
+    &.modal {
+      .modal-dialog {
+        .modal-body {
+          .delete-secret-message-warning {
+            color: colors.$sd-warn-bg;
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/components/pipeline/secrets-and-tokens/secrets/modal/delete/template.hbs
+++ b/app/components/pipeline/secrets-and-tokens/secrets/modal/delete/template.hbs
@@ -1,0 +1,46 @@
+<BsModal
+  id="delete-secret-modal"
+  @onHide={{fn @closeModal}}
+  as |modal|
+>
+  <modal.header>
+    Delete secret {{@secret.name}}
+  </modal.header>
+  <modal.body>
+    {{#if this.errorMessage}}
+      <InfoMessage
+        id="error-message"
+        @message={{this.errorMessage}}
+        @type="warning"
+        @icon="triangle-exclamation"
+      />
+    {{/if}}
+
+    <div class="delete-secret-message">
+      <div class="delete-secret-message-warning">
+        <FaIcon @icon="triangle-exclamation" />
+        <b>Deleting this secret is permanent!</b>
+      </div>
+      <br />
+      <div>
+        If you are sure you want to delete this secret, enter the name of the secret (<b>{{@secret.name}}</b>) below
+      </div>
+    </div>
+    <Input
+      @type="text"
+      @value={{this.secretName}}
+      autofocus={{true}}
+    />
+  </modal.body>
+  <modal.footer>
+    <BsButton
+      id="submit-delete"
+      class="confirm"
+      disabled={{this.isSubmitButtonDisabled}}
+      @defaultText="Delete secret"
+      @pendingText="Deleting secret..."
+      @type="primary"
+      @onClick={{fn this.deleteSecret}}
+    />
+  </modal.footer>
+</BsModal>

--- a/tests/integration/components/pipeline/secrets-and-tokens/secrets/modal/delete/component-test.js
+++ b/tests/integration/components/pipeline/secrets-and-tokens/secrets/modal/delete/component-test.js
@@ -1,0 +1,94 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
+import { click, fillIn, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+
+module(
+  'Integration | Component | pipeline/secrets-and-tokens/modal/delete',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    let shuttle;
+    const secret = {
+      name: 'TEST'
+    };
+
+    hooks.beforeEach(function () {
+      shuttle = this.owner.lookup('service:shuttle');
+
+      this.setProperties({
+        secret,
+        closeModal: () => {}
+      });
+    });
+
+    test('it renders', async function (assert) {
+      await render(
+        hbs`<Pipeline::SecretsAndTokens::Secrets::Modal::Delete
+            @secret={{this.secret}}
+            @closeModal={{this.closeModal}}
+        />`
+      );
+
+      assert.dom('.delete-secret-message').exists({ count: 1 });
+      assert.dom('.delete-secret-message-warning').exists({ count: 1 });
+      assert.dom('input').exists({ count: 1 });
+      assert.dom('#submit-delete').isDisabled();
+    });
+
+    test('it enables the submit button when the token name is correct', async function (assert) {
+      await render(
+        hbs`<Pipeline::SecretsAndTokens::Secrets::Modal::Delete
+            @secret={{this.secret}}
+            @closeModal={{this.closeModal}}
+        />`
+      );
+
+      await fillIn('input', 'TE');
+      assert.dom('#submit-delete').isDisabled();
+
+      await fillIn('input', 'TEST');
+      assert.dom('#submit-delete').isEnabled();
+    });
+
+    test('it displays error message correctly', async function (assert) {
+      sinon.stub(shuttle, 'fetchFromApi').rejects({ message: 'Error message' });
+
+      await render(
+        hbs`<Pipeline::SecretsAndTokens::Secrets::Modal::Delete
+            @secret={{this.secret}}
+            @closeModal={{this.closeModal}}
+        />`
+      );
+      await fillIn('input', 'TEST');
+      await click('#submit-delete');
+
+      assert.dom('#submit-delete').isEnabled();
+      assert.dom('#error-message').exists({ count: 1 });
+    });
+
+    test('it autocloses the modal when the token is deleted', async function (assert) {
+      sinon.stub(shuttle, 'fetchFromApi').resolves();
+
+      const closeModalSpy = sinon.spy();
+
+      this.setProperties({
+        closeModal: closeModalSpy
+      });
+
+      await render(
+        hbs`<Pipeline::SecretsAndTokens::Secrets::Modal::Delete
+            @secret={{this.secret}}
+            @closeModal={{this.closeModal}}
+        />`
+      );
+      await fillIn('input', 'TEST');
+      await click('#submit-delete');
+
+      assert.dom('#submit-delete').isDisabled();
+      assert.true(closeModalSpy.calledOnce, true);
+      assert.true(closeModalSpy.calledWith(secret), true);
+    });
+  }
+);


### PR DESCRIPTION
## Context
Updating the V2 UI for pipeline secrets requires a new set of components to handle management of secrets. This modal provides a new user experience that is in line with the rest of the V2 user experience leveraging modals more heavily for user interactions.

## Objective
Creates a new modal for facilitating deletion of secrets
![Screenshot 2025-04-17 at 16-15-00 minghay_various Secrets](https://github.com/user-attachments/assets/3d1d6e3a-1d11-4b48-9f34-6ef50dfc3a5c)

![Screenshot 2025-04-17 at 16-15-11 minghay_various Secrets](https://github.com/user-attachments/assets/2a2d123e-9a6a-4bbc-8579-c3f0c0fc05f8)

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
