### PR TITLE
feat: Sonar badge modal

### DIFF
--- a/app/components/pipeline/header/component.js
+++ b/app/components/pipeline/header/component.js
@@ -4,9 +4,11 @@ import { service } from '@ember/service';
 import { action } from '@ember/object';
 
 export default class PipelineHeaderComponent extends Component {
-  @service scm;
+  @service('scm') scm;
 
-  @service shuttle;
+  @service('shuttle') shuttle;
+
+  @service('pipeline-page-state') pipelinePageState;
 
   @tracked addToCollectionModalOpen = false;
 
@@ -23,6 +25,9 @@ export default class PipelineHeaderComponent extends Component {
 
     this.pipeline = this.args.pipeline;
     this.getPipelinesWithSameRepo().then(() => {});
+    this.pipelinePageState.setOnForceReloadPipelineHeader(() => {
+      this.pipeline = this.pipelinePageState.getPipeline();
+    });
   }
 
   get pipelineDescription() {

--- a/app/components/pipeline/settings/main/modal/sonar-badge/component.js
+++ b/app/components/pipeline/settings/main/modal/sonar-badge/component.js
@@ -1,0 +1,80 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+
+export default class PipelineSettingsMainModalSonarBadgeComponent extends Component {
+  @service('shuttle') shuttle;
+
+  @service('pipeline-page-state') pipelinePageState;
+
+  @tracked errorMessage;
+
+  @tracked badgeName;
+
+  @tracked badgeUri;
+
+  @tracked isAwaitingResponse = false;
+
+  pipeline;
+
+  hasBadge;
+
+  constructor() {
+    super(...arguments);
+
+    this.pipeline = this.pipelinePageState.getPipeline();
+
+    const sonar = this.pipeline.badges?.sonar;
+
+    this.hasBadge = !!sonar;
+    if (this.hasBadge) {
+      this.badgeName = sonar.name;
+      this.badgeUri = sonar.uri;
+    }
+  }
+
+  get isDisabled() {
+    if (this.isAwaitingResponse) {
+      return true;
+    }
+
+    if (this.hasBadge) {
+      const { sonar } = this.pipeline.badges;
+
+      return this.badgeName === sonar.name && this.badgeUri === sonar.uri;
+    }
+
+    return !this.badgeName && !this.badgeUri;
+  }
+
+  @action
+  async updateBadge() {
+    this.isAwaitingResponse = true;
+
+    const body = {
+      badges: {
+        sonar: {}
+      }
+    };
+
+    if (this.badgeName) {
+      body.badges.sonar.name = this.badgeName;
+    }
+    if (this.badgeUri) {
+      body.badges.sonar.uri = this.badgeUri;
+    }
+
+    return this.shuttle
+      .fetchFromApi('put', `/pipelines/${this.pipeline.id}`, body)
+      .then(pipeline => {
+        this.pipelinePageState.setPipeline(pipeline);
+        this.pipelinePageState.forceReloadPipelineHeader();
+        this.args.closeModal(true);
+      })
+      .catch(err => {
+        this.errorMessage = err.message;
+        this.isAwaitingResponse = false;
+      });
+  }
+}

--- a/app/components/pipeline/settings/main/modal/sonar-badge/styles.scss
+++ b/app/components/pipeline/settings/main/modal/sonar-badge/styles.scss
@@ -1,0 +1,21 @@
+@use 'screwdriver-colors' as colors;
+
+@mixin styles {
+  #edit-sonar-badge-modal {
+    .modal-body {
+      .configuration-container {
+        label {
+          display: flex;
+          flex-direction: column;
+        }
+
+        input {
+          background-color: colors.$sd-flyout-bg;
+          border-radius: 3px;
+          border: 1px solid colors.$sd-light-gray;
+          padding: 0.375rem 0.75rem;
+        }
+      }
+    }
+  }
+}

--- a/app/components/pipeline/settings/main/modal/sonar-badge/template.hbs
+++ b/app/components/pipeline/settings/main/modal/sonar-badge/template.hbs
@@ -1,0 +1,52 @@
+<BsModal
+  id="edit-sonar-badge-modal"
+  @onHide={{fn @closeModal}}
+  as |modal|
+>
+  <modal.header>
+    <div class="modal-title">
+      Edit sonar badge configuration
+    </div>
+  </modal.header>
+  <modal.body>
+    {{#if this.errorMessage}}
+      <InfoMessage
+        @message={{this.errorMessage}}
+        @type="warning"
+        @icon="triangle-exclamation"
+        @dismissible={{false}}
+      />
+    {{/if}}
+
+    <div class="configuration-container">
+      <label>
+        Name
+        <Input
+          id="sonar-badge-name-input"
+          @type="text"
+          @value={{this.badgeName}}
+          placeholder="Sonar badge name"
+        />
+      </label>
+      <label>
+        URI
+        <Input
+          id="sonar-badge-uri-input"
+          @type="text"
+          @value={{this.badgeUri}}
+          placeholder="Sonar badge URI"
+        />
+      </label>
+    </div>
+  </modal.body>
+  <modal.footer>
+    <BsButton
+      id="submit-action"
+      @type="primary"
+      @defaultText="Update"
+      @pendingText="Updating..."
+      @onClick={{fn this.updateBadge}}
+      disabled={{this.isDisabled}}
+    />
+  </modal.footer>
+</BsModal>

--- a/app/pipeline-page-state/service.js
+++ b/app/pipeline-page-state/service.js
@@ -13,6 +13,8 @@ export default class PipelinePageStateService extends Service {
 
   isPr;
 
+  onForceReloadPipelineHeader;
+
   clear() {
     this.pipeline = null;
     this.childPipelines = [];
@@ -20,6 +22,7 @@ export default class PipelinePageStateService extends Service {
     this.stages = [];
     this.jobs = [];
     this.isPr = false;
+    this.onForceReloadPipelineHeader = null;
   }
 
   setPipeline(pipeline) {
@@ -72,5 +75,15 @@ export default class PipelinePageStateService extends Service {
 
   getIsPr() {
     return this.isPr;
+  }
+
+  setOnForceReloadPipelineHeader(callback) {
+    this.onForceReloadPipelineHeader = callback;
+  }
+
+  forceReloadPipelineHeader() {
+    if (this.onForceReloadPipelineHeader) {
+      this.onForceReloadPipelineHeader();
+    }
   }
 }

--- a/tests/integration/components/pipeline/settings/main/modal/sonar-badge/component-test.js
+++ b/tests/integration/components/pipeline/settings/main/modal/sonar-badge/component-test.js
@@ -1,0 +1,136 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
+import { click, fillIn, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+
+module(
+  'Integration | Component | pipeline/settings/main/modal/sonar-badge',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    let pipelinePageState;
+
+    let shuttle;
+
+    const pipelineMock = {
+      id: 123,
+      badges: {
+        sonar: {
+          name: 'sonar',
+          uri: 'https://sonar.example.com/badge'
+        }
+      }
+    };
+
+    hooks.beforeEach(function () {
+      pipelinePageState = this.owner.lookup('service:pipeline-page-state');
+      shuttle = this.owner.lookup('service:shuttle');
+
+      sinon.stub(pipelinePageState, 'getPipeline').returns(pipelineMock);
+    });
+
+    test('it renders', async function (assert) {
+      this.setProperties({
+        closeModal: () => {}
+      });
+
+      await render(
+        hbs`<Pipeline::Settings::Main::Modal::SonarBadge
+            @closeModal={{this.closeModal}}
+        />`
+      );
+
+      assert.dom('.modal-title').exists();
+      assert.dom('#sonar-badge-name-input').exists();
+      assert.dom('#sonar-badge-uri-input').exists();
+      assert.dom('#submit-action').exists();
+    });
+
+    test('it enables submit button correctly', async function (assert) {
+      this.setProperties({
+        closeModal: () => {}
+      });
+
+      await render(
+        hbs`<Pipeline::Settings::Main::Modal::SonarBadge
+            @closeModal={{this.closeModal}}
+        />`
+      );
+
+      assert.dom('#submit-action').isDisabled();
+      await fillIn('#sonar-badge-name-input', 'updated');
+      assert.dom('#submit-action').isEnabled();
+      await fillIn('#sonar-badge-name-input', pipelineMock.badges.sonar.name);
+      assert.dom('#submit-action').isDisabled();
+      await fillIn('#sonar-badge-uri-input', 'https://test.com');
+      assert.dom('#submit-action').isEnabled();
+      await fillIn('#sonar-badge-uri-input', pipelineMock.badges.sonar.uri);
+      assert.dom('#submit-action').isDisabled();
+      await fillIn('#sonar-badge-name-input', '');
+      assert.dom('#submit-action').isEnabled();
+      await fillIn('#sonar-badge-uri-input', '');
+      assert.dom('#submit-action').isEnabled();
+    });
+
+    test('it handles failed API call correctly', async function (assert) {
+      this.setProperties({
+        closeModal: () => {}
+      });
+
+      const errorMessage = 'Failed to update sonar badge';
+
+      sinon.stub(shuttle, 'fetchFromApi').rejects({
+        message: errorMessage
+      });
+
+      await render(
+        hbs`<Pipeline::Settings::Main::Modal::SonarBadge
+            @closeModal={{this.closeModal}}
+        />`
+      );
+      await fillIn('#sonar-badge-name-input', 'updated');
+      await click('#submit-action');
+
+      assert.dom('.modal-body .alert.alert-warning').exists();
+      assert
+        .dom('.modal-body .alert.alert-warning > span')
+        .hasText(errorMessage);
+      assert.dom('#submit-action').isEnabled();
+    });
+
+    test('it handles successful API call correctly', async function (assert) {
+      const setPipelineSpy = sinon.spy(pipelinePageState, 'setPipeline');
+      const reloadHeaderSpy = sinon.spy(
+        pipelinePageState,
+        'forceReloadPipelineHeader'
+      );
+      const closeModalSpy = sinon.spy();
+      const updatedPipeline = {
+        ...pipelineMock,
+        badges: {
+          sonar: {}
+        }
+      };
+
+      sinon.stub(shuttle, 'fetchFromApi').resolves(updatedPipeline);
+
+      this.setProperties({
+        closeModal: closeModalSpy
+      });
+
+      await render(
+        hbs`<Pipeline::Settings::Main::Modal::SonarBadge
+            @closeModal={{this.closeModal}}
+        />`
+      );
+      await fillIn('#sonar-badge-name-input', '');
+      await fillIn('#sonar-badge-uri-input', '');
+      await click('#submit-action');
+
+      assert.equal(setPipelineSpy.calledOnceWith(updatedPipeline), true);
+      assert.equal(reloadHeaderSpy.calledOnce, true);
+      assert.equal(closeModalSpy.calledOnceWith(true), true);
+    });
+  }
+);


### PR DESCRIPTION
## Context
Updating the pipeline settings to a v2 UI to better handle a number of different shortcomings especially around pipelines with many jobs.

## Objective
Creates a modal to update Sonar badge settings
<img width="2052" height="546" alt="Screenshot 2025-07-30 at 11-53-01 minghay_various Settings" src="https://github.com/user-attachments/assets/531fc4a7-5a1b-46e0-bf84-9a5b7b20e0aa" />

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
