### PR TITLE
fix: event rail pr close bug

### DIFF
--- a/app/components/pipeline/workflow/event-rail/component.js
+++ b/app/components/pipeline/workflow/event-rail/component.js
@@ -115,6 +115,11 @@ export default class PipelineWorkflowEventRailComponent extends Component {
       const openPrNums =
         direction === 'gt' ? this.prNums : this.prNums.toReversed();
       const index = openPrNums.indexOf(event.prNum);
+
+      if (index === -1) {
+        return [];
+      }
+
       const prNums = openPrNums.slice(index + 1, index + 1 + EVENT_BATCH_SIZE);
 
       const promises = prNums.map(prNumToFetch => {


### PR DESCRIPTION
## Context
When the user is on the v2 pipeline pull request page, there is a bug that adds a previous pull request card to the top of the event rail:
![Screenshot 2025-05-15 at 15-37-41 minghay_various Pulls](https://github.com/user-attachments/assets/f7cabee9-2a40-41fe-b629-6431a435fcca)

This bug happens when the user is at the top of the event rail (i.e., at the latest pull request events) and the newest pull request is closed/merged (e.g., in the screenshot above, the pull request 3 was closed/merged and pull request 2's event card gets added to the top of the list again).

## Objective
Fixes the issue of adding a previous pull request event card to the event rail when the latest pull request is close/merged

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
