### PR TITLE
External pipeline tooltip links in new window

### DIFF
--- a/app/components/pipeline/workflow/tooltip/template.hbs
+++ b/app/components/pipeline/workflow/tooltip/template.hbs
@@ -6,6 +6,7 @@
         id="remote-pipeline-link"
         @route="v2.pipeline"
         @model={{this.tooltipData.externalTrigger.pipelineId}}
+        target="_blank"
       >
         Go to remote pipeline
       </LinkTo>
@@ -15,6 +16,7 @@
           class="downstream-pipeline-link"
           @route="v2.pipeline"
           @model={{t.pipelineId}}
+          target="_blank"
         >
           Go to downstream pipeline {{t.triggerName}}
         </LinkTo>


### PR DESCRIPTION
## Context
The current general behavior for switching to a different pipeline is to have the links open in a new window.  The graph tooltip links should be updated to follow the same pattern.

## Objective
Updates the graph tooltips to open links to external pipelines in a new window.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
