### PR TITLE
fix(3491): Enable to pass parentEventId when start and start method [2]

### DIFF
--- a/app/components/pipeline-events/component.js
+++ b/app/components/pipeline-events/component.js
@@ -93,10 +93,13 @@ export async function startDetachedBuild(job, options = {}, stage) {
     startFrom = `PR-${prNum}:${startFrom}`;
   }
 
+  const startAction = buildId ? 'RESTART_FROM_BUILD' : 'START_FROM_EVENT';
+
   const eventPayload = {
     buildId,
     pipelineId,
     startFrom,
+    startAction,
     parentBuildId,
     parentEventId,
     groupEventId,
@@ -626,7 +629,8 @@ export default Component.extend(ModelReloaderMixin, {
       const eventPayload = {
         pipelineId,
         startFrom: '~commit',
-        causeMessage: `Manually started by ${user}`
+        causeMessage: `Manually started by ${user}`,
+        startAction: 'START_FROM_LATEST_COMMIT'
       };
 
       if (parameters) {

--- a/app/components/pipeline/modal/confirm-action/component.js
+++ b/app/components/pipeline/modal/confirm-action/component.js
@@ -170,6 +170,15 @@ export default class PipelineModalConfirmActionComponent extends Component {
         : this.args.event;
     const sha = this.args.event?.sha;
 
+    let startAction = 'START_FROM_LATEST_COMMIT';
+
+    if (event) {
+      startAction =
+        this.args.action === 'start'
+          ? 'START_FROM_EVENT'
+          : 'RESTART_FROM_EVENT';
+    }
+
     const data = {
       pipelineId: this.pipeline.id,
       causeMessage: this.isFrozen
@@ -177,7 +186,7 @@ export default class PipelineModalConfirmActionComponent extends Component {
         : `Manually started by ${this.session.data.authenticated.username}`,
       ...buildPostBody(
         this.startFrom,
-        this.args.action,
+        startAction,
         event,
         sha,
         this.args.event?.prNum,

--- a/app/components/pipeline/modal/confirm-action/component.js
+++ b/app/components/pipeline/modal/confirm-action/component.js
@@ -163,7 +163,9 @@ export default class PipelineModalConfirmActionComponent extends Component {
     this.isNotFoundError = false;
 
     const event =
-      this.args.action === 'start' && !this.pipelinePageState.getIsPr()
+      this.args.action === 'start' &&
+      !this.args.job &&
+      !this.pipelinePageState.getIsPr()
         ? null
         : this.args.event;
     const sha = this.args.event?.sha;
@@ -175,6 +177,7 @@ export default class PipelineModalConfirmActionComponent extends Component {
         : `Manually started by ${this.session.data.authenticated.username}`,
       ...buildPostBody(
         this.startFrom,
+        this.args.action,
         event,
         sha,
         this.args.event?.prNum,

--- a/app/components/pipeline/modal/confirm-action/util.js
+++ b/app/components/pipeline/modal/confirm-action/util.js
@@ -41,13 +41,21 @@ export function isParameterized(pipeline, defaultJobParameters, event) {
 /**
  * Build core post body for triggering an event
  * @param jobName {string} Name of the job to start from
+ * @param startAction {string} Name of start type (start or restart)
  * @param event {object} Event object in the shape returned by the API
  * @param sha {string} Commit SHA
  * @param prNum {number} Pull request number
  * @param parameters {object} Parameters to pass to the event
  * @returns {object}
  */
-export const buildPostBody = (jobName, event, sha, prNum, parameters) => {
+export const buildPostBody = (
+  jobName,
+  startAction,
+  event,
+  sha,
+  prNum,
+  parameters
+) => {
   const data = {
     startFrom: jobName
   };
@@ -63,6 +71,7 @@ export const buildPostBody = (jobName, event, sha, prNum, parameters) => {
   } else if (event) {
     data.parentEventId = event.id;
     data.groupEventId = event.groupEventId;
+    data.startAction = startAction;
   } else if (sha) {
     data.sha = sha;
   }

--- a/app/components/pipeline/modal/confirm-action/util.js
+++ b/app/components/pipeline/modal/confirm-action/util.js
@@ -57,7 +57,8 @@ export const buildPostBody = (
   parameters
 ) => {
   const data = {
-    startFrom: jobName
+    startFrom: jobName,
+    startAction
   };
 
   if (prNum) {
@@ -71,7 +72,6 @@ export const buildPostBody = (
   } else if (event) {
     data.parentEventId = event.id;
     data.groupEventId = event.groupEventId;
-    data.startAction = startAction;
   } else if (sha) {
     data.sha = sha;
   }

--- a/app/event/model.js
+++ b/app/event/model.js
@@ -27,6 +27,7 @@ export default Model.extend(ModelReloaderMixin, {
   prNum: attr('number'),
   sha: attr('string'),
   startFrom: attr('string'),
+  startAction: attr('string'),
   status: attr('string', { defaultValue: 'UNKNOWN' }),
   type: attr('string'),
   workflow: attr(),

--- a/app/event/serializer.js
+++ b/app/event/serializer.js
@@ -91,6 +91,10 @@ export default RESTSerializer.extend({
       data.meta = snapshot.attr('meta');
     }
 
+    if (snapshot.attr('startAction')) {
+      data.startAction = snapshot.attr('startAction');
+    }
+
     return assign(hash, data);
   }
 });

--- a/app/pipeline/build/controller.js
+++ b/app/pipeline/build/controller.js
@@ -135,7 +135,8 @@ export default Controller.extend({
       const causeMessage = `Manually started by ${user}`;
       const newEvent = this.store.createRecord('event', {
         buildId,
-        causeMessage
+        causeMessage,
+        startAction: 'RESTART_FROM_BUILD'
       });
 
       return newEvent

--- a/app/pipeline/jobs/index/controller.js
+++ b/app/pipeline/jobs/index/controller.js
@@ -243,15 +243,14 @@ export default Controller.extend(ModelReloaderMixin, {
 
       let eventPayload;
 
+      const buildQueryConfig = { jobId };
+      const build = await this.store.queryRecord('build', buildQueryConfig);
+      const event = await this.store.findRecord('event', build.eventId);
+      const parentEventId = event.id;
+
       if (buildState === 'RESTART') {
-        const buildQueryConfig = { jobId };
-
-        const build = await this.store.queryRecord('build', buildQueryConfig);
-        const event = await this.store.findRecord('event', build.eventId);
-
         const buildId = build.id;
         const { parentBuildId } = build;
-        const parentEventId = event.id;
         const { prNum } = event;
 
         if (prNum) {
@@ -265,13 +264,16 @@ export default Controller.extend(ModelReloaderMixin, {
           startFrom,
           parentBuildId,
           parentEventId,
-          causeMessage
+          causeMessage,
+          startAction: 'start'
         };
       } else {
         eventPayload = {
           pipelineId,
           startFrom,
-          causeMessage
+          causeMessage,
+          parentEventId,
+          startAction: 'restart'
         };
       }
 

--- a/app/pipeline/jobs/index/controller.js
+++ b/app/pipeline/jobs/index/controller.js
@@ -265,7 +265,7 @@ export default Controller.extend(ModelReloaderMixin, {
           parentBuildId,
           parentEventId,
           causeMessage,
-          startAction: 'start'
+          startAction: 'RESTART_FROM_BUILD'
         };
       } else {
         eventPayload = {
@@ -273,7 +273,7 @@ export default Controller.extend(ModelReloaderMixin, {
           startFrom,
           causeMessage,
           parentEventId,
-          startAction: 'restart'
+          startAction: 'START_FROM_EVENT'
         };
       }
 

--- a/tests/integration/components/pipeline-events/component-test.js
+++ b/tests/integration/components/pipeline-events/component-test.js
@@ -112,7 +112,8 @@ module('Integration | Component | pipeline events', function (hooks) {
     assert.deepEqual(payload, {
       pipelineId: '1234',
       startFrom: '~commit',
-      causeMessage: 'Manually started by apple'
+      causeMessage: 'Manually started by apple',
+      startAction: 'START_FROM_LATEST_COMMIT'
     });
   });
 
@@ -201,7 +202,8 @@ module('Integration | Component | pipeline events', function (hooks) {
       buildId: 123,
       parentBuildId: 345,
       parentEventId: 1,
-      causeMessage: 'Manually started by apple'
+      causeMessage: 'Manually started by apple',
+      startAction: 'RESTART_FROM_BUILD'
     });
   });
 
@@ -301,7 +303,8 @@ module('Integration | Component | pipeline events', function (hooks) {
       buildId: 123,
       parentBuildId: 345,
       parentEventId: 1,
-      causeMessage: 'Manually started by apple'
+      causeMessage: 'Manually started by apple',
+      startAction: 'RESTART_FROM_BUILD'
     });
   });
 

--- a/tests/integration/components/pipeline/modal/confirm-action/api-body-test.js
+++ b/tests/integration/components/pipeline/modal/confirm-action/api-body-test.js
@@ -98,7 +98,8 @@ module(
         shuttleStub.calledWith('post', '/events', {
           pipelineId,
           causeMessage: `Manually started by ${username}`,
-          startFrom: '~commit'
+          startFrom: '~commit',
+          startAction: 'START_FROM_LATEST_COMMIT'
         })
       );
     });
@@ -124,7 +125,8 @@ module(
           pipelineId,
           causeMessage: `Manually started by ${username}`,
           startFrom: '~commit',
-          meta: { parameters }
+          meta: { parameters },
+          startAction: 'START_FROM_LATEST_COMMIT'
         })
       );
     });
@@ -285,7 +287,8 @@ module(
           startFrom: '~pr',
           prNum,
           parentEventId: event.id,
-          groupEventId: event.groupEventId
+          groupEventId: event.groupEventId,
+          startAction: 'START_FROM_EVENT'
         })
       );
     });
@@ -318,7 +321,8 @@ module(
           prNum,
           parentEventId: event.id,
           groupEventId: event.groupEventId,
-          meta: { parameters }
+          meta: { parameters },
+          startAction: 'START_FROM_EVENT'
         })
       );
     });
@@ -352,7 +356,8 @@ module(
           startFrom: `PR-${prNum}:${job.name}`,
           prNum,
           parentEventId: event.id,
-          groupEventId: event.groupEventId
+          groupEventId: event.groupEventId,
+          startAction: 'START_FROM_EVENT'
         })
       );
     });
@@ -387,7 +392,8 @@ module(
           prNum,
           parentEventId: event.id,
           groupEventId: event.groupEventId,
-          meta: { parameters }
+          meta: { parameters },
+          startAction: 'START_FROM_EVENT'
         })
       );
     });
@@ -421,7 +427,8 @@ module(
           startFrom: `PR-${prNum}:${job.name}`,
           prNum,
           parentEventId: event.id,
-          groupEventId: event.groupEventId
+          groupEventId: event.groupEventId,
+          startAction: 'RESTART_FROM_EVENT'
         })
       );
     });
@@ -456,7 +463,8 @@ module(
           prNum,
           parentEventId: event.id,
           groupEventId: event.groupEventId,
-          meta: { parameters }
+          meta: { parameters },
+          startAction: 'RESTART_FROM_EVENT'
         })
       );
     });

--- a/tests/integration/components/pipeline/modal/confirm-action/api-body-test.js
+++ b/tests/integration/components/pipeline/modal/confirm-action/api-body-test.js
@@ -154,7 +154,9 @@ module(
           pipelineId,
           causeMessage: `Manually started by ${username}`,
           startFrom: job.name,
-          sha: event.sha
+          parentEventId: event.id,
+          groupEventId: event.groupEventId,
+          startAction: 'START_FROM_EVENT'
         })
       );
     });
@@ -184,8 +186,10 @@ module(
           pipelineId,
           causeMessage: `Manually started by ${username}`,
           startFrom: job.name,
-          sha: event.sha,
-          meta: { parameters }
+          parentEventId: event.id,
+          groupEventId: event.groupEventId,
+          meta: { parameters },
+          startAction: 'START_FROM_EVENT'
         })
       );
     });
@@ -209,14 +213,14 @@ module(
         />`
       );
       await click('#submit-action');
-
       assert.true(
         shuttleStub.calledWith('post', '/events', {
           pipelineId,
           causeMessage: `Manually started by ${username}`,
           startFrom: job.name,
           parentEventId: event.id,
-          groupEventId: event.groupEventId
+          groupEventId: event.groupEventId,
+          startAction: 'RESTART_FROM_EVENT'
         })
       );
     });
@@ -248,7 +252,8 @@ module(
           startFrom: job.name,
           parentEventId: event.id,
           groupEventId: event.groupEventId,
-          meta: { parameters }
+          meta: { parameters },
+          startAction: 'RESTART_FROM_EVENT'
         })
       );
     });

--- a/tests/unit/components/pipeline/modal/confirm-action/util-test.js
+++ b/tests/unit/components/pipeline/modal/confirm-action/util-test.js
@@ -59,9 +59,20 @@ module('Unit | Component | pipeline/modal/confirm-action/util', function () {
   test('buildPostBody sets correct values for new event', function (assert) {
     const jobName = '~commit';
 
-    assert.deepEqual(buildPostBody(jobName, null, null, null, null), {
-      startFrom: jobName
-    });
+    assert.deepEqual(
+      buildPostBody(
+        jobName,
+        'START_FROM_LATEST_COMMIT',
+        null,
+        null,
+        null,
+        null
+      ),
+      {
+        startFrom: jobName,
+        startAction: 'START_FROM_LATEST_COMMIT'
+      }
+    );
   });
 
   test('buildPostBody sets correct values for new event in event group', function (assert) {
@@ -71,21 +82,29 @@ module('Unit | Component | pipeline/modal/confirm-action/util', function () {
       groupEventId: 2
     };
 
-    assert.deepEqual(buildPostBody(jobName, event, null, null, null), {
-      startFrom: jobName,
-      parentEventId: event.id,
-      groupEventId: event.groupEventId
-    });
+    assert.deepEqual(
+      buildPostBody(jobName, 'START_FROM_EVENT', event, null, null, null),
+      {
+        startFrom: jobName,
+        startAction: 'START_FROM_EVENT',
+        parentEventId: event.id,
+        groupEventId: event.groupEventId
+      }
+    );
   });
 
   test('buildPostBody sets correct values for new event from specific sha', function (assert) {
     const jobName = '~commit';
     const sha = 'abc123';
 
-    assert.deepEqual(buildPostBody(jobName, null, sha), {
-      startFrom: jobName,
-      sha
-    });
+    assert.deepEqual(
+      buildPostBody(jobName, 'START_FROM_LATEST_COMMIT', null, sha),
+      {
+        startFrom: jobName,
+        startAction: 'START_FROM_LATEST_COMMIT',
+        sha
+      }
+    );
   });
 
   test('buildPostBody sets correct values for new PR event', function (assert) {
@@ -96,12 +115,16 @@ module('Unit | Component | pipeline/modal/confirm-action/util', function () {
     };
     const prNum = 7;
 
-    assert.deepEqual(buildPostBody(jobName, event, null, prNum), {
-      prNum,
-      startFrom: jobName,
-      parentEventId: event.id,
-      groupEventId: event.groupEventId
-    });
+    assert.deepEqual(
+      buildPostBody(jobName, 'START_FROM_EVENT', event, null, prNum),
+      {
+        prNum,
+        startFrom: jobName,
+        startAction: 'START_FROM_EVENT',
+        parentEventId: event.id,
+        groupEventId: event.groupEventId
+      }
+    );
   });
 
   test('buildPostBody sets correct values for new PR event from specified job', function (assert) {
@@ -112,12 +135,16 @@ module('Unit | Component | pipeline/modal/confirm-action/util', function () {
     };
     const prNum = 7;
 
-    assert.deepEqual(buildPostBody(jobName, event, null, prNum), {
-      prNum,
-      startFrom: `PR-${prNum}:${jobName}`,
-      parentEventId: event.id,
-      groupEventId: event.groupEventId
-    });
+    assert.deepEqual(
+      buildPostBody(jobName, 'START_FROM_EVENT', event, null, prNum),
+      {
+        prNum,
+        startFrom: `PR-${prNum}:${jobName}`,
+        startAction: 'START_FROM_EVENT',
+        parentEventId: event.id,
+        groupEventId: event.groupEventId
+      }
+    );
   });
 
   test('buildPostBody sets correct values for new PR event from specified job with PR prefix', function (assert) {
@@ -128,23 +155,38 @@ module('Unit | Component | pipeline/modal/confirm-action/util', function () {
       groupEventId: 10
     };
 
-    assert.deepEqual(buildPostBody(jobName, event, null, prNum), {
-      prNum,
-      startFrom: jobName,
-      parentEventId: event.id,
-      groupEventId: event.groupEventId
-    });
+    assert.deepEqual(
+      buildPostBody(jobName, 'START_FROM_EVENT', event, null, prNum),
+      {
+        prNum,
+        startFrom: jobName,
+        startAction: 'START_FROM_EVENT',
+        parentEventId: event.id,
+        groupEventId: event.groupEventId
+      }
+    );
   });
 
   test('buildPostBody sets correct values for new event with parameters', function (assert) {
     const jobName = '~commit';
     const parameters = { param: 4 };
 
-    assert.deepEqual(buildPostBody(jobName, null, null, null, parameters), {
-      startFrom: jobName,
-      meta: {
+    assert.deepEqual(
+      buildPostBody(
+        jobName,
+        'START_FROM_LATEST_COMMIT',
+        null,
+        null,
+        null,
         parameters
+      ),
+      {
+        startFrom: jobName,
+        startAction: 'START_FROM_LATEST_COMMIT',
+        meta: {
+          parameters
+        }
       }
-    });
+    );
   });
 });

--- a/tests/unit/pipeline/build/controller-test.js
+++ b/tests/unit/pipeline/build/controller-test.js
@@ -107,7 +107,8 @@ module('Unit | Controller | pipeline/build', function (hooks) {
 
     assert.deepEqual(payload, {
       buildId: 123,
-      causeMessage: 'Manually started by apple'
+      causeMessage: 'Manually started by apple',
+      startAction: 'RESTART_FROM_BUILD'
     });
   });
 
@@ -159,7 +160,8 @@ module('Unit | Controller | pipeline/build', function (hooks) {
 
     assert.deepEqual(payload, {
       buildId: 123,
-      causeMessage: 'Manually started by apple'
+      causeMessage: 'Manually started by apple',
+      startAction: 'RESTART_FROM_BUILD'
     });
     assert.notOk(controller.isShowingModal);
     assert.ok(invalidateStub.called);

--- a/tests/unit/pipeline/jobs/controller-test.js
+++ b/tests/unit/pipeline/jobs/controller-test.js
@@ -122,7 +122,8 @@ module('Unit | Controller | pipeline/jobs/index', function (hooks) {
       startFrom: 'name',
       parentBuildId: 57,
       parentEventId: 10,
-      causeMessage: 'Manually started by apple'
+      causeMessage: 'Manually started by apple',
+      startAction: 'RESTART_FROM_BUILD'
     });
   });
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Before merging this PR, please merge the following PR and update the API to use the updated data-schema.
Otherwise, it will fail validation.
- https://github.com/screwdriver-cd/data-schema/pull/614

If you start a new event based on an event triggered by a branch-specific trigger, the branch is not properly inherited.
This is because parentEvent is not passed at the start.
However, if you pass the parentEventId as is, it becomes impossible to distinguish it from a restart.

Currently, the only way to determine which start method was used from the UI is by checking whether a specific property is included in the payload.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Update the event so that the `parentEventId` is also passed when the event is specified to start.
Furthermore, add the event start method by each UI operation to the payload.

This will allow the API to distinguish between “start” and “restart” without relying on the presence or absence of a parentEventId.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/3491

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
