### PR TITLE
Update event status priority

### DIFF
--- a/app/event/model.js
+++ b/app/event/model.js
@@ -162,7 +162,31 @@ export default Model.extend(ModelReloaderMixin, {
           );
 
           if (validList.length) {
-            status = validList[0].status;
+            let runningCount = 0;
+
+            let failCount = 0;
+
+            let warningCount = 0;
+
+            validList.forEach(b => {
+              if (b.status === 'FAILURE') {
+                failCount += 1;
+              } else if (b.status === 'WARNING') {
+                warningCount += 1;
+              } else if (b.status === 'RUNNING') {
+                runningCount += 1;
+              }
+            });
+
+            if (runningCount > 0) {
+              status = 'RUNNING';
+            } else if (failCount > 0) {
+              status = 'FAILURE';
+            } else if (warningCount > 0) {
+              status = 'WARNING';
+            } else {
+              status = validList[0].status;
+            }
           } else {
             status = this.isComplete ? 'SUCCESS' : 'RUNNING';
           }


### PR DESCRIPTION
## Context
The event status does not accurately highlight build statuses when there are multiple builds with different statuses.

## Objective
Updates the event status calculation to account for multiple builds with different statuses.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3386

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
