### PR TITLE
feat: Navbar for switching between secrets and tokens

### DIFF
--- a/app/components/pipeline/secrets-and-tokens/tab/component.js
+++ b/app/components/pipeline/secrets-and-tokens/tab/component.js
@@ -1,0 +1,19 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+export default class PipelineSecretsAndTokensTabComponent extends Component {
+  @tracked activeTab;
+
+  constructor() {
+    super(...arguments);
+
+    this.activeTab = this.args.activeTab;
+  }
+
+  @action
+  setActiveTab(tab) {
+    this.activeTab = tab;
+    this.args.onTabChange(tab);
+  }
+}

--- a/app/components/pipeline/secrets-and-tokens/tab/styles.scss
+++ b/app/components/pipeline/secrets-and-tokens/tab/styles.scss
@@ -1,0 +1,25 @@
+@use 'screwdriver-colors' as colors;
+@use 'variables';
+
+@mixin styles {
+  #secrets-and-tokens-tab {
+    display: flex;
+    align-items: center;
+
+    ul {
+      border: none;
+
+      li {
+        cursor: pointer;
+        color: colors.$sd-text-med;
+        padding: 0.5rem 2rem;
+
+        &.active {
+          color: colors.$sd-link;
+          font-weight: variables.$weight-bold;
+          border-bottom: 0.2rem solid colors.$sd-link;
+        }
+      }
+    }
+  }
+}

--- a/app/components/pipeline/secrets-and-tokens/tab/template.hbs
+++ b/app/components/pipeline/secrets-and-tokens/tab/template.hbs
@@ -1,0 +1,18 @@
+<div id="secrets-and-tokens-tab">
+  <BsNav @type="tabs" as |nav|>
+    <nav.item
+      id="secrets-tab"
+      class={{if (eq this.activeTab "secrets") "active"}}
+      onClick={{fn this.setActiveTab "secrets"}}
+    >
+      Secrets
+    </nav.item>
+    <nav.item
+      id="tokens-tab"
+      class={{if (eq this.activeTab "tokens") "active"}}
+      onClick={{fn this.setActiveTab "tokens"}}
+    >
+      Tokens
+    </nav.item>
+  </BsNav>
+</div>

--- a/tests/integration/components/pipeline/secrets-and-tokens/tab/component-test.js
+++ b/tests/integration/components/pipeline/secrets-and-tokens/tab/component-test.js
@@ -1,0 +1,44 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
+import { click, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+
+module(
+  'Integration | Component | pipeline/secrets-and-tokens/tab',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test('it renders', async function (assert) {
+      await render(
+        hbs`<Pipeline::SecretsAndTokens::Tab
+            @activeTab="secrets"
+        />`
+      );
+
+      assert.dom('#secrets-tab').exists({ count: 1 });
+      assert.dom('#tokens-tab').exists({ count: 1 });
+      assert.dom('#secrets-tab').hasClass('active');
+    });
+
+    test('it changes tabs correctly', async function (assert) {
+      const onTabChangeSpy = sinon.spy();
+
+      this.setProperties({
+        onTabChange: onTabChangeSpy
+      });
+
+      await render(
+        hbs`<Pipeline::SecretsAndTokens::Tab
+            @activeTab="secrets"
+            @onTabChange={{this.onTabChange}}
+        />`
+      );
+      await click('#tokens-tab');
+
+      assert.dom('#tokens-tab').hasClass('active');
+      assert.equal(onTabChangeSpy.callCount, 1);
+      assert.equal(onTabChangeSpy.calledWith('tokens'), true);
+    });
+  }
+);


### PR DESCRIPTION
## Context
The v2 UI for secrets and tokens splits up the management of secrets and tokens into different sections rather than all being on the same page.  This split requires a new navigation bar to allow switching the UI between the two view.

## Objective
Creates a glimmer component to support switching between the pipeline secrets and token UI
![Screenshot 2025-05-01 at 11-21-27 minghay_child-2 Secrets](https://github.com/user-attachments/assets/37d39cbb-614e-44ea-913e-83a1a2c9b350)

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
