### PR TITLE
fix(3485): v1 -> v2 event redirects navigate to the wrong event in the UI

### DIFF
--- a/app/pipeline/events/route.js
+++ b/app/pipeline/events/route.js
@@ -23,7 +23,13 @@ export default Route.extend({
       return;
     }
 
-    this.replaceWith('v2.pipeline.events', pipeline.id);
+    const { event_id: eventId } = this.paramsFor('pipeline.events.show');
+
+    if (eventId) {
+      this.replaceWith('v2.pipeline.events.show', pipeline.id, eventId);
+    } else {
+      this.replaceWith('v2.pipeline.events', pipeline.id);
+    }
   },
   setupController(controller, model = {}) {
     this._super(controller, model);

--- a/tests/acceptance/pipeline/events/events-test.js
+++ b/tests/acceptance/pipeline/events/events-test.js
@@ -14,6 +14,13 @@ module('Acceptance | pipelines/:id/events', hooks => {
   setupApplicationTest(hooks);
 
   const BASE_URL = `/v2/pipelines/${PIPELINE_ID}/events`;
+  const V1_BASE_URL = `/pipelines/${PIPELINE_ID}/events`;
+
+  test('visiting /pipelines/:id/events/:eventId redirects to the same event in v2', async assert => {
+    await visit(`${V1_BASE_URL}/${DEFAULT_EVENT_ID}`);
+
+    assert.strictEqual(currentURL(), `${BASE_URL}/${DEFAULT_EVENT_ID}`);
+  });
 
   test('visiting /pipelines/:id/events requires being logged in', async assert => {
     await invalidateSession();


### PR DESCRIPTION
## Context

When a user visits a v1 pipeline event URL (e.g. `/pipelines/123456/events/98765`), the `pipeline.events` parent route's `beforeModel()` hook redirects to the v2 UI by calling `this.replaceWith('v2.pipeline.events', pipeline.id)`. This targets the v2 events **index** route, which always resolves to the pipeline's latest event (`pipeline.lastEventId`) — discarding the original `event_id` from the URL.

As a result, users land on the wrong event in v2 instead of the one they originally navigated to.

## Objective

Preserve the `event_id` when redirecting from a v1 event URL to v2. 

The fix reads the `event_id` via `this.paramsFor('pipeline.events.show')` in the parent route's `beforeModel()` hook (Ember parses all route segments from the URL upfront, so child params are available at this point) and redirects directly to `v2.pipeline.events.show` with the same event ID. 
If no event ID is present (e.g. visiting `/pipelines/:id/events` without a specific event), the existing fallback to the latest event is preserved.

An acceptance test is added to verify that visiting a v1 event URL redirects to the equivalent v2 URL with the same event ID.

## References

https://github.com/screwdriver-cd/screwdriver/pull/3485

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
