### PR TITLE
fix: Refactor to inject user settings

### DIFF
--- a/app/components/pipeline/event/card/component.js
+++ b/app/components/pipeline/event/card/component.js
@@ -32,6 +32,8 @@ export default class PipelineEventCardComponent extends Component {
 
   @service('pr-jobs') prJobs;
 
+  @service('settings') settings;
+
   @tracked event;
 
   @tracked builds;
@@ -62,8 +64,6 @@ export default class PipelineEventCardComponent extends Component {
 
   queueName;
 
-  userSettings;
-
   durationIntervalId;
 
   firstCreateTime;
@@ -72,8 +72,6 @@ export default class PipelineEventCardComponent extends Component {
     super(...arguments);
 
     this.queueName = this.args.queueName;
-    this.userSettings = this.args.userSettings;
-
     this.event = this.args.event;
 
     this.showParametersModal = false;
@@ -296,7 +294,7 @@ export default class PipelineEventCardComponent extends Component {
   }
 
   get startDate() {
-    return getStartDate(this.event, this.userSettings);
+    return getStartDate(this.event, this.settings.getSettings());
   }
 
   get isCommitterDifferent() {

--- a/app/components/pipeline/event/card/template.hbs
+++ b/app/components/pipeline/event/card/template.hbs
@@ -242,7 +242,6 @@
             <Pipeline::Modal::EventGroupHistory
               @pipeline={{@pipeline}}
               @event={{@event}}
-              @userSettings={{@userSettings}}
               @isPR={{this.isPR}}
               @closeModal={{this.closeEventHistoryModal}}
             />

--- a/app/components/pipeline/jobs/table/cell/start-time/component.js
+++ b/app/components/pipeline/jobs/table/cell/start-time/component.js
@@ -1,12 +1,15 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
+import { service } from '@ember/service';
 import { toCustomLocaleString } from 'screwdriver-ui/utils/time-range';
 
 export default class PipelineJobsTableCellStartTimeComponent extends Component {
+  @service('settings') settings;
+
   @tracked latestBuild;
 
   get startTime() {
-    const { build, timestampFormat } = this.args.record;
+    const { build } = this.args.record;
 
     if (!build) {
       return null;
@@ -15,7 +18,7 @@ export default class PipelineJobsTableCellStartTimeComponent extends Component {
       return 'Not started';
     }
 
-    if (timestampFormat === 'UTC') {
+    if (this.settings.getSettings().timestampFormat === 'UTC') {
       return toCustomLocaleString(new Date(build.startTime), {
         timeZone: 'UTC'
       });

--- a/app/components/pipeline/jobs/table/component.js
+++ b/app/components/pipeline/jobs/table/component.js
@@ -20,8 +20,6 @@ export default class PipelineJobsTableComponent extends Component {
 
   @service('emt-themes/ember-bootstrap-v5') emberModelTableBootstrapTheme;
 
-  userSettings;
-
   event;
 
   dataReloader;
@@ -38,7 +36,6 @@ export default class PipelineJobsTableComponent extends Component {
     super(...arguments);
 
     this.event = this.args.event;
-    this.userSettings = this.args.userSettings;
     this.data = null;
     this.previousBuilds = new Map();
 
@@ -262,8 +259,7 @@ export default class PipelineJobsTableComponent extends Component {
           build: buildsForJob ? _.last(buildsForJob) : null,
           builds: buildsForJob,
           jobName: getDisplayName(job, this.event?.prNum),
-          stageName: getStageName(job),
-          timestampFormat: this.userSettings.timestampFormat
+          stageName: getStageName(job)
         });
       });
 

--- a/app/components/pipeline/modal/event-group-history/component.js
+++ b/app/components/pipeline/modal/event-group-history/component.js
@@ -5,9 +5,9 @@ import { service } from '@ember/service';
 import ENV from 'screwdriver-ui/config/environment';
 
 export default class PipelineModalEventGroupHistoryComponent extends Component {
-  @service shuttle;
+  @service('shuttle') shuttle;
 
-  @service pipelinePageState;
+  @service('pipeline-page-state') pipelinePageState;
 
   @tracked showCards = false;
 

--- a/app/components/pipeline/modal/event-group-history/template.hbs
+++ b/app/components/pipeline/modal/event-group-history/template.hbs
@@ -18,7 +18,6 @@
         <Pipeline::Event::Card
           @event={{event}}
           @baseEvent={{@event}}
-          @userSettings={{@userSettings}}
           @queueName="eventGroupModal"
           @onClick={{fn @closeModal}}
         />

--- a/app/components/pipeline/modal/search-event/component.js
+++ b/app/components/pipeline/modal/search-event/component.js
@@ -4,9 +4,9 @@ import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 export default class PipelineModalSearchEventComponent extends Component {
-  @service shuttle;
+  @service('shuttle') shuttle;
 
-  @service pipelinePageState;
+  @service('pipeline-page-state') pipelinePageState;
 
   @tracked searchField = 'message';
 

--- a/app/components/pipeline/modal/search-event/template.hbs
+++ b/app/components/pipeline/modal/search-event/template.hbs
@@ -44,7 +44,6 @@
           <Pipeline::Event::Card
             @pipeline={{@pipeline}}
             @event={{event}}
-            @userSettings={{@userSettings}}
             @queueName="searchResults"
           />
         </VerticalCollection>

--- a/app/components/pipeline/workflow/component.js
+++ b/app/components/pipeline/workflow/component.js
@@ -16,11 +16,13 @@ const RESTRICT_PR_ANNOTATION = 'screwdriver.cd/restrictPR';
 export default class PipelineWorkflowComponent extends Component {
   @service router;
 
-  @service shuttle;
+  @service('shuttle') shuttle;
 
-  @service pipelinePageState;
+  @service('pipeline-page-state') pipelinePageState;
 
-  @service workflowDataReload;
+  @service('workflow-data-reload') workflowDataReload;
+
+  @service('settings') settings;
 
   @tracked showDownstreamTriggers = false;
 
@@ -66,7 +68,7 @@ export default class PipelineWorkflowComponent extends Component {
     super(...arguments);
 
     this.pipeline = this.pipelinePageState.getPipeline();
-    this.userSettings = this.args.userSettings;
+    this.userSettings = this.settings.getSettings();
     this.latestEvent = this.args.latestEvent;
     this.dataReloadId = this.workflowDataReload.start(
       this.pipeline.id,

--- a/app/components/pipeline/workflow/event-rail/template.hbs
+++ b/app/components/pipeline/workflow/event-rail/template.hbs
@@ -15,7 +15,6 @@
       <FaIcon @icon="magnifying-glass" />
       {{#if this.showSearchEventModal}}
         <Pipeline::Modal::SearchEvent
-          @userSettings={{@userSettings}}
           @closeModal={{this.closeSearchEventModal}}
         />
       {{/if}}
@@ -51,7 +50,6 @@
       >
         <Pipeline::Event::Card
           @event={{event}}
-          @userSettings={{@userSettings}}
           @queueName="eventRail"
           @allowEventAction={{true}}
           @showParameters={{true}}

--- a/app/components/pipeline/workflow/template.hbs
+++ b/app/components/pipeline/workflow/template.hbs
@@ -3,7 +3,6 @@
   {{did-update this.update @event}}
 >
   <Pipeline::Workflow::EventRail
-    @userSettings={{this.userSettings}}
     @event={{this.eventRailAnchor}}
     @prNums={{@prNums}}
     @reloadEvents={{@reloadEventRail}}
@@ -137,7 +136,6 @@
         {{else if this.showEventJobsTable}}
           <Pipeline::Jobs::Table
             @event={{this.event}}
-            @userSettings={{this.userSettings}}
           />
         {{else if this.showBuildCostsTable}}
           <Pipeline::Jobs::Table::CostTable

--- a/app/v2/pipeline/events/index/route.js
+++ b/app/v2/pipeline/events/index/route.js
@@ -2,12 +2,11 @@ import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 
 export default class NewPipelineEventsIndexRoute extends Route {
-  @service shuttle;
+  @service('shuttle') shuttle;
 
-  @service pipelinePageState;
+  @service('pipeline-page-state') pipelinePageState;
 
   async model() {
-    const model = this.modelFor('v2.pipeline.events');
     const pipeline = this.pipelinePageState.getPipeline();
 
     const latestEvent = pipeline.lastEventId
@@ -18,7 +17,6 @@ export default class NewPipelineEventsIndexRoute extends Route {
       : null;
 
     return {
-      userSettings: model.userSettings,
       latestEvent
     };
   }

--- a/app/v2/pipeline/events/index/template.hbs
+++ b/app/v2/pipeline/events/index/template.hbs
@@ -1,4 +1,3 @@
 <Pipeline::Workflow
-  @userSettings={{this.model.userSettings}}
   @noEvents={{true}}
 />

--- a/app/v2/pipeline/events/route.js
+++ b/app/v2/pipeline/events/route.js
@@ -2,16 +2,11 @@ import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 
 export default class NewPipelineEventsRoute extends Route {
-  @service shuttle;
+  @service('settings') settings;
 
   async model() {
-    const userSettings = await this.shuttle.fetchFromApi(
-      'get',
-      '/users/settings'
-    );
-
-    return {
-      userSettings
-    };
+    if (!this.settings.getSettings()) {
+      await this.settings.fetchSettings();
+    }
   }
 }

--- a/app/v2/pipeline/events/show/route.js
+++ b/app/v2/pipeline/events/show/route.js
@@ -3,13 +3,12 @@ import { service } from '@ember/service';
 import { NotFoundError } from 'ember-ajax/errors';
 
 export default class NewPipelineEventsShowRoute extends Route {
-  @service shuttle;
+  @service('shuttle') shuttle;
 
-  @service pipelinePageState;
+  @service('pipeline-page-state') pipelinePageState;
 
   async model(params, transition) {
     const eventId = params.event_id;
-    const model = this.modelFor('v2.pipeline.events');
     const pipelineId = this.pipelinePageState.getPipelineId();
 
     let latestEvent;
@@ -58,7 +57,6 @@ export default class NewPipelineEventsShowRoute extends Route {
       });
 
     return {
-      userSettings: model.userSettings,
       event,
       latestEvent,
       invalidEvent: event === null

--- a/app/v2/pipeline/events/show/template.hbs
+++ b/app/v2/pipeline/events/show/template.hbs
@@ -1,5 +1,4 @@
 <Pipeline::Workflow
-  @userSettings={{this.model.userSettings}}
   @event={{this.model.event}}
   @latestEvent={{this.model.latestEvent}}
   @invalidEvent={{this.model.invalidEvent}}

--- a/app/v2/pipeline/jobs/route.js
+++ b/app/v2/pipeline/jobs/route.js
@@ -2,9 +2,11 @@ import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 
 export default class NewPipelineJobsRoute extends Route {
-  @service shuttle;
+  @service('shuttle') shuttle;
 
-  @service pipelinePageState;
+  @service('pipeline-page-state') pipelinePageState;
+
+  @service('settings') settings;
 
   async model() {
     const pipelineId = this.pipelinePageState.getPipelineId();
@@ -15,13 +17,8 @@ export default class NewPipelineJobsRoute extends Route {
         this.pipelinePageState.setJobs(jobs);
       });
 
-    const userSettings = await this.shuttle.fetchFromApi(
-      'get',
-      '/users/settings'
-    );
-
-    return {
-      userSettings
-    };
+    if (!this.settings.getSettings()) {
+      await this.settings.fetchSettings();
+    }
   }
 }

--- a/app/v2/pipeline/jobs/template.hbs
+++ b/app/v2/pipeline/jobs/template.hbs
@@ -2,6 +2,4 @@
 
 <Pipeline::Tab />
 
-<Pipeline::Jobs::Table
-  @userSettings={{this.model.userSettings}}
-/>
+<Pipeline::Jobs::Table />

--- a/app/v2/pipeline/pulls/index/route.js
+++ b/app/v2/pipeline/pulls/index/route.js
@@ -13,7 +13,6 @@ export default class V2PipelinePullsIndexRoute extends Route {
   @service('pr-jobs') prJobs;
 
   async model() {
-    const model = this.modelFor('v2.pipeline.pulls');
     const pullRequestJobs = this.prJobs.getPullRequestJobs();
 
     let event;
@@ -33,7 +32,6 @@ export default class V2PipelinePullsIndexRoute extends Route {
     }
 
     return {
-      ...model,
       event
     };
   }

--- a/app/v2/pipeline/pulls/index/template.hbs
+++ b/app/v2/pipeline/pulls/index/template.hbs
@@ -1,4 +1,3 @@
 <Pipeline::Workflow
-  @userSettings={{this.model.userSettings}}
   @noEvents={{true}}
 />

--- a/app/v2/pipeline/pulls/route.js
+++ b/app/v2/pipeline/pulls/route.js
@@ -8,6 +8,8 @@ export default class NewPipelinePullsRoute extends Route {
 
   @service('pr-jobs') prJobs;
 
+  @service('settings') settings;
+
   activate() {
     this.pipelinePageState.setIsPr(true);
   }
@@ -19,10 +21,9 @@ export default class NewPipelinePullsRoute extends Route {
   async model() {
     const pipelineId = this.pipelinePageState.getPipelineId();
 
-    const userSettings = await this.shuttle.fetchFromApi(
-      'get',
-      '/users/settings'
-    );
+    if (!this.settings.getSettings()) {
+      await this.settings.fetchSettings();
+    }
 
     await this.shuttle
       .fetchFromApi('get', `/pipelines/${pipelineId}/stages`)
@@ -37,9 +38,5 @@ export default class NewPipelinePullsRoute extends Route {
       });
 
     await this.prJobs.setPullRequestJobs();
-
-    return {
-      userSettings
-    };
   }
 }

--- a/app/v2/pipeline/pulls/show/route.js
+++ b/app/v2/pipeline/pulls/show/route.js
@@ -13,7 +13,6 @@ export default class V2PipelinePullsShowRoute extends Route {
   @service('pr-jobs') prJobs;
 
   async model(params, transition) {
-    const model = this.modelFor('v2.pipeline.pulls');
     const prNums = getPrNumbers(this.prJobs.getPullRequestJobs());
 
     let latestEvent;
@@ -65,7 +64,6 @@ export default class V2PipelinePullsShowRoute extends Route {
     this.prJobs.setPipelinePageStateJobs(event);
 
     return {
-      ...model,
       event,
       latestEvent,
       prNums: Array.from(prNums).sort((a, b) => a - b),

--- a/app/v2/pipeline/pulls/show/template.hbs
+++ b/app/v2/pipeline/pulls/show/template.hbs
@@ -1,5 +1,4 @@
 <Pipeline::Workflow
-  @userSettings={{this.model.userSettings}}
   @event={{this.model.event}}
   @latestEvent={{this.model.latestEvent}}
   @prNums={{this.model.prNums}}

--- a/tests/integration/components/pipeline/event/card/component-test.js
+++ b/tests/integration/components/pipeline/event/card/component-test.js
@@ -14,6 +14,8 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
   let event;
 
   hooks.beforeEach(function () {
+    const settings = this.owner.lookup('service:settings');
+
     router = this.owner.lookup('service:router');
     workflowDataReload = this.owner.lookup('service:workflow-data-reload');
 
@@ -25,6 +27,8 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
       creator: { name: 'batman' },
       meta: {}
     };
+
+    sinon.stub(settings, 'getSettings').returns({});
   });
 
   test('it renders title when event is first in group', async function (assert) {
@@ -37,14 +41,12 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
       .callsFake(() => {});
 
     this.setProperties({
-      event,
-      userSettings: {}
+      event
     });
 
     await render(
       hbs`<Pipeline::Event::Card
         @event={{this.event}}
-        @userSettings={{this.userSettings}}
       />`
     );
 
@@ -63,14 +65,12 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
     event.groupEventId = 3;
 
     this.setProperties({
-      event,
-      userSettings: {}
+      event
     });
 
     await render(
       hbs`<Pipeline::Event::Card
         @event={{this.event}}
-        @userSettings={{this.userSettings}}
       />`
     );
 
@@ -89,14 +89,12 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
       });
 
     this.setProperties({
-      event,
-      userSettings: {}
+      event
     });
 
     await render(
       hbs`<Pipeline::Event::Card
         @event={{this.event}}
-        @userSettings={{this.userSettings}}
       />`
     );
 
@@ -138,8 +136,7 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
       });
 
     this.setProperties({
-      event,
-      userSettings: {}
+      event
     });
 
     await render(
@@ -147,7 +144,6 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
         @event={{this.event}}
         @builds={{this.builds}}
         @latestCommitEvent={{this.latestCommitEvent}}
-        @userSettings={{this.userSettings}}
       />`
     );
 
@@ -167,14 +163,12 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
 
     event.meta = { label: 'Testing 123' };
     this.setProperties({
-      event,
-      userSettings: {}
+      event
     });
 
     await render(
       hbs`<Pipeline::Event::Card
         @event={{this.event}}
-        @userSettings={{this.userSettings}}
       />`
     );
 
@@ -199,14 +193,12 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
     };
 
     this.setProperties({
-      event,
-      userSettings: {}
+      event
     });
 
     await render(
       hbs`<Pipeline::Event::Card
         @event={{this.event}}
-        @userSettings={{this.userSettings}}
         @showParameters={{true}}
       />`
     );
@@ -232,14 +224,12 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
     };
 
     this.setProperties({
-      event,
-      userSettings: {}
+      event
     });
 
     await render(
       hbs`<Pipeline::Event::Card
         @event={{this.event}}
-        @userSettings={{this.userSettings}}
         @showEventGroup={{true}}
       />`
     );
@@ -261,14 +251,12 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
       });
 
     this.setProperties({
-      event,
-      userSettings: {}
+      event
     });
 
     await render(
       hbs`<Pipeline::Event::Card
         @event={{this.event}}
-        @userSettings={{this.userSettings}}
         @allowEventAction={{true}}
       />`
     );
@@ -292,14 +280,12 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
       });
 
     this.setProperties({
-      event,
-      userSettings: {}
+      event
     });
 
     await render(
       hbs`<Pipeline::Event::Card
         @event={{this.event}}
-        @userSettings={{this.userSettings}}
       />`
     );
 
@@ -319,14 +305,12 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
       });
 
     this.setProperties({
-      event,
-      userSettings: {}
+      event
     });
 
     await render(
       hbs`<Pipeline::Event::Card
         @event={{this.event}}
-        @userSettings={{this.userSettings}}
       />`
     );
 
@@ -351,14 +335,12 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
       });
 
     this.setProperties({
-      event,
-      userSettings: {}
+      event
     });
 
     await render(
       hbs`<Pipeline::Event::Card
         @event={{this.event}}
-        @userSettings={{this.userSettings}}
       />`
     );
 
@@ -384,14 +366,12 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
       });
 
     this.setProperties({
-      event,
-      userSettings: {}
+      event
     });
 
     await render(
       hbs`<Pipeline::Event::Card
         @event={{this.event}}
-        @userSettings={{this.userSettings}}
       />`
     );
 
@@ -427,14 +407,12 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
     event.prNum = 4;
 
     this.setProperties({
-      event,
-      userSettings: {}
+      event
     });
 
     await render(
       hbs`<Pipeline::Event::Card
         @event={{this.event}}
-        @userSettings={{this.userSettings}}
       />`
     );
 
@@ -455,14 +433,12 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
     event.type = 'pr';
     event.prNum = 4;
     this.setProperties({
-      event,
-      userSettings: {}
+      event
     });
 
     await render(
       hbs`<Pipeline::Event::Card
         @event={{this.event}}
-        @userSettings={{this.userSettings}}
         @allowEventAction={{true}}
       />`
     );
@@ -482,15 +458,13 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
       });
 
     this.setProperties({
-      event,
-      userSettings: {}
+      event
     });
 
     await render(
       hbs`<Pipeline::Event::Card
         @event={{this.event}}
         @baseEvent={{this.event}}
-        @userSettings={{this.userSettings}}
       />`
     );
 

--- a/tests/integration/components/pipeline/jobs/table/cell/start-time/component-test.js
+++ b/tests/integration/components/pipeline/jobs/table/cell/start-time/component-test.js
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
 
 module(
   'Integration | Component | pipeline/jobs/table/cell/start-time',
@@ -9,6 +10,14 @@ module(
     setupRenderingTest(hooks);
 
     const job = { id: 123, name: 'main' };
+
+    hooks.beforeEach(function () {
+      const settings = this.owner.lookup('service:settings');
+
+      sinon.stub(settings, 'getSettings').returns({
+        timestampFormat: 'UTC'
+      });
+    });
 
     test('it renders', async function (assert) {
       this.setProperties({
@@ -33,8 +42,7 @@ module(
           build: {
             id: 1,
             startTime: '2021-01-01T20:30:00.000Z'
-          },
-          timestampFormat: 'UTC'
+          }
         }
       });
 
@@ -51,8 +59,7 @@ module(
       this.setProperties({
         record: {
           job,
-          build: { id: 1 },
-          timestampFormat: 'UTC'
+          build: { id: 1 }
         }
       });
 

--- a/tests/integration/components/pipeline/modal/event-group-history/component-test.js
+++ b/tests/integration/components/pipeline/modal/event-group-history/component-test.js
@@ -17,10 +17,12 @@ module(
       const pipelinePageState = this.owner.lookup(
         'service:pipeline-page-state'
       );
+      const settings = this.owner.lookup('service:settings');
 
       sinon.stub(router, 'currentURL').value('');
       sinon.stub(shuttle, 'fetchFromApi').resolves(mockApiResponse);
       sinon.stub(pipelinePageState, 'getPipelineId').returns(1);
+      sinon.stub(settings, 'getSettings').returns({});
     });
 
     hooks.afterEach(function () {
@@ -45,14 +47,12 @@ module(
 
       this.setProperties({
         event: { ...mockEvent, id: 1 },
-        userSettings: {},
         closeModal: () => {}
       });
 
       await render(
         hbs`<Pipeline::Modal::EventGroupHistory
             @event={{this.event}}
-            @userSettings={{this.userSettings}}
             @closeModal={{this.closeModal}}
         />`
       );
@@ -78,14 +78,12 @@ module(
 
       this.setProperties({
         event: { ...mockEvent, id: 1 },
-        userSettings: {},
         closeModal: () => {}
       });
 
       await render(
         hbs`<Pipeline::Modal::EventGroupHistory
             @event={{this.event}}
-            @userSettings={{this.userSettings}}
             @isPR={{true}}
             @closeModal={{this.closeModal}}
         />`

--- a/tests/integration/components/pipeline/modal/search-event/component-test.js
+++ b/tests/integration/components/pipeline/modal/search-event/component-test.js
@@ -14,20 +14,20 @@ module(
       const pipelinePageState = this.owner.lookup(
         'service:pipeline-page-state'
       );
+      const settings = this.owner.lookup('service:settings');
 
       sinon.stub(pipelinePageState, 'getPipelineId').returns(123);
       sinon.stub(pipelinePageState, 'getIsPr').returns(false);
+      sinon.stub(settings, 'getSettings').returns({});
     });
 
     test('it renders', async function (assert) {
       this.setProperties({
-        userSettings: {},
         closeModal: () => {}
       });
 
       await render(
         hbs`<Pipeline::Modal::SearchEvent
-            @userSettings={{this.userSettings}}
             @closeModal={{this.closeModal}}
         />`
       );
@@ -48,13 +48,11 @@ module(
       sinon.stub(shuttle, 'fetchFromApi').resolves([]);
 
       this.setProperties({
-        userSettings: {},
         closeModal: () => {}
       });
 
       await render(
         hbs`<Pipeline::Modal::SearchEvent
-            @userSettings={{this.userSettings}}
             @closeModal={{this.closeModal}}
         />`
       );
@@ -77,13 +75,11 @@ module(
         .resolves([]);
 
       this.setProperties({
-        userSettings: {},
         closeModal: () => {}
       });
 
       await render(
         hbs`<Pipeline::Modal::SearchEvent
-            @userSettings={{this.userSettings}}
             @closeModal={{this.closeModal}}
         />`
       );
@@ -107,13 +103,11 @@ module(
       const spyShuttle = sinon.spy(shuttle, 'fetchFromApi');
 
       this.setProperties({
-        userSettings: {},
         closeModal: () => {}
       });
 
       await render(
         hbs`<Pipeline::Modal::SearchEvent
-            @userSettings={{this.userSettings}}
             @closeModal={{this.closeModal}}
         />`
       );
@@ -136,13 +130,11 @@ module(
       sinon.stub(shuttle, 'fetchFromApi').resolves([]);
 
       this.setProperties({
-        userSettings: {},
         closeModal: () => {}
       });
 
       await render(
         hbs`<Pipeline::Modal::SearchEvent
-            @userSettings={{this.userSettings}}
             @closeModal={{this.closeModal}}
         />`
       );


### PR DESCRIPTION
## Context
https://github.com/screwdriver-cd/ui/pull/1437 added an injectable ember service to manage user settings.  The v2 UI components that previously required user settings should now have the settings injected at the component level where they are used rather than passed around as component parameters.

## Objective
Refactors the v2 UI components to use the injected user settings where necessary.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
