### PR TITLE
fix: Refactor create secret modal to use service

### DIFF
--- a/app/components/pipeline/secrets-and-tokens/secrets/modal/create/component.js
+++ b/app/components/pipeline/secrets-and-tokens/secrets/modal/create/component.js
@@ -4,9 +4,11 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 
 export default class PipelineSecretsAndTokensModalCreateComponent extends Component {
-  @service shuttle;
+  @service('shuttle') shuttle;
 
-  @service pipelinePageState;
+  @service('pipeline-page-state') pipelinePageState;
+
+  @service('pipeline-secrets') pipelineSecrets;
 
   @tracked errorMessage;
 
@@ -20,22 +22,19 @@ export default class PipelineSecretsAndTokensModalCreateComponent extends Compon
 
   @tracked allowInPr;
 
-  secretNames;
-
   constructor() {
     super(...arguments);
 
     this.isAwaitingResponse = false;
     this.wasActionSuccessful = false;
     this.allowInPr = false;
-    this.secretNames = this.args.secrets.map(secret => secret.name);
   }
 
   isSecretNameInvalid() {
     const secretNameRegex = /^[A-Z][A-Z_]*$/;
 
     return this.secretName
-      ? this.secretNames.includes(this.secretName) ||
+      ? this.pipelineSecrets.secretNames.includes(this.secretName) ||
           secretNameRegex.test(this.secretName) === false
       : false;
   }

--- a/tests/integration/components/pipeline/secrets-and-tokens/secrets/modal/create/component-test.js
+++ b/tests/integration/components/pipeline/secrets-and-tokens/secrets/modal/create/component-test.js
@@ -11,23 +11,26 @@ module(
 
     let shuttle;
 
+    let pipelineSecrets;
+
     hooks.beforeEach(function () {
       const pipelinePageState = this.owner.lookup('service:pipelinePageState');
 
+      pipelineSecrets = this.owner.lookup('service:pipelineSecrets');
       shuttle = this.owner.lookup('service:shuttle');
 
       sinon.stub(pipelinePageState, 'getPipelineId').returns(1);
+
+      pipelineSecrets.secretNames = [];
     });
 
     test('it renders', async function (assert) {
       this.setProperties({
-        secrets: [],
         closeModal: () => {}
       });
 
       await render(
         hbs`<Pipeline::SecretsAndTokens::Secrets::Modal::Create
-          @secrets={{this.secrets}}
           @closeModal={{this.closeModal}}
         />`
       );
@@ -44,14 +47,14 @@ module(
     });
 
     test('it sets invalid class on invalid input', async function (assert) {
+      pipelineSecrets.secretNames.push('TEST');
+
       this.setProperties({
-        secrets: [{ name: 'TEST' }],
         closeModal: () => {}
       });
 
       await render(
         hbs`<Pipeline::SecretsAndTokens::Secrets::Modal::Create
-            @secrets={{this.secrets}}
             @closeModal={{this.closeModal}}
         />`
       );
@@ -69,13 +72,11 @@ module(
 
     test('it enables submit button when secret name is valid and value is not blank', async function (assert) {
       this.setProperties({
-        secrets: [],
         closeModal: () => {}
       });
 
       await render(
         hbs`<Pipeline::SecretsAndTokens::Secrets::Modal::Create
-            @secrets={{this.secrets}}
             @closeModal={{this.closeModal}}
         />`
       );
@@ -93,13 +94,11 @@ module(
       sinon.stub(shuttle, 'fetchFromApi').rejects({ message: 'error' });
 
       this.setProperties({
-        secrets: [],
         closeModal: () => {}
       });
 
       await render(
         hbs`<Pipeline::SecretsAndTokens::Secrets::Modal::Create
-          @secrets={{this.secrets}}
           @closeModal={{this.closeModal}}
         />`
       );
@@ -121,13 +120,11 @@ module(
       sinon.stub(shuttle, 'fetchFromApi').resolves(newSecret);
 
       this.setProperties({
-        secrets: [],
         closeModal: closeModalSpy
       });
 
       await render(
         hbs`<Pipeline::SecretsAndTokens::Secrets::Modal::Create
-          @secrets={{this.secrets}}
           @closeModal={{this.closeModal}}
         />`
       );


### PR DESCRIPTION
## Context
https://github.com/screwdriver-cd/ui/pull/1408 added an injectable service for secrets.  The create secret modal can be simplified by using said service.

## Objective
Refactors the create secret modal to use injectable services.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
