### PR TITLE
feat: Tokens service

### DIFF
--- a/app/components/tokens/component.js
+++ b/app/components/tokens/component.js
@@ -7,6 +7,8 @@ import _ from 'lodash';
 export default class TokensComponent extends Component {
   @service shuttle;
 
+  @service('tokens') tokensService;
+
   @service pipelinePageState;
 
   @tracked errorMessage;
@@ -23,6 +25,16 @@ export default class TokensComponent extends Component {
     this.isCreateTokenButtonDisabled = true;
     this.isCreateTokenModalOpen = false;
     this.tokens = [];
+
+    this.tokensService
+      .fetchTokens(this.pipelinePageState.getPipelineId())
+      .then(() => {
+        this.isCreateTokenButtonDisabled = false;
+        this.tokens = this.tokensService.tokens;
+      })
+      .catch(errorMessage => {
+        this.errorMessage = errorMessage;
+      });
   }
 
   get type() {
@@ -32,22 +44,6 @@ export default class TokensComponent extends Component {
 
   get scope() {
     return this.args.type === 'pipeline' ? 'this pipeline' : 'your account';
-  }
-
-  @action
-  async fetchTokens() {
-    const pipelineId = this.pipelinePageState.getPipelineId();
-    const url = pipelineId ? `/pipelines/${pipelineId}/tokens` : '/tokens';
-
-    await this.shuttle
-      .fetchFromApi('get', url)
-      .then(tokens => {
-        this.tokens = tokens;
-        this.isCreateTokenButtonDisabled = false;
-      })
-      .catch(err => {
-        this.errorMessage = err.message;
-      });
   }
 
   @action

--- a/app/components/tokens/modal/create/component.js
+++ b/app/components/tokens/modal/create/component.js
@@ -8,6 +8,8 @@ export default class TokensModalCreateComponent extends Component {
 
   @service pipelinePageState;
 
+  @service('tokens') tokensService;
+
   @tracked errorMessage;
 
   @tracked tokenName;
@@ -22,19 +24,16 @@ export default class TokensModalCreateComponent extends Component {
 
   @tracked newToken;
 
-  tokenNames;
-
   constructor() {
     super(...arguments);
 
     this.isAwaitingResponse = false;
     this.wasActionSuccessful = false;
     this.isCopyButtonDisabled = false;
-    this.tokenNames = this.args.tokens.map(token => token.name);
   }
 
   isTokenNameInvalid() {
-    return this.tokenNames.includes(this.tokenName);
+    return this.tokensService.tokenNames.includes(this.tokenName);
   }
 
   get inputClass() {
@@ -80,6 +79,7 @@ export default class TokensModalCreateComponent extends Component {
       })
       .then(response => {
         this.newToken = response;
+        this.tokensService.addToken(response);
         this.wasActionSuccessful = true;
       })
       .catch(err => {

--- a/app/components/tokens/modal/edit/component.js
+++ b/app/components/tokens/modal/edit/component.js
@@ -6,6 +6,8 @@ import { service } from '@ember/service';
 export default class TokensModalEditComponent extends Component {
   @service shuttle;
 
+  @service('tokens') tokensService;
+
   @service pipelinePageState;
 
   @tracked errorMessage;
@@ -23,11 +25,10 @@ export default class TokensModalEditComponent extends Component {
 
     this.isAwaitingResponse = false;
     this.wasActionSuccessful = false;
-    this.tokenNames = this.args.token.tokens.map(token => token.name);
   }
 
   isTokenNameInvalid() {
-    return this.tokenNames.includes(this.tokenName);
+    return this.tokensService.tokenNames.includes(this.tokenName);
   }
 
   get inputClass() {

--- a/app/components/tokens/table/cell/actions/component.js
+++ b/app/components/tokens/table/cell/actions/component.js
@@ -1,8 +1,11 @@
 import Component from '@glimmer/component';
-import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
 
 export default class TokensTableCellActionsComponent extends Component {
+  @service('tokens') tokensService;
+
   @tracked isEditTokenModalOpen;
 
   @tracked isRefreshTokenModalOpen;
@@ -27,7 +30,8 @@ export default class TokensTableCellActionsComponent extends Component {
     this.isEditTokenModalOpen = false;
 
     if (updatedToken) {
-      this.args.record.onUpdated(updatedToken);
+      this.tokensService.updateToken(updatedToken);
+      this.args.record.onSuccess();
     }
   }
 
@@ -51,7 +55,8 @@ export default class TokensTableCellActionsComponent extends Component {
     this.isDeleteTokenModalOpen = false;
 
     if (deletedToken) {
-      this.args.record.onDeleted(deletedToken);
+      this.tokensService.deleteToken(deletedToken);
+      this.args.record.onSuccess();
     }
   }
 }

--- a/app/components/tokens/table/component.js
+++ b/app/components/tokens/table/component.js
@@ -5,17 +5,11 @@ import { tracked } from '@glimmer/tracking';
 import { dom } from '@fortawesome/fontawesome-svg-core';
 
 export default class TokensTableComponent extends Component {
-  @tracked data;
+  @service('tokens') tokensService;
 
   @service('emt-themes/ember-bootstrap-v5') emberModelTableBootstrapTheme;
 
-  tokens;
-
-  constructor() {
-    super(...arguments);
-
-    this.tokens = this.args.tokens;
-  }
+  @tracked data;
 
   get columns() {
     return [
@@ -55,46 +49,19 @@ export default class TokensTableComponent extends Component {
   @action
   async initialize(element) {
     dom.i2svg({ node: element });
-
-    this.mapTokens();
   }
 
   @action
-  updateTokens(element, [tokens]) {
-    tokens.push(...this.tokens);
-    this.tokens = tokens;
-
-    this.mapTokens();
-  }
-
   mapTokens() {
-    this.data = this.tokens.map(token => {
+    this.data = this.tokensService.tokens.map(token => {
       return {
         id: token.id,
         name: token.name,
         description: token.description,
         lastUsed: token.lastUsed,
         type: this.args.type,
-        onUpdated: this.onTokenUpdated,
-        onDeleted: this.onTokenDeleted,
-        tokens: this.tokens
+        onSuccess: this.mapTokens
       };
     });
-  }
-
-  @action
-  onTokenUpdated(updatedToken) {
-    this.tokens = this.data.map(token => {
-      return token.id === updatedToken.id ? updatedToken : token;
-    });
-
-    this.mapTokens();
-  }
-
-  @action
-  onTokenDeleted(deletedToken) {
-    this.tokens = this.data.filter(token => token.id !== deletedToken.id);
-
-    this.mapTokens();
   }
 }

--- a/app/components/tokens/table/template.hbs
+++ b/app/components/tokens/table/template.hbs
@@ -10,7 +10,7 @@
   @onDisplayDataChanged={{this.onDisplayDataChanged}}
 
   {{did-insert this.initialize}}
-  {{did-update this.updateTokens @tokens}}
+  {{did-update this.mapTokens @tokens}}
 
   as |MT|
 >

--- a/app/components/tokens/template.hbs
+++ b/app/components/tokens/template.hbs
@@ -1,7 +1,4 @@
-<div
-  class="tokens-container"
-  {{did-insert this.fetchTokens}}
->
+<div class="tokens-container">
   {{#if this.errorMessage}}
     <InfoMessage
       id="error-message"
@@ -38,7 +35,6 @@
         {{#if this.isCreateTokenModalOpen}}
           <Tokens::Modal::Create
             @type={{@type}}
-            @tokens={{this.tokens}}
             @closeModal={{this.closeCreateTokenModal}}
           />
         {{/if}}

--- a/app/tokens/service.js
+++ b/app/tokens/service.js
@@ -1,0 +1,58 @@
+import Service, { service } from '@ember/service';
+
+export default class TokensService extends Service {
+  @service shuttle;
+
+  tokens;
+
+  tokenNames;
+
+  constructor() {
+    super(...arguments);
+
+    this.tokens = [];
+    this.tokenNames = [];
+  }
+
+  clear() {
+    this.tokens = [];
+    this.tokenNames = [];
+  }
+
+  async fetchTokens(pipelineId) {
+    this.clear();
+
+    const url = pipelineId ? `/pipelines/${pipelineId}/tokens` : '/tokens';
+
+    return this.shuttle
+      .fetchFromApi('get', url)
+      .then(tokens => {
+        this.tokens = tokens;
+        tokens.forEach(token => {
+          this.tokenNames.push(token.name);
+        });
+      })
+      .catch(err => {
+        return err.message;
+      });
+  }
+
+  addToken(newToken) {
+    this.tokens.splice(0, 0, newToken);
+    this.tokenNames.splice(0, 0, newToken.name);
+  }
+
+  updateToken(updatedToken) {
+    const index = this.tokens.findIndex(token => token.id === updatedToken.id);
+
+    this.tokens[index] = updatedToken;
+    this.tokenNames[index] = updatedToken.name;
+  }
+
+  deleteToken(deletedToken) {
+    const index = this.tokens.findIndex(token => token.id === deletedToken.id);
+
+    this.tokens.splice(index, 1);
+    this.tokenNames.splice(index, 1);
+  }
+}

--- a/tests/integration/components/tokens/component-test.js
+++ b/tests/integration/components/tokens/component-test.js
@@ -7,18 +7,18 @@ import sinon from 'sinon';
 module('Integration | Component | tokens', function (hooks) {
   setupRenderingTest(hooks);
 
-  let shuttle;
+  let tokensService;
 
   hooks.beforeEach(function () {
     const pipelinePageState = this.owner.lookup('service:pipeline-page-state');
 
-    shuttle = this.owner.lookup('service:shuttle');
+    tokensService = this.owner.lookup('service:tokens');
 
     sinon.stub(pipelinePageState, 'getPipelineId').returns(123);
   });
 
   test('it renders', async function (assert) {
-    sinon.stub(shuttle, 'fetchFromApi').resolves([]);
+    sinon.stub(tokensService, 'fetchTokens').resolves([]);
 
     await render(
       hbs`<Tokens
@@ -38,7 +38,7 @@ module('Integration | Component | tokens', function (hooks) {
   });
 
   test('it renders error message', async function (assert) {
-    sinon.stub(shuttle, 'fetchFromApi').rejects({ message: 'error' });
+    sinon.stub(tokensService, 'fetchTokens').rejects('error');
 
     await render(
       hbs`<Tokens
@@ -47,7 +47,6 @@ module('Integration | Component | tokens', function (hooks) {
     );
 
     assert.dom('#error-message').exists();
-    assert.dom('#error-message').hasText('× error');
     assert.dom('.tokens-header').exists({ count: 1 });
     assert.dom('.tokens-header-text').exists({ count: 1 });
     assert.dom('.tokens-header-title').exists({ count: 1 });

--- a/tests/integration/components/tokens/modal/edit/component-test.js
+++ b/tests/integration/components/tokens/modal/edit/component-test.js
@@ -11,6 +11,7 @@ module('Integration | Component | tokens/modal/edit', function (hooks) {
 
   hooks.beforeEach(function () {
     const pipelinePageState = this.owner.lookup('service:pipelinePageState');
+    const tokensService = this.owner.lookup('service:tokens');
 
     shuttle = this.owner.lookup('service:shuttle');
 
@@ -19,11 +20,12 @@ module('Integration | Component | tokens/modal/edit', function (hooks) {
     this.setProperties({
       token: {
         name: 'test',
-        type: 'pipeline',
-        tokens: [{ name: 'exists' }]
+        type: 'pipeline'
       },
       closeModal: () => {}
     });
+
+    tokensService.tokenNames = ['exists'];
   });
 
   test('it renders', async function (assert) {

--- a/tests/unit/tokens/service-test.js
+++ b/tests/unit/tokens/service-test.js
@@ -1,0 +1,91 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
+import sinon from 'sinon';
+
+module('Unit | Service | tokens', function (hooks) {
+  setupTest(hooks);
+
+  let shuttle;
+
+  let tokensService;
+
+  hooks.beforeEach(function () {
+    tokensService = this.owner.lookup('service:tokens');
+    shuttle = this.owner.lookup('service:shuttle');
+
+    tokensService.clear();
+  });
+
+  test('it exists', function (assert) {
+    assert.ok(tokensService);
+  });
+
+  test('fetchTokens fetches tokens', async function (assert) {
+    sinon
+      .stub(shuttle, 'fetchFromApi')
+      .resolves([{ name: 'TOKEN1' }, { name: 'TOKEN2' }]);
+
+    await tokensService.fetchTokens();
+
+    assert.equal(tokensService.tokens.length, 2);
+    assert.equal(tokensService.tokenNames.length, 2);
+  });
+
+  test('fetchTokens returns error message', async function (assert) {
+    sinon.stub(shuttle, 'fetchFromApi').rejects({ message: 'error' });
+
+    const errorMessage = await tokensService.fetchTokens();
+
+    assert.equal(tokensService.tokens.length, 0);
+    assert.equal(tokensService.tokenNames.length, 0);
+    assert.equal(errorMessage, 'error');
+  });
+
+  test('addToken adds a token correctly', async function (assert) {
+    const tokenName = 'first';
+
+    tokensService.tokens = [{ name: tokenName }];
+    tokensService.tokenNames = [tokenName];
+
+    tokensService.addToken({ name: 'new' });
+
+    assert.equal(tokensService.tokens.length, 2);
+    assert.equal(tokensService.tokenNames.length, 2);
+    assert.equal(tokensService.tokens[0].name, 'new');
+  });
+
+  test('updateToken updates a token correctly', async function (assert) {
+    const updatedToken = { id: 2, name: 'CHANGED', description: 'updated' };
+
+    sinon.stub(shuttle, 'fetchFromApi').resolves([
+      { id: 1, name: 'TOKEN1' },
+      { id: 2, name: 'TOKEN2' }
+    ]);
+
+    await tokensService.fetchTokens();
+    tokensService.updateToken(updatedToken);
+
+    assert.equal(tokensService.tokens.length, 2);
+    assert.equal(tokensService.tokenNames.length, 2);
+    assert.equal(tokensService.tokens[1].name, updatedToken.name);
+    assert.equal(tokensService.tokens[1].description, updatedToken.description);
+  });
+
+  test('deleteToken deletes a token correctly', async function (assert) {
+    const deletedToken = { id: 1, name: 'TOKEN1' };
+
+    sinon.stub(shuttle, 'fetchFromApi').resolves([
+      { id: 0, name: 'TOKEN0' },
+      { id: 1, name: 'TOKEN1' },
+      { id: 2, name: 'TOKEN2' }
+    ]);
+
+    await tokensService.fetchTokens();
+    tokensService.deleteToken(deletedToken);
+
+    assert.equal(tokensService.tokens.length, 2);
+    assert.equal(tokensService.tokenNames.length, 2);
+    assert.equal(tokensService.tokens[1].name, 'TOKEN2');
+    assert.equal(tokensService.tokenNames[1], 'TOKEN2');
+  });
+});


### PR DESCRIPTION
## Context
The V2 UI for managing tokens has a bit of interplay between various parent and child components.  In its current implementation, a lot of this interplay state is being passed around and tracked in a very ad hoc manner.  The token management for the components can be refactored into an injectable service so that the state does not need to be passed around.

## Objective
1. Creates an injectable service to manage the tokens as various user actions are taken
2. Refactors the token components to use the newly created service

## References


## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
