### PR TITLE
fix: margin spacing

### DIFF
--- a/app/components/pipeline/settings/cache/table/styles.scss
+++ b/app/components/pipeline/settings/cache/table/styles.scss
@@ -17,6 +17,10 @@
       display: flex;
       align-items: center;
       height: $clear-cache-button-height;
+
+      #clear-jobs-cache-button {
+        margin-right: 1rem;
+      }
     }
 
     .table-main {


### PR DESCRIPTION
## Context
The spacing between the cache button and the number of selected job cache text is missing a margin value

## Objective
Adds the correct margin spacing value

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
