### PR TITLE
feat(3388): Keep URL when show the 404 page

### DIFF
--- a/app/commands/detail/route.js
+++ b/app/commands/detail/route.js
@@ -1,6 +1,7 @@
 import { inject as service } from '@ember/service';
 import RSVP from 'rsvp';
 import Route from '@ember/routing/route';
+import { NotFoundError } from '../../utils/not-found-error';
 
 export default Route.extend({
   router: service(),
@@ -13,7 +14,7 @@ export default Route.extend({
       const [verPayload, tagPayload] = arr;
 
       if (verPayload.length === 0) {
-        this.router.transitionTo('/404');
+        throw new NotFoundError('Command not found');
       }
 
       tagPayload.forEach(tagObj => {
@@ -41,14 +42,5 @@ export default Route.extend({
   setupController(controller, model) {
     this._super(controller, model);
     controller.reset();
-  },
-  actions: {
-    error(error) {
-      if (error.status === 404) {
-        this.router.transitionTo('/404');
-      }
-
-      return true;
-    }
   }
 });

--- a/app/commands/detail/version/route.js
+++ b/app/commands/detail/version/route.js
@@ -1,6 +1,7 @@
 import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
 import { compareVersions } from 'screwdriver-ui/helpers/compare-versions';
+import { NotFoundError } from '../../../utils/not-found-error';
 
 export default Route.extend({
   router: service(),
@@ -17,7 +18,7 @@ export default Route.extend({
     const tagExists = tagPayload.filter(c => c.tag === params.version);
 
     if (tagExists.length === 0 && versionExists.length === 0) {
-      this.router.transitionTo('/404');
+      throw new NotFoundError('Command not found');
     }
 
     if (versionExists.length > 0) {

--- a/app/dashboard/route.js
+++ b/app/dashboard/route.js
@@ -2,6 +2,7 @@ import Route from '@ember/routing/route';
 import { get } from '@ember/object';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 import { inject as service } from '@ember/service';
+import { is404 } from '../utils/not-found-error';
 
 export default Route.extend(AuthenticatedRouteMixin, {
   router: service(),
@@ -28,8 +29,14 @@ export default Route.extend(AuthenticatedRouteMixin, {
   },
 
   actions: {
-    error(/* error, transition */) {
+    error(error) {
+      if (is404(error)) {
+        return true;
+      }
+
       this.router.replaceWith('home');
+
+      return false;
     }
   }
 });

--- a/app/dashboard/show/route.js
+++ b/app/dashboard/show/route.js
@@ -2,6 +2,7 @@ import RSVP from 'rsvp';
 import Route from '@ember/routing/route';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 import { inject as service } from '@ember/service';
+import { is404 } from '../../utils/not-found-error';
 
 export default Route.extend(AuthenticatedRouteMixin, {
   store: service(),
@@ -17,10 +18,10 @@ export default Route.extend(AuthenticatedRouteMixin, {
   },
 
   actions: {
-    error(/* error, transition */) {
+    error(error) {
       localStorage.removeItem('lastViewedCollectionId');
 
-      return this.router.transitionTo('/404');
+      return is404(error);
     }
   }
 });

--- a/app/pipeline/build/index/route.js
+++ b/app/pipeline/build/index/route.js
@@ -1,5 +1,6 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
+import { is404, NotFoundError } from '../../../utils/not-found-error';
 
 export default Route.extend({
   router: service(),
@@ -14,9 +15,13 @@ export default Route.extend({
         activeTab: 'steps'
       });
     },
-    error(error) {
-      if (error && Array.isArray(error.errors)) {
-        this.router.transitionTo('/404');
+    error(error, transition) {
+      if ((error && Array.isArray(error.errors)) || is404(error)) {
+        transition.abort();
+        this.intermediateTransitionTo(
+          'error',
+          new NotFoundError('Build not found')
+        );
       }
 
       return false;

--- a/app/pipeline/events/route.js
+++ b/app/pipeline/events/route.js
@@ -4,6 +4,7 @@ import { inject as service } from '@ember/service';
 import RSVP from 'rsvp';
 import ENV from 'screwdriver-ui/config/environment';
 import getErrorMessage from 'screwdriver-ui/utils/error-messages';
+import { NotFoundError } from '../../utils/not-found-error';
 
 export default Route.extend({
   store: service(),
@@ -79,17 +80,16 @@ export default Route.extend({
         count: ENV.APP.NUM_EVENTS_LISTED
       }),
       triggers: this.triggerService.getDownstreamTriggers(pipelineId),
-      pipelinePreference: await this.pipelineService.getUserPipelinePreference(
-        pipelineId
-      ),
-      desiredJobNameLength: await this.userSettings.getDisplayJobNameLength()
+      pipelinePreference:
+        this.pipelineService.getUserPipelinePreference(pipelineId),
+      desiredJobNameLength: this.userSettings.getDisplayJobNameLength()
     }).catch(err => {
       const errorMessage = getErrorMessage(err);
 
       if (errorMessage !== '') {
         pipelineEventsController.set('errorMessage', errorMessage);
       } else {
-        this.router.transitionTo('/404');
+        throw new NotFoundError('Pipeline not found');
       }
     });
   },

--- a/app/pipeline/jobs/index/route.js
+++ b/app/pipeline/jobs/index/route.js
@@ -4,6 +4,7 @@ import ENV from 'screwdriver-ui/config/environment';
 import RSVP from 'rsvp';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 import getErrorMessage from 'screwdriver-ui/utils/error-messages';
+import { NotFoundError } from '../../../utils/not-found-error';
 
 export default Route.extend(AuthenticatedRouteMixin, {
   store: service(),
@@ -48,7 +49,7 @@ export default Route.extend(AuthenticatedRouteMixin, {
       if (errorMessage !== '') {
         pipelineJobsIndexController.set('errorMessage', errorMessage);
       } else {
-        this.router.transitionTo('/404');
+        throw new NotFoundError('Job not found');
       }
     });
   },

--- a/app/pipeline/route.js
+++ b/app/pipeline/route.js
@@ -3,6 +3,7 @@ import Route from '@ember/routing/route';
 import { set } from '@ember/object';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 import { inject as service } from '@ember/service';
+import { NotFoundError } from '../utils/not-found-error';
 
 export default Route.extend(AuthenticatedRouteMixin, {
   routeAfterAuthentication: 'pipeline',
@@ -19,14 +20,10 @@ export default Route.extend(AuthenticatedRouteMixin, {
     });
 
     return RSVP.hash({
-      pipeline: this.store
-        .findRecord('pipeline', params.pipeline_id)
-        .catch(() => {
-          this.router.transitionTo('/404');
-
-          return [];
-        }),
+      pipeline: this.store.findRecord('pipeline', params.pipeline_id),
       collections
+    }).catch(() => {
+      throw new NotFoundError('Pipeline not found');
     });
   },
   deactivate() {

--- a/app/routes/error.js
+++ b/app/routes/error.js
@@ -1,0 +1,11 @@
+// app/routes/application/error.js
+import Route from '@ember/routing/route';
+import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+import { is404 } from '../utils/not-found-error';
+
+export default Route.extend(AuthenticatedRouteMixin, {
+  setupController(controller, error) {
+    this._super(...arguments);
+    controller.set('is404', is404(error));
+  }
+});

--- a/app/templates/error.hbs
+++ b/app/templates/error.hbs
@@ -1,5 +1,9 @@
-<ErrorView
-  @statusCode={{this.model.reason.errors.statusCode}}
-  @statusMessage={{this.model.reason.errors.error}}
-  @errorMessage={{this.model.reason.errors.message}}
-/>
+{{#if this.is404}}
+  {{404-display}}
+{{else}}
+  <ErrorView
+    @statusCode={{this.model.reason.errors.statusCode}}
+    @statusMessage={{this.model.reason.errors.error}}
+    @errorMessage={{this.model.reason.errors.message}}
+  />
+{{/if}}

--- a/app/templates/job/detail/route.js
+++ b/app/templates/job/detail/route.js
@@ -3,6 +3,7 @@ import RSVP from 'rsvp';
 import Route from '@ember/routing/route';
 import timeRange from 'screwdriver-ui/utils/time-range';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+import { NotFoundError } from '../../../utils/not-found-error';
 
 export default Route.extend(AuthenticatedRouteMixin, {
   router: service(),
@@ -64,7 +65,7 @@ export default Route.extend(AuthenticatedRouteMixin, {
       templateData = templateData.filter(t => t.namespace === params.namespace);
 
       if (templateData.length === 0) {
-        this.router.transitionTo('/404');
+        throw new NotFoundError('Template not found');
       }
 
       [...templateData, ...templateDataFiltered].forEach(template => {
@@ -112,13 +113,6 @@ export default Route.extend(AuthenticatedRouteMixin, {
     refreshModel: function refreshModel() {
       this.set('fetchAll', true);
       this.refresh();
-    },
-    error(error) {
-      if (error.status === 404) {
-        this.router.transitionTo('/404');
-      }
-
-      return true;
     }
   }
 });

--- a/app/templates/job/detail/version/route.js
+++ b/app/templates/job/detail/version/route.js
@@ -2,6 +2,7 @@ import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
 import { compareVersions } from 'screwdriver-ui/helpers/compare-versions';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+import { NotFoundError } from '../../../../utils/not-found-error';
 
 export default Route.extend(AuthenticatedRouteMixin, {
   store: service(),
@@ -16,7 +17,7 @@ export default Route.extend(AuthenticatedRouteMixin, {
     const tagExists = tagPayload.filter(t => t.tag === pVersion);
 
     if (tagExists.length === 0 && versionExists.length === 0) {
-      this.router.transitionTo('/404');
+      throw new NotFoundError('Template not found');
     }
 
     if (versionExists.length > 0) {

--- a/app/templates/pipeline/detail/route.js
+++ b/app/templates/pipeline/detail/route.js
@@ -3,6 +3,7 @@ import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-rout
 import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
 import { compareVersions } from 'screwdriver-ui/helpers/compare-versions';
+import { NotFoundError } from '../../../utils/not-found-error';
 
 export default class TemplatesPipelineDetailRoute extends Route.extend(
   AuthenticatedRouteMixin
@@ -80,7 +81,7 @@ export default class TemplatesPipelineDetailRoute extends Route.extend(
         v.fullName = fullName;
       });
     } catch (err) {
-      this.router.transitionTo('/404');
+      throw new NotFoundError('Pipeline template not found');
     }
 
     return {

--- a/app/templates/pipeline/detail/version/route.js
+++ b/app/templates/pipeline/detail/version/route.js
@@ -2,6 +2,7 @@ import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
 import { compareVersions } from 'screwdriver-ui/helpers/compare-versions';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+import { NotFoundError } from '../../../../utils/not-found-error';
 
 export default class TemplatesPipelineDetailVersionRoute extends Route.extend(
   AuthenticatedRouteMixin
@@ -19,7 +20,7 @@ export default class TemplatesPipelineDetailVersionRoute extends Route.extend(
     const tagExists = tagPayload.filter(t => t.tag === pVersion);
 
     if (tagExists.length === 0 && versionExists.length === 0) {
-      this.router.transitionTo('/404');
+      throw new NotFoundError('Pipeline template not found');
     }
 
     if (versionExists.length > 0) {

--- a/app/user-settings/preferences/route.js
+++ b/app/user-settings/preferences/route.js
@@ -2,6 +2,7 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import RSVP from 'rsvp';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+import { NotFoundError } from '../../utils/not-found-error';
 
 export default Route.extend(AuthenticatedRouteMixin, {
   router: service(),
@@ -11,10 +12,8 @@ export default Route.extend(AuthenticatedRouteMixin, {
   model() {
     return RSVP.hash({
       desiredJobNameLength: this.userSettings.getDisplayJobNameLength()
-    }).catch(e => {
-      console.log('error', e);
-
-      this.router.transitionTo('/404');
+    }).catch(() => {
+      throw new NotFoundError('User not found');
     });
   }
 });

--- a/app/utils/not-found-error.js
+++ b/app/utils/not-found-error.js
@@ -1,0 +1,25 @@
+import { NotFoundError as DataNotFoundError } from '@ember-data/adapter/error';
+
+/**
+ * Not Found Error
+ */
+class NotFoundError extends Error {
+  statusCode = 404;
+}
+
+/**
+ * return whether error means Not Found
+ * @param  {Object} error Any error object
+ * @return {Boolean}
+ */
+function is404(error) {
+  return (
+    error instanceof DataNotFoundError ||
+    error instanceof NotFoundError ||
+    error?.status === 404 ||
+    error?.code === 404 ||
+    error?.statusCode === 404
+  );
+}
+
+export { is404, NotFoundError };

--- a/tests/acceptance/commands-test.js
+++ b/tests/acceptance/commands-test.js
@@ -73,6 +73,21 @@ module('Acceptance | commands', function (hooks) {
       { 'Content-Type': 'application/json' },
       JSON.stringify([])
     ]);
+    server.get('http://localhost:8080/v4/commands/not/exist', () => [
+      200,
+      { 'Content-Type': 'application/json' },
+      JSON.stringify([])
+    ]);
+    server.get('http://localhost:8080/v4/commands/not/exist/tags', () => [
+      200,
+      { 'Content-Type': 'application/json' },
+      JSON.stringify([])
+    ]);
+    server.get('http://localhost:8080/v4/commands/foo/bar/not-exist', () => [
+      200,
+      { 'Content-Type': 'application/json' },
+      JSON.stringify([])
+    ]);
   });
 
   hooks.afterEach(function () {
@@ -122,5 +137,21 @@ module('Acceptance | commands', function (hooks) {
       .includesText(
         'Commands share binaries (or scripts) across multiple jobs.'
       );
+  });
+
+  test('visiting /commands/not/exist', async assert => {
+    await authenticateSession({ token: adminJWT });
+    await visit('/commands/not/exist');
+
+    assert.equal(currentURL(), '/commands/not/exist');
+    assert.dom('.code').hasText('404');
+  });
+
+  test('visiting /commands/foo/bar/not-exist', async assert => {
+    await authenticateSession({ token: adminJWT });
+    await visit('/commands/foo/bar/not-exist');
+
+    assert.equal(currentURL(), '/commands/foo/bar/not-exist');
+    assert.dom('.code').hasText('404');
   });
 });

--- a/tests/acceptance/dashboards-test.js
+++ b/tests/acceptance/dashboards-test.js
@@ -133,6 +133,18 @@ module('Acceptance | dashboards', function (hooks) {
     assert.dom('.pipeline-card').exists({ count: 2 });
   });
 
+  test('visiting /dashboards/404', async function (assert) {
+    server.get('http://localhost:8080/v4/collections/404', () => [
+      404,
+      { 'Content-Type': 'application/json' }
+    ]);
+    await authenticateSession({ token: 'fakeToken' });
+    await visit('/dashboards/404');
+
+    assert.equal(currentURL(), '/dashboards/404');
+    assert.dom('.code').hasText('404');
+  });
+
   test('creating a collection', async function (assert) {
     assert.expect(7);
 

--- a/tests/acceptance/pipeline-builds-test.js
+++ b/tests/acceptance/pipeline-builds-test.js
@@ -36,6 +36,11 @@ module('Acceptance | pipeline build', function (hooks) {
       JSON.stringify(pipeline)
     ]);
 
+    server.get('http://localhost:8080/v4/pipelines/404', () => [
+      404,
+      { 'Content-Type': 'application/json' }
+    ]);
+
     server.get('http://localhost:8080/v4/pipelines/4/jobs', () => [
       200,
       { 'Content-Type': 'application/json' },
@@ -115,6 +120,11 @@ module('Acceptance | pipeline build', function (hooks) {
         JSON.stringify(build)
       ];
     });
+
+    server.get('http://localhost:8080/v4/builds/404', () => [
+      404,
+      { 'Content-Type': 'application/json' }
+    ]);
 
     server.get('http://localhost:8080/v4/builds/statuses', () => [
       200,
@@ -260,5 +270,25 @@ module('Acceptance | pipeline build', function (hooks) {
     await visit('/pipelines/4/pulls');
     assert.equal(currentURL(), '/pipelines/4/pulls');
     assert.dom('.column-tabs-view .nav-link.active').hasText('Pull Requests');
+  });
+
+  test('visiting /pipelines/404', async function (assert) {
+    injectScmServiceStub(this);
+
+    await authenticateSession({ token: 'fakeToken' });
+    await visit('/pipelines/404');
+
+    assert.equal(currentURL(), '/pipelines/404');
+    assert.dom('.code').hasText('404');
+  });
+
+  test('visiting /builds/404', async function (assert) {
+    injectScmServiceStub(this);
+
+    await authenticateSession({ token: 'fakeToken' });
+    await visit('/builds/404');
+
+    assert.equal(currentURL(), '/builds/404');
+    assert.dom('.code').hasText('404');
   });
 });

--- a/tests/acceptance/pipeline-template-test.js
+++ b/tests/acceptance/pipeline-template-test.js
@@ -436,4 +436,13 @@ module('Acceptance | pipeline template', function (hooks) {
       .dom('table.table td div.version-cell')
       .includesText('1.0.3 - latest');
   });
+
+  test('visiting /templates/pipeline/not/exist', async function (assert) {
+    await authenticateSession({ token: fakeToken });
+
+    await visit('/templates/pipeline/not/exist');
+
+    assert.strictEqual(currentURL(), '/templates/pipeline/not/exist');
+    assert.dom('.code').hasText('404');
+  });
 });

--- a/tests/acceptance/templates-test.js
+++ b/tests/acceptance/templates-test.js
@@ -80,6 +80,21 @@ module('Acceptance | templates', function (hooks) {
       { 'Content-Type': 'application/json' },
       JSON.stringify([])
     ]);
+    server.get('http://localhost:8080/v4/templates/not%2Fexist', () => [
+      200,
+      { 'Content-Type': 'application/json' },
+      JSON.stringify([])
+    ]);
+    server.get('http://localhost:8080/v4/templates/not%2Fexist/metrics', () => [
+      200,
+      { 'Content-Type': 'application/json' },
+      JSON.stringify([])
+    ]);
+    server.get('http://localhost:8080/v4/templates/not%2Fexist/tags', () => [
+      200,
+      { 'Content-Type': 'application/json' },
+      JSON.stringify([])
+    ]);
   });
 
   hooks.afterEach(function () {
@@ -117,5 +132,21 @@ module('Acceptance | templates', function (hooks) {
       'Templates > foo/bar@1.0.0',
       'Page title is correct'
     );
+  });
+
+  test('visiting /templates/job/not/exist', async assert => {
+    await authenticateSession({ token: adminJWT });
+    await visit('/templates/job/not/exist');
+
+    assert.equal(currentURL(), '/templates/job/not/exist');
+    assert.dom('.code').hasText('404');
+  });
+
+  test('visiting /templates/job/foo/bar/not-exist', async assert => {
+    await authenticateSession({ token: adminJWT });
+    await visit('/templates/job/foo/bar/not-exist');
+
+    assert.equal(currentURL(), '/templates/job/foo/bar/not-exist');
+    assert.dom('.code').hasText('404');
   });
 });

--- a/tests/unit/commands/detail/router-test.js
+++ b/tests/unit/commands/detail/router-test.js
@@ -48,7 +48,7 @@ module('Unit | Route | commands/detail', function (hooks) {
     });
   });
 
-  test('it asks for the list of commands for a non-exist name', function (assert) {
+  test('it asks for the list of commands for a non-exist name', async function (assert) {
     this.owner.register('service:command', commandServiceStub2);
     const route = this.owner.lookup('route:commands/detail');
     const stub = sinon.stub();
@@ -62,8 +62,7 @@ module('Unit | Route | commands/detail', function (hooks) {
     this.owner.unregister('service:router');
     this.owner.register('service:router', routerServiceMock);
 
-    return route.model({ namespace: 'foo', name: 'baz' }).then(() => {
-      assert.ok(stub.calledOnce, 'transitionTo was called once');
-    });
+    await assert.rejects(route.model({ namespace: 'foo', name: 'baz' }));
+    assert.ok(stub.notCalled);
   });
 });

--- a/tests/unit/commands/detail/version/router-test.js
+++ b/tests/unit/commands/detail/version/router-test.js
@@ -88,9 +88,8 @@ module('Unit | Route | commands/detail/version', function (hooks) {
     this.owner.unregister('service:router');
     this.owner.register('service:router', routerServiceMock);
 
-    route.model({ version: '9.9.9' });
-
-    assert.ok(stub.calledOnce, 'transitionTo was called once');
+    assert.throws(() => route.model({ version: '9.9.9' }));
+    assert.ok(stub.notCalled);
   });
 
   test('it asks for the command for a given name and non-exist tag', function (assert) {
@@ -110,8 +109,7 @@ module('Unit | Route | commands/detail/version', function (hooks) {
     this.owner.unregister('service:router');
     this.owner.register('service:router', routerServiceMock);
 
-    route.model({ version: 'foo' });
-
-    assert.ok(stub.calledOnce, 'transitionTo was called once');
+    assert.throws(() => route.model({ version: 'foo' }));
+    assert.ok(stub.notCalled);
   });
 });

--- a/tests/unit/templates/job/detail/route-test.js
+++ b/tests/unit/templates/job/detail/route-test.js
@@ -108,7 +108,7 @@ module('Unit | Route | templates/job/detail', function (hooks) {
     });
   });
 
-  test('it asks for the list of templates for a non-exist name', function (assert) {
+  test('it asks for the list of templates for a non-exist name', async function (assert) {
     this.owner.register('service:template', templateServiceStub2);
     const route = this.owner.lookup('route:templates/job/detail');
     const stub = sinon.stub();
@@ -121,9 +121,7 @@ module('Unit | Route | templates/job/detail', function (hooks) {
     this.owner.register('service:router', routerServiceMock);
 
     assert.ok(route);
-
-    return route.model({ namespace: 'foo', name: 'hoge' }).then(() => {
-      assert.ok(stub.calledOnce, 'transitionTo was called once');
-    });
+    await assert.rejects(route.model({ namespace: 'foo', name: 'hoge' }));
+    assert.ok(stub.notCalled);
   });
 });

--- a/tests/unit/templates/job/detail/version/router-test.js
+++ b/tests/unit/templates/job/detail/version/router-test.js
@@ -91,7 +91,7 @@ module('Unit | Route | templates/job/detail/version', function (hooks) {
     assert.equal(controller.versionOrTagFromUrl, 'stable');
   });
 
-  test('it asks for the template for a given name and non-exist version', function (assert) {
+  test('it asks for the template for a given name and non-exist version', async function (assert) {
     const route = this.owner.lookup('route:templates/job/detail/version');
 
     route.modelFor = () => {
@@ -108,13 +108,11 @@ module('Unit | Route | templates/job/detail/version', function (hooks) {
     this.owner.register('service:router', routerServiceMock);
 
     assert.ok(route);
-
-    route.model({ version: '9.9.9' });
-
-    assert.ok(stub.calledOnce, 'transitionTo was called once');
+    await assert.rejects(route.model({ version: '9.9.9' }));
+    assert.true(stub.notCalled);
   });
 
-  test('it asks for the template for a given name and non-exist tag', function (assert) {
+  test('it asks for the template for a given name and non-exist tag', async function (assert) {
     const route = this.owner.lookup('route:templates/job/detail/version');
 
     route.modelFor = () => {
@@ -131,9 +129,7 @@ module('Unit | Route | templates/job/detail/version', function (hooks) {
     this.owner.register('service:router', routerServiceMock);
 
     assert.ok(route);
-
-    route.model({ version: 'foo' });
-
-    assert.ok(stub.calledOnce, 'transitionTo was called once');
+    await assert.rejects(route.model({ version: 'foo' }));
+    assert.true(stub.notCalled);
   });
 });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Screwdriver UI redirects to the `/404` page when access non-existent content or non-permitted content.
Users need to re-fill in the full URL to fix it, but that is a little hard.

https://github.com/screwdriver-cd/screwdriver/issues/3388

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Keep original URL when show the 404 page using [Error Substates](https://guides.emberjs.com/v4.12.0/routing/loading-and-error-substates/) feature.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

- Issue - https://github.com/screwdriver-cd/screwdriver/issues/3388

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
