### PR TITLE
feat: Modal update pipeline repository settings

### DIFF
--- a/app/components/pipeline/settings/main/modal/pipeline/component.js
+++ b/app/components/pipeline/settings/main/modal/pipeline/component.js
@@ -1,0 +1,67 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+
+import { getCheckoutUrl } from 'screwdriver-ui/utils/git';
+
+export default class PipelineSettingsMainModalPipelineComponent extends Component {
+  @service('shuttle') shuttle;
+
+  @service('pipeline-page-state') pipelinePageState;
+
+  @tracked errorMessage;
+
+  @tracked checkoutUrl;
+
+  @tracked sourceDir;
+
+  @tracked isAwaitingResponse = false;
+
+  pipeline;
+
+  originalCheckoutUrl;
+
+  constructor() {
+    super(...arguments);
+
+    this.pipeline = this.pipelinePageState.getPipeline();
+
+    this.originalCheckoutUrl = getCheckoutUrl({
+      appId: this.pipeline.scmRepo.name,
+      scmUri: this.pipeline.scmUri
+    });
+    this.checkoutUrl = this.originalCheckoutUrl;
+    this.sourceDir = this.pipeline.scmRepo.rootDir;
+  }
+
+  get isDisabled() {
+    if (this.isAwaitingResponse) {
+      return true;
+    }
+
+    return (
+      this.checkoutUrl === this.originalCheckoutUrl &&
+      this.sourceDir === this.pipeline.scmRepo.rootDir
+    );
+  }
+
+  @action
+  async updatePipeline() {
+    this.isAwaitingResponse = true;
+
+    return this.shuttle
+      .fetchFromApi('put', `/pipelines/${this.pipeline.id}`, {
+        checkoutUrl: this.checkoutUrl,
+        rootDir: this.sourceDir
+      })
+      .then(pipeline => {
+        this.pipelinePageState.setPipeline(pipeline);
+        this.args.closeModal(true);
+      })
+      .catch(err => {
+        this.errorMessage = err.message;
+        this.isAwaitingResponse = false;
+      });
+  }
+}

--- a/app/components/pipeline/settings/main/modal/pipeline/styles.scss
+++ b/app/components/pipeline/settings/main/modal/pipeline/styles.scss
@@ -1,0 +1,21 @@
+@use 'screwdriver-colors' as colors;
+
+@mixin styles {
+  #edit-pipeline-modal {
+    .modal-body {
+      .configuration-container {
+        label {
+          display: flex;
+          flex-direction: column;
+        }
+
+        input {
+          background-color: colors.$sd-flyout-bg;
+          border-radius: 3px;
+          border: 1px solid colors.$sd-light-gray;
+          padding: 0.375rem 0.75rem;
+        }
+      }
+    }
+  }
+}

--- a/app/components/pipeline/settings/main/modal/pipeline/template.hbs
+++ b/app/components/pipeline/settings/main/modal/pipeline/template.hbs
@@ -1,0 +1,52 @@
+<BsModal
+  id="edit-pipeline-modal"
+  @onHide={{fn @closeModal}}
+  as |modal|
+>
+  <modal.header>
+    <div class="modal-title">
+      Edit pipeline configuration
+    </div>
+  </modal.header>
+  <modal.body>
+    {{#if this.errorMessage}}
+      <InfoMessage
+        @message={{this.errorMessage}}
+        @type="warning"
+        @icon="triangle-exclamation"
+        @dismissible={{false}}
+      />
+    {{/if}}
+
+    <div class="configuration-container">
+      <label>
+        Checkout URL
+        <Input
+          id="checkout-url-input"
+          @type="text"
+          @value={{this.checkoutUrl}}
+          placeholder="Checkout URL is required"
+        />
+      </label>
+      <label>
+        Source directory
+        <Input
+          id="source-directory-input"
+          @type="text"
+          @value={{this.sourceDir}}
+          placeholder="Source directory is relative to the checkout URL (e.g., 'src')"
+        />
+      </label>
+    </div>
+  </modal.body>
+  <modal.footer>
+    <BsButton
+      id="submit-action"
+      @type="primary"
+      @defaultText="Update"
+      @pendingText="Updating..."
+      @onClick={{fn this.updatePipeline}}
+      disabled={{this.isDisabled}}
+    />
+  </modal.footer>
+</BsModal>

--- a/tests/integration/components/pipeline/settings/main/modal/pipeline/component-test.js
+++ b/tests/integration/components/pipeline/settings/main/modal/pipeline/component-test.js
@@ -1,0 +1,126 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
+import { click, fillIn, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+
+module(
+  'Integration | Component | pipeline/settings/main/modal/pipeline',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    let pipelinePageState;
+
+    let shuttle;
+
+    const pipelineMock = {
+      id: 123,
+      scmRepo: {
+        name: 'test/repo',
+        rootDir: ''
+      },
+      scmUri: 'git@testgit.com'
+    };
+
+    hooks.beforeEach(function () {
+      pipelinePageState = this.owner.lookup('service:pipeline-page-state');
+      shuttle = this.owner.lookup('service:shuttle');
+
+      sinon.stub(pipelinePageState, 'getPipeline').returns(pipelineMock);
+    });
+
+    test('it renders', async function (assert) {
+      this.setProperties({
+        closeModal: () => {}
+      });
+
+      await render(
+        hbs`<Pipeline::Settings::Main::Modal::Pipeline
+            @closeModal={{this.closeModal}}
+        />`
+      );
+
+      assert.dom('.modal-title').exists();
+      assert.dom('#checkout-url-input').exists();
+      assert.dom('#source-directory-input').exists();
+      assert.dom('#submit-action').exists();
+    });
+
+    test('it enables submit button correctly', async function (assert) {
+      this.setProperties({
+        closeModal: () => {}
+      });
+
+      await render(
+        hbs`<Pipeline::Settings::Main::Modal::Pipeline
+            @closeModal={{this.closeModal}}
+        />`
+      );
+
+      assert.dom('#submit-action').isDisabled();
+      await fillIn('#source-directory-input', 'src');
+      assert.dom('#submit-action').isEnabled();
+      await fillIn('#source-directory-input', '');
+      assert.dom('#submit-action').isDisabled();
+      await fillIn('#checkout-url-input', 'abc');
+      assert.dom('#submit-action').isEnabled();
+      await fillIn('#source-directory-input', 'src');
+      assert.dom('#submit-action').isEnabled();
+    });
+
+    test('it handles failed API call correctly', async function (assert) {
+      this.setProperties({
+        closeModal: () => {}
+      });
+
+      const errorMessage = 'Failed to update pipeline';
+
+      sinon.stub(shuttle, 'fetchFromApi').rejects({
+        message: errorMessage
+      });
+
+      await render(
+        hbs`<Pipeline::Settings::Main::Modal::Pipeline
+            @closeModal={{this.closeModal}}
+        />`
+      );
+      await fillIn('#source-directory-input', 'src');
+      await click('#submit-action');
+
+      assert.dom('.modal-body .alert.alert-warning').exists();
+      assert
+        .dom('.modal-body .alert.alert-warning > span')
+        .hasText(errorMessage);
+      assert.dom('#submit-action').isEnabled();
+    });
+
+    test('it handles successful API call correctly', async function (assert) {
+      const pipelinePageStateSpy = sinon.spy(pipelinePageState, 'setPipeline');
+      const closeModalSpy = sinon.spy();
+      const rootDir = 'src';
+      const updatedPipeline = {
+        ...pipelineMock,
+        scmRepo: {
+          rootDir
+        }
+      };
+
+      sinon.stub(shuttle, 'fetchFromApi').resolves(updatedPipeline);
+
+      this.setProperties({
+        closeModal: closeModalSpy
+      });
+
+      await render(
+        hbs`<Pipeline::Settings::Main::Modal::Pipeline
+            @closeModal={{this.closeModal}}
+        />`
+      );
+      await fillIn('#source-directory-input', rootDir);
+      await click('#submit-action');
+
+      assert.equal(pipelinePageStateSpy.calledOnceWith(updatedPipeline), true);
+      assert.equal(closeModalSpy.calledOnceWith(true), true);
+    });
+  }
+);


### PR DESCRIPTION
## Context
Updating the pipeline settings to a v2 UI to better handle a number of different shortcomings especially around pipelines with many jobs.

## Objective
Creates a modal to update pipeline repository settings
<img width="2052" height="548" alt="Screenshot 2025-07-29 at 12-23-24 minghay_various Settings" src="https://github.com/user-attachments/assets/e356c2a7-d3ab-4d25-993d-7a7ce62e2128" />

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
