### PR TITLE
feat: User settings as an injectable service

### DIFF
--- a/app/settings/service.js
+++ b/app/settings/service.js
@@ -1,0 +1,43 @@
+import Service, { service } from '@ember/service';
+
+export default class SettingsService extends Service {
+  @service('shuttle') shuttle;
+
+  settings;
+
+  getSettings() {
+    return this.settings;
+  }
+
+  getSettingsForPipeline(pipelineId) {
+    return this.settings ? this.settings[pipelineId] || {} : {};
+  }
+
+  async fetchSettings() {
+    await this.shuttle
+      .fetchFromApi('get', '/users/settings')
+      .then(settings => {
+        this.settings = settings;
+      })
+      .catch(err => {
+        console.error('Error fetching settings:', err);
+        throw err;
+      });
+  }
+
+  async updateSettings(newSettings) {
+    await this.shuttle
+      .fetchFromApi('put', '/users/settings', {
+        settings: {
+          ...newSettings
+        }
+      })
+      .then(updatedSettings => {
+        this.settings = updatedSettings;
+      })
+      .catch(err => {
+        console.error('Error updating settings:', err);
+        throw err;
+      });
+  }
+}

--- a/tests/unit/settings/service-test.js
+++ b/tests/unit/settings/service-test.js
@@ -1,0 +1,105 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'screwdriver-ui/tests/helpers';
+import sinon from 'sinon';
+
+module('Unit | Service | settings', function (hooks) {
+  setupTest(hooks);
+
+  let service;
+
+  let shuttle;
+
+  let mockSettings;
+
+  hooks.beforeEach(function () {
+    service = this.owner.lookup('service:settings');
+    shuttle = this.owner.lookup('service:shuttle');
+
+    mockSettings = {
+      displayJobNameLength: 20,
+      timestampFormat: 'LOCAL_TIMEZONE',
+      allowNotification: false
+    };
+  });
+
+  test('it exists', function (assert) {
+    assert.ok(service);
+  });
+
+  test('getSettings returns undefined initially', function (assert) {
+    assert.equal(service.getSettings(), undefined);
+  });
+
+  test('getSettingsForPipeline returns empty object pipeline with no configurations', function (assert) {
+    const pipelineId = 123;
+
+    assert.deepEqual(service.getSettingsForPipeline(pipelineId), {});
+
+    service.settings = mockSettings;
+    assert.deepEqual(service.getSettingsForPipeline(pipelineId), {});
+  });
+
+  test('getSettingsForPipeline returns configuration for pipeline', function (assert) {
+    const pipelineId = 123;
+    const mockPipelineSettings = {
+      showPRJobs: true
+    };
+
+    service.settings = mockSettings;
+    service.settings[pipelineId] = mockPipelineSettings;
+
+    assert.deepEqual(
+      service.getSettingsForPipeline(pipelineId),
+      mockPipelineSettings
+    );
+  });
+
+  test('fetchSettings sets settings on successful API call', async function (assert) {
+    sinon.stub(shuttle, 'fetchFromApi').resolves(mockSettings);
+
+    await service.fetchSettings();
+    assert.equal(service.getSettings(), mockSettings);
+  });
+
+  test('fetchSettings throws error on unsuccessful API call', async function (assert) {
+    const mockError = new Error('API error');
+
+    sinon.stub(shuttle, 'fetchFromApi').rejects(mockError);
+
+    service
+      .fetchSettings()
+      .then(() => {
+        assert.fail('Expected fetchSettings to throw an error');
+      })
+      .catch(err => {
+        assert.equal(err, mockError);
+      });
+  });
+
+  test('updateSettings updates settings on successful API call', async function (assert) {
+    const updatedSettings = {
+      ...mockSettings,
+      displayJobNameLength: 30
+    };
+
+    sinon.stub(shuttle, 'fetchFromApi').resolves(updatedSettings);
+
+    await service.updateSettings(updatedSettings);
+    assert.equal(service.getSettings(), updatedSettings);
+  });
+
+  test('updateSettings throws error on unsuccessful API call', async function (assert) {
+    const mockError = new Error('API error');
+
+    sinon.stub(shuttle, 'fetchFromApi').rejects(mockError);
+
+    service
+      .updateSettings(mockSettings)
+      .then(() => {
+        assert.fail('Expected fetchSettings to throw an error');
+      })
+      .catch(err => {
+        assert.equal(err, mockError);
+      });
+  });
+});


### PR DESCRIPTION
## Context
The V2 UI is moving off of ember data and requires a new injectable service to managing user settings.  This injectable service will refactored into a few existing V2 components as well an upcoming component for pipeline settings.

## Objective
Creates a simple injectable service with the core functionality for managing user settings.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
