### PR TITLE
fix: Use lastEventId to fetch event directly

### DIFF
--- a/app/v2/pipeline/events/index/route.js
+++ b/app/v2/pipeline/events/index/route.js
@@ -8,14 +8,12 @@ export default class NewPipelineEventsIndexRoute extends Route {
 
   async model() {
     const model = this.modelFor('v2.pipeline.events');
-    const pipelineId = this.pipelinePageState.getPipelineId();
+    const pipeline = this.pipelinePageState.getPipeline();
 
-    const latestEvent = await this.shuttle
-      // TODO: Change back to count=1 when the API bug is resolved -> https://github.com/screwdriver-cd/screwdriver/issues/3308
-      .fetchFromApi('get', `/pipelines/${pipelineId}/events?page=1&count=2`)
-      .then(events => {
-        return events[0];
-      });
+    const latestEvent = await this.shuttle.fetchFromApi(
+      'get',
+      `/events/${pipeline.lastEventId}`
+    );
 
     return {
       userSettings: model.userSettings,

--- a/app/v2/pipeline/events/show/route.js
+++ b/app/v2/pipeline/events/show/route.js
@@ -24,15 +24,13 @@ export default class NewPipelineEventsShowRoute extends Route {
         .fetchFromApi('get', `/events/${eventId}`)
         .catch(async err => {
           if (err instanceof NotFoundError) {
-            latestEvent = await this.shuttle
-              // TODO: Change back to count=1 when the API bug is resolved -> https://github.com/screwdriver-cd/screwdriver/issues/3308
-              .fetchFromApi(
-                'get',
-                `/pipelines/${pipelineId}/events?page=1&count=2`
-              )
-              .then(events => {
-                return events[0];
-              });
+            const latestEventId =
+              this.pipelinePageState.getPipeline().lastEventId;
+
+            latestEvent = await this.shuttle.fetchFromApi(
+              'get',
+              `/events/${latestEventId}`
+            );
 
             return null;
           }


### PR DESCRIPTION
## Context
https://github.com/screwdriver-cd/screwdriver/issues/3308 is tracking a performance issue with the query parameters.  However, the `lastEventId` field on the pipeline response has the needed information to fetch the event data directly.

## Objective
Change the API call to fetch the latest event data directly

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
