### PR TITLE
Improve UX on disabled pipelines

### DIFF
--- a/app/components/build-banner/component.js
+++ b/app/components/build-banner/component.js
@@ -175,7 +175,10 @@ export default Component.extend({
     {
       get() {
         if (this.buildAction === 'Restart') {
-          if (this.pipelineState === 'INACTIVE') {
+          if (
+            this.pipelineState === 'INACTIVE' ||
+            this.pipelineState === 'DISABLED'
+          ) {
             this.set('isButtonDisabledLoaded', true);
 
             return true;

--- a/app/components/pipeline-header/component.js
+++ b/app/components/pipeline-header/component.js
@@ -1,6 +1,10 @@
 import { get, computed } from '@ember/object';
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
+import {
+  isDisabledPipeline,
+  getDisabledPipelineMessage
+} from 'screwdriver-ui/utils/pipeline';
 
 export default Component.extend({
   showCollectionModal: false,
@@ -12,6 +16,19 @@ export default Component.extend({
   addCollectionError: null,
   addCollectionSuccess: null,
   dropdownText: 'Add to collection',
+  isDisabledPipeline: computed('pipeline.state', {
+    get() {
+      return isDisabledPipeline(this.pipeline);
+    }
+  }),
+  disabledPipelineMessage: computed(
+    'pipeline.{stateChanger,stateChangeTime,stateChangeMessage}',
+    {
+      get() {
+        return getDisabledPipelineMessage(this.pipeline);
+      }
+    }
+  ),
   sonarBadgeDescription: computed('sonarBadgeName', {
     get() {
       let sonarBadgeDescription = 'SonarQube project';

--- a/app/components/pipeline-header/template.hbs
+++ b/app/components/pipeline-header/template.hbs
@@ -1,3 +1,12 @@
+{{#if this.isDisabledPipeline}}
+  <div class="pipeline-header-message-container">
+    <InfoMessage
+      @message={{this.disabledPipelineMessage}}
+      @type="warning"
+      @icon="ban"
+    />
+  </div>
+{{/if}}
 {{#if this.addCollectionError}}
   <div class="pipeline-header-message-container">
     <InfoMessage

--- a/app/components/pipeline/event/card/component.js
+++ b/app/components/pipeline/event/card/component.js
@@ -93,7 +93,7 @@ export default class PipelineEventCardComponent extends Component {
 
     this.virtualJobIds = new Set();
     this.pipelinePageState.getJobs().forEach(job => {
-      if (job.permutations[0].annotations['screwdriver.cd/virtualJob']) {
+      if (job.permutations[0].annotations?.['screwdriver.cd/virtualJob']) {
         this.virtualJobIds.add(job.id);
       }
     });

--- a/app/components/pipeline/header/component.js
+++ b/app/components/pipeline/header/component.js
@@ -6,7 +6,9 @@ import { htmlSafe } from '@ember/template';
 
 import {
   hasSonarBadge,
-  isInactivePipeline
+  isInactivePipeline,
+  isDisabledPipeline,
+  getDisabledPipelineMessage
 } from 'screwdriver-ui/utils/pipeline';
 
 export default class PipelineHeaderComponent extends Component {
@@ -100,6 +102,16 @@ export default class PipelineHeaderComponent extends Component {
 
   get isInactivePipeline() {
     return isInactivePipeline(this.pipeline);
+  }
+
+  get isDisabledPipeline() {
+    console.log('check if disbaled', isDisabledPipeline(this.pipeline));
+
+    return isDisabledPipeline(this.pipeline);
+  }
+
+  get disabledPipelineMessage() {
+    return getDisabledPipelineMessage(this.pipeline);
   }
 
   @action

--- a/app/components/pipeline/header/component.js
+++ b/app/components/pipeline/header/component.js
@@ -105,8 +105,6 @@ export default class PipelineHeaderComponent extends Component {
   }
 
   get isDisabledPipeline() {
-    console.log('check if disbaled', isDisabledPipeline(this.pipeline));
-
     return isDisabledPipeline(this.pipeline);
   }
 

--- a/app/components/pipeline/header/template.hbs
+++ b/app/components/pipeline/header/template.hbs
@@ -1,6 +1,20 @@
 <div id="pipeline-header"
   {{did-update this.updatePipeline @pipeline}}
 >
+  {{#if this.isInactivePipeline}}
+    <InfoMessage
+        @message="Pipeline is inactive and no new events can be started. You can activate the pipeline by adding the SCM URL in the parent pipeline yaml configuration."
+        @type="info"
+        @icon="triangle-exclamation"
+      />
+  {{/if}}
+  {{#if this.isDisabledPipeline}}
+    <InfoMessage
+        @message={{this.disabledPipelineMessage}}
+        @type="warning"
+        @icon="ban"
+      />
+  {{/if}}
   <div class="header-main">
     <LinkTo
       id="pipeline-link"
@@ -107,12 +121,5 @@
     <div class="pipeline-description">
       {{this.pipelineDescription}}
     </div>
-  {{/if}}
-  {{#if this.isInactivePipeline}}
-    <InfoMessage
-        @message="Pipeline is inactive and no new events can be started. You can activate the pipeline by adding the SCM URL in the parent pipeline yaml configuration."
-        @type="info"
-        @icon="triangle-exclamation"
-      />
   {{/if}}
 </div>

--- a/app/components/pipeline/settings/main/modal/toggle-pipeline/component.js
+++ b/app/components/pipeline/settings/main/modal/toggle-pipeline/component.js
@@ -60,6 +60,7 @@ export default class PipelineSettingsMainModalTogglePipelineComponent extends Co
       .fetchFromApi('put', `/pipelines/${this.pipeline.id}`, payload)
       .then(pipeline => {
         this.pipelinePageState.setPipeline(pipeline);
+        this.pipelinePageState.forceReloadPipelineHeader();
         this.args.closeModal(true);
       })
       .catch(err => {

--- a/app/utils/pipeline.js
+++ b/app/utils/pipeline.js
@@ -1,3 +1,5 @@
+import humanizeDuration from 'humanize-duration';
+
 const getStateIcon = state => {
   let icon;
 
@@ -49,6 +51,45 @@ const hasDisabledPipelines = pipelines => {
   return !!disabledPipeline;
 };
 
+const getDisabledPipelineMessage = pipeline => {
+  const { stateChanger, stateChangeTime, stateChangeMessage } = pipeline;
+
+  let message = 'This pipeline is disabled and new events will not be started.';
+
+  let disabledBy = '';
+
+  if (stateChanger) {
+    disabledBy = `Disabled by ${stateChanger}`;
+  }
+
+  if (stateChangeTime) {
+    const timeAgo = `${humanizeDuration(
+      Date.now() - new Date(stateChangeTime),
+      { round: true, largest: 1 }
+    )} ago`;
+
+    disabledBy = disabledBy
+      ? `${disabledBy} ${timeAgo}`
+      : `Disabled ${timeAgo}`;
+  }
+
+  const contextParts = [];
+
+  if (disabledBy) {
+    contextParts.push(disabledBy);
+  }
+
+  if (stateChangeMessage) {
+    contextParts.push(`Reason: ${stateChangeMessage}`);
+  }
+
+  if (contextParts.length) {
+    message += ` ${contextParts.join('. ')}.`;
+  }
+
+  return message;
+};
+
 const hasSonarBadge = pipeline => {
   const sonar = pipeline.badges?.sonar;
 
@@ -69,5 +110,6 @@ export {
   hasActivePipelines,
   isDisabledPipeline,
   hasDisabledPipelines,
+  getDisabledPipelineMessage,
   hasSonarBadge
 };

--- a/tests/integration/components/build-banner/component-test.js
+++ b/tests/integration/components/build-banner/component-test.js
@@ -933,4 +933,31 @@ module('Integration | Component | build banner', function (hooks) {
         'https://app.saucelabs.com/builds/vdc/aabbccddeeffggIsNotAReadBuildID'
       );
   });
+
+  test('it renders a disabled restart button when pipeline is disabled', async function (assert) {
+    assert.expect(2);
+
+    this.set('buildStepsMock', buildStepsMock);
+    this.set('eventMock', prEventMock);
+    this.set('prEvents', new EmberPromise(resolves => resolves([])));
+    this.set('isButtonDisabledLoaded', true);
+    this.set('jobDisabled', new EmberPromise(resolves => resolves(false)));
+
+    await render(hbs`<BuildBanner
+      @buildContainer="node:6"
+      @duration="5 seconds"
+      @buildStatus="ABORTED"
+      @buildStart="2016-11-04T20:09:41.238Z"
+      @buildSteps={{this.buildStepsMock}}
+      @jobName="PR-671"
+      @jobDisabled={{this.jobDisabled}}
+      @pipelineState="DISABLED"
+      @isAuthenticated={{true}}
+      @event={{this.eventMock}}
+      @prEvents={{this.prEvents}}
+    />`);
+
+    assert.dom('button').hasText('Restart');
+    assert.dom('button').hasAttribute('disabled');
+  });
 });

--- a/tests/integration/components/pipeline-header/component-test.js
+++ b/tests/integration/components/pipeline-header/component-test.js
@@ -200,4 +200,58 @@ module('Integration | Component | pipeline header', function (hooks) {
       .dom('div.header-items-container .header-item:nth-child(4)')
       .hasText('Parent Pipeline');
   });
+
+  test('it renders a warning banner when pipeline is disabled', async function (assert) {
+    const pipelineMock = EmberObject.create({
+      appId: 'batman/batmobile',
+      hubUrl: 'http://example.com/batman/batmobile',
+      branch: 'master',
+      scmContext: 'github:github.com',
+      state: 'DISABLED',
+      stateChanger: 'alice',
+      stateChangeMessage: 'Migrating to v2'
+    });
+
+    injectScmServiceStub(this);
+
+    this.set('pipelineMock', pipelineMock);
+    await render(hbs`<PipelineHeader @pipeline={{this.pipelineMock}} />`);
+
+    assert
+      .dom('.pipeline-header-message-container .alert-warning')
+      .exists({ count: 1 });
+    assert
+      .dom('.pipeline-header-message-container .alert-warning')
+      .includesText('disabled');
+    assert
+      .dom('.pipeline-header-message-container .alert-warning')
+      .includesText('alice');
+    assert
+      .dom('.pipeline-header-message-container .alert-warning')
+      .includesText('Migrating to v2');
+  });
+
+  test('it renders default disabled banner message when optional fields are absent', async function (assert) {
+    const pipelineMock = EmberObject.create({
+      appId: 'batman/batmobile',
+      hubUrl: 'http://example.com/batman/batmobile',
+      branch: 'master',
+      scmContext: 'github:github.com',
+      state: 'DISABLED'
+    });
+
+    injectScmServiceStub(this);
+
+    this.set('pipelineMock', pipelineMock);
+    await render(hbs`<PipelineHeader @pipeline={{this.pipelineMock}} />`);
+
+    assert
+      .dom('.pipeline-header-message-container .alert-warning')
+      .exists({ count: 1 });
+    assert
+      .dom('.pipeline-header-message-container .alert-warning')
+      .includesText(
+        'This pipeline is disabled and new events will not be started.'
+      );
+  });
 });

--- a/tests/integration/components/pipeline/header/component-test.js
+++ b/tests/integration/components/pipeline/header/component-test.js
@@ -188,4 +188,38 @@ module('Integration | Component | pipeline/header', function (hooks) {
       .hasAttribute('href', `/v2/pipelines/${newPipelineId}`);
     assert.dom('#repo-pipelines .branch').hasText(newBranch);
   });
+
+  test('it renders a warning banner when pipeline is disabled', async function (assert) {
+    pipeline.state = 'DISABLED';
+    pipeline.stateChanger = 'alice';
+    pipeline.stateChangeMessage = 'Migrating to v2';
+
+    await render(
+      hbs`<Pipeline::Header
+        @pipeline={{this.pipeline}}
+      />`
+    );
+
+    assert.dom('.alert-warning').exists({ count: 1 });
+    assert.dom('.alert-warning').includesText('disabled');
+    assert.dom('.alert-warning').includesText('alice');
+    assert.dom('.alert-warning').includesText('Migrating to v2');
+  });
+
+  test('it renders default disabled banner message when optional fields are absent', async function (assert) {
+    pipeline.state = 'DISABLED';
+
+    await render(
+      hbs`<Pipeline::Header
+        @pipeline={{this.pipeline}}
+      />`
+    );
+
+    assert.dom('.alert-warning').exists({ count: 1 });
+    assert
+      .dom('.alert-warning')
+      .includesText(
+        'This pipeline is disabled and new events will not be started.'
+      );
+  });
 });

--- a/tests/mock/jobs.js
+++ b/tests/mock/jobs.js
@@ -9,7 +9,7 @@ export const mockJobs = [
     pipelineId: PIPELINE_ID,
     state: 'ENABLED',
     archived: false,
-    permutations: [{}]
+    permutations: [{ annotations: {} }]
   },
   {
     id: 12346,
@@ -17,7 +17,7 @@ export const mockJobs = [
     pipelineId: PIPELINE_ID,
     state: 'ENABLED',
     archived: false,
-    permutations: [{}]
+    permutations: [{ annotations: {} }]
   },
   {
     id: 12347,
@@ -25,7 +25,7 @@ export const mockJobs = [
     pipelineId: PIPELINE_ID,
     state: 'ENABLED',
     archived: false,
-    permutations: [{}]
+    permutations: [{ annotations: {} }]
   },
   {
     id: 12348,
@@ -33,7 +33,7 @@ export const mockJobs = [
     pipelineId: PIPELINE_ID,
     state: 'ENABLED',
     archived: false,
-    permutations: [{}]
+    permutations: [{ annotations: {} }]
   },
   {
     id: 12349,
@@ -41,6 +41,6 @@ export const mockJobs = [
     pipelineId: PIPELINE_ID,
     state: 'ENABLED',
     archived: false,
-    permutations: [{}]
+    permutations: [{ annotations: {} }]
   }
 ];


### PR DESCRIPTION
## Context
When a pipeline is disabled, there is no clear indication on many pipeline pages of that fact.  This causes unnecessary confusion about the state of a pipeline.  Additionally, the build detail page does not disable the restart button even though it should.

## Objective
Improves the UI and overall user experience to indicate whether the pipeline is disabled.  Both the V2 UI and the old UI show the same banner indicating that the pipeline is disabled.

<img width="2662" height="490" alt="Screenshot 2026-05-11 at 19-37-46 minghay_various Events" src="https://github.com/user-attachments/assets/daa17945-93ee-43d1-9553-26552bf88d47" />


## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
