### PR TITLE
feat: V2 settings toggle

### DIFF
--- a/app/components/app-header/component.js
+++ b/app/components/app-header/component.js
@@ -60,10 +60,19 @@ export default Component.extend({
 
         if (targetURL.includes('pulls')) {
           targetURL = `${targetURL.split('pulls/')[0]}pulls`;
+        } else if (targetURL.includes('settings')) {
+          targetURL = targetURL.split('settings')[0];
+          targetURL = targetURL.endsWith('/') ? targetURL : `${targetURL}/`;
+          targetURL = `${targetURL}options`;
         }
         localStorage.removeItem('newUI');
       } else {
         targetURL = `/v2${currentURL}`;
+
+        if (targetURL.endsWith('/options')) {
+          targetURL = targetURL.replace('/options', '/settings');
+        }
+
         localStorage.setItem('newUI', 'true');
       }
 

--- a/app/components/app-header/template.hbs
+++ b/app/components/app-header/template.hbs
@@ -185,7 +185,7 @@
               <ddm.item>
                 {{#if this.hasAlternativeRoute}}
                   <span class="switch-ui dropdown-item"
-                    title="{{if this.isNewUIRoute "Back to classic" "Try new"}} interface"
+                    title="{{if this.isNewUI "Back to classic" "Try new"}} interface"
                     {{action "switchUI"}}
                   >
                     {{if this.isNewUI "Back to classic" "Try new"}} interface

--- a/app/opt-in-route-mapping/service.js
+++ b/app/opt-in-route-mapping/service.js
@@ -27,5 +27,15 @@ export default class OptInRouteMappingService extends Service {
 
     this.routeMappings.set('pipeline.pulls', 'v2.pipeline.pulls.show');
     this.routeMappings.set('v2.pipeline.pulls.show', 'pipeline.pulls');
+
+    this.routeMappings.set('pipeline.options', 'v2.pipeline.settings.index');
+    this.routeMappings.set('v2.pipeline.settings.index', 'pipeline.options');
+    this.routeMappings.set('v2.pipeline.settings.cache', 'pipeline.options');
+    this.routeMappings.set('v2.pipeline.settings.jobs', 'pipeline.options');
+    this.routeMappings.set('v2.pipeline.settings.metrics', 'pipeline.options');
+    this.routeMappings.set(
+      'v2.pipeline.settings.preferences',
+      'pipeline.options'
+    );
   }
 }

--- a/app/pipeline/options/route.js
+++ b/app/pipeline/options/route.js
@@ -6,6 +6,13 @@ export default Route.extend({
   session: service(),
   router: service(),
   routeAfterAuthentication: 'pipeline.options',
+  beforeModel() {
+    if (localStorage.getItem('newUI') === 'true') {
+      const { pipeline_id: pipelineId } = this.paramsFor('pipeline');
+
+      this.transitionTo('v2.pipeline.settings.index', pipelineId);
+    }
+  },
   model() {
     // Guests should not access this page
     if (get(this, 'session.data.authenticated.isGuest')) {


### PR DESCRIPTION
## Context
Users should be able to toggle between the legacy and v2 UI for pipeline settings

## Objective
1. Creates the proper mapping for the v2 pipeline settings routes so users can switch between the two interfaces
2. Fixes a typo causing the hover text to display incorrect information

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
