### PR TITLE
feat: update event rail to display cause message from pr-closed workflow

### DIFF
--- a/app/components/pipeline-event-row/template.hbs
+++ b/app/components/pipeline-event-row/template.hbs
@@ -51,9 +51,15 @@
     <div class="date greyOut">
       Started {{this.startDate.content}}
     </div>
-    <span class="message" title={{this.event.commit.message}}>
+    {{#if (eq this.event.startFrom "~pr-closed")}}
+      <span class="message" title={{this.event.causeMessage}}>
+        {{this.event.causeMessage}}
+      </span>
+    {{else}}
+      <span class="message" title={{this.event.commit.message}}>
       {{this.event.truncatedMessage}}
-    </span>
+      </span>
+    {{/if}}
     <div class="by">
       {{#if this.isCommitterDifferent}}
         <span>

--- a/app/components/pipeline-event-row/template.hbs
+++ b/app/components/pipeline-event-row/template.hbs
@@ -51,7 +51,7 @@
     <div class="date greyOut">
       Started {{this.startDate.content}}
     </div>
-    {{#if (eq this.event.startFrom "~pr-closed")}}
+    {{#if (starts-with this.event.startFrom "~pr-closed")}}
       <span class="message" title={{this.event.causeMessage}}>
         {{this.event.causeMessage}}
       </span>

--- a/app/components/pipeline/event/card/template.hbs
+++ b/app/components/pipeline/event/card/template.hbs
@@ -84,7 +84,7 @@
 
   <div class="event-card-body">
    
-    {{#if (eq this.event.startFrom "~pr-closed")}}
+    {{#if (starts-with this.event.startFrom "~pr-closed")}}
       <div class="message" title={{this.event.causeMessage}}>
         {{this.event.causeMessage}}
       </div>

--- a/app/components/pipeline/event/card/template.hbs
+++ b/app/components/pipeline/event/card/template.hbs
@@ -83,10 +83,17 @@
   </div>
 
   <div class="event-card-body">
+   
+    {{#if (eq this.event.startFrom "~pr-closed")}}
+      <div class="message" title={{this.event.causeMessage}}>
+        {{this.event.causeMessage}}
+      </div>
+    {{else}}
     <div class="message" title={{@event.commit.message}}>
       {{this.truncatedMessage}}
     </div>
-
+    {{/if}}
+  
     {{#if this.eventLabel}}
       <div class="label">
         <div class="label-contents" title={{this.eventLabel}}>

--- a/app/components/pipeline/workflow/component.js
+++ b/app/components/pipeline/workflow/component.js
@@ -6,6 +6,7 @@ import { isComplete, isSkipped } from 'screwdriver-ui/utils/pipeline/event';
 import { getDisplayJobNameLength, getWorkflowGraph } from './util';
 import { extractEventStages } from '../../../utils/graph-tools';
 
+const PR_CLOSED_EVENT = '~pr-closed';
 const BUILD_QUEUE_NAME = 'graph';
 const STAGE_BUILD_QUEUE_NAME = 'stageBuilds';
 const LATEST_COMMIT_EVENT_QUEUE_NAME = 'latestCommitEvent';
@@ -261,6 +262,10 @@ export default class PipelineWorkflowComponent extends Component {
     return this.pipelinePageState.getIsPr();
   }
 
+  get isPRClosed() {
+    return this.event?.startFrom === PR_CLOSED_EVENT;
+  }
+
   get eventRailAnchor() {
     return this.args.invalidEvent ? this.latestEvent : this.event;
   }
@@ -277,7 +282,7 @@ export default class PipelineWorkflowComponent extends Component {
   }
 
   get hasPrRestrictions() {
-    if (!this.isPR) {
+    if (!this.isPR && !this.isPRClosed) {
       return false;
     }
 


### PR DESCRIPTION
## Context

SD configuration currently does not support pull_request closed trigger, to enable this feature we need to additional parsed information from webhook

## Objective

This PR updates event rail to display cause message when start from is pr-closed 

## References

https://github.com/screwdriver-cd/data-schema/pull/597

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
