### PR TITLE
feat: Modal for webhooks sync

### DIFF
--- a/app/components/pipeline/settings/main/modal/sync/component.js
+++ b/app/components/pipeline/settings/main/modal/sync/component.js
@@ -1,0 +1,72 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+
+export default class PipelineSettingsMainModalSyncComponent extends Component {
+  @service('shuttle') shuttle;
+
+  @service('pipeline-page-state') pipelinePageState;
+
+  @tracked errorMessage;
+
+  @tracked isAwaitingResponse;
+
+  @tracked wasActionSuccessful;
+
+  get headerText() {
+    switch (this.args.syncType) {
+      case 'webhooks':
+        return 'Sync Webhooks';
+      case 'pullrequests':
+        return 'Sync Pull Requests';
+      default:
+        return 'Sync Pipeline';
+    }
+  }
+
+  get syncMessageText() {
+    switch (this.args.syncType) {
+      case 'webhooks':
+        return 'This will sync the webhooks for the pipeline.  Syncing webhooks will ensure that the pipeline will be notified of the corresponding actions taken in your repository.';
+      case 'pullrequests':
+        return 'This will sync the pull requests for the pipeline.  Syncing pull requests will ensure that the pull requests displayed in the pipeline are the same as those in your repository.';
+      default:
+        return 'This will sync the pipeline to ensure that various settings and configurations of your pipeline are displayed properly.';
+    }
+  }
+
+  get isSubmitButtonDisabled() {
+    return !!(this.wasActionSuccessful || this.isAwaitingResponse);
+  }
+
+  @action
+  async sync() {
+    this.isAwaitingResponse = true;
+
+    let url = `/pipelines/${this.pipelinePageState.getPipelineId()}/sync`;
+
+    switch (this.args.syncType) {
+      case 'webhooks':
+      case 'pullrequests':
+        url += `/${this.args.syncType}`;
+        break;
+      default:
+        break;
+    }
+
+    return this.shuttle
+      .fetchFromApi('post', url)
+      .then(() => {
+        this.wasActionSuccessful = true;
+        this.args.closeModal();
+      })
+      .catch(err => {
+        this.wasActionSuccessful = false;
+        this.errorMessage = err.message;
+      })
+      .finally(() => {
+        this.isAwaitingResponse = false;
+      });
+  }
+}

--- a/app/components/pipeline/settings/main/modal/sync/template.hbs
+++ b/app/components/pipeline/settings/main/modal/sync/template.hbs
@@ -1,0 +1,34 @@
+<BsModal
+  id="pipeline-settings-sync-modal"
+  @onHide={{fn @closeModal}}
+  as |modal|
+>
+  <modal.header>
+    {{this.headerText}}
+  </modal.header>
+  <modal.body>
+    {{#if this.errorMessage}}
+      <InfoMessage
+        id="error-message"
+        @message={{this.errorMessage}}
+        @type="warning"
+        @icon="triangle-exclamation"
+      />
+    {{/if}}
+
+    <div>
+      {{this.syncMessageText}}
+    </div>
+  </modal.body>
+  <modal.footer>
+    <BsButton
+      id="submit-sync-button"
+      class="confirm"
+      disabled={{this.isSubmitButtonDisabled}}
+      @defaultText="Sync"
+      @pendingText="Syncing"
+      @type="primary"
+      @onClick={{fn this.sync}}
+    />
+  </modal.footer>
+</BsModal>

--- a/tests/integration/components/pipeline/settings/main/modal/sync/component-test.js
+++ b/tests/integration/components/pipeline/settings/main/modal/sync/component-test.js
@@ -1,0 +1,88 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
+import { click, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+
+module(
+  'Integration | Component | pipeline/settings/main/modal/sync',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    let shuttle;
+
+    hooks.beforeEach(function () {
+      const pipelinePageStateService = this.owner.lookup(
+        'service:pipelinePageState'
+      );
+
+      shuttle = this.owner.lookup('service:shuttle');
+
+      sinon.stub(pipelinePageStateService, 'getPipelineId').returns(1);
+    });
+
+    test('it renders', async function (assert) {
+      this.setProperties({
+        syncType: 'webhooks',
+        closeModal: () => {}
+      });
+
+      await render(
+        hbs`<Pipeline::Settings::Main::Modal::Sync
+            @syncType={{this.syncType}}
+            @closeModal={{this.closeModal}}
+        />`
+      );
+
+      assert.dom('.modal-header').hasText('Sync Webhooks ×');
+      assert.dom('#error-message').doesNotExist();
+      assert.dom('#submit-sync-button').exists();
+      assert.dom('#submit-sync-button').isEnabled();
+    });
+
+    test('it handles API error correctly', async function (assert) {
+      sinon.stub(shuttle, 'fetchFromApi').rejects({ message: 'error' });
+
+      this.setProperties({
+        syncType: 'webhooks',
+        closeModal: () => {}
+      });
+
+      await render(
+        hbs`<Pipeline::Settings::Main::Modal::Sync
+            @syncType={{this.syncType}}
+            @closeModal={{this.closeModal}}
+        />`
+      );
+
+      await click('#submit-sync-button');
+
+      assert.dom('#error-message').exists();
+      assert.dom('#submit-sync-button').isNotDisabled();
+    });
+
+    test('it handles API success correctly', async function (assert) {
+      const closeModalSpy = sinon.spy();
+
+      sinon.stub(shuttle, 'fetchFromApi').resolves();
+
+      this.setProperties({
+        syncType: 'webhooks',
+        closeModal: closeModalSpy
+      });
+
+      await render(
+        hbs`<Pipeline::Settings::Main::Modal::Sync
+            @syncType={{this.syncType}}
+            @closeModal={{this.closeModal}}
+        />`
+      );
+
+      await click('#submit-sync-button');
+
+      assert.dom('#submit-sync-button').isDisabled();
+      assert.dom('#error-message').doesNotExist();
+      assert.true(closeModalSpy.calledOnce);
+    });
+  }
+);


### PR DESCRIPTION
## Context
Updating the pipeline settings to a v2 UI to better handle a number of different shortcomings especially around pipelines with many jobs.

## Objective
Creates a modal for force resync of webhooks
<img width="2052" height="344" alt="Screenshot 2025-08-07 at 12-19-02 Finance_yfinancemicroservices Settings" src="https://github.com/user-attachments/assets/a54bf976-cf70-4a6b-af79-da03a4975722" />
<img width="2052" height="386" alt="Screenshot 2025-08-07 at 12-18-52 Finance_yfinancemicroservices Settings" src="https://github.com/user-attachments/assets/1677f6b7-c4d2-4d2e-9029-48d59fabd044" />
<img width="2052" height="340" alt="Screenshot 2025-08-07 at 12-18-42 Finance_yfinancemicroservices Settings" src="https://github.com/user-attachments/assets/4d34973b-6d32-465b-83a6-aeebc2c84994" />

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
