### PR TITLE
fix: Update modal transition paths

### DIFF
--- a/app/components/pipeline/event/card/template.hbs
+++ b/app/components/pipeline/event/card/template.hbs
@@ -72,7 +72,6 @@
           />
           {{#if this.showStartEventModal}}
             <Pipeline::Modal::StartEvent
-              @pipeline={{@pipeline}}
               @event={{@event}}
               @closeModal={{this.closeStartEventModal}}
             />
@@ -83,7 +82,7 @@
   </div>
 
   <div class="event-card-body">
-   
+
     {{#if (starts-with this.event.startFrom "~pr-closed")}}
       <div class="message" title={{this.event.causeMessage}}>
         {{this.event.causeMessage}}
@@ -93,7 +92,7 @@
       {{this.truncatedMessage}}
     </div>
     {{/if}}
-  
+
     {{#if this.eventLabel}}
       <div class="label">
         <div class="label-contents" title={{this.eventLabel}}>

--- a/app/components/pipeline/modal/confirm-action/component.js
+++ b/app/components/pipeline/modal/confirm-action/component.js
@@ -12,13 +12,13 @@ import {
 export default class PipelineModalConfirmActionComponent extends Component {
   @service router;
 
-  @service shuttle;
-
-  @service pipelinePageState;
-
-  @service workflowDataReload;
-
   @service session;
+
+  @service('shuttle') shuttle;
+
+  @service('pipeline-page-state') pipelinePageState;
+
+  @service('workflow-data-reload') workflowDataReload;
 
   @tracked errorMessage = null;
 
@@ -62,7 +62,7 @@ export default class PipelineModalConfirmActionComponent extends Component {
   }
 
   get isLatestNonPrCommitEvent() {
-    return this.args.event.type === 'pr' ? true : this.isLatestCommitEvent;
+    return this.pipelinePageState.getIsPr() ? true : this.isLatestCommitEvent;
   }
 
   get isFrozen() {
@@ -113,21 +113,15 @@ export default class PipelineModalConfirmActionComponent extends Component {
       .then(event => {
         this.args.closeModal();
 
-        if (this.router.currentRouteName === 'v2.pipeline.events.show') {
-          this.router.transitionTo('v2.pipeline.events.show', {
-            event,
-            reloadEventRail: true,
-            id: event.id
-          });
-        } else if (this.router.currentRouteName === 'v2.pipeline.pulls.show') {
-          this.router.transitionTo('v2.pipeline.pulls.show', {
-            event,
-            reloadEventRail: true,
-            id: event.prNum,
-            pull_request_number: event.prNum,
-            sha: event.sha
-          });
-        }
+        const route = this.pipelinePageState.getIsPr()
+          ? 'v2.pipeline.pulls.show'
+          : 'v2.pipeline.events.show';
+
+        this.router.transitionTo(route, {
+          event,
+          reloadEventRail: true,
+          id: event.id
+        });
       })
       .catch(err => {
         this.wasActionSuccessful = false;

--- a/app/components/pipeline/modal/start-event/component.js
+++ b/app/components/pipeline/modal/start-event/component.js
@@ -11,11 +11,11 @@ import { buildPostBody } from 'screwdriver-ui/utils/pipeline/modal/request';
 export default class PipelineModalStartEventComponent extends Component {
   @service router;
 
-  @service shuttle;
-
   @service session;
 
-  @service pipelinePageState;
+  @service('shuttle') shuttle;
+
+  @service('pipeline-page-state') pipelinePageState;
 
   @tracked errorMessage = null;
 
@@ -79,21 +79,15 @@ export default class PipelineModalStartEventComponent extends Component {
       .then(event => {
         this.args.closeModal();
 
-        if (this.router.currentRouteName === 'v2.pipeline.events.show') {
-          this.router.transitionTo('v2.pipeline.events.show', {
-            event,
-            reloadEventRail: true,
-            id: event.id
-          });
-        } else if (this.router.currentRouteName === 'v2.pipeline.pulls.show') {
-          this.router.transitionTo('v2.pipeline.pulls.show', {
-            event,
-            reloadEventRail: true,
-            id: event.prNum,
-            pull_request_number: event.prNum,
-            sha: event.sha
-          });
-        }
+        const route = this.pipelinePageState.getIsPr()
+          ? 'v2.pipeline.pulls.show'
+          : 'v2.pipeline.events.show';
+
+        this.router.transitionTo(route, {
+          event,
+          reloadEventRail: true,
+          id: event.id
+        });
       })
       .catch(err => {
         this.wasActionSuccessful = false;

--- a/app/components/pipeline/workflow/event-rail/component.js
+++ b/app/components/pipeline/workflow/event-rail/component.js
@@ -114,7 +114,7 @@ export default class PipelineWorkflowEventRailComponent extends Component {
 
       const openPrNums =
         direction === 'gt' ? this.prNums : this.prNums.toReversed();
-      const index = openPrNums.indexOf(event.prNum);
+      const index = openPrNums.indexOf(parseInt(event.prNum, 10));
 
       if (index === -1) {
         return [];

--- a/tests/integration/components/pipeline/modal/confirm-action/component-test.js
+++ b/tests/integration/components/pipeline/modal/confirm-action/component-test.js
@@ -9,6 +9,12 @@ module(
   function (hooks) {
     setupRenderingTest(hooks);
 
+    let event;
+
+    let job;
+
+    let isPr;
+
     hooks.beforeEach(function () {
       const workflowDataReload = this.owner.lookup(
         'service:workflow-data-reload'
@@ -23,15 +29,20 @@ module(
 
       sinon.stub(pipelinePageState, 'getPipeline').returns({ id: 987 });
       sinon.stub(pipelinePageState, 'getJobs').returns([]);
+      sinon.stub(pipelinePageState, 'getIsPr').returns(isPr);
+
+      event = {
+        commit: { message: 'commit message', url: 'http://foo.com' },
+        sha: 'deadbeef0123456789'
+      };
+      job = { name: 'main' };
+      isPr = false;
     });
 
     test('it renders start action', async function (assert) {
       this.setProperties({
-        event: {
-          commit: { message: 'commit message', url: 'http://foo.com' },
-          sha: 'deadbeef0123456789'
-        },
-        job: { name: 'main' },
+        event,
+        job,
         closeModal: () => {}
       });
       await render(
@@ -53,12 +64,11 @@ module(
     });
 
     test('it renders restart action', async function (assert) {
+      job.status = 'SUCCESS';
+
       this.setProperties({
-        event: {
-          commit: { message: 'commit message', url: 'http://foo.com' },
-          sha: 'deadbeef0123456789'
-        },
-        job: { name: 'main', status: 'SUCCESS' },
+        event,
+        job,
         closeModal: () => {}
       });
       await render(
@@ -74,11 +84,8 @@ module(
 
     test('it renders stage name if set', async function (assert) {
       this.setProperties({
-        event: {
-          commit: { message: 'commit message', url: 'http://foo.com' },
-          sha: 'deadbeef0123456789'
-        },
-        job: { name: 'main' },
+        event,
+        job,
         stage: { name: 'stage' },
         closeModal: () => {}
       });
@@ -97,12 +104,10 @@ module(
     });
 
     test('it renders warning message for non-latest commit event', async function (assert) {
+      event.sha = '0123456789deadbeef';
       this.setProperties({
-        event: {
-          commit: { message: 'commit message', url: 'http://foo.com' },
-          sha: '0123456789deadbeef'
-        },
-        job: { name: 'main' },
+        event,
+        job,
         closeModal: () => {}
       });
       await render(
@@ -117,13 +122,11 @@ module(
     });
 
     test('it does not render warning message for pr commit event', async function (assert) {
+      isPr = true;
+
       this.setProperties({
-        event: {
-          commit: { message: 'commit message', url: 'http://foo.com' },
-          sha: 'deadbeef0123456789',
-          type: 'pr'
-        },
-        job: { name: 'main' },
+        event,
+        job,
         closeModal: () => {}
       });
       await render(
@@ -138,12 +141,11 @@ module(
     });
 
     test('it renders reason input for frozen job', async function (assert) {
+      job.status = 'FROZEN';
+
       this.setProperties({
-        event: {
-          commit: { message: 'commit message', url: 'http://foo.com' },
-          sha: 'deadbeef0123456789'
-        },
-        job: { name: 'main', status: 'FROZEN' },
+        event,
+        job,
         closeModal: () => {}
       });
       await render(
@@ -160,17 +162,15 @@ module(
     });
 
     test('it renders parameter input for parameterized job', async function (assert) {
+      event.meta = {
+        parameters: {
+          param1: { value: 'abc' }
+        }
+      };
+
       this.setProperties({
-        event: {
-          commit: { message: 'commit message', url: 'http://foo.com' },
-          sha: 'deadbeef0123456789',
-          meta: {
-            parameters: {
-              param1: { value: 'abc' }
-            }
-          }
-        },
-        job: { name: 'main' },
+        event,
+        job,
         closeModal: () => {}
       });
       await render(
@@ -205,12 +205,11 @@ module(
     });
 
     test('it enables submit button when reason is provided for frozen job', async function (assert) {
+      job.status = 'FROZEN';
+
       this.setProperties({
-        event: {
-          commit: { message: 'commit message', url: 'http://foo.com' },
-          sha: 'deadbeef0123456789'
-        },
-        job: { name: 'main', status: 'FROZEN' },
+        event,
+        job,
         closeModal: () => {}
       });
       await render(
@@ -232,11 +231,8 @@ module(
       const closeModalSpy = sinon.spy();
 
       this.setProperties({
-        event: {
-          commit: { message: 'commit message', url: 'http://foo.com' },
-          sha: 'deadbeef0123456789'
-        },
-        job: { name: 'main' },
+        event,
+        job,
         closeModal: closeModalSpy
       });
 
@@ -265,11 +261,8 @@ module(
         .rejects({ message: errorMessage });
 
       this.setProperties({
-        event: {
-          commit: { message: 'commit message', url: 'http://foo.com' },
-          sha: 'deadbeef0123456789'
-        },
-        job: { name: 'main' },
+        event,
+        job,
         closeModal: () => {}
       });
 

--- a/tests/integration/components/pipeline/modal/start-event/component-test.js
+++ b/tests/integration/components/pipeline/modal/start-event/component-test.js
@@ -82,6 +82,7 @@ module(
 
       sinon.stub(pipelinePageState, 'getPipeline').returns({});
       sinon.stub(pipelinePageState, 'getJobs').returns([]);
+      sinon.stub(pipelinePageState, 'getIsPr').returns(false);
 
       this.setProperties({
         closeModal: closeModalSpy


### PR DESCRIPTION
## Context
https://github.com/screwdriver-cd/ui/pull/1423 changed the pull request URL to be based on the event id.  There are 2 modals that have transitions that still need to be updated to use the new path scheme.

## Objective
1.  Updates the needed modal path transitions to pass in the proper model data
2. Fixes and issue where the `prNum` value is a string value instead of and int
3. Removes a lingering and unneeded `@pipeline` argument on the glimmer component

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
