### PR TITLE
fix: Fixes job state change metadata

### DIFF
--- a/app/utils/pipeline/graph/tooltip.js
+++ b/app/utils/pipeline/graph/tooltip.js
@@ -23,7 +23,7 @@ export const nodeCanShowTooltip = node => {
  * @param jobs    Jobs for the pipeline (API response from /pipelines/:id/jobs)
  * @param builds  Builds for the pipeline (API response from /pipelines/:id/builds)
  */
-export function getTooltipData(node, event, jobs, builds = []) {
+export function getTooltipData(node, event, jobs = [], builds = []) {
   const isTrigger = node.name.startsWith('~');
 
   if (isTrigger) {
@@ -68,11 +68,21 @@ export function getTooltipData(node, event, jobs, builds = []) {
   };
 
   const job = { ...node };
+  const originalJob = jobs.find(j => j.name === job.name);
 
-  if (event.prNum) {
-    const originalJob = jobs.find(j => j.name === job.name);
-
-    job.isDisabled = originalJob ? originalJob.state === 'DISABLED' : false;
+  if (originalJob) {
+    job.isDisabled = originalJob.state === 'DISABLED';
+    if (job.stateChanger) {
+      job.stateChanger = originalJob.stateChanger;
+    }
+    if (
+      originalJob.stateChangeMessage &&
+      originalJob.stateChangeMessage !== ' '
+    ) {
+      job.stateChangeMessage = originalJob.stateChangeMessage;
+    }
+  } else if (event.prNum) {
+    job.isDisabled = false;
   }
 
   const build = builds.find(b => b.jobId === node.id);

--- a/tests/unit/utils/pipeline/graph/tooltip-test.js
+++ b/tests/unit/utils/pipeline/graph/tooltip-test.js
@@ -118,7 +118,7 @@ module('Unit | Utility | pipeline-graph | tooltip', function () {
     assert.deepEqual(tooltipData.selectedEvent, event);
   });
 
-  test('it gets tooltip data for disabled PR event', function (assert) {
+  test('it gets tooltip data for disabled job', function (assert) {
     const workflowGraph = {
       nodes: [
         { name: '~pr' },
@@ -138,7 +138,7 @@ module('Unit | Utility | pipeline-graph | tooltip', function () {
       },
       prNum: 1
     };
-    const jobs = [{ name: 'p1', state: 'DISABLED' }];
+    const jobs = [{ name: 'p1', state: 'DISABLED', stateChangeMessage: ' ' }];
 
     const tooltipData = getTooltipData(
       {
@@ -177,7 +177,8 @@ module('Unit | Utility | pipeline-graph | tooltip', function () {
     );
 
     assert.deepEqual(tooltipData.job, {
-      name: 'main'
+      name: 'main',
+      isDisabled: false
     });
     assert.deepEqual(tooltipData.selectedEvent, event);
   });
@@ -207,6 +208,7 @@ module('Unit | Utility | pipeline-graph | tooltip', function () {
 
     assert.deepEqual(tooltipData.job, {
       name: 'main',
+      isDisabled: false,
       buildId: 123,
       status: 'SUCCESS'
     });


### PR DESCRIPTION
## Context
The tooltip should set a job's state change metadata from the jobs data coming from the API response.

## Objective
Updates the tooltip metadata setting to use the correct data sources.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
