### PR TITLE
feat: Modal for managing job metrics settings

### DIFF
--- a/app/components/pipeline/settings/metrics/modal/toggle/component.js
+++ b/app/components/pipeline/settings/metrics/modal/toggle/component.js
@@ -1,0 +1,93 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import getJobIdsForPayload from './util';
+
+export default class PipelineSettingsMetricsModalToggleComponent extends Component {
+  @service('shuttle') shuttle;
+
+  @service('pipeline-page-state') pipelinePageState;
+
+  @tracked errorMessage = null;
+
+  @tracked isDisabled = false;
+
+  jobs;
+
+  isInclude;
+
+  constructor() {
+    super(...arguments);
+
+    this.jobs = this.args.jobs;
+    this.isInclude = this.args.isInclude;
+  }
+
+  get modalTitle() {
+    const toggleAction = this.isInclude ? 'Include' : 'Exclude';
+
+    if (this.jobs.length === 1) {
+      return `${toggleAction} ${this.jobs[0].name}?`;
+    }
+
+    return `${toggleAction} ${this.jobs.length} jobs?`;
+  }
+
+  get toggleJobsMessage() {
+    const toggleAction = this.isInclude ? 'include' : 'exclude';
+
+    if (this.jobs.length === 1) {
+      return `Are you sure you want to ${toggleAction} this job in your downtime metrics?`;
+    }
+
+    return `Are you sure you want to ${toggleAction} the following jobs in your downtime metrics?`;
+  }
+
+  get jobNames() {
+    return this.jobs
+      .map(job => job.name)
+      .sort()
+      .join(', ');
+  }
+
+  get toggleAction() {
+    return this.isInclude ? 'Include' : 'Exclude';
+  }
+
+  get pendingActionText() {
+    return this.isInclude ? 'Including' : 'Excluding';
+  }
+
+  @action
+  async toggleJobs() {
+    this.isDisabled = true;
+
+    const jobIdsPayload = getJobIdsForPayload(
+      this.pipelinePageState.getPipeline(),
+      this.jobs,
+      this.isInclude
+    );
+
+    const payload = {
+      settings: {
+        metricsDowntimeJobs: jobIdsPayload
+      }
+    };
+
+    return this.shuttle
+      .fetchFromApi(
+        'put',
+        `/pipelines/${this.pipelinePageState.getPipelineId()}`,
+        payload
+      )
+      .then(response => {
+        this.pipelinePageState.setPipeline(response);
+        this.args.closeModal(true);
+      })
+      .catch(err => {
+        this.isDisabled = false;
+        this.errorMessage = err.message;
+      });
+  }
+}

--- a/app/components/pipeline/settings/metrics/modal/toggle/styles.scss
+++ b/app/components/pipeline/settings/metrics/modal/toggle/styles.scss
@@ -1,0 +1,11 @@
+@mixin styles {
+  #toggle-multiple-downtime-jobs-modal {
+    .modal-body {
+      .toggle-jobs-list {
+        height: 4rem;
+        overflow: auto;
+        margin: 1rem 0;
+      }
+    }
+  }
+}

--- a/app/components/pipeline/settings/metrics/modal/toggle/template.hbs
+++ b/app/components/pipeline/settings/metrics/modal/toggle/template.hbs
@@ -1,0 +1,41 @@
+<BsModal
+  id="toggle-multiple-downtime-jobs-modal"
+  @onHide={{fn @closeModal}}
+  as |modal|
+>
+  <modal.header>
+    <div class="modal-title">
+      {{this.modalTitle}}
+    </div>
+  </modal.header>
+  <modal.body>
+    {{#if this.errorMessage}}
+      <InfoMessage
+        @message={{this.errorMessage}}
+        @type="warning"
+        @icon="triangle-exclamation"
+        @dismissible={{false}}
+      />
+    {{/if}}
+
+    <div id="modal-downtime-jobs-message">
+      {{this.toggleJobsMessage}}
+    </div>
+
+    {{#if (gt this.jobs.length 1)}}
+      <div class="toggle-jobs-list">
+        {{this.jobNames}}
+      </div>
+    {{/if}}
+  </modal.body>
+  <modal.footer>
+    <BsButton
+      id="submit-action"
+      @type="primary"
+      @defaultText={{this.toggleAction}}
+      @pendingText={{this.pendingActionText}}
+      @onClick={{fn this.toggleJobs}}
+      disabled={{this.isDisabled}}
+    />
+  </modal.footer>
+</BsModal>

--- a/app/components/pipeline/settings/metrics/modal/toggle/util.js
+++ b/app/components/pipeline/settings/metrics/modal/toggle/util.js
@@ -1,0 +1,31 @@
+/**
+ * Utility function to get job ids for payload based on the pipeline and jobs provided.
+ * @param pipeline Pipeline object returned from the API
+ * @param jobs Array of job objects
+ * @param isInclude Boolean indicating whether to include or exclude jobs
+ * @return {Array} Array of job ids
+ */
+export default function getJobIdsForPayload(pipeline, jobs, isInclude) {
+  const includedJobs = pipeline.settings.metricsDowntimeJobs || [];
+  const jobIdsPayload = [];
+
+  if (isInclude) {
+    const jobIdsToInclude = new Set(includedJobs);
+
+    jobs.forEach(job => {
+      jobIdsToInclude.add(job.id);
+    });
+
+    jobIdsPayload.push(...Array.from(jobIdsToInclude));
+  } else {
+    const jobIdsToExclude = new Set(includedJobs);
+
+    jobs.forEach(job => {
+      jobIdsToExclude.delete(job.id);
+    });
+
+    jobIdsPayload.push(...Array.from(jobIdsToExclude));
+  }
+
+  return jobIdsPayload.sort();
+}

--- a/tests/integration/components/pipeline/settings/metrics/modal/toggle/component-test.js
+++ b/tests/integration/components/pipeline/settings/metrics/modal/toggle/component-test.js
@@ -1,0 +1,126 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
+import { click, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+
+module(
+  'Integration | Component | pipeline/settings/metrics/modal/toggle',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    let shuttle;
+
+    let pipelinePageState;
+
+    let mockPipeline;
+
+    hooks.beforeEach(function () {
+      shuttle = this.owner.lookup('service:shuttle');
+      pipelinePageState = this.owner.lookup('service:pipeline-page-state');
+
+      mockPipeline = {
+        id: 123,
+        settings: {}
+      };
+
+      sinon.stub(pipelinePageState, 'getPipeline').returns(mockPipeline);
+      sinon.stub(pipelinePageState, 'getPipelineId').returns(mockPipeline.id);
+    });
+
+    test('it renders', async function (assert) {
+      this.setProperties({
+        jobs: [{ id: 123, name: 'job1' }],
+        closeModal: () => {}
+      });
+
+      await render(
+        hbs`<Pipeline::Settings::Metrics::Modal::Toggle
+          @jobs={{this.jobs}}
+          @isInclude={{true}}
+          @closeModal={{this.closeModal}}
+        />`
+      );
+
+      assert.dom('.modal-title').exists();
+      assert.dom('#modal-downtime-jobs-message').exists();
+      assert.dom('.toggle-jobs-list').doesNotExist();
+      assert.dom('#submit-action').exists();
+    });
+
+    test('it renders for multiple jobs', async function (assert) {
+      this.setProperties({
+        jobs: [
+          { id: 123, name: 'job1' },
+          { id: 987, name: 'job2' }
+        ],
+        closeModal: () => {}
+      });
+
+      await render(
+        hbs`<Pipeline::Settings::Metrics::Modal::Toggle
+          @jobs={{this.jobs}}
+          @isInclude={{true}}
+          @closeModal={{this.closeModal}}
+        />`
+      );
+
+      assert.dom('.modal-title').exists();
+      assert.dom('#modal-downtime-jobs-message').exists();
+      assert.dom('.toggle-jobs-list').exists();
+      assert.dom('#submit-action').exists();
+    });
+
+    test('it handles failed API call correctly', async function (assert) {
+      sinon
+        .stub(shuttle, 'fetchFromApi')
+        .rejects({ message: 'API call failed' });
+
+      this.setProperties({
+        jobs: [{ id: 123, name: 'job1' }],
+        closeModal: () => {}
+      });
+
+      await render(
+        hbs`<Pipeline::Settings::Metrics::Modal::Toggle
+          @jobs={{this.jobs}}
+          @isInclude={{true}}
+          @closeModal={{this.closeModal}}
+        />`
+      );
+      await click('#submit-action');
+
+      assert.dom('.modal-title').exists();
+      assert.dom('#modal-downtime-jobs-message').exists();
+      assert.dom('.toggle-jobs-list').doesNotExist();
+      assert.dom('#submit-action').exists();
+    });
+
+    test('it handles successful API call correctly', async function (assert) {
+      const setPipelineSpy = sinon.spy(pipelinePageState, 'setPipeline');
+      const closeModalSpy = sinon.spy();
+      const mockResponse = {
+        id: 1
+      };
+
+      sinon.stub(shuttle, 'fetchFromApi').resolves(mockResponse);
+
+      this.setProperties({
+        jobs: [{ id: 123, name: 'job1' }],
+        closeModal: closeModalSpy
+      });
+
+      await render(
+        hbs`<Pipeline::Settings::Metrics::Modal::Toggle
+          @jobs={{this.jobs}}
+          @isInclude={{true}}
+          @closeModal={{this.closeModal}}
+        />`
+      );
+      await click('#submit-action');
+
+      assert.equal(setPipelineSpy.calledOnceWith(mockResponse), true);
+      assert.equal(closeModalSpy.calledOnceWith(true), true);
+    });
+  }
+);

--- a/tests/unit/components/pipeline/settings/metrics/modal/toggle/util-test.js
+++ b/tests/unit/components/pipeline/settings/metrics/modal/toggle/util-test.js
@@ -1,0 +1,45 @@
+import { module, test } from 'qunit';
+import getJobIdsForPayload from 'screwdriver-ui/components/pipeline/settings/metrics/modal/toggle/util';
+
+module(
+  'Unit | Component | pipeline/settings/metrics/modal/toggle/util',
+  function () {
+    const jobs = [{ id: 1 }, { id: 2 }];
+
+    test('getJobIdsForPayload adds jobs when none already exist', function (assert) {
+      const pipeline = {
+        settings: {}
+      };
+
+      assert.deepEqual(getJobIdsForPayload(pipeline, jobs, true), [1, 2]);
+    });
+
+    test('getJobIdsForPayload adds jobs when jobs already exist', function (assert) {
+      const pipeline = {
+        settings: {
+          metricsDowntimeJobs: [3]
+        }
+      };
+
+      assert.deepEqual(getJobIdsForPayload(pipeline, jobs, true), [1, 2, 3]);
+    });
+
+    test('getJobIdsForPayload remove jobs when none already exist', function (assert) {
+      const pipeline = {
+        settings: {}
+      };
+
+      assert.deepEqual(getJobIdsForPayload(pipeline, jobs, false), []);
+    });
+
+    test('getJobIdsForPayload remove jobs when none already exist', function (assert) {
+      const pipeline = {
+        settings: {
+          metricsDowntimeJobs: [1, 3]
+        }
+      };
+
+      assert.deepEqual(getJobIdsForPayload(pipeline, jobs, false), [3]);
+    });
+  }
+);


### PR DESCRIPTION
## Context
Updating the pipeline settings to a v2 UI to better handle a number of different shortcomings especially around pipelines with many jobs.

## Objective
Creates a component for managing pipeline jobs configuration for the metrics page.  

The modal supports including or excluding a job from the metrics:
<img width="2052" height="344" alt="Screenshot 2025-08-05 at 12-58-58 minghay_various Settings" src="https://github.com/user-attachments/assets/9a829e3f-40d2-4e9a-8ddc-8f0336821e64" />

The modal supports including or excluding multiple jobs from the metrics as a bulk action:
<img width="2052" height="512" alt="Screenshot 2025-08-05 at 12-59-49 minghay_various Settings" src="https://github.com/user-attachments/assets/92a2d3c6-3781-40cc-b2b2-a49501b5acdb" />

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
