### PR TITLE
fix: event duration shows 0 second when the last build is virtual

### DIFF
--- a/app/event/model.js
+++ b/app/event/model.js
@@ -99,6 +99,7 @@ export default Model.extend(ModelReloaderMixin, {
 
       if (this.isComplete) {
         lastEndTime = builds
+          .filter(item => item.endTime)
           .map(item => item.endTime)
           .sort()
           .pop();

--- a/tests/unit/event/model-test.js
+++ b/tests/unit/event/model-test.js
@@ -241,11 +241,16 @@ module('Unit | Model | event', function (hooks) {
       endTime: new Date(elapsed20secsTime),
       status: 'ABORTED'
     });
+    const build3 = this.owner.lookup('service:store').createRecord('build', {
+      jobId: 3,
+      createTime: new Date(eventStartTime),
+      status: 'SUCCESS'
+    });
     const model = run(() =>
       this.owner.lookup('service:store').createRecord('event')
     );
 
-    run(() => model.set('builds', [build2, build1]));
+    run(() => model.set('builds', [build2, build1, build3]));
 
     await settled();
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

The duration shows `0 seconds` when the last build is virtual since the virtual builds do not have `endTime`.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Filter the builds without `endTime` to get the last build's end time properly.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
