### PR TITLE
fix(3433): prevent workflow graph render crashes from edges referencing missing nodes

### DIFF
--- a/app/utils/graph-tools.js
+++ b/app/utils/graph-tools.js
@@ -436,6 +436,10 @@ const calcNodeDepths = graph => {
     depth[n.name] = 0;
   });
   graph.edges.forEach(({ src, dest }) => {
+    if (!nodes[src] || !nodes[dest]) {
+      return;
+    }
+
     if (!edges[src]) {
       edges[src] = [];
     }
@@ -955,6 +959,8 @@ const decorateGraph = ({
     const destNode = node(nodes, e.dest);
 
     if (!srcNode || !destNode) {
+      e.hidden = true;
+
       return;
     }
 

--- a/tests/unit/utils/graph-tools-test.js
+++ b/tests/unit/utils/graph-tools-test.js
@@ -144,6 +144,63 @@ module('Unit | Utility | graph tools', function () {
     assert.deepEqual(result, expectedOutput);
   });
 
+  test('it hides edges from unknown external triggers to existing external jobs', function (assert) {
+    const inputGraph = {
+      nodes: [
+        { name: '~commit' },
+        { name: 'main-job' },
+        { name: 'sd@123:external-job' }
+      ],
+      edges: [
+        { src: '~commit', dest: 'main-job' },
+        {
+          src: 'main-job',
+          dest: 'sd@123:external-job'
+        },
+        {
+          src: '~sd@456:upstream-job',
+          dest: 'sd@123:external-job'
+        }
+      ]
+    };
+    const expectedOutput = {
+      nodes: [
+        { name: '~commit', pos: { x: 0, y: 0 } },
+        { name: 'main-job', pos: { x: 1, y: 0 } },
+        { name: 'sd@123:external-job', pos: { x: 2, y: 0 } }
+      ],
+      edges: [
+        {
+          src: '~commit',
+          dest: 'main-job',
+          from: { x: 0, y: 0 },
+          to: { x: 1, y: 0 }
+        },
+        {
+          src: 'main-job',
+          dest: 'sd@123:external-job',
+          from: { x: 1, y: 0 },
+          to: { x: 2, y: 0 }
+        },
+        {
+          src: '~sd@456:upstream-job',
+          dest: 'sd@123:external-job',
+          hidden: true
+        }
+      ],
+      stages: [],
+      stageEdges: [],
+      meta: {
+        height: 1,
+        width: 3
+      }
+    };
+
+    const result = decorateGraph({ inputGraph });
+
+    assert.deepEqual(result, expectedOutput);
+  });
+
   test('it processes a more complex graph without builds', function (assert) {
     const expectedOutput = {
       nodes: [


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Some workflow graphs can include edges whose src or dest does not exist in nodes.
This can happen because of upstream workflowGraph generation issues, including the known case tracked in https://github.com/screwdriver-cd/screwdriver/issues/3206.

When that data reaches the UI, graph decoration can leave those edges without usable coordinates, and the workflow graph rendering may fail at draw time.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
This PR makes workflow graph rendering resilient to edges that reference missing nodes.

Intentional changes:

- Mark edges as hidden when their src or dest node cannot be found during graph decoration
- Prevent invalid edges from being passed to the renderer
- Add a regression test for an external-trigger workflow case where an edge points to an existing destination node but its source node is missing from nodes

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/3433

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
