### PR TITLE
feat: Improve event group history

### DIFF
--- a/app/components/pipeline/event/card/component.js
+++ b/app/components/pipeline/event/card/component.js
@@ -26,11 +26,11 @@ import {
 export default class PipelineEventCardComponent extends Component {
   @service router;
 
-  @service workflowDataReload;
+  @service('workflow-data-reload') workflowDataReload;
 
-  @service pipelinePageState;
+  @service('pipeline-page-state') pipelinePageState;
 
-  @service selectedPrSha;
+  @service('selected-pr-sha') selectedPrSha;
 
   @tracked event;
 
@@ -261,6 +261,16 @@ export default class PipelineEventCardComponent extends Component {
     return this.isPR
       ? isSelectedEvent && this.selectedPrSha.isEventSelected(event)
       : isSelectedEvent;
+  }
+
+  get isOutlined() {
+    const { baseEvent } = this.args;
+
+    if (!baseEvent) {
+      return false;
+    }
+
+    return this.event.id === baseEvent.id;
   }
 
   get title() {

--- a/app/components/pipeline/event/card/styles.scss
+++ b/app/components/pipeline/event/card/styles.scss
@@ -20,6 +20,11 @@
       background: rgba(colors.$sd-pale-purple, 0.5);
     }
 
+    &.outlined {
+      border-width: 2px;
+      border-color: colors.$sd-running;
+    }
+
     &.filtered {
       visibility: hidden;
       height: 0;

--- a/app/components/pipeline/event/card/template.hbs
+++ b/app/components/pipeline/event/card/template.hbs
@@ -1,5 +1,5 @@
 <div
-  class="event-card{{if this.isHighlighted " highlighted"}}{{if this.hideCard " filtered"}}"
+  class="event-card{{if this.isHighlighted " highlighted"}}{{if this.isOutlined " outlined"}}{{if this.hideCard " filtered"}}"
   title={{this.title}}
   {{did-insert this.initialize}}
   {{did-update this.update @event}}

--- a/app/components/pipeline/modal/event-group-history/component.js
+++ b/app/components/pipeline/modal/event-group-history/component.js
@@ -9,6 +9,8 @@ export default class PipelineModalEventGroupHistoryComponent extends Component {
 
   @service pipelinePageState;
 
+  @tracked showCards = false;
+
   @tracked events = [];
 
   intervalId;
@@ -39,6 +41,10 @@ export default class PipelineModalEventGroupHistoryComponent extends Component {
     return `Events in group: ${this.args.event.groupEventId}`;
   }
 
+  get eventId() {
+    return String(this.args.event.id);
+  }
+
   @action
   fetchGroupEvents() {
     const baseUrl = `/pipelines/${this.pipelinePageState.getPipelineId()}/events?`;
@@ -49,6 +55,10 @@ export default class PipelineModalEventGroupHistoryComponent extends Component {
     this.shuttle.fetchFromApi('get', url).then(events => {
       if (this.events.length < events.length) {
         this.events = events;
+
+        if (!this.showCards) {
+          this.showCards = true;
+        }
       }
     });
   }

--- a/app/components/pipeline/modal/event-group-history/template.hbs
+++ b/app/components/pipeline/modal/event-group-history/template.hbs
@@ -7,18 +7,21 @@
     <div class="modal-title">{{this.modalHeaderText}}</div>
   </modal.header>
   <modal.body>
-    <VerticalCollection
-      @items={{this.events}}
-      @estimateHeight={{150}}
-      @idForFirstItem={{@event.id}}
-      as |event|
-    >
-      <Pipeline::Event::Card
-        @event={{event}}
-        @userSettings={{@userSettings}}
-        @queueName="eventGroupModal"
-        @onClick={{fn @closeModal}}
-      />
-    </VerticalCollection>
+    {{#if this.showCards}}
+      <VerticalCollection
+        @items={{this.events}}
+        @estimateHeight={{150}}
+        @key={{"id"}}
+        @idForFirstItem={{this.eventId}}
+        as |event|
+      >
+        <Pipeline::Event::Card
+          @event={{event}}
+          @userSettings={{@userSettings}}
+          @queueName="eventGroupModal"
+          @onClick={{fn @closeModal}}
+        />
+      </VerticalCollection>
+    {{/if}}
   </modal.body>
 </BsModal>

--- a/app/components/pipeline/modal/event-group-history/template.hbs
+++ b/app/components/pipeline/modal/event-group-history/template.hbs
@@ -17,6 +17,7 @@
       >
         <Pipeline::Event::Card
           @event={{event}}
+          @baseEvent={{@event}}
           @userSettings={{@userSettings}}
           @queueName="eventGroupModal"
           @onClick={{fn @closeModal}}

--- a/tests/integration/components/pipeline/event/card/component-test.js
+++ b/tests/integration/components/pipeline/event/card/component-test.js
@@ -528,4 +528,31 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
 
     assert.dom('.highlighted').exists();
   });
+
+  test('it renders card outline', async function (assert) {
+    sinon.stub(router, 'currentURL').value('/pipelines/1/events/11');
+    sinon
+      .stub(workflowDataReload, 'registerLatestCommitEventCallback')
+      .callsFake(() => {});
+    sinon
+      .stub(workflowDataReload, 'registerBuildsCallback')
+      .callsFake((queueName, id, callback) => {
+        callback([{ status: 'SUCCESS' }]);
+      });
+
+    this.setProperties({
+      event,
+      userSettings: {}
+    });
+
+    await render(
+      hbs`<Pipeline::Event::Card
+        @event={{this.event}}
+        @baseEvent={{this.event}}
+        @userSettings={{this.userSettings}}
+      />`
+    );
+
+    assert.dom('.outlined').exists();
+  });
 });

--- a/tests/integration/components/pipeline/event/card/component-test.js
+++ b/tests/integration/components/pipeline/event/card/component-test.js
@@ -7,13 +7,31 @@ import sinon from 'sinon';
 module('Integration | Component | pipeline/event/card', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('it renders title when event is first in group', async function (assert) {
-    const router = this.owner.lookup('service:router');
-    const workflowDataReload = this.owner.lookup(
-      'service:workflow-data-reload'
-    );
+  let router;
 
-    sinon.stub(router, 'currentURL').value('/v2/pipelines/1/events/11');
+  let workflowDataReload;
+
+  let selectedPrSha;
+
+  let event;
+
+  hooks.beforeEach(function () {
+    router = this.owner.lookup('service:router');
+    workflowDataReload = this.owner.lookup('service:workflow-data-reload');
+    selectedPrSha = this.owner.lookup('service:selected-pr-sha');
+
+    event = {
+      id: 11,
+      groupEventId: 11,
+      sha: 'abc123def456',
+      commit: { author: { name: 'batman' }, message: 'Some amazing changes' },
+      creator: { name: 'batman' },
+      meta: {}
+    };
+  });
+
+  test('it renders title when event is first in group', async function (assert) {
+    sinon.stub(router, 'currentURL').value('/pipelines/1/events/11');
     sinon
       .stub(workflowDataReload, 'registerLatestCommitEventCallback')
       .callsFake(() => {});
@@ -22,14 +40,7 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
       .callsFake(() => {});
 
     this.setProperties({
-      event: {
-        id: 11,
-        groupEventId: 11,
-        sha: 'abc123def456',
-        commit: { author: { name: 'batman' }, message: 'Some amazing changes' },
-        creator: { name: 'batman' },
-        meta: {}
-      },
+      event,
       userSettings: {}
     });
 
@@ -44,12 +55,7 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
   });
 
   test('it renders title when event is in group', async function (assert) {
-    const router = this.owner.lookup('service:router');
-    const workflowDataReload = this.owner.lookup(
-      'service:workflow-data-reload'
-    );
-
-    sinon.stub(router, 'currentURL').value('/v2/pipelines/1/events/11');
+    sinon.stub(router, 'currentURL').value('/pipelines/1/events/11');
     sinon
       .stub(workflowDataReload, 'registerLatestCommitEventCallback')
       .callsFake(() => {});
@@ -57,15 +63,10 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
       .stub(workflowDataReload, 'registerBuildsCallback')
       .callsFake(() => {});
 
+    event.groupEventId = 3;
+
     this.setProperties({
-      event: {
-        id: 11,
-        groupEventId: 3,
-        sha: 'abc123def456',
-        commit: { author: { name: 'batman' }, message: 'Some amazing changes' },
-        creator: { name: 'batman' },
-        meta: {}
-      },
+      event,
       userSettings: {}
     });
 
@@ -80,12 +81,7 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
   });
 
   test('it renders core elements', async function (assert) {
-    const router = this.owner.lookup('service:router');
-    const workflowDataReload = this.owner.lookup(
-      'service:workflow-data-reload'
-    );
-
-    sinon.stub(router, 'currentURL').value('/v2/pipelines/1/events/11');
+    sinon.stub(router, 'currentURL').value('/pipelines/1/events/11');
     sinon
       .stub(workflowDataReload, 'registerLatestCommitEventCallback')
       .callsFake(() => {});
@@ -96,13 +92,7 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
       });
 
     this.setProperties({
-      event: {
-        id: 11,
-        sha: 'abc123def456',
-        commit: { author: { name: 'batman' }, message: 'Some amazing changes' },
-        creator: { name: 'batman' },
-        meta: {}
-      },
+      event,
       userSettings: {}
     });
 
@@ -113,22 +103,24 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
       />`
     );
 
-    assert.dom('.highlighted').exists({ count: 1 });
-    assert.dom('.event-card-title .event-status').exists({ count: 1 });
+    assert.dom('.highlighted').exists();
+    assert.dom('.outlined').doesNotExist();
+    assert.dom('.filtered').doesNotExist();
+    assert.dom('.event-card-title .event-status').exists();
     assert.dom('.event-card-title .event-status').hasClass('SUCCESS');
-    assert.dom('.event-card-title .event-status svg').exists({ count: 1 });
+    assert.dom('.event-card-title .event-status svg').exists();
     assert.dom('.event-card-title pr-title').doesNotExist();
-    assert.dom('.event-card-title .sha').exists({ count: 1 });
+    assert.dom('.event-card-title .sha').exists();
     assert.dom('.event-card-title .start-event-button').doesNotExist();
 
-    assert.dom('.event-card-body').exists({ count: 1 });
-    assert.dom('.event-card-body .message').exists({ count: 1 });
+    assert.dom('.event-card-body').exists();
+    assert.dom('.event-card-body .message').exists();
     assert.dom('.event-card-body .label').doesNotExist();
-    assert.dom('.event-card-body .by').exists({ count: 1 });
-    assert.dom('.event-card-body .time').exists({ count: 1 });
+    assert.dom('.event-card-body .by').exists();
+    assert.dom('.event-card-body .time').exists();
 
-    assert.dom('.event-card-footer .counts').exists({ count: 1 });
-    assert.dom('.event-card-footer .event-buttons').exists({ count: 1 });
+    assert.dom('.event-card-footer .counts').exists();
+    assert.dom('.event-card-footer .event-buttons').exists();
     assert
       .dom('.event-card-footer .event-buttons .parameters-button')
       .doesNotExist();
@@ -138,12 +130,7 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
   });
 
   test('it does not render highlight', async function (assert) {
-    const router = this.owner.lookup('service:router');
-    const workflowDataReload = this.owner.lookup(
-      'service:workflow-data-reload'
-    );
-
-    sinon.stub(router, 'currentURL').value('/v2/pipelines/1/events/99');
+    sinon.stub(router, 'currentURL').value('/pipelines/1/events/99');
     sinon
       .stub(workflowDataReload, 'registerLatestCommitEventCallback')
       .callsFake(() => {});
@@ -154,13 +141,7 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
       });
 
     this.setProperties({
-      event: {
-        id: 11,
-        sha: 'abc123def456',
-        commit: { author: { name: 'batman' }, message: 'Some amazing changes' },
-        creator: { name: 'batman' },
-        meta: {}
-      },
+      event,
       userSettings: {}
     });
 
@@ -177,12 +158,7 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
   });
 
   test('it renders event label', async function (assert) {
-    const router = this.owner.lookup('service:router');
-    const workflowDataReload = this.owner.lookup(
-      'service:workflow-data-reload'
-    );
-
-    sinon.stub(router, 'currentURL').value('/v2/pipelines/1/events/11');
+    sinon.stub(router, 'currentURL').value('/pipelines/1/events/11');
     sinon
       .stub(workflowDataReload, 'registerLatestCommitEventCallback')
       .callsFake(() => {});
@@ -192,14 +168,9 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
         callback([{ status: 'SUCCESS' }]);
       });
 
+    event.meta = { label: 'Testing 123' };
     this.setProperties({
-      event: {
-        id: 11,
-        sha: 'abc123def456',
-        commit: { author: { name: 'batman' }, message: 'Some amazing changes' },
-        creator: { name: 'batman' },
-        meta: { label: 'Testing 123' }
-      },
+      event,
       userSettings: {}
     });
 
@@ -210,16 +181,11 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
       />`
     );
 
-    assert.dom('.event-card-body .label').exists({ count: 1 });
+    assert.dom('.event-card-body .label').exists();
   });
 
   test('it renders button for parameters', async function (assert) {
-    const router = this.owner.lookup('service:router');
-    const workflowDataReload = this.owner.lookup(
-      'service:workflow-data-reload'
-    );
-
-    sinon.stub(router, 'currentURL').value('/v2/pipelines/1/events/11');
+    sinon.stub(router, 'currentURL').value('/pipelines/1/events/11');
     sinon
       .stub(workflowDataReload, 'registerLatestCommitEventCallback')
       .callsFake(() => {});
@@ -229,18 +195,14 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
         callback([{ status: 'SUCCESS' }]);
       });
 
+    event.meta = {
+      parameters: {
+        foo: { value: 'bar' }
+      }
+    };
+
     this.setProperties({
-      event: {
-        id: 11,
-        sha: 'abc123def456',
-        commit: { author: { name: 'batman' }, message: 'Some amazing changes' },
-        creator: { name: 'batman' },
-        meta: {
-          parameters: {
-            foo: { value: 'bar' }
-          }
-        }
-      },
+      event,
       userSettings: {}
     });
 
@@ -252,18 +214,11 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
       />`
     );
 
-    assert
-      .dom('.event-card-footer .event-buttons .parameters-button')
-      .exists({ count: 1 });
+    assert.dom('.event-card-footer .event-buttons .parameters-button').exists();
   });
 
   test('it renders button for event group', async function (assert) {
-    const router = this.owner.lookup('service:router');
-    const workflowDataReload = this.owner.lookup(
-      'service:workflow-data-reload'
-    );
-
-    sinon.stub(router, 'currentURL').value('/v2/pipelines/1/events/11');
+    sinon.stub(router, 'currentURL').value('/pipelines/1/events/11');
     sinon
       .stub(workflowDataReload, 'registerLatestCommitEventCallback')
       .callsFake(() => {});
@@ -273,18 +228,14 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
         callback([{ status: 'SUCCESS' }]);
       });
 
+    event.meta = {
+      parameters: {
+        foo: { value: 'bar' }
+      }
+    };
+
     this.setProperties({
-      event: {
-        id: 11,
-        sha: 'abc123def456',
-        commit: { author: { name: 'batman' }, message: 'Some amazing changes' },
-        creator: { name: 'batman' },
-        meta: {
-          parameters: {
-            foo: { value: 'bar' }
-          }
-        }
-      },
+      event,
       userSettings: {}
     });
 
@@ -298,16 +249,11 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
 
     assert
       .dom('.event-card-footer .event-buttons .event-group-button')
-      .exists({ count: 1 });
+      .exists();
   });
 
   test('it renders abort button for running event', async function (assert) {
-    const router = this.owner.lookup('service:router');
-    const workflowDataReload = this.owner.lookup(
-      'service:workflow-data-reload'
-    );
-
-    sinon.stub(router, 'currentURL').value('/v2/pipelines/1/events/11');
+    sinon.stub(router, 'currentURL').value('/pipelines/1/events/11');
     sinon
       .stub(workflowDataReload, 'registerLatestCommitEventCallback')
       .callsFake(() => {});
@@ -318,13 +264,7 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
       });
 
     this.setProperties({
-      event: {
-        id: 11,
-        sha: 'abc123def456',
-        commit: { author: { name: 'batman' }, message: 'Some amazing changes' },
-        creator: { name: 'batman' },
-        meta: {}
-      },
+      event,
       userSettings: {}
     });
 
@@ -336,17 +276,13 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
       />`
     );
 
-    assert.dom('.event-card-title .abort-event-button').exists({ count: 1 });
+    assert.dom('.event-card-title .abort-event-button').exists();
   });
 
   test('it renders latest commit badge', async function (assert) {
-    const router = this.owner.lookup('service:router');
-    const workflowDataReload = this.owner.lookup(
-      'service:workflow-data-reload'
-    );
     const latestCommitSha = 'abc123def456';
 
-    sinon.stub(router, 'currentURL').value('/v2/pipelines/1/events/11');
+    sinon.stub(router, 'currentURL').value('/pipelines/1/events/11');
     sinon
       .stub(workflowDataReload, 'registerLatestCommitEventCallback')
       .callsFake((queueName, id, callback) => {
@@ -359,13 +295,7 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
       });
 
     this.setProperties({
-      event: {
-        id: 11,
-        sha: latestCommitSha,
-        commit: { author: { name: 'batman' }, message: 'Some amazing changes' },
-        creator: { name: 'batman' },
-        meta: {}
-      },
+      event,
       userSettings: {}
     });
 
@@ -376,17 +306,12 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
       />`
     );
 
-    assert.dom('.event-card-title .sha .latest-commit').exists({ count: 1 });
+    assert.dom('.event-card-title .sha .latest-commit').exists();
     assert.dom('.event-card-title .sha .latest-commit').hasText('#abc123d');
   });
 
   test('it does not render counts for collapsed event', async function (assert) {
-    const router = this.owner.lookup('service:router');
-    const workflowDataReload = this.owner.lookup(
-      'service:workflow-data-reload'
-    );
-
-    sinon.stub(router, 'currentURL').value('/v2/pipelines/1/events/11');
+    sinon.stub(router, 'currentURL').value('/pipelines/1/events/11');
     sinon
       .stub(workflowDataReload, 'registerLatestCommitEventCallback')
       .callsFake(() => {});
@@ -397,13 +322,7 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
       });
 
     this.setProperties({
-      event: {
-        id: 11,
-        sha: 'abc123def456',
-        commit: { author: { name: 'batman' }, message: 'Some amazing changes' },
-        creator: { name: 'batman' },
-        meta: {}
-      },
+      event,
       userSettings: {}
     });
 
@@ -418,192 +337,7 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
   });
 
   test('it renders count values', async function (assert) {
-    const router = this.owner.lookup('service:router');
-    const workflowDataReload = this.owner.lookup(
-      'service:workflow-data-reload'
-    );
-
-    sinon.stub(router, 'currentURL').value('/v2/pipelines/1/events/11');
-    sinon
-      .stub(workflowDataReload, 'registerLatestCommitEventCallback')
-      .callsFake(() => {});
-    sinon
-      .stub(workflowDataReload, 'registerBuildsCallback')
-      .callsFake((queueName, id, callback) => {
-        callback([
-          { status: 'SUCCESS' },
-          { status: 'UNSTABLE' },
-          { status: 'SUCCESS' },
-          { status: 'FAILURE' }
-        ]);
-      });
-
-    this.setProperties({
-      event: {
-        id: 11,
-        sha: 'abc123def456',
-        commit: { author: { name: 'batman' }, message: 'Some amazing changes' },
-        creator: { name: 'batman' },
-        meta: {}
-      },
-      userSettings: {}
-    });
-
-    await render(
-      hbs`<Pipeline::Event::Card
-        @event={{this.event}}
-        @userSettings={{this.userSettings}}
-      />`
-    );
-
-    assert.dom('.event-card-footer .counts .failures').exists({ count: 1 });
-    assert.dom('.event-card-footer .counts .warnings').exists({ count: 1 });
-    assert.dom('.event-card-footer .counts .successes').exists({ count: 1 });
-  });
-
-  test('it re-renders correctly when event changes', async function (assert) {
-    const router = this.owner.lookup('service:router');
-    const workflowDataReload = this.owner.lookup(
-      'service:workflow-data-reload'
-    );
-
-    sinon.stub(router, 'currentURL').value('/v2/pipelines/1/events/11');
-    sinon
-      .stub(workflowDataReload, 'registerLatestCommitEventCallback')
-      .callsFake(() => {});
-    sinon
-      .stub(workflowDataReload, 'registerBuildsCallback')
-      .onCall(0)
-      .callsFake((queueName, id, callback) => {
-        callback([{ status: 'SUCCESS' }]);
-      })
-      .onCall(1)
-      .callsFake((queueName, id, callback) => {
-        callback([{ status: 'FAILURE' }]);
-      });
-
-    this.setProperties({
-      event: {
-        id: 11,
-        sha: 'abc123def456',
-        commit: { author: { name: 'batman' }, message: 'Some amazing changes' },
-        creator: { name: 'batman' },
-        meta: {}
-      },
-      userSettings: {}
-    });
-
-    await render(
-      hbs`<Pipeline::Event::Card
-        @event={{this.event}}
-        @userSettings={{this.userSettings}}
-      />`
-    );
-
-    assert.dom('.event-card-title .event-status').hasClass('SUCCESS');
-    assert.dom('.event-card-title .sha').hasText('#abc123d');
-
-    this.setProperties({
-      event: {
-        id: 12,
-        sha: 'deadbeef123',
-        commit: { author: { name: 'robin' }, message: 'New change' },
-        creator: { name: 'robin' },
-        meta: {}
-      }
-    });
-
-    await rerender();
-
-    assert.dom('.event-card-title .event-status').hasClass('FAILURE');
-    assert.dom('.event-card-title .sha').hasText('#deadbee');
-  });
-
-  test('it renders latest commit badge', async function (assert) {
-    const router = this.owner.lookup('service:router');
-    const workflowDataReload = this.owner.lookup(
-      'service:workflow-data-reload'
-    );
-    const latestCommitSha = 'abc123def456';
-
-    sinon.stub(router, 'currentURL').value('/v2/pipelines/1/events/11');
-    sinon
-      .stub(workflowDataReload, 'registerLatestCommitEventCallback')
-      .callsFake((queueName, id, callback) => {
-        callback({ sha: latestCommitSha });
-      });
-    sinon
-      .stub(workflowDataReload, 'registerBuildsCallback')
-      .callsFake((queueName, id, callback) => {
-        callback([{ status: 'SUCCESS' }]);
-      });
-
-    this.setProperties({
-      event: {
-        id: 11,
-        sha: latestCommitSha,
-        commit: { author: { name: 'batman' }, message: 'Some amazing changes' },
-        creator: { name: 'batman' },
-        meta: {}
-      },
-      userSettings: {}
-    });
-
-    await render(
-      hbs`<Pipeline::Event::Card
-        @event={{this.event}}
-        @userSettings={{this.userSettings}}
-      />`
-    );
-
-    assert.dom('.event-card-title .sha .latest-commit').exists({ count: 1 });
-    assert.dom('.event-card-title .sha .latest-commit').hasText('#abc123d');
-  });
-
-  test('it does not render counts for collapsed event', async function (assert) {
-    const router = this.owner.lookup('service:router');
-    const workflowDataReload = this.owner.lookup(
-      'service:workflow-data-reload'
-    );
-
-    sinon.stub(router, 'currentURL').value('/v2/pipelines/1/events/11');
-    sinon
-      .stub(workflowDataReload, 'registerLatestCommitEventCallback')
-      .callsFake(() => {});
-    sinon
-      .stub(workflowDataReload, 'registerBuildsCallback')
-      .callsFake((queueName, id, callback) => {
-        callback([{ status: 'COLLAPSED' }]);
-      });
-
-    this.setProperties({
-      event: {
-        id: 11,
-        sha: 'abc123def456',
-        commit: { author: { name: 'batman' }, message: 'Some amazing changes' },
-        creator: { name: 'batman' },
-        meta: {}
-      },
-      userSettings: {}
-    });
-
-    await render(
-      hbs`<Pipeline::Event::Card
-        @event={{this.event}}
-        @userSettings={{this.userSettings}}
-      />`
-    );
-
-    assert.dom('.event-card-footer .counts .count').doesNotExist();
-  });
-
-  test('it renders count values', async function (assert) {
-    const router = this.owner.lookup('service:router');
-    const workflowDataReload = this.owner.lookup(
-      'service:workflow-data-reload'
-    );
-
-    sinon.stub(router, 'currentURL').value('/v2/pipelines/1/events/11');
+    sinon.stub(router, 'currentURL').value('/pipelines/1/events/11');
     sinon
       .stub(workflowDataReload, 'registerLatestCommitEventCallback')
       .callsFake(() => {});
@@ -620,13 +354,7 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
       });
 
     this.setProperties({
-      event: {
-        id: 11,
-        sha: 'abc123def456',
-        commit: { author: { name: 'batman' }, message: 'Some amazing changes' },
-        creator: { name: 'batman' },
-        meta: {}
-      },
+      event,
       userSettings: {}
     });
 
@@ -637,18 +365,13 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
       />`
     );
 
-    assert.dom('.event-card-footer .counts .failures').exists({ count: 1 });
-    assert.dom('.event-card-footer .counts .warnings').exists({ count: 1 });
-    assert.dom('.event-card-footer .counts .successes').exists({ count: 1 });
+    assert.dom('.event-card-footer .counts .failures').exists();
+    assert.dom('.event-card-footer .counts .warnings').exists();
+    assert.dom('.event-card-footer .counts .successes').exists();
   });
 
   test('it re-renders correctly when event changes', async function (assert) {
-    const router = this.owner.lookup('service:router');
-    const workflowDataReload = this.owner.lookup(
-      'service:workflow-data-reload'
-    );
-
-    sinon.stub(router, 'currentURL').value('/v2/pipelines/1/events/11');
+    sinon.stub(router, 'currentURL').value('/pipelines/1/events/11');
     sinon
       .stub(workflowDataReload, 'registerLatestCommitEventCallback')
       .callsFake(() => {});
@@ -664,13 +387,7 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
       });
 
     this.setProperties({
-      event: {
-        id: 11,
-        sha: 'abc123def456',
-        commit: { author: { name: 'batman' }, message: 'Some amazing changes' },
-        creator: { name: 'batman' },
-        meta: {}
-      },
+      event,
       userSettings: {}
     });
 
@@ -701,12 +418,7 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
   });
 
   test('it renders PR title', async function (assert) {
-    const router = this.owner.lookup('service:router');
-    const workflowDataReload = this.owner.lookup(
-      'service:workflow-data-reload'
-    );
-
-    sinon.stub(router, 'currentURL').value('/v2/pipelines/1/pulls/2');
+    sinon.stub(router, 'currentURL').value('/pipelines/1/pulls/2');
     sinon
       .stub(workflowDataReload, 'registerLatestCommitEventCallback')
       .callsFake(() => {});
@@ -714,17 +426,11 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
       .stub(workflowDataReload, 'registerBuildsCallback')
       .callsFake(() => {});
 
+    event.type = 'pr';
+    event.prNum = 4;
+
     this.setProperties({
-      event: {
-        id: 11,
-        groupEventId: 11,
-        sha: 'abc123def456',
-        commit: { author: { name: 'batman' }, message: 'Some amazing changes' },
-        creator: { name: 'batman' },
-        meta: {},
-        type: 'pr',
-        prNum: 4
-      },
+      event,
       userSettings: {}
     });
 
@@ -735,18 +441,13 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
       />`
     );
 
-    assert.dom('.event-card-title .pr-title').exists({ count: 1 });
+    assert.dom('.event-card-title .pr-title').exists();
     assert.dom('.event-card-title .pr-title').containsText('PR-4');
     assert.dom('.event-card-title .start-event-button').doesNotExist();
   });
 
   test('it renders start event button for PR', async function (assert) {
-    const router = this.owner.lookup('service:router');
-    const workflowDataReload = this.owner.lookup(
-      'service:workflow-data-reload'
-    );
-
-    sinon.stub(router, 'currentURL').value('/v2/pipelines/1/pulls/2');
+    sinon.stub(router, 'currentURL').value('/pipelines/1/pulls/2');
     sinon
       .stub(workflowDataReload, 'registerLatestCommitEventCallback')
       .callsFake(() => {});
@@ -754,17 +455,10 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
       .stub(workflowDataReload, 'registerBuildsCallback')
       .callsFake(() => {});
 
+    event.type = 'pr';
+    event.prNum = 4;
     this.setProperties({
-      event: {
-        id: 11,
-        groupEventId: 11,
-        sha: 'abc123def456',
-        commit: { author: { name: 'batman' }, message: 'Some amazing changes' },
-        creator: { name: 'batman' },
-        meta: {},
-        type: 'pr',
-        prNum: 4
-      },
+      event,
       userSettings: {}
     });
 
@@ -776,17 +470,11 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
       />`
     );
 
-    assert.dom('.event-card-title .start-event-button').exists({ count: 1 });
+    assert.dom('.event-card-title .start-event-button').exists();
   });
 
   test('it does not render highlight for PR', async function (assert) {
-    const router = this.owner.lookup('service:router');
-    const workflowDataReload = this.owner.lookup(
-      'service:workflow-data-reload'
-    );
-    const selectedPrSha = this.owner.lookup('service:selected-pr-sha');
-
-    sinon.stub(router, 'currentURL').value('/v2/pipelines/1/pulls/2');
+    sinon.stub(router, 'currentURL').value('/pipelines/1/pulls/2');
     sinon
       .stub(workflowDataReload, 'registerLatestCommitEventCallback')
       .callsFake(() => {});
@@ -795,17 +483,11 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
       .callsFake(() => {});
     sinon.stub(selectedPrSha, 'isEventSelected').returns(false);
 
+    event.type = 'pr';
+    event.prNum = 4;
+
     this.setProperties({
-      event: {
-        id: 11,
-        groupEventId: 11,
-        sha: 'abc123def456',
-        commit: { author: { name: 'batman' }, message: 'Some amazing changes' },
-        creator: { name: 'batman' },
-        meta: {},
-        type: 'pr',
-        prNum: 4
-      },
+      event,
       userSettings: {}
     });
 
@@ -820,13 +502,7 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
   });
 
   test('it renders PR highlight', async function (assert) {
-    const router = this.owner.lookup('service:router');
-    const workflowDataReload = this.owner.lookup(
-      'service:workflow-data-reload'
-    );
-    const selectedPrSha = this.owner.lookup('service:selected-pr-sha');
-
-    sinon.stub(router, 'currentURL').value('/v2/pipelines/1/pulls/4');
+    sinon.stub(router, 'currentURL').value('/pipelines/1/pulls/4');
     sinon
       .stub(workflowDataReload, 'registerLatestCommitEventCallback')
       .callsFake(() => {});
@@ -835,17 +511,11 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
       .callsFake(() => {});
     sinon.stub(selectedPrSha, 'isEventSelected').returns(true);
 
+    event.type = 'pr';
+    event.prNum = 4;
+
     this.setProperties({
-      event: {
-        id: 11,
-        groupEventId: 11,
-        sha: 'abc123def456',
-        commit: { author: { name: 'batman' }, message: 'Some amazing changes' },
-        creator: { name: 'batman' },
-        meta: {},
-        type: 'pr',
-        prNum: 4
-      },
+      event,
       userSettings: {}
     });
 
@@ -856,6 +526,6 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
       />`
     );
 
-    assert.dom('.highlighted').exists({ count: 1 });
+    assert.dom('.highlighted').exists();
   });
 });


### PR DESCRIPTION
## Context
When the event history modal is opened from an event, there isn't any good indication of which event within the history user opened the modal from.  Additionally, when the event history modal loads, it always opens to the latest event at the top of the history.

## Objective
1. Cleans up some testing
2. Fixes the event modal to load the event history anchored around the event card from which the modal was opened from
3. Adds an outline styling to the event card that the user opened the event history modal from
![Screenshot 2025-05-16 at 12-51-10 minghay_various Events](https://github.com/user-attachments/assets/ba5ac920-02ce-4603-a0d1-24622d4938a7)

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
