### PR TITLE
Fix: issue with builds dereference

### DIFF
--- a/app/components/pipeline/workflow/component.js
+++ b/app/components/pipeline/workflow/component.js
@@ -367,12 +367,14 @@ export default class PipelineWorkflowComponent extends Component {
   isEventInAws(builds) {
     this.isBuildClusterAws = false;
 
-    builds.forEach(() => {
+    if (builds) {
       // TODO: See if this is the best way to check if a build is in AWS
+      // builds.forEach(() => {
       // if (build.buildClusterName.startsWith('aws')) {
       //   this.isBuildClusterAws = true;
       // }
-    });
+      // });
+    }
   }
 
   @action


### PR DESCRIPTION
## Context
https://github.com/screwdriver-cd/ui/pull/1398 added in some experimental work for exposing AWS build cost information.  As it was mostly experimental but still something worth pursuing in the future, the basic implementation was disabled in https://github.com/screwdriver-cd/ui/pull/1400.  Unfortunately, the original experimental work still had a bug where the `builds` may be null/undefined and should not be dereferenced.

## Objective
Fixes the issue where `builds` should not be dereferenced.

## References
https://github.com/screwdriver-cd/ui/pull/1398
https://github.com/screwdriver-cd/ui/pull/1400

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
