### PR TITLE
fix(CVE-2022-37434): try openresty/openresty:1.29.2.3-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openresty/openresty:1.21.4.1-2-alpine
+FROM openresty/openresty:1.29.2.3-alpine
 COPY nginx.conf /usr/local/openresty/nginx/conf/nginx.conf
 WORKDIR /usr/local/openresty/nginx/html
 RUN set -x \


### PR DESCRIPTION
## Context

ui image was flagged for CVE-2022-37434

## Objective

resolve CVE-2022-37434

## References

CVE-2022-37434

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
