### PR TITLE
fix: Update graph when job is toggled by tooltip

### DIFF
--- a/app/components/pipeline/workflow/component.js
+++ b/app/components/pipeline/workflow/component.js
@@ -54,6 +54,8 @@ export default class PipelineWorkflowComponent extends Component {
 
   @tracked collapsedStages;
 
+  @tracked jobToggledByTooltip;
+
   workflowGraph;
 
   workflowGraphWithDownstreamTriggers;
@@ -395,5 +397,10 @@ export default class PipelineWorkflowComponent extends Component {
   setShowBuildCostsTable() {
     this.showGraph = false;
     this.showEventJobsTable = false;
+  }
+
+  @action
+  onJobToggle(job) {
+    this.jobToggledByTooltip = job;
   }
 }

--- a/app/components/pipeline/workflow/graph/template.hbs
+++ b/app/components/pipeline/workflow/graph/template.hbs
@@ -1,4 +1,4 @@
 <div id="workflow-graph"
   {{did-insert this.draw}}
-  {{did-update this.redraw @workflowGraph @builds @stageBuilds @event @collapsedStages}}
+  {{did-update this.redraw @workflowGraph @builds @stageBuilds @event @collapsedStages @toggledJob}}
 />

--- a/app/components/pipeline/workflow/template.hbs
+++ b/app/components/pipeline/workflow/template.hbs
@@ -99,6 +99,7 @@
             @displayStageTooltip={{true}}
             @setShowStageTooltip={{this.setShowStageTooltip}}
             @toggleStageView={{this.toggleStageView}}
+            @toggledJob={{this.jobToggledByTooltip}}
           />
 
           {{#if this.showTooltip}}
@@ -107,6 +108,7 @@
               @event={{this.event}}
               @builds={{this.builds}}
               @workflowGraph={{this.workflowGraphToDisplay}}
+              @onJobToggle={{this.onJobToggle}}
             />
           {{/if}}
           {{#if this.showStageTooltip}}

--- a/app/components/pipeline/workflow/tooltip/component.js
+++ b/app/components/pipeline/workflow/tooltip/component.js
@@ -144,6 +144,7 @@ export default class PipelineWorkflowTooltipComponent extends Component {
 
     if (updated) {
       this.setTooltipData();
+      this.args.onJobToggle(this.tooltipData.job);
     }
   }
 


### PR DESCRIPTION
## Context
In the v2 UI, the workflow graph does not update a job's disabled/enabled state when toggled via the tooltip menu.

## Objective
Adds support for updating the workflow graph to when a job's state is changed via the tooltip menu.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
