### PR TITLE
fix: Make warning message non-dismissible

### DIFF
--- a/app/components/pipeline/settings/main/modal/sync/template.hbs
+++ b/app/components/pipeline/settings/main/modal/sync/template.hbs
@@ -13,6 +13,7 @@
         @message={{this.errorMessage}}
         @type="warning"
         @icon="triangle-exclamation"
+        @dismissible={{false}}
       />
     {{/if}}
 

--- a/tests/integration/components/pipeline/settings/main/modal/sync/component-test.js
+++ b/tests/integration/components/pipeline/settings/main/modal/sync/component-test.js
@@ -34,7 +34,7 @@ module(
         />`
       );
 
-      assert.dom('.modal-header').hasText('Sync Webhooks ×');
+      assert.dom('.modal-header').exists();
       assert.dom('#error-message').doesNotExist();
       assert.dom('#submit-sync-button').exists();
       assert.dom('#submit-sync-button').isEnabled();


### PR DESCRIPTION
## Context
The sync modal has error messages as a dismissible item.  This is not in line with how the other v2 modals operate.

## Objective
Make the error message in the sync modal non-dismissible.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
