### PR TITLE
fix: Fix trigger toggle state not reflecting in event graph

### DIFF
--- a/app/components/pipeline/workflow/component.js
+++ b/app/components/pipeline/workflow/component.js
@@ -224,7 +224,9 @@ export default class PipelineWorkflowComponent extends Component {
       workflowGraph,
       this.pipelinePageState.getTriggers()
     );
-    this.workflowGraphToDisplay = this.workflowGraph;
+    this.workflowGraphToDisplay = this.showDownstreamTriggers
+      ? this.workflowGraphWithDownstreamTriggers
+      : this.workflowGraph;
   }
 
   @action


### PR DESCRIPTION
## Context
When the toggle downstream triggers toggle is set to true, the workflow graph does not maintain the toggle state properly when switching between different events of the pipeline.

## Objective
Fixes the issue where when a new event is selected, the workflow graph automatically defaults to hiding the downstream triggers.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
