### PR TITLE
feat: make the start/restart actions easier to understand

### DIFF
--- a/app/components/pipeline/event/card/component.js
+++ b/app/components/pipeline/event/card/component.js
@@ -8,6 +8,7 @@ import {
   isComplete,
   isSkipped
 } from 'screwdriver-ui/utils/pipeline/event';
+import { getTruncatedSha } from 'screwdriver-ui/utils/git';
 import {
   getDurationText,
   getExternalPipelineId,
@@ -17,7 +18,6 @@ import {
   getStartDate,
   getSuccessCount,
   getTruncatedMessage,
-  getTruncatedSha,
   getWarningCount,
   isCommitterDifferent,
   isExternalTrigger
@@ -361,7 +361,7 @@ export default class PipelineEventCardComponent extends Component {
   }
 
   get truncatedSha() {
-    return `#${getTruncatedSha(this.event)}`;
+    return `#${getTruncatedSha(this.event.sha)}`;
   }
 
   get isLatestCommit() {

--- a/app/components/pipeline/event/card/util.js
+++ b/app/components/pipeline/event/card/util.js
@@ -20,10 +20,6 @@ const shortEnglishHumanizer = humanizeDuration.humanizer({
   }
 });
 
-export const getTruncatedSha = event => {
-  return event.sha.slice(0, 7);
-};
-
 export const getTruncatedMessage = (event, length) => {
   const commitMessage = event.commit.message;
 

--- a/app/components/pipeline/modal/confirm-action/component.js
+++ b/app/components/pipeline/modal/confirm-action/component.js
@@ -65,7 +65,7 @@ export default class PipelineModalConfirmActionComponent extends Component {
     this.defaultJobParameters = extractDefaultJobParameters(
       this.pipelinePageState.getJobs()
     );
-    if (this.args.action === 'start' && !job) {
+    if (this.isFreshRunAction && !job) {
       this.startFrom = this.pipelinePageState.getIsPr() ? '~pr' : '~commit';
       this.jobName = this.startFrom;
     } else {
@@ -109,6 +109,14 @@ export default class PipelineModalConfirmActionComponent extends Component {
     }
 
     return false;
+  }
+
+  get isFreshRunAction() {
+    return this.args.action === 'start';
+  }
+
+  get isRestartAction() {
+    return this.args.action === 'restart';
   }
 
   get notice() {
@@ -176,10 +184,9 @@ export default class PipelineModalConfirmActionComponent extends Component {
     let startAction = 'START_FROM_LATEST_COMMIT';
 
     if (event) {
-      startAction =
-        this.args.action === 'start'
-          ? 'START_FROM_EVENT'
-          : 'RESTART_FROM_EVENT';
+      startAction = this.isFreshRunAction
+        ? 'START_FROM_EVENT'
+        : 'RESTART_FROM_EVENT';
     }
 
     const data = {

--- a/app/components/pipeline/modal/confirm-action/styles.scss
+++ b/app/components/pipeline/modal/confirm-action/styles.scss
@@ -43,6 +43,29 @@
         color: colors.$sd-light-gray;
         padding-top: 2.5rem;
       }
+
+      .no-parent-event {
+        display: inline-block;
+        background-color: colors.$sd-warn-bg;
+        color: colors.$sd-white !important;
+        border-radius: 3px;
+        padding: 3px 5px;
+      }
+
+      .danger-tooltip {
+        .tooltip-inner {
+          background: colors.$sd-white;
+          color: colors.$sd-warn-bg;
+
+          border: 1px solid colors.$sd-warn-bg;
+          border-radius: 6px;
+
+          font-weight: 600;
+        }
+        .arrow::before {
+          border-right-color: colors.$sd-warn-bg;
+        }
+      }
     }
   }
 }

--- a/app/components/pipeline/modal/confirm-action/template.hbs
+++ b/app/components/pipeline/modal/confirm-action/template.hbs
@@ -53,6 +53,23 @@
           #{{this.truncatedSha}}
         </a>
       </div>
+      <div id="confirm-action-parent-event">
+        Parent event:
+        {{#if (eq @action "restart")}}
+          <code>{{@event.id}}</code>
+        {{else}}
+          <span class="no-parent-event">None</span>
+          <BsTooltip
+            @placement="right"
+            @triggerElement=".no-parent-event"
+            @renderInPlace={{true}}
+            @delayHide="100"
+            class="danger-tooltip"
+          >
+            This run will NOT inherit metadata or build statuses from parent event.
+          </BsTooltip>
+        {{/if}}
+      </div>
     {{/if}}
 
     {{#if this.isFrozen}}

--- a/app/components/pipeline/modal/confirm-action/template.hbs
+++ b/app/components/pipeline/modal/confirm-action/template.hbs
@@ -53,24 +53,25 @@
           #{{this.truncatedSha}}
         </a>
       </div>
-      <div id="confirm-action-parent-event">
-        Parent event:
-        {{#if (eq @action "restart")}}
-          <code>{{@event.id}}</code>
-        {{else}}
-          <span class="no-parent-event">None</span>
-          <BsTooltip
-            @placement="right"
-            @triggerElement=".no-parent-event"
-            @renderInPlace={{true}}
-            @delayHide="100"
-            class="danger-tooltip"
-          >
-            This run will NOT inherit metadata or build statuses from parent event.
-          </BsTooltip>
-        {{/if}}
-      </div>
     {{/if}}
+
+    <div id="confirm-action-parent-event">
+      Parent event:
+      {{#if (and @event.id this.isRestartAction)}}
+        <code>{{@event.id}}</code>
+      {{else}}
+        <span class="no-parent-event">None</span>
+        <BsTooltip
+          @placement="right"
+          @triggerElement=".no-parent-event"
+          @renderInPlace={{true}}
+          @delayHide="100"
+          class="danger-tooltip"
+        >
+          This run will NOT inherit metadata or build statuses from parent event.
+        </BsTooltip>
+      {{/if}}
+    </div>
 
     {{#if this.isFrozen}}
       <div class="frozen-reason">

--- a/app/components/pipeline/modal/confirm-action/template.hbs
+++ b/app/components/pipeline/modal/confirm-action/template.hbs
@@ -56,7 +56,7 @@
     {{/if}}
 
     <div id="confirm-action-parent-event">
-      Parent event:
+      Parent event ID:
       {{#if (and @event.id this.isRestartAction)}}
         <code>{{@event.id}}</code>
       {{else}}

--- a/app/components/pipeline/workflow/tooltip/component.js
+++ b/app/components/pipeline/workflow/tooltip/component.js
@@ -5,6 +5,7 @@ import { service } from '@ember/service';
 import { isActivePipeline } from 'screwdriver-ui/utils/pipeline';
 import { getTooltipData } from 'screwdriver-ui/utils/pipeline/graph/tooltip';
 import { canJobStart } from 'screwdriver-ui/utils/pipeline-workflow';
+import { getTruncatedSha } from 'screwdriver-ui/utils/git';
 
 export default class PipelineWorkflowTooltipComponent extends Component {
   @service router;
@@ -99,6 +100,10 @@ export default class PipelineWorkflowTooltipComponent extends Component {
     }
 
     return description;
+  }
+
+  get truncatedSha() {
+    return `#${getTruncatedSha(this.args.event.sha)}`;
   }
 
   @action

--- a/app/components/pipeline/workflow/tooltip/styles.scss
+++ b/app/components/pipeline/workflow/tooltip/styles.scss
@@ -44,5 +44,17 @@
     hr {
       width: 100%;
     }
+
+    #run-job-label {
+      padding-bottom: 0;
+    }
+
+    ul#run-job-block {
+      padding-left: 1em;
+
+      li::marker {
+        content: '';
+      }
+    }
   }
 }

--- a/app/components/pipeline/workflow/tooltip/styles.scss
+++ b/app/components/pipeline/workflow/tooltip/styles.scss
@@ -52,6 +52,9 @@
     ul#run-job-block {
       padding-left: 1em;
 
+      li {
+        margin-top: 0.2em;
+      }
       li::marker {
         content: '';
       }

--- a/app/components/pipeline/workflow/tooltip/template.hbs
+++ b/app/components/pipeline/workflow/tooltip/template.hbs
@@ -66,20 +66,57 @@
             </p>
         {{else}}
           {{#if this.canJobStartFromView}}
-            <a
-              id="restart-job-link"
-              href="#"
-              {{on "click" (fn this.openConfirmActionModal "restart")}}
-            >
-              Restart event from here
-            </a>
-            <a
-              id="start-job-link"
-               href="#"
-              {{on "click" (fn this.openConfirmActionModal "start")}}
-            >
-             Start a new event from here
-            </a>
+            <p id="run-job-label">
+              Run job at {{this.truncatedSha}}
+            </p>
+            <ul id="run-job-block">
+              <li>
+                <a
+                  id="restart-job-link"
+                  class="run-job-help"
+                  href="#"
+                  {{on "click" (fn this.openConfirmActionModal "restart")}}
+                >
+                  <FaIcon
+                    @icon="rotate-right"
+                    @fixedWidth="true"
+                    @prefix="fas"
+                  />
+                  Restart (Inherit)
+                </a>
+                <BsTooltip
+                  @placement="right"
+                  @triggerElement="#restart-job-link"
+                  @renderInPlace={{true}}
+                  @delayHide="100"
+                >
+                  Use this event's metadata and build statuses.
+                </BsTooltip>
+              </li>
+              <li>
+                <a
+                  id="start-job-link"
+                  class="run-job-help"
+                  href="#"
+                  {{on "click" (fn this.openConfirmActionModal "start")}}
+                >
+                  <FaIcon
+                    @icon="circle-play"
+                    @fixedWidth="true"
+                    @prefix="far"
+                  />
+                  New Run (Fresh)
+                </a>
+                <BsTooltip
+                  @placement="right"
+                  @triggerElement="#start-job-link"
+                  @renderInPlace={{true}}
+                  @delayHide="100"
+                >
+                  Clean start from this job. No metadata or build statuses.
+                </BsTooltip>
+              </li>
+            </ul>
           {{/if}}
         {{/if}}
       {{/if}}

--- a/app/components/pipeline/workflow/tooltip/template.hbs
+++ b/app/components/pipeline/workflow/tooltip/template.hbs
@@ -87,7 +87,7 @@
                 <BsTooltip
                   @placement="right"
                   @triggerElement="#restart-job-link"
-                  @renderInPlace={{true}}
+                  @renderInPlace={{false}}
                   @delayHide="100"
                 >
                   Use this event's metadata and build statuses.
@@ -110,7 +110,7 @@
                 <BsTooltip
                   @placement="right"
                   @triggerElement="#start-job-link"
-                  @renderInPlace={{true}}
+                  @renderInPlace={{false}}
                   @delayHide="100"
                 >
                   Clean start from this job. No metadata or build statuses.

--- a/app/utils/git.js
+++ b/app/utils/git.js
@@ -41,4 +41,14 @@ function getCheckoutUrl(config) {
   return checkoutUrl;
 }
 
-export { parse, getCheckoutUrl };
+/**
+ * Get a truncated commit sha.
+ *   e.g. abc1234
+ * @param {String} sha commit sha
+ * @returns {String}   Returns a truncated commit sha.
+ */
+function getTruncatedSha(sha) {
+  return sha.slice(0, 7);
+}
+
+export { parse, getCheckoutUrl, getTruncatedSha };

--- a/tests/integration/components/pipeline/modal/confirm-action/component-test.js
+++ b/tests/integration/components/pipeline/modal/confirm-action/component-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
-import { click, fillIn, render } from '@ember/test-helpers';
+import { click, fillIn, render, triggerEvent } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 
@@ -71,6 +71,13 @@ module(
         .dom('#confirm-action-commit-link')
         .hasAttribute('href', 'http://foo.com');
       assert.dom('#confirm-action-parent-event').hasText('Parent event: None');
+
+      await triggerEvent('.no-parent-event', 'mouseenter');
+      assert
+        .dom('.tooltip')
+        .hasText(
+          'This run will NOT inherit metadata or build statuses from parent event.'
+        );
     });
 
     test('it renders restart action', async function (assert) {
@@ -93,6 +100,25 @@ module(
 
       assert.dom('.modal-title').hasText('Are you sure you want to restart?');
       assert.dom('#confirm-action-parent-event').hasText('Parent event: 123');
+    });
+
+    test('it renders parent event warning without an event', async function (assert) {
+      this.setProperties({
+        action: 'start',
+        event: undefined,
+        job,
+        closeModal: () => {}
+      });
+      await render(
+        hbs`<Pipeline::Modal::ConfirmAction
+            @action={{this.action}}
+            @event={{this.event}}
+            @job={{this.job}}
+            @closeModal={{this.closeModal}}
+        />`
+      );
+
+      assert.dom('#confirm-action-parent-event').hasText('Parent event: None');
     });
 
     test('it renders stage name if set', async function (assert) {
@@ -162,7 +188,6 @@ module(
       );
 
       assert.dom('#not-latest-warning').doesNotExist();
-      assert.dom('#confirm-action-parent-event').doesNotExist();
     });
 
     test('it does not render warning message for pr commit event', async function (assert) {

--- a/tests/integration/components/pipeline/modal/confirm-action/component-test.js
+++ b/tests/integration/components/pipeline/modal/confirm-action/component-test.js
@@ -70,7 +70,9 @@ module(
       assert
         .dom('#confirm-action-commit-link')
         .hasAttribute('href', 'http://foo.com');
-      assert.dom('#confirm-action-parent-event').hasText('Parent event: None');
+      assert
+        .dom('#confirm-action-parent-event')
+        .hasText('Parent event ID: None');
 
       await triggerEvent('.no-parent-event', 'mouseenter');
       assert
@@ -99,7 +101,9 @@ module(
       );
 
       assert.dom('.modal-title').hasText('Are you sure you want to restart?');
-      assert.dom('#confirm-action-parent-event').hasText('Parent event: 123');
+      assert
+        .dom('#confirm-action-parent-event')
+        .hasText('Parent event ID: 123');
     });
 
     test('it renders parent event warning without an event', async function (assert) {
@@ -118,7 +122,9 @@ module(
         />`
       );
 
-      assert.dom('#confirm-action-parent-event').hasText('Parent event: None');
+      assert
+        .dom('#confirm-action-parent-event')
+        .hasText('Parent event ID: None');
     });
 
     test('it renders stage name if set', async function (assert) {

--- a/tests/integration/components/pipeline/modal/confirm-action/component-test.js
+++ b/tests/integration/components/pipeline/modal/confirm-action/component-test.js
@@ -38,6 +38,7 @@ module(
       sinon.stub(pipelinePageState, 'getIsPr').returns(isPr);
 
       event = {
+        id: 123,
         commit: { message: 'commit message', url: 'http://foo.com' },
         sha: 'deadbeef0123456789'
       };
@@ -69,6 +70,7 @@ module(
       assert
         .dom('#confirm-action-commit-link')
         .hasAttribute('href', 'http://foo.com');
+      assert.dom('#confirm-action-parent-event').hasText('Parent event: None');
     });
 
     test('it renders restart action', async function (assert) {
@@ -90,6 +92,7 @@ module(
       );
 
       assert.dom('.modal-title').hasText('Are you sure you want to restart?');
+      assert.dom('#confirm-action-parent-event').hasText('Parent event: 123');
     });
 
     test('it renders stage name if set', async function (assert) {
@@ -159,6 +162,7 @@ module(
       );
 
       assert.dom('#not-latest-warning').doesNotExist();
+      assert.dom('#confirm-action-parent-event').doesNotExist();
     });
 
     test('it does not render warning message for pr commit event', async function (assert) {

--- a/tests/integration/components/pipeline/workflow/tooltip/component-test.js
+++ b/tests/integration/components/pipeline/workflow/tooltip/component-test.js
@@ -1,9 +1,10 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
-import { render } from '@ember/test-helpers';
+import { render, triggerEvent } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import sinon from 'sinon';
+import { mockGraph } from '../../../../../mock/workflow-graph';
 
 module('Integration | Component | pipeline/workflow/tooltip', function (hooks) {
   setupRenderingTest(hooks);
@@ -15,6 +16,56 @@ module('Integration | Component | pipeline/workflow/tooltip', function (hooks) {
       .stub(pipelinePageState, 'getPipeline')
       .returns({ id: 987, state: 'ACTIVE' });
     sinon.stub(pipelinePageState, 'getJobs').returns([]);
+  });
+
+  test('it renders run job actions', async function (assert) {
+    authenticateSession();
+
+    const router = this.owner.lookup('service:router');
+
+    sinon.stub(router, 'currentRoute').value({
+      name: 'events'
+    });
+
+    this.setProperties({
+      d3Data: {
+        node: {
+          name: 'main',
+          isDisabled: false
+        },
+        d3Event: { clientX: 0, clientY: 0 },
+        sizes: { ICON_SIZE: 0 }
+      },
+      event: { sha: '1234567890abcdefg' },
+      builds: [],
+      workflowGraph: mockGraph
+    });
+
+    await render(
+      hbs`<Pipeline::Workflow::Tooltip
+        @d3Data={{this.d3Data}}
+        @event={{this.event}}
+        @builds={{this.builds}}
+        @workflowGraph={{this.workflowGraph}}
+      />`
+    );
+
+    assert.dom('#run-job-label').hasText('Run job at #1234567');
+    assert.dom('#restart-job-link').hasText('Restart (Inherit)');
+    assert.dom('#start-job-link').hasText('New Run (Fresh)');
+
+    await triggerEvent('#restart-job-link', 'mouseenter');
+    assert
+      .dom('.tooltip')
+      .hasText("Use this event's metadata and build statuses.");
+
+    await triggerEvent('#restart-job-link', 'mouseleave');
+    assert.dom('.tooltip').doesNotExist();
+
+    await triggerEvent('#start-job-link', 'mouseenter');
+    assert
+      .dom('.tooltip')
+      .hasText('Clean start from this job. No metadata or build statuses.');
   });
 
   test('it renders build detail and metrics links', async function (assert) {

--- a/tests/unit/components/pipeline/event/card/util-test.js
+++ b/tests/unit/components/pipeline/event/card/util-test.js
@@ -9,17 +9,12 @@ import {
   getStartDate,
   getSuccessCount,
   getTruncatedMessage,
-  getTruncatedSha,
   getWarningCount,
   isCommitterDifferent,
   isExternalTrigger
 } from 'screwdriver-ui/components/pipeline/event/card/util';
 
 module('Unit | Component | pipeline/event/card/util', function () {
-  test('getTruncatedSha returns correct value', function (assert) {
-    assert.equal(getTruncatedSha({ sha: 'deadbeef12345' }), 'deadbee');
-  });
-
   test('getTruncatedMessage returns correct value', function (assert) {
     assert.equal(
       getTruncatedMessage({ commit: { message: 'Super duper string' } }, 5),

--- a/tests/unit/utils/git-test.js
+++ b/tests/unit/utils/git-test.js
@@ -83,4 +83,8 @@ module('Unit | Utility | git', function () {
 
     assert.ok(result.valid, `${orgGitUrl} is valid`);
   });
+
+  test('it returns a truncated sha', function (assert) {
+    assert.equal(git.getTruncatedSha('deadbeef12345'), 'deadbee');
+  });
 });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Some users does not really understand the difference between start and restart.
So they cannot choose the suitable action.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

This PR will add the explain of the start/restart actions on the tooltip and the confirm modal as below.

<img width="575" height="387" alt="tooltip" src="https://github.com/user-attachments/assets/5e1880d5-8c77-4632-aa53-f9b4d9160e52" />
<img width="674" height="412" alt="modal" src="https://github.com/user-attachments/assets/0aa9032f-dbb4-4866-b63f-2478e29f52be" />

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
