### PR TITLE
fix: Reactor to more easily shared utility

### DIFF
--- a/app/components/pipeline/jobs/table/component.js
+++ b/app/components/pipeline/jobs/table/component.js
@@ -6,8 +6,12 @@ import { dom } from '@fortawesome/fontawesome-svg-core';
 import _ from 'lodash';
 import { statuses } from 'screwdriver-ui/utils/build';
 import { isComplete } from 'screwdriver-ui/utils/pipeline/event';
+import {
+  getDisplayName,
+  getStageName
+} from 'screwdriver-ui/utils/pipeline/job';
 import DataReloader from './dataReloader';
-import { getDisplayName, getStageName, sortJobs } from './util';
+import sortJobs from './util';
 
 const INITIAL_PAGE_SIZE = 10;
 

--- a/app/components/pipeline/jobs/table/cost-table/component.js
+++ b/app/components/pipeline/jobs/table/cost-table/component.js
@@ -5,8 +5,9 @@ import { tracked } from '@glimmer/tracking';
 import { dom } from '@fortawesome/fontawesome-svg-core';
 import _ from 'lodash';
 import { isComplete } from 'screwdriver-ui/utils/pipeline/event';
+import { getDisplayName } from 'screwdriver-ui/utils/pipeline/job';
 import DataReloader from '../dataReloader';
-import { getDisplayName, sortJobs } from '../util';
+import sortJobs from '../util';
 
 const INITIAL_PAGE_SIZE = 10;
 

--- a/app/components/pipeline/jobs/table/util.js
+++ b/app/components/pipeline/jobs/table/util.js
@@ -1,34 +1,8 @@
 /**
- * Get the display name of the job.  Uses the display name configured in the annotation if available.
- * @param job {Object} Job in the format returned by the API
- * @param prNum {Number} PR number
- * @returns {string}
- */
-export function getDisplayName(job, prNum) {
-  const jobName = prNum ? job.name.slice(`PR-${prNum}:`.length) : job.name;
-  const { annotations } = job?.permutations?.[0] || {};
-
-  if (annotations) {
-    return annotations['screwdriver.cd/displayName'] || jobName;
-  }
-
-  return jobName;
-}
-
-/**
- * Get the stage name of the job.
- * @param job {Object} Job in the format returned by the API
- * @returns {string}
- */
-export function getStageName(job) {
-  return job?.permutations?.[0]?.stage?.name;
-}
-
-/**
  * Comparator function that sorts jobs by the build status first, then stage name, and finally job name.
  * When sorting by build status, the ordering is ordered by the status color: red, yellow, blue, green, grey, no-status (i.e., jobs that did not run).
  */
-export function sortJobs(a, b) {
+export default function sortJobs(a, b) {
   const statusA = a.build?.status;
   const statusB = b.build?.status;
 

--- a/app/utils/pipeline/job.js
+++ b/app/utils/pipeline/job.js
@@ -1,0 +1,25 @@
+/**
+ * Get the display name of the job.  Uses the display name configured in the annotation if available.
+ * @param job {Object} Job in the format returned by the API
+ * @param prNum {Number} PR number
+ * @returns {string}
+ */
+export function getDisplayName(job, prNum) {
+  const jobName = prNum ? job.name.slice(`PR-${prNum}:`.length) : job.name;
+  const { annotations } = job?.permutations?.[0] || {};
+
+  if (annotations) {
+    return annotations['screwdriver.cd/displayName'] || jobName;
+  }
+
+  return jobName;
+}
+
+/**
+ * Get the stage name of the job.
+ * @param job {Object} Job in the format returned by the API
+ * @returns {string}
+ */
+export function getStageName(job) {
+  return job?.permutations?.[0]?.stage?.name;
+}

--- a/tests/unit/components/pipeline/jobs/table/util-test.js
+++ b/tests/unit/components/pipeline/jobs/table/util-test.js
@@ -1,60 +1,7 @@
 import { module, test } from 'qunit';
-import {
-  getDisplayName,
-  getStageName,
-  sortJobs
-} from 'screwdriver-ui/components/pipeline/jobs/table/util';
+import sortJobs from 'screwdriver-ui/components/pipeline/jobs/table/util';
 
 module('Unit | Component | pipeline/jobs/table/util', function () {
-  test('getDisplayName uses job name', function (assert) {
-    const job = { name: 'abc123' };
-
-    assert.equal(getDisplayName(job), job.name);
-  });
-
-  test('getDisplayName uses configured annotation name', function (assert) {
-    const configuredName = 'configuredName';
-    const job = {
-      name: 'abc123',
-      permutations: [
-        { annotations: { 'screwdriver.cd/displayName': configuredName } }
-      ]
-    };
-
-    assert.equal(getDisplayName(job), configuredName);
-  });
-
-  test('getDisplayName removes PR- prefix', function (assert) {
-    const prNum = 123;
-    const job = { name: `PR-${prNum}:abc123` };
-
-    assert.equal(getDisplayName(job, prNum), 'abc123');
-  });
-
-  test('getStageName uses stage name', function (assert) {
-    const job = {
-      name: 'abc123',
-      permutations: [
-        {
-          stage: {
-            name: 'production'
-          }
-        }
-      ]
-    };
-
-    assert.equal(getStageName(job), job.permutations[0].stage.name);
-  });
-
-  test('getStageName returns null when stage name when it does not exist', function (assert) {
-    const job = {
-      name: 'abc123',
-      permutations: [{}]
-    };
-
-    assert.equal(getStageName(job), undefined);
-  });
-
   test('sortJobs compares jobs correctly', function (assert) {
     assert.equal(
       sortJobs(

--- a/tests/unit/utils/pipeline/job-test.js
+++ b/tests/unit/utils/pipeline/job-test.js
@@ -1,0 +1,56 @@
+import { module, test } from 'qunit';
+import {
+  getDisplayName,
+  getStageName
+} from 'screwdriver-ui/utils/pipeline/job';
+
+module('Unit | Component | pipeline/jobs/table/util', function () {
+  test('getDisplayName uses job name', function (assert) {
+    const job = { name: 'abc123' };
+
+    assert.equal(getDisplayName(job), job.name);
+  });
+
+  test('getDisplayName uses configured annotation name', function (assert) {
+    const configuredName = 'configuredName';
+    const job = {
+      name: 'abc123',
+      permutations: [
+        { annotations: { 'screwdriver.cd/displayName': configuredName } }
+      ]
+    };
+
+    assert.equal(getDisplayName(job), configuredName);
+  });
+
+  test('getDisplayName removes PR- prefix', function (assert) {
+    const prNum = 123;
+    const job = { name: `PR-${prNum}:abc123` };
+
+    assert.equal(getDisplayName(job, prNum), 'abc123');
+  });
+
+  test('getStageName uses stage name', function (assert) {
+    const job = {
+      name: 'abc123',
+      permutations: [
+        {
+          stage: {
+            name: 'production'
+          }
+        }
+      ]
+    };
+
+    assert.equal(getStageName(job), job.permutations[0].stage.name);
+  });
+
+  test('getStageName returns null when stage name when it does not exist', function (assert) {
+    const job = {
+      name: 'abc123',
+      permutations: [{}]
+    };
+
+    assert.equal(getStageName(job), undefined);
+  });
+});


### PR DESCRIPTION
## Context
Some job utility functions should be refactored to a more shareable utility

## Objective
Refactors the utility functions for extracting a job's display name and stage into a more shareable utility

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
