### PR TITLE
fix: display navbar when expand hamburger menu

### DIFF
--- a/app/components/app-header/styles.scss
+++ b/app/components/app-header/styles.scss
@@ -16,6 +16,11 @@
     background-color: $grey-800;
     border-color: $grey-800;
     height: $app-header-height;
+
+    @media screen and (max-width: 992px) {
+      min-height: $app-header-height;
+      height: unset;
+    }
   }
 
   .navbar-dark .navbar-nav .nav-link {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

The navigation menu does not appear when expand the hamburger menu on a small display.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Display the navigation menu even on small devices.

![eg](https://github.com/user-attachments/assets/a6495af6-e5f4-4fac-827c-7e6bd4ec46b4)

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
