### PR TITLE
fix: Add missing titles

### DIFF
--- a/app/components/pipeline/settings/main/template.hbs
+++ b/app/components/pipeline/settings/main/template.hbs
@@ -102,6 +102,7 @@
         @type="primary"
         @outline="true"
         @onClick={{fn this.sync "webhooks"}}
+        title="Sync SCM webhooks"
       >
         <FaIcon @icon="rotate" />
       </BsButton>
@@ -120,6 +121,7 @@
         @type="primary"
         @outline="true"
         @onClick={{fn this.sync "pullrequests"}}
+        title="Sync pull requests"
       >
         <FaIcon @icon="rotate" />
       </BsButton>
@@ -138,6 +140,7 @@
         @type="primary"
         @outline="true"
         @onClick={{fn this.sync "pipeline"}}
+        title="Sync pipeline"
       >
         <FaIcon @icon="rotate" />
       </BsButton>

--- a/app/components/pipeline/settings/main/template.hbs
+++ b/app/components/pipeline/settings/main/template.hbs
@@ -18,7 +18,7 @@
       @type="primary"
       @onClick={{this.showUpdatePipelineModal}}
       @outline={{true}}
-      title="Edit pipeline alias"
+      title="Edit pipeline"
     >
       <FaIcon @icon="pen" />
       {{#if this.isUpdatePipelineModalOpen}}


### PR DESCRIPTION
## Context
The buttons in the v2 UI for pipeline settings has some missing and erroneous button titles.

## Objective
1. Adds the missing button titles for the buttons that require titles
2. Fixes the erroneous button title

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
