### PR TITLE
fix: Fix missing last event ID

### DIFF
--- a/app/v2/pipeline/events/index/route.js
+++ b/app/v2/pipeline/events/index/route.js
@@ -10,10 +10,12 @@ export default class NewPipelineEventsIndexRoute extends Route {
     const model = this.modelFor('v2.pipeline.events');
     const pipeline = this.pipelinePageState.getPipeline();
 
-    const latestEvent = await this.shuttle.fetchFromApi(
-      'get',
-      `/events/${pipeline.lastEventId}`
-    );
+    const latestEvent = pipeline.lastEventId
+      ? await this.shuttle.fetchFromApi(
+          'get',
+          `/events/${pipeline.lastEventId}`
+        )
+      : null;
 
     return {
       userSettings: model.userSettings,


### PR DESCRIPTION
## Context
https://github.com/screwdriver-cd/ui/pull/1425 extracts the last event ID directly from the response payload; however, for pipelines that do not have any events, the last event ID is undefined.

## Objective
Fixes the issue where a pipeline with no events does not display the UI correctly

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
