### PR TITLE
fix: Fixes an issue where event status is CREATED

### DIFF
--- a/app/components/pipeline-event-row/component.js
+++ b/app/components/pipeline-event-row/component.js
@@ -61,6 +61,14 @@ export default Component.extend({
     });
   },
 
+  stoppableEventStatus: computed('event.status', {
+    get() {
+      const eventStatus = this.get('event.status');
+
+      return eventStatus !== 'UNKNOWN' && eventStatus !== 'CREATED';
+    }
+  }),
+
   numberOfParameters: computed(
     'pipelineParameters',
     'jobParameters',

--- a/app/components/pipeline-event-row/template.hbs
+++ b/app/components/pipeline-event-row/template.hbs
@@ -28,7 +28,7 @@
         {{/if}}
         {{#if this.event.label}}<div class="label">{{linkify this.event.label target="_blank" rel="nofollow" urlLength=30}}</div>{{/if}}
       {{/if}}
-      {{#if (and this.event.isRunning (not-eq this.event.status "UNKNOWN"))}}
+      {{#if (and this.event.isRunning this.stoppableEventStatus)}}
         <BsButton
           @onClick={{action this.stopEvent this.event}}
           class="stopButton"


### PR DESCRIPTION
## Context
https://github.com/screwdriver-cd/models/pull/645 introduced an event status to be returned on the API payload and at that point all events have at least a default status set to `CREATED`.  In the v1 UI, the event card never expected the event status to be provided and therefore defaults the status to `UNKNOWN` and relies on the subsequent builds to compute the event status.

## Objective
Adds additional handling for the `CREATED` event status that should allow the v1 event card to display the `STOP` button correctly.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
