### PR TITLE
Disable AWS cluster logic

### DIFF
--- a/app/components/pipeline/workflow/component.js
+++ b/app/components/pipeline/workflow/component.js
@@ -360,10 +360,11 @@ export default class PipelineWorkflowComponent extends Component {
   isEventInAws(builds) {
     this.isBuildClusterAws = false;
 
-    builds.forEach(build => {
-      if (build.buildClusterName.startsWith('aws')) {
-        this.isBuildClusterAws = true;
-      }
+    builds.forEach(() => {
+      // TODO: See if this is the best way to check if a build is in AWS
+      // if (build.buildClusterName.startsWith('aws')) {
+      //   this.isBuildClusterAws = true;
+      // }
     });
   }
 


### PR DESCRIPTION
## Context
The AWS cluster determination logic is really simple.  Additional work should be done with the backend to properly determine if an event is built within AWS.

## Objective
Disables the simple AWS logic for the time being.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
