### PR TITLE
feat: Glimmer modal to override secrets

### DIFF
--- a/app/components/pipeline/secrets-and-tokens/secrets/modal/override/component.js
+++ b/app/components/pipeline/secrets-and-tokens/secrets/modal/override/component.js
@@ -1,0 +1,65 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+
+export default class PipelineSecretsAndTokensModalOverrideComponent extends Component {
+  @service shuttle;
+
+  @service pipelinePageState;
+
+  @tracked errorMessage;
+
+  @tracked isAwaitingResponse;
+
+  @tracked wasActionSuccessful;
+
+  @tracked secretValue;
+
+  @tracked allowInPr;
+
+  constructor() {
+    super(...arguments);
+
+    this.isAwaitingResponse = false;
+    this.wasActionSuccessful = false;
+    this.allowInPr = this.args.secret.allowInPr;
+  }
+
+  @action
+  toggleAllowInPr() {
+    this.allowInPr = !this.allowInPr;
+  }
+
+  get isSubmitButtonDisabled() {
+    if (this.wasActionSuccessful || this.isAwaitingResponse) {
+      return true;
+    }
+
+    return !this.secretValue;
+  }
+
+  @action
+  async overrideSecret() {
+    this.isAwaitingResponse = true;
+
+    return this.shuttle
+      .fetchFromApi('post', `/secrets/`, {
+        pipelineId: this.pipelinePageState.getPipelineId(),
+        name: this.args.secret.name,
+        value: this.secretValue,
+        allowInPR: this.allowInPr
+      })
+      .then(response => {
+        this.wasActionSuccessful = true;
+        this.args.closeModal(response);
+      })
+      .catch(err => {
+        this.wasActionSuccessful = false;
+        this.errorMessage = err.message;
+      })
+      .finally(() => {
+        this.isAwaitingResponse = false;
+      });
+  }
+}

--- a/app/components/pipeline/secrets-and-tokens/secrets/modal/override/styles.scss
+++ b/app/components/pipeline/secrets-and-tokens/secrets/modal/override/styles.scss
@@ -1,0 +1,57 @@
+@use 'screwdriver-colors' as colors;
+@use 'screwdriver-toggle' as toggle;
+
+@mixin styles {
+  #override-secret-modal {
+    &.modal {
+      .modal-dialog {
+        .modal-body {
+          .override-secret {
+            display: flex;
+            flex-direction: column;
+
+            label {
+              display: flex;
+              align-items: center;
+
+              div {
+                width: 6rem;
+              }
+
+              input {
+                flex: 1;
+
+                &.invalid {
+                  color: colors.$sd-warn-bg;
+                  outline: 2px solid colors.$sd-warn-bg;
+                  border-radius: 3px;
+                  border: none;
+                }
+              }
+            }
+
+            #allow-in-pr-container {
+              display: flex;
+              align-items: center;
+
+              label {
+                margin-bottom: 0;
+              }
+
+              @include toggle.styles;
+
+              #allow-in-pr-toggle {
+                justify-content: left;
+              }
+            }
+          }
+        }
+        .modal-footer {
+          #submit-secret {
+            width: 11rem;
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/components/pipeline/secrets-and-tokens/secrets/modal/override/template.hbs
+++ b/app/components/pipeline/secrets-and-tokens/secrets/modal/override/template.hbs
@@ -1,0 +1,54 @@
+<BsModal
+  id="override-secret-modal"
+  @onHide={{fn @closeModal}}
+  as |modal|
+>
+  <modal.header>
+    Override inherited secret: {{@secret.name}}
+  </modal.header>
+  <modal.body>
+    {{#if this.errorMessage}}
+      <InfoMessage
+        id="error-message"
+        @message={{this.errorMessage}}
+        @type="warning"
+        @icon="triangle-exclamation"
+      />
+    {{/if}}
+
+    <div class="override-secret">
+      <label>
+        <div>Value:</div>
+        <Input
+          id="secret-value-input"
+          @type="text"
+          @value={{this.secretValue}}
+          disabled={{this.isInvalidValue}}
+        />
+      </label>
+      <div id="allow-in-pr-container">
+        <label>
+          <div>Allow in PR:</div>
+        </label>
+        <XToggle
+          id="allow-in-pr-toggle"
+          @size="small"
+          @theme="light"
+          @value={{this.allowInPr}}
+          @onToggle={{fn this.toggleAllowInPr}}
+        />
+      </div>
+    </div>
+  </modal.body>
+  <modal.footer>
+    <BsButton
+      id="submit-secret"
+      class="confirm"
+      disabled={{this.isSubmitButtonDisabled}}
+      @defaultText="Override secret"
+      @pendingText="Overriding secret..."
+      @type="primary"
+      @onClick={{fn this.overrideSecret}}
+    />
+  </modal.footer>
+</BsModal>

--- a/tests/integration/components/pipeline/secrets-and-tokens/secrets/modal/override/component-test.js
+++ b/tests/integration/components/pipeline/secrets-and-tokens/secrets/modal/override/component-test.js
@@ -1,0 +1,103 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
+import { click, fillIn, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+
+module(
+  'Integration | Component | pipeline/secrets-and-tokens/modal/override',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    let shuttle;
+
+    hooks.beforeEach(function () {
+      const pipelinePageState = this.owner.lookup('service:pipelinePageState');
+
+      shuttle = this.owner.lookup('service:shuttle');
+
+      sinon.stub(pipelinePageState, 'getPipelineId').returns(1);
+
+      this.setProperties({
+        secret: {
+          name: 'TEST',
+          allowInPr: false
+        },
+        closeModal: () => {}
+      });
+    });
+
+    test('it renders', async function (assert) {
+      await render(
+        hbs`<Pipeline::SecretsAndTokens::Secrets::Modal::Override
+            @secret={{this.secret}}
+            @closeModal={{this.closeModal}}
+        />`
+      );
+
+      assert.dom('.modal-header').hasText('Override inherited secret: TEST ×');
+      assert.dom('#error-message').doesNotExist();
+      assert.dom('#submit-secret').exists({ count: 1 });
+      assert.dom('#submit-secret').isDisabled();
+    });
+
+    test('it enables submit button correctly', async function (assert) {
+      await render(
+        hbs`<Pipeline::SecretsAndTokens::Secrets::Modal::Override
+            @secret={{this.secret}}
+            @closeModal={{this.closeModal}}
+        />`
+      );
+
+      assert.dom('#submit-secret').isDisabled();
+
+      await click('#allow-in-pr-toggle input');
+      assert.dom('#submit-secret').isDisabled();
+
+      await fillIn('#secret-value-input', 'updated');
+      assert.dom('#submit-secret').isEnabled();
+    });
+
+    test('it handles API error', async function (assert) {
+      sinon.stub(shuttle, 'fetchFromApi').rejects({ message: 'error' });
+
+      await render(
+        hbs`<Pipeline::SecretsAndTokens::Secrets::Modal::Override
+            @secret={{this.secret}}
+            @closeModal={{this.closeModal}}
+        />`
+      );
+      await fillIn('#secret-value-input', 'updated');
+      await click('#submit-secret');
+
+      assert.dom('#error-message').exists({ count: 1 });
+      assert.dom('#submit-secret').isEnabled();
+    });
+
+    test('it closes modal with correct argument', async function (assert) {
+      const closeModalSpy = sinon.spy();
+      const newSecret = {
+        id: 123
+      };
+
+      sinon.stub(shuttle, 'fetchFromApi').resolves(newSecret);
+
+      this.setProperties({
+        closeModal: closeModalSpy
+      });
+
+      await render(
+        hbs`<Pipeline::SecretsAndTokens::Secrets::Modal::Override
+            @secret={{this.secret}}
+            @closeModal={{this.closeModal}}
+        />`
+      );
+      await fillIn('#secret-value-input', 'updated');
+      await click('#submit-secret');
+
+      assert.dom('#submit-secret').isDisabled();
+      assert.true(closeModalSpy.calledOnce);
+      assert.equal(closeModalSpy.calledWith(newSecret), true);
+    });
+  }
+);


### PR DESCRIPTION
## Context
Updating the V2 UI for pipeline secrets requires a new set of components to handle management of secrets. This modal provides a new user experience that is in line with the rest of the V2 user experience leveraging modals more heavily for user interactions.


## Objective
Creates a new modal to facilitate overriding of inherited secrets

![Screenshot 2025-04-29 at 13-57-53 minghay_child-2 Secrets](https://github.com/user-attachments/assets/e1e04f76-3525-470c-bfaf-1a612e812c89)
![Screenshot 2025-04-29 at 13-58-08 minghay_child-2 Secrets](https://github.com/user-attachments/assets/b62bbd70-2ea4-4d09-afbf-160965fbf0e9)
![Screenshot 2025-04-29 at 13-58-50 minghay_child-2 Secrets](https://github.com/user-attachments/assets/8c93bc0c-c3ad-4145-87f5-6b8ab27f2670)

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
