### PR TITLE
feat(3475): Ability to enable/disable pipeline in V2 UI

### DIFF
--- a/app/components/pipeline/settings/main/component.js
+++ b/app/components/pipeline/settings/main/component.js
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
+import humanizeDuration from 'humanize-duration';
 
 import { hasSonarBadge } from 'screwdriver-ui/utils/pipeline';
 import { getCheckoutUrl } from 'screwdriver-ui/utils/git';
@@ -27,6 +28,8 @@ export default class PipelineSettingsMainComponent extends Component {
 
   @tracked isSetVisibilityModalOpen = false;
 
+  @tracked isTogglePipelineModalOpen = false;
+
   @tracked pipeline;
 
   @tracked syncType;
@@ -35,6 +38,23 @@ export default class PipelineSettingsMainComponent extends Component {
     super(...arguments);
 
     this.pipeline = this.pipelinePageState.getPipeline();
+  }
+
+  get isPipelineDisabled() {
+    return this.pipeline.state === 'DISABLED';
+  }
+
+  get stateChangeTimeWords() {
+    const { stateChangeTime } = this.pipeline;
+
+    if (!stateChangeTime) {
+      return null;
+    }
+
+    return `${humanizeDuration(Date.now() - new Date(stateChangeTime), {
+      round: true,
+      largest: 1
+    })} ago`;
   }
 
   get isPublic() {
@@ -211,6 +231,20 @@ export default class PipelineSettingsMainComponent extends Component {
 
     if (pipelineDeleted) {
       this.router.transitionTo('home');
+    }
+  }
+
+  @action
+  showTogglePipelineModal() {
+    this.isTogglePipelineModalOpen = true;
+  }
+
+  @action
+  async closeTogglePipelineModal(wasChanged) {
+    this.isTogglePipelineModalOpen = false;
+
+    if (wasChanged) {
+      this.pipeline = this.pipelinePageState.getPipeline();
     }
   }
 

--- a/app/components/pipeline/settings/main/modal/toggle-pipeline/component.js
+++ b/app/components/pipeline/settings/main/modal/toggle-pipeline/component.js
@@ -1,0 +1,70 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+
+export default class PipelineSettingsMainModalTogglePipelineComponent extends Component {
+  @service shuttle;
+
+  @service('pipeline-page-state') pipelinePageState;
+
+  @tracked errorMessage = null;
+
+  @tracked stateChangeMessage = '';
+
+  @tracked isSubmitting = false;
+
+  pipeline;
+
+  constructor() {
+    super(...arguments);
+
+    this.pipeline = this.pipelinePageState.getPipeline();
+  }
+
+  get isDisabled() {
+    return this.pipeline.state === 'DISABLED';
+  }
+
+  get modalTitle() {
+    const name = this.pipeline.name || this.pipeline.id;
+
+    return this.isDisabled
+      ? `Enable pipeline: ${name}?`
+      : `Disable pipeline: ${name}?`;
+  }
+
+  get actionButtonText() {
+    return this.isDisabled ? 'Enable' : 'Disable';
+  }
+
+  get pendingText() {
+    return this.isDisabled ? 'Enabling' : 'Disabling';
+  }
+
+  get newState() {
+    return this.isDisabled ? 'ACTIVE' : 'DISABLED';
+  }
+
+  @action
+  async togglePipeline() {
+    this.isSubmitting = true;
+
+    const payload = { state: this.newState };
+
+    if (this.stateChangeMessage) {
+      payload.stateChangeMessage = this.stateChangeMessage;
+    }
+
+    await this.shuttle
+      .fetchFromApi('put', `/pipelines/${this.pipeline.id}`, payload)
+      .then(pipeline => {
+        this.pipelinePageState.setPipeline(pipeline);
+        this.args.closeModal(true);
+      })
+      .catch(err => {
+        this.errorMessage = err.message;
+        this.isSubmitting = false;
+      });
+  }
+}

--- a/app/components/pipeline/settings/main/modal/toggle-pipeline/styles.scss
+++ b/app/components/pipeline/settings/main/modal/toggle-pipeline/styles.scss
@@ -1,0 +1,30 @@
+@use 'screwdriver-colors' as colors;
+
+@mixin styles {
+  #toggle-pipeline-modal {
+    #toggle-pipeline-message {
+      .toggle-pipeline-message-warning {
+        color: colors.$sd-warn-bg;
+
+        svg {
+          margin-right: 0.25rem;
+        }
+      }
+    }
+
+    .modal-body {
+      label {
+        display: flex;
+        flex-direction: column;
+        margin-top: 1rem;
+
+        input {
+          background-color: colors.$sd-flyout-bg;
+          border-radius: 3px;
+          border: 1px solid colors.$sd-light-gray;
+          padding: 0.375rem 0.75rem;
+        }
+      }
+    }
+  }
+}

--- a/app/components/pipeline/settings/main/modal/toggle-pipeline/template.hbs
+++ b/app/components/pipeline/settings/main/modal/toggle-pipeline/template.hbs
@@ -1,0 +1,63 @@
+<BsModal
+  id="toggle-pipeline-modal"
+  @onHide={{fn @closeModal}}
+  as |modal|
+>
+  <modal.header>
+    <div class="modal-title">{{this.modalTitle}}</div>
+  </modal.header>
+  <modal.body>
+    {{#if this.errorMessage}}
+      <InfoMessage
+        @message={{this.errorMessage}}
+        @type="warning"
+        @icon="triangle-exclamation"
+        @dismissible={{false}}
+      />
+    {{/if}}
+
+    <div id="toggle-pipeline-message">
+      {{#if this.isDisabled}}
+        <div>
+          Re-enabling this pipeline will allow new builds to be triggered again.
+        </div>
+        <br />
+        <div>
+          <b>Are you sure you want to enable this pipeline?</b>
+        </div>
+      {{else}}
+        <div class="toggle-pipeline-message-warning">
+          <FaIcon @icon="triangle-exclamation" />
+          <b>Disabling this pipeline will prevent new builds from being triggered.</b>
+        </div>
+        <br />
+        <div>
+          Existing builds will not be affected, but no new events will start new builds.
+        </div>
+        <br />
+        <div>
+          <b>Are you sure you want to disable this pipeline?</b>
+        </div>
+      {{/if}}
+    </div>
+
+    <label>
+      Reason
+      <Input
+        @value={{this.stateChangeMessage}}
+        autofocus="autofocus"
+        placeholder="Reason for the state change (optional)"
+      />
+    </label>
+  </modal.body>
+  <modal.footer>
+    <BsButton
+      id="toggle-pipeline-action"
+      @type="danger"
+      @defaultText={{this.actionButtonText}}
+      @pendingText={{this.pendingText}}
+      @onClick={{fn this.togglePipeline}}
+      disabled={{this.isSubmitting}}
+    />
+  </modal.footer>
+</BsModal>

--- a/app/components/pipeline/settings/main/styles.scss
+++ b/app/components/pipeline/settings/main/styles.scss
@@ -5,12 +5,14 @@
 @use 'modal/pipeline-alias/styles' as pipelineAliasModal;
 @use 'modal/sonar-badge/styles' as sonarBadgeModal;
 @use 'modal/change-visibility/styles' as changeVisibility;
+@use 'modal/toggle-pipeline/styles' as togglePipeline;
 
 @mixin styles {
   @include pipelineModal.styles;
   @include pipelineAliasModal.styles;
   @include sonarBadgeModal.styles;
   @include changeVisibility.styles;
+  @include togglePipeline.styles;
 
   #pipeline-settings-main-tab-contents {
     .section {

--- a/app/components/pipeline/settings/main/template.hbs
+++ b/app/components/pipeline/settings/main/template.hbs
@@ -181,6 +181,57 @@
   <div class="section">
     <div class="text-container">
       <div class="title">
+        {{#if this.isPipelineDisabled}}
+          Enable this pipeline
+        {{else}}
+          Disable this pipeline
+        {{/if}}
+      </div>
+      <div>
+        {{#if this.isPipelineDisabled}}
+          Re-enable the pipeline to allow new builds to be triggered.
+        {{else}}
+          Disabling a pipeline prevents new builds from being triggered.
+        {{/if}}
+      </div>
+      <div class="configuration">
+        <div id="pipeline-settings-main-pipeline-state">
+          State: <b>{{this.pipeline.state}}</b>
+        </div>
+        {{#if this.pipeline.stateChanger}}
+          <div id="pipeline-settings-main-state-changer">
+            {{if this.isPipelineDisabled "Disabled" "Enabled"}}
+            by <b>{{this.pipeline.stateChanger}}</b>
+            {{#if this.stateChangeTimeWords}}
+              <i>{{this.stateChangeTimeWords}}</i>
+            {{/if}}
+          </div>
+          {{#if this.pipeline.stateChangeMessage}}
+            <div id="pipeline-settings-main-state-change-message">
+              Reason: {{this.pipeline.stateChangeMessage}}
+            </div>
+          {{/if}}
+        {{/if}}
+      </div>
+    </div>
+    <BsButton
+      @type="primary"
+      @outline="true"
+      @onClick={{this.showTogglePipelineModal}}
+      title={{if this.isPipelineDisabled "Enable pipeline" "Disable pipeline"}}
+    >
+      <FaIcon @icon={{if this.isPipelineDisabled "play" "ban"}} />
+      {{#if this.isTogglePipelineModalOpen}}
+        <Pipeline::Settings::Main::Modal::TogglePipeline
+          @closeModal={{this.closeTogglePipelineModal}}
+        />
+      {{/if}}
+    </BsButton>
+  </div>
+
+  <div class="section">
+    <div class="text-container">
+      <div class="title">
         Admins
       </div>
       <div class="pipeline-admin-description">

--- a/app/utils/pipeline.js
+++ b/app/utils/pipeline.js
@@ -8,6 +8,9 @@ const getStateIcon = state => {
     case 'INACTIVE':
       icon = 'circle-xmark';
       break;
+    case 'DISABLED':
+      icon = 'ban';
+      break;
     default:
       icon = '';
       break;
@@ -36,6 +39,16 @@ const hasActivePipelines = pipelines => {
   return !!activePipeline;
 };
 
+const isDisabledPipeline = pipeline => {
+  return pipeline.state === 'DISABLED';
+};
+
+const hasDisabledPipelines = pipelines => {
+  const disabledPipeline = pipelines.find(p => isDisabledPipeline(p));
+
+  return !!disabledPipeline;
+};
+
 const hasSonarBadge = pipeline => {
   const sonar = pipeline.badges?.sonar;
 
@@ -54,5 +67,7 @@ export {
   hasInactivePipelines,
   isActivePipeline,
   hasActivePipelines,
+  isDisabledPipeline,
+  hasDisabledPipelines,
   hasSonarBadge
 };

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "Dao Lam <daolam112@gmail.com>",
     "Darren Matsumoto <aeneascorrupt@gmail.com>",
     "Dekus Lam <dekusdenial@hotmail.com>",
+    "Dayanand Sagar <sagar1312@mail.com>",
     "Jeremiah Wuenschel <jeremiah.wuenschel@gmail.com>",
     "Min Zhang <minzhang@andrew.cmu.edu>",
     "Noah Katzman <nbkatzman@gmail.com>",

--- a/tests/integration/components/pipeline/settings/main/component-test.js
+++ b/tests/integration/components/pipeline/settings/main/component-test.js
@@ -26,7 +26,7 @@ module('Integration | Component | pipeline/settings/main', function (hooks) {
 
     await render(hbs`<Pipeline::Settings::Main />`);
 
-    assert.dom('.section').exists({ count: 9 });
+    assert.dom('.section').exists({ count: 10 });
     assert.dom('.pipeline-settings-danger-zone').exists();
     assert
       .dom('#pipeline-settings-main-visibility')
@@ -45,7 +45,7 @@ module('Integration | Component | pipeline/settings/main', function (hooks) {
 
     await render(hbs`<Pipeline::Settings::Main />`);
 
-    assert.dom('.section').exists({ count: 8 });
+    assert.dom('.section').exists({ count: 9 });
     assert.dom('.pipeline-settings-danger-zone').exists();
     assert.dom('.pipeline-settings-danger-zone').exists({ count: 1 });
   });
@@ -77,7 +77,7 @@ module('Integration | Component | pipeline/settings/main', function (hooks) {
 
     await render(hbs`<Pipeline::Settings::Main />`);
 
-    assert.dom('.section').exists({ count: 9 });
+    assert.dom('.section').exists({ count: 10 });
     assert.dom('.pipeline-settings-danger-zone').exists();
     assert
       .dom('#pipeline-settings-main-visibility')
@@ -97,11 +97,87 @@ module('Integration | Component | pipeline/settings/main', function (hooks) {
 
     await render(hbs`<Pipeline::Settings::Main />`);
 
-    assert.dom('.section').exists({ count: 9 });
+    assert.dom('.section').exists({ count: 10 });
     assert.dom('.pipeline-settings-danger-zone').exists();
     assert
       .dom('#pipeline-settings-main-visibility')
       .hasText('Visibility: Public');
     assert.dom('.pipeline-settings-danger-zone').exists({ count: 2 });
+  });
+
+  test('it shows pipeline state as ACTIVE when pipeline is enabled', async function (assert) {
+    const pipelineMock = {
+      scmRepo: { name: 'myOrg/myRepo' },
+      scmUri: 'github.com:12345:master',
+      admins: {},
+      state: 'ACTIVE'
+    };
+
+    sinon.stub(pipelinePageState, 'getPipeline').returns(pipelineMock);
+
+    await render(hbs`<Pipeline::Settings::Main />`);
+
+    assert
+      .dom('#pipeline-settings-main-pipeline-state')
+      .hasText('State: ACTIVE');
+  });
+
+  test('it shows pipeline state as DISABLED when pipeline is disabled', async function (assert) {
+    const pipelineMock = {
+      scmRepo: { name: 'myOrg/myRepo' },
+      scmUri: 'github.com:12345:master',
+      admins: {},
+      state: 'DISABLED'
+    };
+
+    sinon.stub(pipelinePageState, 'getPipeline').returns(pipelineMock);
+
+    await render(hbs`<Pipeline::Settings::Main />`);
+
+    assert
+      .dom('#pipeline-settings-main-pipeline-state')
+      .hasText('State: DISABLED');
+  });
+
+  test('it shows state changer info when stateChanger is present', async function (assert) {
+    const pipelineMock = {
+      scmRepo: { name: 'myOrg/myRepo' },
+      scmUri: 'github.com:12345:master',
+      admins: {},
+      state: 'DISABLED',
+      stateChanger: 'jdoe',
+      stateChangeTime: new Date().toISOString(),
+      stateChangeMessage: 'Disabling for maintenance'
+    };
+
+    sinon.stub(pipelinePageState, 'getPipeline').returns(pipelineMock);
+
+    await render(hbs`<Pipeline::Settings::Main />`);
+
+    assert.dom('#pipeline-settings-main-state-changer').exists();
+    assert
+      .dom('#pipeline-settings-main-state-changer')
+      .containsText('Disabled');
+    assert.dom('#pipeline-settings-main-state-changer').containsText('jdoe');
+    assert.dom('#pipeline-settings-main-state-change-message').exists();
+    assert
+      .dom('#pipeline-settings-main-state-change-message')
+      .containsText('Disabling for maintenance');
+  });
+
+  test('it does not show state changer info when stateChanger is absent', async function (assert) {
+    const pipelineMock = {
+      scmRepo: { name: 'myOrg/myRepo' },
+      scmUri: 'github.com:12345:master',
+      admins: {},
+      state: 'ACTIVE'
+    };
+
+    sinon.stub(pipelinePageState, 'getPipeline').returns(pipelineMock);
+
+    await render(hbs`<Pipeline::Settings::Main />`);
+
+    assert.dom('#pipeline-settings-main-state-changer').doesNotExist();
+    assert.dom('#pipeline-settings-main-state-change-message').doesNotExist();
   });
 });

--- a/tests/integration/components/pipeline/settings/main/modal/toggle-pipeline/component-test.js
+++ b/tests/integration/components/pipeline/settings/main/modal/toggle-pipeline/component-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
-import { render } from '@ember/test-helpers';
+import { click, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 
@@ -60,9 +60,7 @@ module(
 
       assert.dom('.modal-title').hasText('Disable pipeline: myOrg/myRepo?');
       assert.dom('.toggle-pipeline-message-warning').exists({ count: 1 });
-      assert
-        .dom('#toggle-pipeline-action')
-        .hasAttribute('data-default-text', 'Disable');
+      assert.dom('#toggle-pipeline-action').hasText('Disable');
     });
 
     test('it renders enable confirmation when pipeline is disabled', async function (assert) {
@@ -83,9 +81,7 @@ module(
 
       assert.dom('.modal-title').hasText('Enable pipeline: myOrg/myRepo?');
       assert.dom('.toggle-pipeline-message-warning').doesNotExist();
-      assert
-        .dom('#toggle-pipeline-action')
-        .hasAttribute('data-default-text', 'Enable');
+      assert.dom('#toggle-pipeline-action').hasText('Enable');
     });
 
     test('it handles failed API call', async function (assert) {
@@ -108,9 +104,7 @@ module(
         />`
       );
 
-      await (
-        await import('@ember/test-helpers')
-      ).click('#toggle-pipeline-action');
+      await click('#toggle-pipeline-action');
 
       assert.dom('.alert').exists({ count: 1 });
     });
@@ -144,9 +138,7 @@ module(
         />`
       );
 
-      await (
-        await import('@ember/test-helpers')
-      ).click('#toggle-pipeline-action');
+      await click('#toggle-pipeline-action');
 
       assert.ok(
         setPipelineStub.calledWith(updatedPipeline),
@@ -183,9 +175,7 @@ module(
         />`
       );
 
-      await (
-        await import('@ember/test-helpers')
-      ).click('#toggle-pipeline-action');
+      await click('#toggle-pipeline-action');
 
       assert.ok(
         setPipelineStub.calledWith(updatedPipeline),

--- a/tests/integration/components/pipeline/settings/main/modal/toggle-pipeline/component-test.js
+++ b/tests/integration/components/pipeline/settings/main/modal/toggle-pipeline/component-test.js
@@ -1,0 +1,197 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+
+module(
+  'Integration | Component | pipeline/settings/main/modal/toggle-pipeline',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    let pipelinePageState;
+
+    let shuttle;
+
+    hooks.beforeEach(function () {
+      pipelinePageState = this.owner.lookup('service:pipeline-page-state');
+      shuttle = this.owner.lookup('service:shuttle');
+    });
+
+    test('it renders core components', async function (assert) {
+      const pipelineMock = {
+        id: 123,
+        name: 'myOrg/myRepo',
+        state: 'ACTIVE'
+      };
+
+      sinon.stub(pipelinePageState, 'getPipeline').returns(pipelineMock);
+      this.setProperties({ closeModal: () => {} });
+
+      await render(
+        hbs`<Pipeline::Settings::Main::Modal::TogglePipeline
+            @closeModal={{this.closeModal}}
+        />`
+      );
+
+      assert.dom('.modal-header').exists({ count: 1 });
+      assert.dom('.modal-title').exists({ count: 1 });
+      assert.dom('.alert').doesNotExist();
+      assert.dom('#toggle-pipeline-message').exists({ count: 1 });
+      assert.dom('.modal-footer').exists({ count: 1 });
+      assert.dom('#toggle-pipeline-action').exists({ count: 1 });
+    });
+
+    test('it renders disable confirmation when pipeline is active', async function (assert) {
+      const pipelineMock = {
+        id: 123,
+        name: 'myOrg/myRepo',
+        state: 'ACTIVE'
+      };
+
+      sinon.stub(pipelinePageState, 'getPipeline').returns(pipelineMock);
+      this.setProperties({ closeModal: () => {} });
+
+      await render(
+        hbs`<Pipeline::Settings::Main::Modal::TogglePipeline
+            @closeModal={{this.closeModal}}
+        />`
+      );
+
+      assert.dom('.modal-title').hasText('Disable pipeline: myOrg/myRepo?');
+      assert.dom('.toggle-pipeline-message-warning').exists({ count: 1 });
+      assert
+        .dom('#toggle-pipeline-action')
+        .hasAttribute('data-default-text', 'Disable');
+    });
+
+    test('it renders enable confirmation when pipeline is disabled', async function (assert) {
+      const pipelineMock = {
+        id: 123,
+        name: 'myOrg/myRepo',
+        state: 'DISABLED'
+      };
+
+      sinon.stub(pipelinePageState, 'getPipeline').returns(pipelineMock);
+      this.setProperties({ closeModal: () => {} });
+
+      await render(
+        hbs`<Pipeline::Settings::Main::Modal::TogglePipeline
+            @closeModal={{this.closeModal}}
+        />`
+      );
+
+      assert.dom('.modal-title').hasText('Enable pipeline: myOrg/myRepo?');
+      assert.dom('.toggle-pipeline-message-warning').doesNotExist();
+      assert
+        .dom('#toggle-pipeline-action')
+        .hasAttribute('data-default-text', 'Enable');
+    });
+
+    test('it handles failed API call', async function (assert) {
+      const pipelineMock = {
+        id: 123,
+        name: 'myOrg/myRepo',
+        state: 'ACTIVE'
+      };
+
+      sinon.stub(pipelinePageState, 'getPipeline').returns(pipelineMock);
+      sinon
+        .stub(shuttle, 'fetchFromApi')
+        .rejects(new Error('Internal server error'));
+
+      this.setProperties({ closeModal: () => {} });
+
+      await render(
+        hbs`<Pipeline::Settings::Main::Modal::TogglePipeline
+            @closeModal={{this.closeModal}}
+        />`
+      );
+
+      await (
+        await import('@ember/test-helpers')
+      ).click('#toggle-pipeline-action');
+
+      assert.dom('.alert').exists({ count: 1 });
+    });
+
+    test('it handles successful disable', async function (assert) {
+      const pipelineMock = {
+        id: 123,
+        name: 'myOrg/myRepo',
+        state: 'ACTIVE'
+      };
+      const updatedPipeline = { ...pipelineMock, state: 'DISABLED' };
+
+      const getPipelineStub = sinon
+        .stub(pipelinePageState, 'getPipeline')
+        .returns(pipelineMock);
+      const setPipelineStub = sinon.stub(pipelinePageState, 'setPipeline');
+
+      sinon.stub(shuttle, 'fetchFromApi').resolves(updatedPipeline);
+
+      let closedWith;
+
+      this.setProperties({
+        closeModal: result => {
+          closedWith = result;
+        }
+      });
+
+      await render(
+        hbs`<Pipeline::Settings::Main::Modal::TogglePipeline
+            @closeModal={{this.closeModal}}
+        />`
+      );
+
+      await (
+        await import('@ember/test-helpers')
+      ).click('#toggle-pipeline-action');
+
+      assert.ok(
+        setPipelineStub.calledWith(updatedPipeline),
+        'setPipeline called with updated pipeline'
+      );
+      assert.strictEqual(closedWith, true, 'closeModal called with true');
+      assert.ok(getPipelineStub.called);
+    });
+
+    test('it handles successful enable', async function (assert) {
+      const pipelineMock = {
+        id: 123,
+        name: 'myOrg/myRepo',
+        state: 'DISABLED'
+      };
+      const updatedPipeline = { ...pipelineMock, state: 'ACTIVE' };
+
+      sinon.stub(pipelinePageState, 'getPipeline').returns(pipelineMock);
+      const setPipelineStub = sinon.stub(pipelinePageState, 'setPipeline');
+
+      sinon.stub(shuttle, 'fetchFromApi').resolves(updatedPipeline);
+
+      let closedWith;
+
+      this.setProperties({
+        closeModal: result => {
+          closedWith = result;
+        }
+      });
+
+      await render(
+        hbs`<Pipeline::Settings::Main::Modal::TogglePipeline
+            @closeModal={{this.closeModal}}
+        />`
+      );
+
+      await (
+        await import('@ember/test-helpers')
+      ).click('#toggle-pipeline-action');
+
+      assert.ok(
+        setPipelineStub.calledWith(updatedPipeline),
+        'setPipeline called with updated pipeline'
+      );
+      assert.strictEqual(closedWith, true, 'closeModal called with true');
+    });
+  }
+);

--- a/tests/unit/utils/pipeline-test.js
+++ b/tests/unit/utils/pipeline-test.js
@@ -6,6 +6,8 @@ const {
   hasInactivePipelines,
   isActivePipeline,
   hasActivePipelines,
+  isDisabledPipeline,
+  hasDisabledPipelines,
   hasSonarBadge
 } = pipeline;
 
@@ -14,10 +16,13 @@ module('Unit | Utility | pipeline', function () {
   const ACTIVE_PIPELINE_2 = { id: 2, state: 'ACTIVE' };
   const INACTIVE_PIPELINE_1 = { id: 3, state: 'INACTIVE' };
   const INACTIVE_PIPELINE_2 = { id: 4, state: 'INACTIVE' };
+  const DISABLED_PIPELINE_1 = { id: 5, state: 'DISABLED' };
+  const DISABLED_PIPELINE_2 = { id: 6, state: 'DISABLED' };
 
   test('it gets the right fs class name for given state', assert => {
     assert.equal(getStateIcon('ACTIVE'), 'circle-check');
     assert.equal(getStateIcon('INACTIVE'), 'circle-xmark');
+    assert.equal(getStateIcon('DISABLED'), 'ban');
     assert.equal(getStateIcon('some_incorrect_state'), '');
     assert.equal(getStateIcon(''), '');
     assert.equal(getStateIcon(), '');
@@ -63,6 +68,27 @@ module('Unit | Utility | pipeline', function () {
     assert.notOk(hasActivePipelines([INACTIVE_PIPELINE_2]));
     assert.notOk(
       hasActivePipelines([INACTIVE_PIPELINE_1, INACTIVE_PIPELINE_2])
+    );
+  });
+
+  test('it checks if pipeline is disabled', assert => {
+    assert.ok(isDisabledPipeline(DISABLED_PIPELINE_1));
+    assert.ok(isDisabledPipeline(DISABLED_PIPELINE_2));
+
+    assert.notOk(isDisabledPipeline(ACTIVE_PIPELINE_1));
+    assert.notOk(isDisabledPipeline(INACTIVE_PIPELINE_1));
+  });
+
+  test('it checks if disabled pipeline exists', assert => {
+    assert.ok(hasDisabledPipelines([DISABLED_PIPELINE_1]));
+    assert.ok(hasDisabledPipelines([DISABLED_PIPELINE_1, DISABLED_PIPELINE_2]));
+    assert.ok(hasDisabledPipelines([ACTIVE_PIPELINE_1, DISABLED_PIPELINE_1]));
+
+    assert.notOk(hasDisabledPipelines([]));
+    assert.notOk(hasDisabledPipelines([ACTIVE_PIPELINE_1]));
+    assert.notOk(hasDisabledPipelines([INACTIVE_PIPELINE_1]));
+    assert.notOk(
+      hasDisabledPipelines([ACTIVE_PIPELINE_1, INACTIVE_PIPELINE_1])
     );
   });
 


### PR DESCRIPTION
## Context

Screwdriver supports enabling and disabling individual jobs to prevent builds from being created or executed for those jobs. This is useful for temporarily pausing specific parts of a pipeline without removing them.

However, for large pipelines with many jobs, managing this at the job level becomes time-consuming and inefficient — each job must be disabled individually. There is currently no way to disable an entire pipeline in one action.

Additionally, pipelines currently only support three states: ACTIVE, INACTIVE (used for child pipelines managed by a config pipeline), and DELETING. There is no first-class concept of a user-initiated disabled state at the pipeline level.

## Objective

Exposes the new pipeline DISABLED state (added in screwdriver-cd/screwdriver#3476) in the V2 pipeline settings page, following the same patterns used for job enable/disable.

Changes:
- Add Disable/Enable Pipeline section to the settings main page, placed after the Sync sections and before Admins, with plain section styling (no danger zone)
- Add Pipeline::Settings::Main::Modal::TogglePipeline confirmation modal with an optional reason input; sends PUT /pipelines/:id with { state: 'DISABLED' } or { state: 'ACTIVE' } to toggle pipeline state
- Display stateChanger, stateChangeTime (humanized), and stateChangeMessage below the current pipeline state when a state change has been recorded
- Add isDisabledPipeline / hasDisabledPipelines utilities and DISABLED icon ('ban') to app/utils/pipeline.js
- Add integration tests for the new modal and update existing settings main component tests for revised section/danger-zone counts
- Add contributor entry to package.json

**When the pipeline is enabled**
<img width="1677" height="723" alt="image" src="https://github.com/user-attachments/assets/375531df-178d-43d4-9ae0-97e8f07cb034" />

**Status Change Confirmation Modal**
<img width="1722" height="884" alt="image" src="https://github.com/user-attachments/assets/7cac0aa9-a006-4a4a-a69e-5399848bd2aa" />

**When the pipeline is disabled**
<img width="1724" height="786" alt="image" src="https://github.com/user-attachments/assets/96ef9509-58e0-4509-b73c-a3f487a97b27" />


## References

https://github.com/screwdriver-cd/screwdriver/issues/3475

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
