### PR TITLE
feat: Glimmer component table for secrets

### DIFF
--- a/app/components/pipeline/secrets-and-tokens/secrets/table/cell/actions/component.js
+++ b/app/components/pipeline/secrets-and-tokens/secrets/table/cell/actions/component.js
@@ -1,0 +1,42 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+
+export default class PipelineSecretsAndTokensTableCellActionsComponent extends Component {
+  @service('pipeline-secrets') pipelineSecrets;
+
+  @tracked isEditSecretModalOpen = false;
+
+  @tracked isDeleteSecretModalOpen = false;
+
+  @action
+  showEditSecretModal() {
+    this.isEditSecretModalOpen = true;
+  }
+
+  @action
+  closeEditSecretModal(updatedSecret) {
+    this.isEditSecretModalOpen = false;
+
+    if (updatedSecret) {
+      this.pipelineSecrets.replaceSecret(updatedSecret);
+      this.args.record.onSuccess();
+    }
+  }
+
+  @action
+  showDeleteSecretModal() {
+    this.isDeleteSecretModalOpen = true;
+  }
+
+  @action
+  closeDeleteSecretModal(deletedSecret) {
+    this.isDeleteSecretModalOpen = false;
+
+    if (deletedSecret) {
+      this.pipelineSecrets.deleteSecret(deletedSecret);
+      this.args.record.onSuccess();
+    }
+  }
+}

--- a/app/components/pipeline/secrets-and-tokens/secrets/table/cell/actions/template.hbs
+++ b/app/components/pipeline/secrets-and-tokens/secrets/table/cell/actions/template.hbs
@@ -1,0 +1,43 @@
+<div class="actions-button-container">
+  <BsButton
+    @type="primary"
+    @outline={{true}}
+    @onClick={{this.showEditSecretModal}}
+  >
+    <FaIcon
+      @icon="pen"
+      @outline={{true}}
+    />
+    {{#if this.isEditSecretModalOpen}}
+      <Pipeline::SecretsAndTokens::Secrets::Modal::Edit
+        @secret={{@record}}
+        @closeModal={{this.closeEditSecretModal}}
+      />
+    {{/if}}
+  </BsButton>
+
+  {{#if (or @record.overridden (not @record.inherited))}}
+    <BsButton
+      @type="danger"
+      @outline={{true}}
+      @onClick={{this.showDeleteSecretModal}}
+      disabled={{this.isActionDisabled}}
+    >
+      {{#if @record.overridden}}
+        <FaIcon
+          @icon="rotate-left"
+        />
+      {{else}}
+        <FaIcon
+          @icon="trash"
+        />
+      {{/if}}
+      {{#if this.isDeleteSecretModalOpen}}
+        <Pipeline::SecretsAndTokens::Secrets::Modal::Delete
+          @secret={{@record}}
+          @closeModal={{this.closeDeleteSecretModal}}
+        />
+      {{/if}}
+    </BsButton>
+  {{/if}}
+</div>

--- a/app/components/pipeline/secrets-and-tokens/secrets/table/cell/allowed-in-pr/styles.scss
+++ b/app/components/pipeline/secrets-and-tokens/secrets/table/cell/allowed-in-pr/styles.scss
@@ -1,0 +1,9 @@
+@use 'screwdriver-colors' as colors;
+
+@mixin styles {
+  .allowed-in-pr-container {
+    display: flex;
+    justify-content: center;
+    color: colors.$sd-success;
+  }
+}

--- a/app/components/pipeline/secrets-and-tokens/secrets/table/cell/allowed-in-pr/template.hbs
+++ b/app/components/pipeline/secrets-and-tokens/secrets/table/cell/allowed-in-pr/template.hbs
@@ -1,0 +1,7 @@
+{{#if @record.allowInPr}}
+  <div class="allowed-in-pr-container">
+    <FaIcon
+      @icon="circle-check"
+    />
+  </div>
+{{/if}}

--- a/app/components/pipeline/secrets-and-tokens/secrets/table/cell/inherited/styles.scss
+++ b/app/components/pipeline/secrets-and-tokens/secrets/table/cell/inherited/styles.scss
@@ -1,0 +1,9 @@
+@use 'screwdriver-colors' as colors;
+
+@mixin styles {
+  .inherited-container {
+    display: flex;
+    justify-content: center;
+    color: colors.$sd-success;
+  }
+}

--- a/app/components/pipeline/secrets-and-tokens/secrets/table/cell/inherited/template.hbs
+++ b/app/components/pipeline/secrets-and-tokens/secrets/table/cell/inherited/template.hbs
@@ -1,0 +1,7 @@
+{{#if @record.inherited}}
+  <div class="inherited-container">
+    <FaIcon
+      @icon="circle-check"
+    />
+  </div>
+{{/if}}

--- a/app/components/pipeline/secrets-and-tokens/secrets/table/component.js
+++ b/app/components/pipeline/secrets-and-tokens/secrets/table/component.js
@@ -1,0 +1,98 @@
+import Component from '@glimmer/component';
+import { service } from '@ember/service';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import { dom } from '@fortawesome/fontawesome-svg-core';
+
+export default class PipelineSecretsAndTokensTableComponent extends Component {
+  @service('pipeline-page-state') pipelinePageState;
+
+  @service('pipeline-secrets') pipelineSecrets;
+
+  @service('emt-themes/ember-bootstrap-v5') emberModelTableBootstrapTheme;
+
+  @tracked data;
+
+  get columns() {
+    return [
+      {
+        title: 'KEY',
+        propertyName: 'name',
+        className: 'key-column',
+        filteredBy: 'name'
+      },
+      {
+        title: 'ALLOWED IN PR',
+        propertyName: 'allowedInPr',
+        className: 'allow-in-pr-column',
+        component: 'allowedInPrCell',
+        filteredBy: 'allowInPr',
+        filterWithSelect: true,
+        predefinedFilterOptions: ['Yes', 'No'],
+        filterFunction: (_val, filterVal, row) => {
+          if (filterVal === 'Yes') {
+            return row.allowInPr === true;
+          }
+
+          return row.allowInPr === false;
+        }
+      },
+      {
+        title: 'INHERITED',
+        propertyName: 'inherited',
+        className: 'inherited-column',
+        component: 'inheritedCell',
+        filteredBy: 'inherited',
+        filterWithSelect: true,
+        predefinedFilterOptions: ['Yes', 'No'],
+        filterFunction: (_val, filterVal, row) => {
+          if (filterVal === 'Yes') {
+            return row.inherited === true;
+          }
+
+          return row.inherited === false;
+        }
+      },
+      {
+        title: 'ACTIONS',
+        className: 'actions-column',
+        component: 'actionsCell'
+      }
+    ];
+  }
+
+  get theme() {
+    const theme = this.emberModelTableBootstrapTheme;
+
+    theme.table = 'table table-condensed table-hover table-sm';
+
+    return theme;
+  }
+
+  @action
+  async initialize(element) {
+    dom.i2svg({ node: element });
+  }
+
+  @action
+  mapSecrets() {
+    const { inheritedSecrets } = this.pipelineSecrets;
+    const secrets = Array.from(this.pipelineSecrets.secrets.values()).sort(
+      (a, b) => a.name.localeCompare(b.name)
+    );
+
+    this.data = secrets.map(secret => {
+      return {
+        id: secret.id,
+        name: secret.name,
+        allowInPr: secret.allowInPR,
+        pipelineId: secret.pipelineId,
+        inherited: inheritedSecrets.has(secret.name),
+        overridden: inheritedSecrets.has(secret.name)
+          ? secret.pipelineId === this.pipelinePageState.getPipelineId()
+          : false,
+        onSuccess: this.mapSecrets
+      };
+    });
+  }
+}

--- a/app/components/pipeline/secrets-and-tokens/secrets/table/styles.scss
+++ b/app/components/pipeline/secrets-and-tokens/secrets/table/styles.scss
@@ -1,0 +1,68 @@
+@use 'screwdriver-colors' as colors;
+@use 'ember-models-table';
+
+@use 'cell/allowed-in-pr/styles' as allowedInPr;
+@use 'cell/inherited/styles' as inherited;
+
+@mixin styles {
+  .secrets-table {
+    @include ember-models-table.styles;
+
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+
+    $table-footer-height: 2.5rem;
+
+    .table-main {
+      max-height: calc(100% - $table-footer-height);
+      margin-top: 0;
+      overflow: scroll;
+
+      table {
+        table-layout: fixed;
+        width: 100%;
+
+        .key-column {
+          padding-left: 1rem;
+          overflow: auto;
+        }
+
+        .allow-in-pr-column,
+        .inherited-column,
+        .actions-column {
+          width: 10rem;
+        }
+
+        thead {
+          position: sticky;
+          top: 0;
+          background: colors.$sd-white;
+          z-index: 1;
+
+          th {
+            border: none;
+          }
+        }
+
+        tbody {
+          .key-column {
+            padding-left: 1rem;
+          }
+
+          .allow-in-pr-column {
+            @include allowedInPr.styles;
+          }
+
+          .inherited-column {
+            @include inherited.styles;
+          }
+        }
+      }
+    }
+
+    .table-footer {
+      height: $table-footer-height;
+    }
+  }
+}

--- a/app/components/pipeline/secrets-and-tokens/secrets/table/template.hbs
+++ b/app/components/pipeline/secrets-and-tokens/secrets/table/template.hbs
@@ -1,0 +1,66 @@
+<ModelsTable
+  class="secrets-table"
+  @data={{this.data}}
+  @columns={{this.columns}}
+  @columnComponents={{hash
+    allowedInPrCell=(component "pipeline/secrets-and-tokens/secrets/table/cell/allowed-in-pr")
+    inheritedCell=(component "pipeline/secrets-and-tokens/secrets/table/cell/inherited")
+    actionsCell=(component "pipeline/secrets-and-tokens/secrets/table/cell/actions")
+  }}
+  @themeInstance={{this.theme}}
+  @onDisplayDataChanged={{this.onDisplayDataChanged}}
+
+  {{did-insert this.initialize}}
+  {{did-update this.mapSecrets @pipelineId @secrets}}
+
+  as |MT|
+>
+<div class="table-main">
+  <MT.Table />
+</div>
+
+<div class="table-footer">
+  <MT.Summary
+    class="entry-summary"
+    as |Summary|
+  >
+    {{Summary.summary}}
+  </MT.Summary>
+
+  <MT.PageSizeSelect class="select-pagination-size"/>
+
+  <MT.PaginationSimple class="pagination-controls" as |PS|>
+    <div class="page-navigation">
+      <BsButton
+        disabled={{if PS.goToBackEnabled false true}}
+        @onClick={{fn PS.goToFirst}}
+      >
+        <FaIcon @icon="angle-double-left"/>
+      </BsButton>
+      <BsButton
+        disabled={{if PS.goToBackEnabled false true}}
+        @onClick={{fn PS.goToPrev}}
+      >
+        <FaIcon @icon="angle-left"/>
+      </BsButton>
+      <BsButton
+        disabled={{if PS.goToForwardEnabled false true}}
+        @onClick={{fn PS.goToNext}}
+      >
+        <FaIcon @icon="angle-right"/>
+      </BsButton>
+      <BsButton
+        disabled={{if PS.goToForwardEnabled false true}}
+        @onClick={{fn PS.goToLast}}
+      >
+        <FaIcon @icon="angle-double-right"/>
+      </BsButton>
+    </div>
+
+    <div class="page-select">
+      <label class="input-group-text">Page:</label>
+      <PS.PageNumberSelect/>
+    </div>
+  </MT.PaginationSimple>
+</div>
+</ModelsTable>

--- a/tests/integration/components/pipeline/secrets-and-tokens/secrets/table/cell/actions/component-test.js
+++ b/tests/integration/components/pipeline/secrets-and-tokens/secrets/table/cell/actions/component-test.js
@@ -1,0 +1,61 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module(
+  'Integration | Component | pipeline/secrets-and-tokens/table/cell/actions',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test('it renders', async function (assert) {
+      this.setProperties({
+        record: {}
+      });
+
+      await render(
+        hbs`<Pipeline::SecretsAndTokens::Secrets::Table::Cell::Actions
+            @record={{this.record}}
+        />`
+      );
+
+      assert.dom('button').exists({ count: 2 });
+      assert.dom('button svg.fa-trash').exists();
+    });
+
+    test('it renders for inherited secrets', async function (assert) {
+      this.setProperties({
+        record: {
+          inherited: true,
+          overridden: false
+        }
+      });
+
+      await render(
+        hbs`<Pipeline::SecretsAndTokens::Secrets::Table::Cell::Actions
+            @record={{this.record}}
+        />`
+      );
+
+      assert.dom('button').exists({ count: 1 });
+    });
+
+    test('it renders for overridden secrets', async function (assert) {
+      this.setProperties({
+        record: {
+          inherited: true,
+          overridden: true
+        }
+      });
+
+      await render(
+        hbs`<Pipeline::SecretsAndTokens::Secrets::Table::Cell::Actions
+            @record={{this.record}}
+        />`
+      );
+
+      assert.dom('button').exists({ count: 2 });
+      assert.dom('button svg.fa-rotate-left').exists();
+    });
+  }
+);

--- a/tests/integration/components/pipeline/secrets-and-tokens/secrets/table/cell/allowed-in-pr/component-test.js
+++ b/tests/integration/components/pipeline/secrets-and-tokens/secrets/table/cell/allowed-in-pr/component-test.js
@@ -1,0 +1,41 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module(
+  'Integration | Component | pipeline/secrets-and-tokens/secrets/table/cell/allowed-in-pr',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test('it renders', async function (assert) {
+      this.setProperties({
+        record: {
+          allowInPr: true
+        }
+      });
+
+      await render(
+        hbs`<Pipeline::SecretsAndTokens::Secrets::Table::Cell::AllowedInPr
+            @record={{this.record}}
+        />`
+      );
+
+      assert.dom('.allowed-in-pr-container').exists();
+    });
+
+    test('it does not render when allowedInPr is not set', async function (assert) {
+      this.setProperties({
+        record: {}
+      });
+
+      await render(
+        hbs`<Pipeline::SecretsAndTokens::Secrets::Table::Cell::AllowedInPr
+            @record={{this.record}}
+        />`
+      );
+
+      assert.dom('.allowed-in-pr-container').doesNotExist();
+    });
+  }
+);

--- a/tests/integration/components/pipeline/secrets-and-tokens/secrets/table/cell/inherited/component-test.js
+++ b/tests/integration/components/pipeline/secrets-and-tokens/secrets/table/cell/inherited/component-test.js
@@ -1,0 +1,39 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module(
+  'Integration | Component | pipeline/secrets-and-tokens/secrets/table/cell/inherited',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test('it renders', async function (assert) {
+      this.setProperties({
+        record: {
+          inherited: true
+        }
+      });
+      await render(
+        hbs`<Pipeline::SecretsAndTokens::Secrets::Table::Cell::Inherited
+            @record={{this.record}}
+        />`
+      );
+
+      assert.dom('.inherited-container').exists();
+    });
+
+    test('it does not render when inherited is not set', async function (assert) {
+      this.setProperties({
+        record: {}
+      });
+      await render(
+        hbs`<Pipeline::SecretsAndTokens::Secrets::Table::Cell::Inherited
+            @record={{this.record}}
+        />`
+      );
+
+      assert.dom('.inherited-container').doesNotExist();
+    });
+  }
+);


### PR DESCRIPTION
## Context
The V2 UI needs a table component to allow users to modify existing secrets. Creating new pipeline secrets will be handled in an outer wrapping component that integrates this table component within it.

## Objective
Creates a table to allow users to manage pipeline secrets.  Secrets that are inherited from a parent pipeline can be overridden and reverted.

![Screenshot 2025-05-12 at 16-49-30 minghay_child-2 Secrets](https://github.com/user-attachments/assets/8c619b3a-67ed-4f3b-9b51-fac2fdce2bdf)

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
