### PR TITLE
Modal to clear pipeline and job caches

### DIFF
--- a/app/components/pipeline/settings/cache/modal/clear/component.js
+++ b/app/components/pipeline/settings/cache/modal/clear/component.js
@@ -1,0 +1,138 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+
+export default class PipelineSettingsCacheModalClearComponent extends Component {
+  @service('shuttle') shuttle;
+
+  @service('pipeline-page-state') pipelinePageState;
+
+  @tracked errorMessage = null;
+
+  @tracked isDisabled = false;
+
+  @tracked jobs;
+
+  jobIdsCleared = [];
+
+  clearPipeline = false;
+
+  constructor() {
+    super(...arguments);
+
+    this.clearPipeline = this.args.jobs === undefined;
+    this.jobs = this.args.jobs ? Array.from(this.args.jobs) : [];
+  }
+
+  get modalTitle() {
+    if (this.clearPipeline) {
+      return 'Clear pipeline cache?';
+    }
+
+    if (this.jobs.length === 1) {
+      return `Clear cache for ${this.jobs[0].name}?`;
+    }
+
+    return `Clear cache for ${this.jobs.length} jobs?`;
+  }
+
+  get clearCacheMessage() {
+    if (this.clearPipeline) {
+      return 'Are you sure you want to clear the pipeline cache?';
+    }
+
+    if (this.jobs.length === 1) {
+      return `Are you sure you want to clear the cache for the job ${this.jobs[0].name}?`;
+    }
+
+    return 'Are you sure you want to clear the cache for the following jobs?';
+  }
+
+  get jobNames() {
+    return this.jobs
+      .map(job => job.name)
+      .sort()
+      .join(', ');
+  }
+
+  @action
+  async clearCache() {
+    this.isDisabled = true;
+    const pipelineId = this.pipelinePageState.getPipelineId();
+
+    if (this.clearPipeline) {
+      return this.shuttle
+        .fetchFromApi(
+          'delete',
+          `/pipelines/${pipelineId}/caches?scope=pipelines&cacheId=${pipelineId}`
+        )
+        .then(() => {
+          this.args.closeModal(true);
+        })
+        .catch(err => {
+          this.errorMessage = err.message;
+          this.isDisabled = false;
+        });
+    }
+
+    const jobIds = [];
+
+    return Promise.allSettled(
+      this.jobs.map(job => {
+        jobIds.push(job.id);
+
+        return this.shuttle.fetchFromApi(
+          'delete',
+          `/pipelines/${pipelineId}/caches?scope=jobs&cacheId=${job.id}`
+        );
+      })
+    ).then(results => {
+      let failureMessage;
+      const jobsClearedOnRequest = [];
+
+      results.forEach((result, i) => {
+        if (result.status === 'fulfilled') {
+          const jobId = jobIds[i];
+
+          jobsClearedOnRequest.push(jobId);
+          this.jobIdsCleared.push(jobId);
+        } else if (!failureMessage) {
+          failureMessage = result.reason.message;
+        }
+      });
+
+      if (jobsClearedOnRequest.length > 0) {
+        if (jobsClearedOnRequest.length === this.jobs.length) {
+          this.errorMessage = null;
+
+          this.args.closeModal(true, this.jobIdsCleared);
+        } else {
+          this.errorMessage = `${failureMessage}\nRetry clearing the failed jobs again?`;
+
+          const jobsToRetry = [];
+
+          this.jobs.forEach(job => {
+            if (!this.jobIdsCleared.includes(job.id)) {
+              jobsToRetry.push(job);
+            }
+          });
+          this.jobs = jobsToRetry;
+          this.isDisabled = false;
+        }
+      } else {
+        this.errorMessage = `${results[0].reason.message}`;
+        this.isDisabled = false;
+      }
+    });
+  }
+
+  @action
+  closeModal() {
+    if (this.clearPipeline) {
+      return this.args.closeModal(false);
+    }
+
+    return this.args.closeModal(false, this.jobIdsCleared);
+  }
+}

--- a/app/components/pipeline/settings/cache/modal/clear/styles.scss
+++ b/app/components/pipeline/settings/cache/modal/clear/styles.scss
@@ -1,0 +1,11 @@
+@mixin styles {
+  #clear-cache-modal {
+    .modal-body {
+      .clear-jobs-cache-list {
+        height: 4rem;
+        overflow: auto;
+        margin: 1rem 0;
+      }
+    }
+  }
+}

--- a/app/components/pipeline/settings/cache/modal/clear/template.hbs
+++ b/app/components/pipeline/settings/cache/modal/clear/template.hbs
@@ -1,0 +1,42 @@
+<BsModal
+  id="clear-cache-modal"
+  @onHide={{this.closeModal}}
+  as |modal|
+>
+  <modal.header>
+    <div class="modal-title">
+      {{this.modalTitle}}
+    </div>
+  </modal.header>
+  <modal.body>
+    {{#if this.errorMessage}}
+      <InfoMessage
+        id="error-message"
+        @message={{this.errorMessage}}
+        @type="warning"
+        @icon="triangle-exclamation"
+        @dismissible={{false}}
+      />
+    {{/if}}
+
+    <div>
+      {{this.clearCacheMessage}}
+    </div>
+
+    {{#if (gt this.jobNames.length 1)}}
+      <div class="clear-jobs-cache-list">
+        {{this.jobNames}}
+      </div>
+    {{/if}}
+  </modal.body>
+  <modal.footer>
+    <BsButton
+      id="submit-action"
+      @type="primary"
+      @defaultText="Clear"
+      @pendingText="Clearing..."
+      @onClick={{fn this.clearCache}}
+      disabled={{this.isDisabled}}
+    />
+  </modal.footer>
+</BsModal>

--- a/tests/integration/components/pipeline/settings/cache/modal/clear/component-test.js
+++ b/tests/integration/components/pipeline/settings/cache/modal/clear/component-test.js
@@ -1,0 +1,159 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
+import { click, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+
+module(
+  'Integration | Component | pipeline/settings/cache/modal/clear',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    let shuttle;
+
+    hooks.beforeEach(function () {
+      const pipelinePageStateService = this.owner.lookup(
+        'service:pipelinePageState'
+      );
+
+      shuttle = this.owner.lookup('service:shuttle');
+
+      sinon.stub(pipelinePageStateService, 'getPipelineId').returns(1);
+    });
+
+    test('it renders for clear pipeline cache', async function (assert) {
+      this.setProperties({
+        closeModal: () => {}
+      });
+
+      await render(
+        hbs`<Pipeline::Settings::Cache::Modal::Clear
+            @closeModal={{this.closeModal}}
+        />`
+      );
+
+      assert.dom('.modal-header').exists();
+      assert.dom('#error-message').doesNotExist();
+      assert.dom('#submit-action').exists();
+      assert.dom('#submit-action').isEnabled();
+    });
+
+    test('it renders for clear jobs cache', async function (assert) {
+      this.setProperties({
+        jobs: new Set([
+          { id: 1, name: 'job1' },
+          { id: 2, name: 'job2' }
+        ]),
+        closeModal: () => {}
+      });
+
+      await render(
+        hbs`<Pipeline::Settings::Cache::Modal::Clear
+            @jobs={{this.jobs}}
+            @closeModal={{this.closeModal}}
+        />`
+      );
+
+      assert.dom('.modal-header').exists();
+      assert.dom('#error-message').doesNotExist();
+      assert.dom('.clear-jobs-cache-list').exists();
+      assert.dom('#submit-action').exists();
+      assert.dom('#submit-action').isEnabled();
+    });
+
+    test('it renders error message on API failure', async function (assert) {
+      const errorMessage = 'An error occurred while clearing the cache.';
+
+      sinon.stub(shuttle, 'fetchFromApi').rejects({ message: errorMessage });
+
+      this.setProperties({
+        closeModal: () => {}
+      });
+
+      await render(
+        hbs`<Pipeline::Settings::Cache::Modal::Clear
+            @closeModal={{this.closeModal}}
+        />`
+      );
+      await click('#submit-action');
+
+      assert.dom('#error-message').exists();
+      assert.dom('#error-message').hasText(errorMessage);
+      assert.dom('#submit-action').isEnabled();
+    });
+
+    test('it renders error message on API failures clearing jobs', async function (assert) {
+      const errorMessage = 'An error occurred while clearing the cache.';
+
+      sinon
+        .stub(shuttle, 'fetchFromApi')
+        .onCall(0)
+        .resolves()
+        .onCall(1)
+        .rejects({ message: errorMessage })
+        .onCall(2)
+        .rejects({ message: errorMessage });
+
+      this.setProperties({
+        jobs: new Set([
+          { id: 1, name: 'job1' },
+          { id: 2, name: 'retry' },
+          { id: 3, name: 'retry2' }
+        ]),
+        closeModal: () => {}
+      });
+
+      await render(
+        hbs`<Pipeline::Settings::Cache::Modal::Clear
+            @jobs={{this.jobs}}
+            @closeModal={{this.closeModal}}
+        />`
+      );
+      await click('#submit-action');
+
+      assert.dom('#error-message').exists();
+      assert.dom('.clear-jobs-cache-list').exists();
+      assert.dom('#submit-action').isEnabled();
+    });
+
+    test('it handles API success', async function (assert) {
+      const closeModalSpy = sinon.spy();
+
+      sinon.stub(shuttle, 'fetchFromApi').resolves();
+
+      this.setProperties({
+        closeModal: closeModalSpy
+      });
+
+      await render(
+        hbs`<Pipeline::Settings::Cache::Modal::Clear
+            @closeModal={{this.closeModal}}
+        />`
+      );
+      await click('#submit-action');
+
+      assert.equal(closeModalSpy.calledOnceWith(true), true);
+    });
+
+    test('it handles API success for job clear', async function (assert) {
+      const closeModalSpy = sinon.spy();
+
+      sinon.stub(shuttle, 'fetchFromApi').resolves();
+
+      this.setProperties({
+        jobs: new Set([{ id: 1, name: 'job1' }]),
+        closeModal: closeModalSpy
+      });
+
+      await render(
+        hbs`<Pipeline::Settings::Cache::Modal::Clear
+            @jobs={{this.jobs}}
+            @closeModal={{this.closeModal}}
+        />`
+      );
+      await click('#submit-action');
+
+      assert.equal(closeModalSpy.calledOnceWith(true, [1]), true);
+    });
+  }
+);


### PR DESCRIPTION
## Context
Updating the pipeline settings to a v2 UI to better handle a number of different shortcomings especially around pipelines with many jobs.

## Objective
Creates a modal for clearing pipeline and jobs caches.
<img width="2052" height="338" alt="Screenshot 2025-08-08 at 12-07-25 minghay_various Settings" src="https://github.com/user-attachments/assets/7e85e9cf-22c9-448c-bc59-1c22b3149545" />
<img width="2052" height="508" alt="Screenshot 2025-08-08 at 12-07-49 minghay_various Settings" src="https://github.com/user-attachments/assets/7468abc3-9029-42f0-8f3d-3633d25a5b17" />

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
