### PR TITLE
fix: event start behavior from the pipeline jobs view

### DIFF
--- a/app/components/pipeline/jobs/table/cell/actions/component.js
+++ b/app/components/pipeline/jobs/table/cell/actions/component.js
@@ -20,9 +20,9 @@ export default class PipelineJobsTableCellActionsComponent extends Component {
 
   @tracked confirmAction;
 
-  event;
+  @tracked event = null;
 
-  latestCommitEvent;
+  @tracked latestCommitEvent = null;
 
   constructor() {
     super(...arguments);
@@ -47,57 +47,53 @@ export default class PipelineJobsTableCellActionsComponent extends Component {
     return isStopButtonDisabled(this.args.record.build);
   }
 
+  async fetchLatestCommitEvent() {
+    return this.shuttle.fetchFromApi(
+      'get',
+      `/pipelines/${this.pipeline.id}/latestCommitEvent`
+    );
+  }
+
+  async fetchRestartEvent() {
+    const { build } = this.args.record;
+
+    const eventId = build.meta.build
+      ? build.meta.build.eventId
+      : await this.shuttle
+          .fetchFromApi('get', `/builds/${build.id}`)
+          .then(response => {
+            return response.eventId;
+          });
+
+    return this.shuttle.fetchFromApi('get', `/events/${eventId}`);
+  }
+
   @action
   async openConfirmActionModal(actionType) {
     this.confirmAction = actionType;
-    this.event = this.args.record.event;
+    this.event = this.args.record.event || null;
+    this.latestCommitEvent = null;
 
-    if (!this.event) {
-      const latestCommitEventPromise = this.shuttle.fetchFromApi(
-        'get',
-        `/pipelines/${this.pipeline.id}/latestCommitEvent`
-      );
+    // Jobs view start actions use the latest commit,
+    // so only restart needs to resolve an event from the current build.
+    if (!this.event && actionType === 'restart') {
+      const [event, latestCommitEvent] = await Promise.all([
+        this.fetchRestartEvent(),
+        this.fetchLatestCommitEvent()
+      ]);
 
-      if (actionType === 'start') {
-        Promise.all([
-          this.shuttle.fetchFromApi(
-            'get',
-            `/pipelines/${this.pipeline.id}/events?count=1&type=pipeline`
-          ),
-          latestCommitEventPromise
-        ]).then(([events, latestCommitEvent]) => {
-          this.event = events[0];
-          this.latestCommitEvent = latestCommitEvent;
-          this.showConfirmActionModal = true;
-        });
-      } else {
-        const { build } = this.args.record;
-
-        const eventId = build.meta.build
-          ? build.meta.build.eventId
-          : await this.shuttle
-              .fetchFromApi('get', `/builds/${build.id}`)
-              .then(response => {
-                return response.eventId;
-              });
-
-        Promise.all([
-          this.shuttle.fetchFromApi('get', `/events/${eventId}`),
-          latestCommitEventPromise
-        ]).then(([latestEvent, latestCommitEvent]) => {
-          this.event = latestEvent;
-          this.latestCommitEvent = latestCommitEvent;
-          this.showConfirmActionModal = true;
-        });
-      }
-    } else {
-      this.showConfirmActionModal = true;
+      this.event = event;
+      this.latestCommitEvent = latestCommitEvent;
     }
+
+    this.showConfirmActionModal = true;
   }
 
   @action
   closeConfirmActionModal() {
     this.showConfirmActionModal = false;
+    this.event = null;
+    this.latestCommitEvent = null;
   }
 
   @action

--- a/app/components/pipeline/modal/confirm-action/component.js
+++ b/app/components/pipeline/modal/confirm-action/component.js
@@ -101,6 +101,9 @@ export default class PipelineModalConfirmActionComponent extends Component {
     if (this.startFrom === '~commit' || this.startFrom === '~pr') {
       return false;
     }
+    if (!this.args.event) {
+      return false;
+    }
     if (!this.pipelinePageState.getIsPr() && !this.isLatestCommitEvent) {
       return true;
     }

--- a/tests/integration/components/pipeline/jobs/table/cell/actions/component-test.js
+++ b/tests/integration/components/pipeline/jobs/table/cell/actions/component-test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
 import { click, render } from '@ember/test-helpers';
+import { authenticateSession } from 'ember-simple-auth/test-support';
 import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 
@@ -9,12 +10,25 @@ module(
   function (hooks) {
     setupRenderingTest(hooks);
 
-    hooks.beforeEach(function () {
-      const pipelinePageState = this.owner.lookup(
-        'service:pipeline-page-state'
-      );
+    const pipelineId = 123;
 
-      sinon.stub(pipelinePageState, 'getPipeline').returns({ state: 'ACTIVE' });
+    let pipelinePageState;
+
+    let shuttleStub;
+
+    hooks.beforeEach(async function () {
+      await authenticateSession({ username: 'test-user' });
+
+      pipelinePageState = this.owner.lookup('service:pipeline-page-state');
+      const shuttle = this.owner.lookup('service:shuttle');
+
+      sinon
+        .stub(pipelinePageState, 'getPipeline')
+        .returns({ id: pipelineId, state: 'ACTIVE', parameters: {} });
+      sinon.stub(pipelinePageState, 'getJobs').returns([]);
+      sinon.stub(pipelinePageState, 'getIsPr').returns(false);
+      pipelinePageState.route = 'v2.pipeline.jobs';
+      shuttleStub = sinon.stub(shuttle, 'fetchFromApi').resolves({});
     });
 
     test('it renders', async function (assert) {
@@ -67,6 +81,169 @@ module(
 
       await click('button:nth-of-type(3)');
       assert.dom('.modal-title').hasText('Are you sure you want to restart?');
+    });
+
+    test('it does not fetch an event for start without an event context', async function (assert) {
+      const job = { id: 123, name: 'main', state: 'ENABLED' };
+
+      this.setProperties({
+        record: {
+          job,
+          canStartFromView: true,
+          onCreate: () => {},
+          onDestroy: () => {}
+        }
+      });
+
+      await render(
+        hbs`<Pipeline::Jobs::Table::Cell::Actions
+            @record={{this.record}}
+        />`
+      );
+
+      await click('button:nth-of-type(1)');
+
+      assert.dom('.modal-title').hasText('Are you sure you want to start?');
+      assert.strictEqual(shuttleStub.callCount, 0);
+      assert.dom('#confirm-action-commit').doesNotExist();
+    });
+
+    test('it uses the provided event for start without fetching', async function (assert) {
+      const job = { id: 123, name: 'main', state: 'ENABLED' };
+      const event = {
+        id: 456,
+        sha: 'abc123def456',
+        commit: {
+          url: 'https://example.com',
+          message: 'Latest commit message'
+        },
+        meta: {}
+      };
+
+      this.setProperties({
+        record: {
+          job,
+          event,
+          canStartFromView: true,
+          onCreate: () => {},
+          onDestroy: () => {}
+        }
+      });
+
+      await render(
+        hbs`<Pipeline::Jobs::Table::Cell::Actions
+            @record={{this.record}}
+        />`
+      );
+
+      await click('button:nth-of-type(1)');
+
+      assert.strictEqual(shuttleStub.callCount, 0);
+      assert.dom('#confirm-action-commit').exists({ count: 1 });
+    });
+
+    test('it fetches an event for restart without an event context', async function (assert) {
+      const job = { id: 123, name: 'main', state: 'ENABLED' };
+      const build = { id: 999, meta: {} };
+      const latestEvent = {
+        id: 456,
+        sha: 'abc123def456',
+        commit: {
+          url: 'https://example.com',
+          message: 'Latest commit message'
+        },
+        meta: {}
+      };
+      const latestCommitEvent = { sha: 'abc123def456' };
+
+      shuttleStub.withArgs('get', '/builds/999').resolves({ eventId: 456 });
+      shuttleStub.withArgs('get', '/events/456').resolves(latestEvent);
+      shuttleStub
+        .withArgs('get', `/pipelines/${pipelineId}/latestCommitEvent`)
+        .resolves(latestCommitEvent);
+
+      this.setProperties({
+        record: {
+          job,
+          build,
+          canStartFromView: true,
+          onCreate: () => {},
+          onDestroy: () => {}
+        }
+      });
+
+      await render(
+        hbs`<Pipeline::Jobs::Table::Cell::Actions
+            @record={{this.record}}
+        />`
+      );
+
+      await click('button:nth-of-type(3)');
+
+      assert.true(shuttleStub.calledWith('get', '/builds/999'));
+      assert.true(shuttleStub.calledWith('get', '/events/456'));
+      assert.dom('.modal-title').hasText('Are you sure you want to restart?');
+    });
+
+    test('it starts from latest commit after closing a restart modal', async function (assert) {
+      const job = {
+        id: 123,
+        name: 'main',
+        state: 'ENABLED',
+        permutations: [{}]
+      };
+      const build = { id: 999, meta: {} };
+      const restartEvent = {
+        id: 456,
+        groupEventId: 789,
+        sha: 'abc123def456',
+        commit: {
+          url: 'https://example.com',
+          message: 'Latest commit message'
+        },
+        meta: {}
+      };
+      const latestCommitEvent = { sha: 'abc123def456' };
+
+      shuttleStub.withArgs('get', '/builds/999').resolves({ eventId: 456 });
+      shuttleStub.withArgs('get', '/events/456').resolves(restartEvent);
+      shuttleStub
+        .withArgs('get', `/pipelines/${pipelineId}/latestCommitEvent`)
+        .resolves(latestCommitEvent);
+      shuttleStub.withArgs('post', '/events').resolves({ id: 1000 });
+
+      this.setProperties({
+        record: {
+          job,
+          build,
+          canStartFromView: true,
+          onCreate: () => {},
+          onDestroy: () => {}
+        }
+      });
+
+      await render(
+        hbs`<Pipeline::Jobs::Table::Cell::Actions
+            @record={{this.record}}
+        />`
+      );
+
+      await click('button:nth-of-type(3)');
+      await click('.modal-header .close');
+
+      shuttleStub.resetHistory();
+
+      await click('button:nth-of-type(1)');
+      await click('#submit-action');
+
+      assert.true(
+        shuttleStub.calledWith('post', '/events', {
+          pipelineId,
+          causeMessage: 'Manually started by test-user',
+          startFrom: job.name,
+          startAction: 'START_FROM_LATEST_COMMIT'
+        })
+      );
     });
   }
 );

--- a/tests/integration/components/pipeline/modal/confirm-action/component-test.js
+++ b/tests/integration/components/pipeline/modal/confirm-action/component-test.js
@@ -142,6 +142,25 @@ module(
         );
     });
 
+    test('it does not render warning message without an event', async function (assert) {
+      this.setProperties({
+        action: 'start',
+        event: undefined,
+        job,
+        closeModal: () => {}
+      });
+      await render(
+        hbs`<Pipeline::Modal::ConfirmAction
+            @action={{this.action}}
+            @event={{this.event}}
+            @job={{this.job}}
+            @closeModal={{this.closeModal}}
+        />`
+      );
+
+      assert.dom('#not-latest-warning').doesNotExist();
+    });
+
     test('it does not render warning message for pr commit event', async function (assert) {
       isPr = true;
 


### PR DESCRIPTION
## Context

In the pipeline jobs job list view, the start action was using the SHA from the latest pipeline event instead of the repository's latest commit.

This area had also become harder to follow because the same confirm-action flow is used from both `pipeline/jobs` and `pipeline/workflow`, and the branching logic had grown to cover multiple cases in one place.

In addition, the jobs view modal state was not being reset correctly. After opening the restart modal and closing it, a subsequent start action could incorrectly reuse restart-related event data.

## Objective

Update the pipeline jobs job list view so that the start action uses the repository's latest commit instead of the latest pipeline event SHA.

This PR also:
- refactors the confirm-action branching to make the different jobs view and workflow cases clearer
- fixes stale modal state in the jobs view so restart event data is not carried into a later start action

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
