### PR TITLE
fix: Fix event rail reloading logic

### DIFF
--- a/app/components/pipeline/workflow/event-rail/template.hbs
+++ b/app/components/pipeline/workflow/event-rail/template.hbs
@@ -1,5 +1,6 @@
 <div
   id="event-rail"
+  {{did-insert this.initialize}}
   {{did-update this.update @event @reloadEvents}}
 >
   <div id="event-rail-actions">
@@ -37,23 +38,27 @@
   </div>
 
   <div id="event-cards-container">
-    <VerticalCollection
-      @items={{this.events}}
-      @estimateHeight={{150}}
-      @idForFirstItem={{this.firstItemId}}
-      @firstReached={{this.addNewerEvents}}
-      @lastReached={{this.addOlderEvents}}
-      as |event|
-    >
-      <Pipeline::Event::Card
-        @event={{event}}
-        @userSettings={{@userSettings}}
-        @queueName="eventRail"
-        @allowEventAction={{true}}
-        @showParameters={{true}}
-        @showEventGroup={{true}}
-        @handleFilter={{true}}
-      />
-    </VerticalCollection>
+    {{#if this.showCards}}
+      <VerticalCollection
+        @items={{this.events}}
+        @estimateHeight={{150}}
+        @key={{"id"}}
+        @idForFirstItem={{this.firstItemId}}
+        @firstReached={{this.addNewerEvents}}
+        @lastReached={{this.addOlderEvents}}
+        @registerAPI={{this.registerApi}}
+        as |event|
+      >
+        <Pipeline::Event::Card
+          @event={{event}}
+          @userSettings={{@userSettings}}
+          @queueName="eventRail"
+          @allowEventAction={{true}}
+          @showParameters={{true}}
+          @showEventGroup={{true}}
+          @handleFilter={{true}}
+        />
+      </VerticalCollection>
+    {{/if}}
   </div>
 </div>


### PR DESCRIPTION
## Context
The V2 event rail has an issue where sometimes the selected event doesn't get rendered within the visible space of the event rail.  This is due to a how the underlying vertical collections component functions and is not really set up to handle our use case for updating event cards post initial render.

## Objective
Adjusts the rendering logic to be in line with the vertical collection component expectations

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
