### PR TITLE
feat: Injectable service for managing secrets

### DIFF
--- a/app/pipeline-secrets/service.js
+++ b/app/pipeline-secrets/service.js
@@ -1,0 +1,92 @@
+import Service, { service } from '@ember/service';
+
+export default class PipelineSecretsService extends Service {
+  @service shuttle;
+
+  secrets;
+
+  inheritedSecrets;
+
+  secretNames;
+
+  constructor() {
+    super(...arguments);
+
+    this.secrets = new Map();
+    this.inheritedSecrets = new Map();
+    this.secretNames = [];
+  }
+
+  clear() {
+    this.secrets.clear();
+    this.inheritedSecrets.clear();
+    this.secretNames = [];
+  }
+
+  async fetchSecrets(pipelineId, parentPipelineId) {
+    this.clear();
+
+    const pipelineSecretsPromise = this.shuttle.fetchFromApi(
+      'get',
+      `/pipelines/${pipelineId}/secrets`
+    );
+
+    if (parentPipelineId) {
+      const inheritedSecretsPromise = this.shuttle.fetchFromApi(
+        'get',
+        `/pipelines/${parentPipelineId}/secrets`
+      );
+
+      return Promise.all([pipelineSecretsPromise, inheritedSecretsPromise])
+        .then(([secrets, inheritedSecrets]) => {
+          secrets.forEach(secret => {
+            this.secrets.set(secret.name, secret);
+          });
+          inheritedSecrets.forEach(secret => {
+            this.inheritedSecrets.set(secret.name, secret);
+          });
+          this.extractSecretNames(secrets);
+        })
+        .catch(err => {
+          return err.message;
+        });
+    }
+
+    return pipelineSecretsPromise
+      .then(secrets => {
+        secrets.forEach(secret => {
+          this.secrets.set(secret.name, secret);
+        });
+        this.extractSecretNames(secrets);
+      })
+      .catch(err => {
+        return err.message;
+      });
+  }
+
+  extractSecretNames(secrets) {
+    this.secretNames = secrets.map(secret => secret.name);
+  }
+
+  addSecret(secret) {
+    const { name } = secret;
+
+    this.secrets.set(name, secret);
+    this.secretNames.push(name);
+  }
+
+  replaceSecret(secret) {
+    this.secrets.set(secret.name, secret);
+  }
+
+  deleteSecret(secret) {
+    const { name } = secret;
+
+    if (this.inheritedSecrets.has(name)) {
+      this.secrets.set(name, this.inheritedSecrets.get(name));
+    } else {
+      this.secrets.delete(name);
+      this.secretNames.splice(this.secretNames.indexOf(name), 1);
+    }
+  }
+}

--- a/tests/unit/pipeline-secrets/service-test.js
+++ b/tests/unit/pipeline-secrets/service-test.js
@@ -1,0 +1,123 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
+import sinon from 'sinon';
+
+module('Unit | Service | pipeline-secrets', function (hooks) {
+  setupTest(hooks);
+
+  let pipelineSecrets;
+
+  let shuttle;
+
+  hooks.beforeEach(function () {
+    shuttle = this.owner.lookup('service:shuttle');
+    pipelineSecrets = this.owner.lookup('service:pipeline-secrets');
+
+    pipelineSecrets.clear();
+  });
+
+  test('it exists', function (assert) {
+    assert.ok(pipelineSecrets);
+  });
+
+  test('fetchSecrets fetches just pipeline secrets', async function (assert) {
+    sinon.stub(shuttle, 'fetchFromApi').resolves([{ name: 'TEST' }]);
+
+    await pipelineSecrets.fetchSecrets(123);
+
+    assert.equal(pipelineSecrets.secrets.size, 1);
+    assert.equal(pipelineSecrets.inheritedSecrets.size, 0);
+    assert.equal(pipelineSecrets.secretNames.length, 1);
+  });
+
+  test('fetchSecrets fetches pipeline and inherited secrets', async function (assert) {
+    sinon
+      .stub(shuttle, 'fetchFromApi')
+      .onCall(0)
+      .resolves([{ name: 'PIPELINE' }, { name: 'PARENT' }, { name: 'PARENT2' }])
+      .onCall(1)
+      .resolves([{ name: 'PARENT' }, { name: 'PARENT2' }]);
+
+    await pipelineSecrets.fetchSecrets(123, 987);
+
+    assert.equal(pipelineSecrets.secrets.size, 3);
+    assert.equal(pipelineSecrets.inheritedSecrets.size, 2);
+    assert.equal(pipelineSecrets.secretNames.length, 3);
+  });
+
+  test('fetchSecrets returns error message', async function (assert) {
+    sinon.stub(shuttle, 'fetchFromApi').rejects({ message: 'error' });
+
+    const errorMessage = await pipelineSecrets.fetchSecrets(123);
+
+    assert.equal(pipelineSecrets.secrets.size, 0);
+    assert.equal(pipelineSecrets.inheritedSecrets.size, 0);
+    assert.equal(pipelineSecrets.secretNames.length, 0);
+    assert.equal(errorMessage, 'error');
+  });
+
+  test('addSecret adds a new secret correctly', function (assert) {
+    pipelineSecrets.addSecret({ name: 'ABC' });
+
+    assert.equal(pipelineSecrets.secrets.size, 1);
+    assert.equal(pipelineSecrets.inheritedSecrets.size, 0);
+    assert.equal(pipelineSecrets.secretNames.length, 1);
+  });
+
+  test('replaceSecret removes a new secret correctly', function (assert) {
+    const originalSecret = { name: 'ABC', value: '123' };
+    const updatedSecret = { name: 'ABC', value: '456' };
+
+    pipelineSecrets.addSecret(originalSecret);
+    pipelineSecrets.replaceSecret(updatedSecret);
+
+    assert.equal(pipelineSecrets.secrets.size, 1);
+    assert.equal(pipelineSecrets.inheritedSecrets.size, 0);
+    assert.equal(pipelineSecrets.secretNames.length, 1);
+    assert.deepEqual(
+      pipelineSecrets.secrets.get(updatedSecret.name),
+      updatedSecret
+    );
+  });
+
+  test('deleteSecret removes a secret correctly', async function (assert) {
+    const secret = { name: 'ABC', value: 'abc' };
+    const inheritedSecret = { name: 'INHERITED', value: 'inherited' };
+    const overriddenSecret = { name: 'INHERITED', value: 'overridden' };
+
+    sinon
+      .stub(shuttle, 'fetchFromApi')
+      .onCall(0)
+      .resolves([secret, overriddenSecret])
+      .onCall(1)
+      .resolves([inheritedSecret]);
+
+    await pipelineSecrets.fetchSecrets(123, 987);
+
+    assert.equal(pipelineSecrets.secrets.size, 2);
+    assert.equal(pipelineSecrets.inheritedSecrets.size, 1);
+    assert.equal(pipelineSecrets.secretNames.length, 2);
+    assert.deepEqual(
+      pipelineSecrets.secrets.get(overriddenSecret.name),
+      overriddenSecret
+    );
+
+    pipelineSecrets.deleteSecret(overriddenSecret);
+    assert.equal(pipelineSecrets.secrets.size, 2);
+    assert.equal(pipelineSecrets.inheritedSecrets.size, 1);
+    assert.equal(pipelineSecrets.secretNames.length, 2);
+    assert.deepEqual(
+      pipelineSecrets.secrets.get(overriddenSecret.name),
+      inheritedSecret
+    );
+
+    pipelineSecrets.deleteSecret(secret);
+    assert.equal(pipelineSecrets.secrets.size, 1);
+    assert.equal(pipelineSecrets.inheritedSecrets.size, 1);
+    assert.equal(pipelineSecrets.secretNames.length, 1);
+    assert.deepEqual(
+      pipelineSecrets.secrets.get(inheritedSecret.name),
+      inheritedSecret
+    );
+  });
+});


### PR DESCRIPTION
## Context
Like https://github.com/screwdriver-cd/ui/pull/1406, the secrets also have a lot of state management that should be handled by an injectable service

## Objective
Creates an injectable service for managing secrets.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
