### PR TITLE
fix: navigation from build details page for v2 UI

### DIFF
--- a/app/components/build-banner/component.js
+++ b/app/components/build-banner/component.js
@@ -15,6 +15,7 @@ import {
 const ObjectPromiseProxy = ObjectProxy.extend(PromiseProxyMixin);
 
 export default Component.extend({
+  newUi: false,
   userSettings: service(),
   shuttle: service(),
   classNames: ['build-banner', 'grid'],
@@ -331,6 +332,10 @@ export default Component.extend({
       .catch(() => {
         this.set('allowNotification', false);
       });
+
+    if (localStorage.getItem('newUI') === 'true') {
+      this.set('newUi', true);
+    }
   },
 
   willRender() {

--- a/app/components/build-banner/template.hbs
+++ b/app/components/build-banner/template.hbs
@@ -1,23 +1,44 @@
 <ul>
   <li class="job-name build-{{this.buildStatus}}">
-    {{#if this.event.pr.url}}
-      <LinkTo
-        @route="pipeline.pulls"
-        @model={{this.pipelineId}}
-        class="banner-value"
-      >
-        {{this.jobName}}
-      </LinkTo>
+    {{#if this.newUi}}
+      {{#if this.event.pr.url}}
+        <LinkTo
+          @route="v2.pipeline.pulls.show"
+          @models={{array this.pipelineId this.event.id}}
+          class="banner-value"
+          >
+            {{this.jobName}}
+          </LinkTo>
+      {{else}}
+        <LinkTo
+          @route="v2.pipeline.events.show"
+          @models={{array this.pipelineId this.event.id}}
+          class="banner-value"
+        >
+          {{this.jobName}}
+        </LinkTo>
+      {{/if}}
     {{else}}
-      <LinkTo
-        @route="pipeline.events.show"
-        @models={{array this.pipelineId this.event.id}}
-        @query={{hash jobId=this.jobId}}
-        class="banner-value"
-      >
-        {{this.jobName}}
-      </LinkTo>
+      {{#if this.event.pr.url}}
+        <LinkTo
+          @route="pipeline.pulls"
+          @model={{this.pipelineId}}
+          class="banner-value"
+        >
+          {{this.jobName}}
+        </LinkTo>
+      {{else}}
+        <LinkTo
+          @route="pipeline.events.show"
+          @models={{array this.pipelineId this.event.id}}
+          @query={{hash jobId=this.jobId}}
+          class="banner-value"
+        >
+          {{this.jobName}}
+        </LinkTo>
+      {{/if}}
     {{/if}}
+
     <span class="banner-label">
       Job
     </span>
@@ -251,5 +272,5 @@
       {{/if}}
     {{/if}}
   </li>
-</ul> 
-      
+</ul>
+


### PR DESCRIPTION
## Context
The build details page doesn't navigate to the v2 UI properly.  Due to a few changes in the v2 routes (i.e., pull requests now have a permalink), the navigation to a v2 UI page should go to the most specific route possible.

## Objective
Adds support to navigate back to the proper v2 UI URL.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
