### PR TITLE
fix: Do not update if same event

### DIFF
--- a/app/components/pipeline/workflow/component.js
+++ b/app/components/pipeline/workflow/component.js
@@ -171,6 +171,10 @@ export default class PipelineWorkflowComponent extends Component {
   @action
   update(element, [event]) {
     if (this.event) {
+      if (this.event.id === event.id) {
+        return;
+      }
+
       this.workflowDataReload.removeBuildsCallback(
         BUILD_QUEUE_NAME,
         this.event.id


### PR DESCRIPTION
## Context
In the v2 workflow graph UI, using the tooltip drop down to start a new event for a different job will sometimes automatically close the tooltip when the user selects the `start pipeline from here` option.  The workflow component's `update` function is triggered with a new event object, however the event's are the same and should not trigger any additional update logic.

## Objective
Checks that the event object passed to the update is not the same event (based on event id).  If the event ids are the same, then there is no additional work to do.  The update work further down the function is for updating the component with a different event id.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
