### PR TITLE
fix: event rail loading for PR events

### DIFF
--- a/app/components/pipeline/workflow/event-rail/component.js
+++ b/app/components/pipeline/workflow/event-rail/component.js
@@ -7,6 +7,8 @@ import ENV from 'screwdriver-ui/config/environment';
 const EVENT_BATCH_SIZE = 10;
 
 export default class PipelineWorkflowEventRailComponent extends Component {
+  @service router;
+
   @service('shuttle') shuttle;
 
   @service('workflow-data-reload') workflowDataReload;
@@ -114,10 +116,24 @@ export default class PipelineWorkflowEventRailComponent extends Component {
 
       const openPrNums =
         direction === 'gt' ? this.prNums : this.prNums.toReversed();
-      const index = openPrNums.indexOf(parseInt(event.prNum, 10));
+      const eventPrNum = parseInt(event.prNum, 10);
+
+      let index = openPrNums.indexOf(eventPrNum);
 
       if (index === -1) {
-        return [];
+        const routeEventId = parseInt(
+          this.router.currentRoute.params.event_id,
+          10
+        );
+
+        if (event.id !== routeEventId) {
+          return [];
+        }
+
+        index =
+          direction === 'gt'
+            ? openPrNums.filter(prNum => prNum < eventPrNum).length - 1
+            : openPrNums.filter(prNum => prNum > eventPrNum).length - 1;
       }
 
       const prNums = openPrNums.slice(index + 1, index + 1 + EVENT_BATCH_SIZE);


### PR DESCRIPTION
## Context
The v2 UI allows for permalinks to pull requests keyed off of the event ID.  This means that users can navigate to the pull request view for a PR that is closed/merged.  As a result, the event rail fails to load any open pull requests because the aforementioned PR is not open.

## Objective
Adds in logic to load open pull request events when a user goes to a closed/merged pull request event in the v2 UI.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
