### PR TITLE
Match cost metrics to build id

### DIFF
--- a/app/components/build-banner/component.js
+++ b/app/components/build-banner/component.js
@@ -132,36 +132,36 @@ export default Component.extend({
     }
   }),
 
-  costMetrics: computed('buildMeta', {
+  costMetrics: computed('buildId', 'buildMeta', {
     get() {
-      const { buildMeta } = this;
+      const { buildId, buildMeta } = this;
 
-      return buildMeta?.build?.cost_metrics;
+      return buildMeta?.build?.cost_metrics?.[buildId];
     }
   }),
 
-  buildCpu: computed('buildMeta', {
+  buildCpu: computed('buildId', 'buildMeta', {
     get() {
-      const { buildMeta } = this;
-      const cpu = buildMeta?.build?.cost_metrics?.cpu;
+      const { buildId, buildMeta } = this;
+      const cpu = buildMeta?.build?.cost_metrics?.[buildId].cpu;
 
       return cpu ? String(`${cpu} vCPU`) : '';
     }
   }),
 
-  buildMemory: computed('buildMeta', {
+  buildMemory: computed('buildId', 'buildMeta', {
     get() {
-      const { buildMeta } = this;
-      const memory = buildMeta?.build?.cost_metrics?.memory;
+      const { buildId, buildMeta } = this;
+      const memory = buildMeta?.build?.cost_metrics?.[buildId].memory;
 
       return memory ? String(`${memory} GiB`) : '';
     }
   }),
 
-  buildCost: computed('buildMeta', {
+  buildCost: computed('buildId', 'buildMeta', {
     get() {
-      const { buildMeta } = this;
-      const cost = buildMeta?.build?.cost_metrics?.cost;
+      const { buildId, buildMeta } = this;
+      const cost = buildMeta?.build?.cost_metrics?.[buildId].cost;
 
       return cost ? String(`$${cost.toFixed(4)}`) : '';
     }

--- a/app/components/pipeline/jobs/table/cost-table/component.js
+++ b/app/components/pipeline/jobs/table/cost-table/component.js
@@ -189,7 +189,7 @@ export default class PipelineJobsTableCostTableComponent extends Component {
       this.jobs.forEach(job => {
         const buildsForJob = jobBuildsMap.get(job.id);
         const build = buildsForJob ? _.last(buildsForJob) : null;
-        const costMetrics = build?.meta?.build?.cost_metrics;
+        const costMetrics = build?.meta?.build?.cost_metrics?.[build.id];
         const cpu = costMetrics?.cpu;
         const memory = costMetrics?.memory;
         const cost = costMetrics?.cost;


### PR DESCRIPTION
## Context
Cost metrics have a build id that should be inspected before displaying cost data

## Objective
Match build id in the build meta data to determine of cost metrics belong to the displaying build

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
