### PR TITLE
fix: PR navigation

### DIFF
--- a/app/components/pipeline/workflow/event-rail/component.js
+++ b/app/components/pipeline/workflow/event-rail/component.js
@@ -121,10 +121,9 @@ export default class PipelineWorkflowEventRailComponent extends Component {
       let index = openPrNums.indexOf(eventPrNum);
 
       if (index === -1) {
-        const routeEventId = parseInt(
-          this.router.currentRoute.params.event_id,
-          10
-        );
+        const routeEventId = this.router.currentRoute.attributes.id
+          ? this.router.currentRoute.attributes.id
+          : parseInt(this.router.currentRoute.params.event_id, 10);
 
         if (event.id !== routeEventId) {
           return [];


### PR DESCRIPTION
## Context
When navigating to a new PR event from the event history modal, the ember route does not set the path parameter as the entire model is passed in.  As such, there's a event rail reload issue when the starting PR event is no longer open where any open PRs do not repopulate in the event rail.  Although the event id is not set on the params of the route, model that is set on the route contains the id variable with the correct event id value.

## Objective
Fixes the event rail reloading issue when navigating from a PR event that is no longer open.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3200

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
