### PR TITLE
feat(2856): Add timestamp in downloaded logs [3]

### DIFF
--- a/app/components/build-log/styles.scss
+++ b/app/components/build-log/styles.scss
@@ -96,6 +96,7 @@
     display: inline-block;
     vertical-align: top;
     width: 70px;
+    user-select: none;
   }
 
   .content {
@@ -204,4 +205,97 @@
 }
 .ansi-bright-white-bg {
   background-color: #feffff;
+}
+
+.btn-group {
+  padding: 0 !important;
+
+  .btn-secondary {
+    background-color: initial;
+    border: initial;
+    padding: 0;
+  }
+}
+
+.download-log-menu {
+  min-width: 300px;
+  padding: 5px 10px;
+
+  .parameter-group-list {
+    max-height: 70vh;
+    scroll-behavior: smooth;
+
+    .align-items-start {
+      cursor: initial;
+
+      .col-8 {
+        cursor: initial;
+      }
+    }
+
+    .parameter-group {
+      margin: 10px 10px 0 0;
+      border-radius: 3px;
+      border: 1px solid $sd-separator;
+      padding: 10px;
+      font-weight: 300;
+      color: $sd-text;
+    }
+
+    .parameter-list {
+      &.collapsed {
+        display: none;
+      }
+    }
+
+    .control-label {
+      color: initial;
+      white-space: nowrap;
+      text-align: left;
+      padding: initial;
+      margin: auto 0;
+    }
+
+    .ember-basic-dropdown {
+      width: 150px;
+      padding: 0;
+    }
+
+    .ember-basic-dropdown-trigger {
+      text-align: left;
+      color: initial;
+    }
+
+    .ember-basic-dropdown-content {
+      position: absolute;
+      text-align: left;
+      color: initial;
+    }
+
+    .ember-power-select-option {
+      white-space: nowrap;
+    }
+
+    .ember-basic-dropdown-content-wormhole-origin {
+      padding: 0;
+    }
+
+    .ember-power-select-option {
+      width: fit-content;
+      min-width: 100%;
+    }
+  }
+
+  .x-toggle-component {
+    display: inline-flex;
+
+    .x-toggle-btn {
+      padding: 0.16em 0.1em;
+      cursor: pointer;
+    }
+  }
+
+  .x-toggle:checked + label > .x-toggle-default.x-toggle-btn {
+    background-color: $sd-success;
+  }
 }

--- a/app/components/build-log/template.hbs
+++ b/app/components/build-log/template.hbs
@@ -50,9 +50,93 @@
               Downloading
             </span>
           {{else}}
-            <a onClick={{action "download"}} title="Download">
-              <FaIcon @icon="download" />
-            </a>
+            <BsDropdown
+              @closeOnMenuClick={{false}} as |dd|
+            >
+              <dd.button
+                class="start-with-parameters-button"
+                @onClick={{action "toggleDropdown" dd.toggleDropdown}}
+              >
+                <a title="Download">
+                  <FaIcon @icon="download" />
+                </a>
+              </dd.button>
+              <dd.menu class="download-log-menu">
+                <div class="parameter-group-list">
+                  <ul>
+                    <li>
+                      <div class="row align-items-start">
+                        <div class="control-label col-4">
+                          <span title="Enable timestamp">Enable timestamp</span>
+                        </div>
+                        <div class="col-8">
+                          <div class="toggle-wrapper">
+                            <XToggle
+                              @size="small"
+                              @value={{this.downloadTimestampEnabled}}
+                              @onLabel="downloadTimestampEnabled:true"
+                              @offLabel="disableTimestamp::false"
+                              @onToggle={{action 'onUpdateDownloadTimestampEnabled'}}
+                              title="Enable log timestamps"
+                            />
+                          </div>
+                        </div>
+                      </div>
+                    </li>
+                    <li>
+                      <div class="row align-items-start">
+                        <div class="control-label col-4">
+                          <span title="Timestamp format">Timestamp format</span>
+                        </div>
+                        <div class="col-8">
+                          <PowerSelect
+                            @options={{this.downloadTimestampFormatOptions}}
+                            @renderInPlace={{true}}
+                            @selected={{this.selectedDownloadTimestampFormat}}
+                            @disabled={{not this.downloadTimestampEnabled}}
+                            @searchEnabled={{false}}
+                            @placeholder="Select timestamp"
+                            @onChange={{action 'onUpdateDownloadTimestampFormat'
+                          }} as |timestampFormat|
+                          >
+                            {{timestampFormat.name}}
+                          </PowerSelect>
+                        </div>
+                      </div>
+                    </li>
+                    <li>
+                      <div class="row align-items-start">
+                        <div class="control-label col-4">
+                          <span title="Timezone">Timezone</span>
+                        </div>
+                        <div class="col-8">
+                          <PowerSelect
+                            @options={{this.downloadTimezoneOptions}}
+                            @renderInPlace={{true}}
+                            @selected={{this.selectedDownloadTimezone}}
+                            @disabled={{or (not this.downloadTimestampEnabled) (not this.timezoneEnabled)}}
+                            @searchEnabled={{false}}
+                            @placeholder="Select timezone"
+                            @onChange={{action 'onUpdateDownloadTimezone'
+                          }} as |timezone|
+                          >
+                            {{timezone.name}}
+                          </PowerSelect>
+                        </div>
+                      </div>
+                    </li>
+                  </ul>
+                </div>
+                <div class="btn-group">
+                  <BsButton
+                    @defaultText="Download"
+                    @type="primary"
+                    @buttonType="submit"
+                    @onClick={{action "download"}}
+                  />
+                </div>
+              </dd.menu>
+            </BsDropdown>
           {{/if}}
         {{/unless}}
       </div>


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Allows timestamps to be added to downloaded logs.
Press the Log Download button to display the following download dropdown
<img width="424" height="298" alt="example" src="https://github.com/user-attachments/assets/982fe92c-bfbf-43c4-8efd-e9295031c5d5" />

The following PR is required
- https://github.com/screwdriver-cd/data-schema/pull/605
- https://github.com/screwdriver-cd/screwdriver/pull/3365
## Objective

1. Allows user to select when download logs.
  - Whether to include a timestamp 
  - Timestamp format 
  - Timestamp time zone (Only affects full-time and simple-time format)

2. Prevent timestamps from being selected when copying a step's log by selecting a range of steps on the UI

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/2856

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
