### PR TITLE
feat: Component for main pipeline options configuration

### DIFF
--- a/app/components/pipeline/settings/main/component.js
+++ b/app/components/pipeline/settings/main/component.js
@@ -1,0 +1,113 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+
+import { getCheckoutUrl } from 'screwdriver-ui/utils/git';
+
+export default class PipelineSettingsMainComponent extends Component {
+  @service router;
+
+  @service('pipeline-page-state') pipelinePageState;
+
+  @tracked isUpdatePipelineModalOpen = false;
+
+  @tracked isUpdatePipelineAliasModalOpen = false;
+
+  @tracked isUpdateSonarBadgeModalOpen = false;
+
+  @tracked isDeletePipelineModalOpen = false;
+
+  @tracked pipeline;
+
+  constructor() {
+    super(...arguments);
+
+    this.pipeline = this.pipelinePageState.getPipeline();
+  }
+
+  get checkoutUrl() {
+    return getCheckoutUrl({
+      appId: this.pipeline.scmRepo.name,
+      scmUri: this.pipeline.scmUri
+    });
+  }
+
+  get sonarBadgeName() {
+    return this.pipeline.badges?.sonar?.name;
+  }
+
+  get sonarBadgeUri() {
+    return this.pipeline.badges?.sonar?.uri;
+  }
+
+  get pipelineAdmins() {
+    const admins = [];
+
+    Object.entries(this.pipelinePageState.getPipeline().admins).forEach(
+      ([username, isAdmin]) => {
+        if (isAdmin) {
+          admins.push(username);
+        }
+      }
+    );
+
+    return admins.sort().join(', ');
+  }
+
+  @action
+  showUpdatePipelineModal() {
+    this.isUpdatePipelineModalOpen = true;
+  }
+
+  @action
+  closeUpdatePipelineModal(wasUpdated) {
+    this.isUpdatePipelineModalOpen = false;
+
+    if (wasUpdated) {
+      this.pipeline = this.pipelinePageState.getPipeline();
+    }
+  }
+
+  @action
+  showUpdatePipelineAliasModal() {
+    this.isUpdatePipelineAliasModalOpen = true;
+  }
+
+  @action
+  closeUpdatePipelineAliasModal(wasUpdated) {
+    this.isUpdatePipelineAliasModalOpen = false;
+
+    if (wasUpdated) {
+      this.pipeline = this.pipelinePageState.getPipeline();
+    }
+  }
+
+  @action
+  showUpdateSonarBadgeModal() {
+    this.isUpdateSonarBadgeModalOpen = true;
+  }
+
+  @action
+  closeUpdateSonarBadgeModal(wasUpdated) {
+    this.isUpdateSonarBadgeModalOpen = false;
+
+    if (wasUpdated) {
+      this.pipeline = this.pipelinePageState.getPipeline();
+    }
+  }
+
+  @action
+  showDeletePipelineModal() {
+    this.isDeletePipelineModalOpen = true;
+  }
+
+  @action
+  closeDeletePipelineModal(pipelineDeleted) {
+    this.isDeletePipelineModalOpen = false;
+
+    if (pipelineDeleted) {
+      this.router.transitionTo('home');
+    }
+  }
+}

--- a/app/components/pipeline/settings/main/styles.scss
+++ b/app/components/pipeline/settings/main/styles.scss
@@ -1,0 +1,46 @@
+@use 'screwdriver-colors' as colors;
+@use 'variables';
+
+@use 'modal/pipeline/styles' as pipelineModal;
+@use 'modal/pipeline-alias/styles' as pipelineAliasModal;
+@use 'modal/sonar-badge/styles' as sonarBadgeModal;
+
+@mixin modalStyles {
+  @include pipelineModal.styles;
+  @include pipelineAliasModal.styles;
+  @include sonarBadgeModal.styles;
+}
+
+@mixin styles {
+  #pipeline-settings-main-tab-contents {
+    .section {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+
+      .text-container {
+        .configuration {
+          margin-top: 0.5rem;
+          margin-left: 1rem;
+          font-style: italic;
+        }
+
+        .pipeline-admin-list {
+          font-weight: variables.$weight-bold;
+          margin-top: 1rem;
+          margin-left: 1rem;
+          max-height: 5rem;
+          overflow: auto;
+        }
+      }
+
+      button {
+        margin-right: 1rem;
+      }
+
+      &.pipeline-settings-danger-zone {
+        border-color: colors.$sd-warn-bg;
+      }
+    }
+  }
+}

--- a/app/components/pipeline/settings/main/template.hbs
+++ b/app/components/pipeline/settings/main/template.hbs
@@ -1,0 +1,133 @@
+<div id="pipeline-settings-main-tab-contents">
+  <div class="section">
+    <div class="text-container">
+      <div class="title">
+        Checkout URL and source directory
+      </div>
+      <div>
+        Update your checkout URL and / or source directory.
+      </div>
+
+      <div class="configuration">
+        <div id="pipeline-settings-main-checkout-url">Checkout URL: {{this.checkoutUrl}}</div>
+        <div id="pipeline-settings-main-checkout-directory">Source directory: {{this.pipeline.scmRepo.rootDir}}</div>
+      </div>
+    </div>
+
+    <BsButton
+      @type="primary"
+      @onClick={{this.showUpdatePipelineModal}}
+      @outline={{true}}
+      title="Edit pipeline alias"
+    >
+      <FaIcon @icon="pen" />
+      {{#if this.isUpdatePipelineModalOpen}}
+        <Pipeline::Settings::Main::Modal::Pipeline
+          @closeModal={{this.closeUpdatePipelineModal}}
+        />
+      {{/if}}
+    </BsButton>
+  </div>
+
+  <div class="section">
+    <div class="text-container">
+      <div class="title">
+        Pipeline alias
+      </div>
+      <div>
+        Set your preferred pipeline name for the dashboard view.
+      </div>
+
+      <div class="configuration">
+        <div id="pipeline-settings-main-alias">Alias: {{this.pipeline.settings.aliasName}}</div>
+      </div>
+    </div>
+
+    <BsButton
+      @type="primary"
+      @onClick={{this.showUpdatePipelineAliasModal}}
+      @outline={{true}}
+      title="Edit pipeline alias"
+    >
+      <FaIcon @icon="pen" />
+      {{#if this.isUpdatePipelineAliasModalOpen}}
+        <Pipeline::Settings::Main::Modal::PipelineAlias
+          @closeModal={{this.closeUpdatePipelineAliasModal}}
+        />
+      {{/if}}
+    </BsButton>
+  </div>
+
+  <div class="section">
+    <div class="text-container">
+      <div class="title">
+        Sonar Badge
+      </div>
+      <div>
+        Customize your sonar badge dashboard and link
+      </div>
+
+      <div class="configuration">
+        <div id="pipeline-settings-main-sonar-badge-name">Badge name: {{this.sonarBadgeName}}</div>
+        <div id="pipeline-settings-main-sonar-badge-uri">Badge URI: {{this.sonarBadgeUri}}</div>
+      </div>
+    </div>
+
+    <BsButton
+      @type="primary"
+      @onClick={{this.showUpdateSonarBadgeModal}}
+      @outline={{true}}
+      title="Edit pipeline alias"
+    >
+      <FaIcon @icon="pen" />
+      {{#if this.isUpdateSonarBadgeModalOpen}}
+        <Pipeline::Settings::Main::Modal::SonarBadge
+          @closeModal={{this.closeUpdateSonarBadgeModal}}
+        />
+      {{/if}}
+    </BsButton>
+  </div>
+
+  <div class="section">
+    <div class="text-container">
+      <div class="title">
+        Admins
+      </div>
+      <div>
+        Users with admin permission to this pipeline.
+        <FaIcon
+          @icon="circle-question"
+          @title="If you have write access to the repository, you can become a pipeline admin by starting/stopping builds or syncing the pipeline."
+        />
+      </div>
+
+      <div class="pipeline-admin-list">
+        {{this.pipelineAdmins}}
+      </div>
+    </div>
+  </div>
+
+  <div class="section pipeline-settings-danger-zone">
+    <div class="text-container">
+      <div class="title">
+        Delete this pipeline
+      </div>
+      <div>
+        Once you delete a pipeline, there is no going back.
+      </div>
+    </div>
+    <BsButton
+      @type="danger"
+      @onClick={{this.showDeletePipelineModal}}
+      title="Delete pipeline"
+    >
+      <FaIcon @icon="trash" />
+      {{#if this.isDeletePipelineModalOpen}}
+        <Pipeline::Modal::DeletePipeline
+          @pipeline={{this.pipeline}}
+          @closeModal={{this.closeDeletePipelineModal}}
+        />
+      {{/if}}
+    </BsButton>
+  </div>
+</div>

--- a/tests/integration/components/pipeline/settings/main/component-test.js
+++ b/tests/integration/components/pipeline/settings/main/component-test.js
@@ -1,0 +1,32 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+
+module('Integration | Component | pipeline/settings/main', function (hooks) {
+  setupRenderingTest(hooks);
+
+  let pipelinePageState;
+
+  let pipelineMock;
+
+  hooks.beforeEach(function () {
+    pipelinePageState = this.owner.lookup('service:pipeline-page-state');
+
+    pipelineMock = {
+      scmRepo: { name: 'myOrg/myRepo' },
+      scmUri: 'github.com:12345:master',
+      admins: {}
+    };
+
+    sinon.stub(pipelinePageState, 'getPipeline').returns(pipelineMock);
+  });
+
+  test('it renders', async function (assert) {
+    await render(hbs`<Pipeline::Settings::Main />`);
+
+    assert.dom('.section').exists({ count: 5 });
+    assert.dom('.pipeline-settings-danger-zone').exists();
+  });
+});


### PR DESCRIPTION
## Context
Updating the pipeline settings to a v2 UI to better handle a number of different shortcomings especially around pipelines with many jobs.

## Objective
Creates a component for configuration and displaying primary pipeline settings

<img width="1702" height="1198" alt="Screenshot 2025-08-01 at 10-55-26 minghay_various Settings" src="https://github.com/user-attachments/assets/0b1c6715-e082-4a84-9b3c-b205bd92df06" />

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
