### PR TITLE
feat: Glimmer modal for updating pipeline alias

### DIFF
--- a/app/components/pipeline/settings/main/modal/pipeline-alias/component.js
+++ b/app/components/pipeline/settings/main/modal/pipeline-alias/component.js
@@ -1,0 +1,53 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+
+export default class PipelineSettingsMainModalPipelineAliasComponent extends Component {
+  @service('shuttle') shuttle;
+
+  @service('pipeline-page-state') pipelinePageState;
+
+  @tracked errorMessage;
+
+  @tracked alias;
+
+  @tracked isAwaitingResponse = false;
+
+  pipeline;
+
+  constructor() {
+    super(...arguments);
+
+    this.pipeline = this.pipelinePageState.getPipeline();
+    this.alias = this.pipeline.settings.aliasName;
+  }
+
+  get isDisabled() {
+    if (this.isAwaitingResponse) {
+      return true;
+    }
+
+    return this.alias === this.pipeline.settings.aliasName;
+  }
+
+  @action
+  async updateAlias() {
+    this.isAwaitingResponse = true;
+
+    return this.shuttle
+      .fetchFromApi('put', `/pipelines/${this.pipeline.id}`, {
+        settings: {
+          aliasName: this.alias
+        }
+      })
+      .then(pipeline => {
+        this.pipelinePageState.setPipeline(pipeline);
+        this.args.closeModal(true);
+      })
+      .catch(err => {
+        this.errorMessage = err.message;
+        this.isAwaitingResponse = false;
+      });
+  }
+}

--- a/app/components/pipeline/settings/main/modal/pipeline-alias/styles.scss
+++ b/app/components/pipeline/settings/main/modal/pipeline-alias/styles.scss
@@ -1,0 +1,21 @@
+@use 'screwdriver-colors' as colors;
+
+@mixin styles {
+  #edit-pipeline-alias-modal {
+    .modal-body {
+      .configuration-container {
+        label {
+          display: flex;
+          flex-direction: column;
+        }
+
+        input {
+          background-color: colors.$sd-flyout-bg;
+          border-radius: 3px;
+          border: 1px solid colors.$sd-light-gray;
+          padding: 0.375rem 0.75rem;
+        }
+      }
+    }
+  }
+}

--- a/app/components/pipeline/settings/main/modal/pipeline-alias/template.hbs
+++ b/app/components/pipeline/settings/main/modal/pipeline-alias/template.hbs
@@ -1,0 +1,42 @@
+<BsModal
+  id="edit-pipeline-alias-modal"
+  @onHide={{fn @closeModal}}
+  as |modal|
+>
+  <modal.header>
+    <div class="modal-title">
+      Edit pipeline alias
+    </div>
+  </modal.header>
+  <modal.body>
+    {{#if this.errorMessage}}
+      <InfoMessage
+        @message={{this.errorMessage}}
+        @type="warning"
+        @icon="triangle-exclamation"
+        @dismissible={{false}}
+      />
+    {{/if}}
+
+    <div class="configuration-container">
+      <label>
+        Alias
+        <Input
+          @type="text"
+          @value={{this.alias}}
+          placeholder="Pipeline alias"
+        />
+      </label>
+    </div>
+  </modal.body>
+  <modal.footer>
+    <BsButton
+      id="submit-action"
+      @type="primary"
+      @defaultText="Update"
+      @pendingText="Updating..."
+      @onClick={{fn this.updateAlias}}
+      disabled={{this.isDisabled}}
+    />
+  </modal.footer>
+</BsModal>

--- a/tests/integration/components/pipeline/settings/main/modal/pipeline-alias/component-test.js
+++ b/tests/integration/components/pipeline/settings/main/modal/pipeline-alias/component-test.js
@@ -1,0 +1,115 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
+import { click, fillIn, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+
+module(
+  'Integration | Component | pipeline/settings/main/modal/pipeline-alias',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    let pipelinePageState;
+
+    let shuttle;
+
+    const pipelineMock = {
+      id: 123,
+      settings: {}
+    };
+
+    hooks.beforeEach(function () {
+      pipelinePageState = this.owner.lookup('service:pipeline-page-state');
+      shuttle = this.owner.lookup('service:shuttle');
+
+      sinon.stub(pipelinePageState, 'getPipeline').returns(pipelineMock);
+    });
+
+    test('it renders', async function (assert) {
+      this.setProperties({
+        closeModal: () => {}
+      });
+
+      await render(
+        hbs`<Pipeline::Settings::Main::Modal::PipelineAlias
+            @closeModal={{this.closeModal}}
+        />`
+      );
+
+      assert.dom('.modal-title').exists();
+      assert.dom('.configuration-container input').exists();
+      assert.dom('#submit-action').exists();
+    });
+
+    test('it enables submit button correctly', async function (assert) {
+      this.setProperties({
+        closeModal: () => {}
+      });
+
+      await render(
+        hbs`<Pipeline::Settings::Main::Modal::PipelineAlias
+            @closeModal={{this.closeModal}}
+        />`
+      );
+
+      assert.dom('#submit-action').isDisabled();
+      await fillIn('.configuration-container input', 'my-alias');
+      assert.dom('#submit-action').isEnabled();
+    });
+
+    test('it handles failed API call correctly', async function (assert) {
+      this.setProperties({
+        closeModal: () => {}
+      });
+
+      const errorMessage = 'Failed to update pipeline';
+
+      sinon.stub(shuttle, 'fetchFromApi').rejects({
+        message: errorMessage
+      });
+
+      await render(
+        hbs`<Pipeline::Settings::Main::Modal::PipelineAlias
+            @closeModal={{this.closeModal}}
+        />`
+      );
+      await fillIn('.configuration-container input', 'my-alias');
+      await click('#submit-action');
+
+      assert.dom('.modal-body .alert.alert-warning').exists();
+      assert
+        .dom('.modal-body .alert.alert-warning > span')
+        .hasText(errorMessage);
+      assert.dom('#submit-action').isEnabled();
+    });
+
+    test('it handles successful API call correctly', async function (assert) {
+      const pipelinePageStateSpy = sinon.spy(pipelinePageState, 'setPipeline');
+      const closeModalSpy = sinon.spy();
+      const alias = 'my-alias';
+      const updatedPipeline = {
+        ...pipelineMock,
+        settings: {
+          aliasName: alias
+        }
+      };
+
+      sinon.stub(shuttle, 'fetchFromApi').resolves(updatedPipeline);
+
+      this.setProperties({
+        closeModal: closeModalSpy
+      });
+
+      await render(
+        hbs`<Pipeline::Settings::Main::Modal::PipelineAlias
+            @closeModal={{this.closeModal}}
+        />`
+      );
+      await fillIn('.configuration-container input', alias);
+      await click('#submit-action');
+
+      assert.equal(pipelinePageStateSpy.calledOnceWith(updatedPipeline), true);
+      assert.equal(closeModalSpy.calledOnceWith(true), true);
+    });
+  }
+);


### PR DESCRIPTION
## Context
Updating the pipeline settings to a v2 UI to better handle a number of different shortcomings especially around pipelines with many jobs.

## Objective
Creates a modal to update pipeline alias
<img width="2052" height="422" alt="Screenshot 2025-07-30 at 11-52-51 minghay_various Settings" src="https://github.com/user-attachments/assets/fb9d833c-8287-469b-bfc7-0dc4cceaf5c2" />

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
