### PR TITLE
feat: support reverting overridden secrets

### DIFF
--- a/app/components/pipeline/secrets-and-tokens/secrets/modal/delete/component.js
+++ b/app/components/pipeline/secrets-and-tokens/secrets/modal/delete/component.js
@@ -4,7 +4,7 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 
 export default class PipelineSecretsAndTokensModalDeleteComponent extends Component {
-  @service shuttle;
+  @service('shuttle') shuttle;
 
   @tracked errorMessage;
 
@@ -21,12 +21,42 @@ export default class PipelineSecretsAndTokensModalDeleteComponent extends Compon
     this.wasActionSuccessful = false;
   }
 
+  isSecretOverridden() {
+    return this.args.secret.overridden;
+  }
+
+  getSecretName() {
+    return this.args.secret.name;
+  }
+
+  get modalHeader() {
+    return this.isSecretOverridden()
+      ? `Revert overridden secret value for ${this.getSecretName()}`
+      : `Delete secret ${this.getSecretName()}`;
+  }
+
   get isSubmitButtonDisabled() {
     if (this.wasActionSuccessful || this.isAwaitingResponse) {
       return true;
     }
 
-    return this.secretName !== this.args.secret.name;
+    return this.secretName !== this.getSecretName();
+  }
+
+  get deleteSecretNote() {
+    return this.isSecretOverridden()
+      ? `Reverts the secret value to the inherited value`
+      : 'Deleting this secret is permanent!';
+  }
+
+  get buttonDefaultText() {
+    return this.isSecretOverridden() ? 'Revert secret' : 'Delete secret';
+  }
+
+  get buttonPendingText() {
+    return this.isSecretOverridden()
+      ? 'Reverting secret...'
+      : 'Deleting secret...';
   }
 
   @action

--- a/app/components/pipeline/secrets-and-tokens/secrets/modal/delete/template.hbs
+++ b/app/components/pipeline/secrets-and-tokens/secrets/modal/delete/template.hbs
@@ -4,7 +4,7 @@
   as |modal|
 >
   <modal.header>
-    Delete secret {{@secret.name}}
+    {{this.modalHeader}}
   </modal.header>
   <modal.body>
     {{#if this.errorMessage}}
@@ -19,11 +19,17 @@
     <div class="delete-secret-message">
       <div class="delete-secret-message-warning">
         <FaIcon @icon="triangle-exclamation" />
-        <b>Deleting this secret is permanent!</b>
+        <b>{{this.deleteSecretNote}}</b>
       </div>
       <br />
       <div>
-        If you are sure you want to delete this secret, enter the name of the secret (<b>{{@secret.name}}</b>) below
+        If you are sure you want to
+        {{#if @secret.overridden}}
+          revert
+        {{else}}
+          delete
+        {{/if}}
+        this secret, enter the name of the secret (<b>{{@secret.name}}</b>) below
       </div>
     </div>
     <Input
@@ -37,8 +43,8 @@
       id="submit-delete"
       class="confirm"
       disabled={{this.isSubmitButtonDisabled}}
-      @defaultText="Delete secret"
-      @pendingText="Deleting secret..."
+      @defaultText={{this.buttonDefaultText}}
+      @pendingText={{this.buttonPendingText}}
       @type="primary"
       @onClick={{fn this.deleteSecret}}
     />


### PR DESCRIPTION
## Context
In the v2 UI, deleting a secret should have better messaging as to whether the secret is deleted or reverted.

## Objective
Improves the messaging in the delete secret modal to be less ambiguous.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
