### PR TITLE
fix: Invalid event dereference

### DIFF
--- a/app/components/pipeline/workflow/component.js
+++ b/app/components/pipeline/workflow/component.js
@@ -166,19 +166,26 @@ export default class PipelineWorkflowComponent extends Component {
 
   @action
   update(element, [event]) {
-    const { workflowGraph } = this.event;
+    if (this.event) {
+      this.workflowDataReload.removeBuildsCallback(
+        BUILD_QUEUE_NAME,
+        this.event.id
+      );
+
+      this.workflowDataReload.removeStageBuildsCallback(
+        STAGE_BUILD_QUEUE_NAME,
+        this.event.id
+      );
+    }
+
+    const { workflowGraph } = event;
     const hasStages = !!extractEventStages(workflowGraph).length;
     const builds = this.workflowDataReload.getBuildsForEvent(event.id);
 
-    this.workflowDataReload.removeBuildsCallback(
-      BUILD_QUEUE_NAME,
-      this.event.id
-    );
-
-    this.workflowDataReload.removeStageBuildsCallback(
-      STAGE_BUILD_QUEUE_NAME,
-      this.event.id
-    );
+    this.event = event;
+    this.builds = builds;
+    this.showTooltip = false;
+    this.showStageTooltip = false;
 
     this.isEventInAws(builds);
 
@@ -207,11 +214,6 @@ export default class PipelineWorkflowComponent extends Component {
         );
       }
     }
-
-    this.event = event;
-    this.builds = builds;
-    this.showTooltip = false;
-    this.showStageTooltip = false;
 
     this.setWorkflowGraphFromEvent();
   }


### PR DESCRIPTION
## Context
When the v2 pipeline landing page is initially loaded without an event (i.e., the page is displaying for an invalid event for the pipeline), navigating to a new event for the pipeline fails to render the page correctly due to an invalid event dereference.

## Objective
Fixes the component update logic to avoid an invalid event from being dereferenced

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
