### PR TITLE
fix(3491): always restart from V1 tooltip

### DIFF
--- a/app/components/pipeline-events/component.js
+++ b/app/components/pipeline-events/component.js
@@ -51,7 +51,7 @@ export async function stopBuild(givenEvent, job) {
   }
 }
 
-// eslint-disable-next-line require-jsdoc
+// eslint-disable-next-line require-jsdoc, default-param-last
 export async function startDetachedBuild(job, options = {}, stage) {
   this.set('isShowingModal', true);
 
@@ -93,7 +93,8 @@ export async function startDetachedBuild(job, options = {}, stage) {
     startFrom = `PR-${prNum}:${startFrom}`;
   }
 
-  const startAction = buildId ? 'RESTART_FROM_BUILD' : 'START_FROM_EVENT';
+  // Always restart in V1 tooltip
+  const startAction = buildId ? 'RESTART_FROM_BUILD' : 'RESTART_FROM_EVENT';
 
   const eventPayload = {
     buildId,

--- a/tests/integration/components/pipeline-events/component-test.js
+++ b/tests/integration/components/pipeline-events/component-test.js
@@ -117,6 +117,94 @@ module('Integration | Component | pipeline events', function (hooks) {
     });
   });
 
+  test('it starts a build from event', async function (assert) {
+    assert.expect(7);
+    server.get('http://localhost:8080/v4/events/2/builds', () => [
+      201,
+      { 'Content-Type': 'application/json' },
+      JSON.stringify([{ id: '1234' }])
+    ]);
+    server.post('http://localhost:8080/v4/events', () => [
+      201,
+      { 'Content-Type': 'application/json' },
+      JSON.stringify({
+        id: '2'
+      })
+    ]);
+    server.put('http://localhost:8080/v4/events/5678', () => []);
+
+    const component = this.owner.lookup('component:pipeline-events');
+
+    run(() => {
+      component.store.push({
+        data: {
+          id: '123',
+          type: 'build',
+          attributes: {
+            parentBuildId: '345'
+          }
+        }
+      });
+
+      component.set('previousModelEvents', [
+        {
+          id: '1',
+          sha: 'sha',
+          pipelineId: '1234'
+        }
+      ]);
+
+      component.set('selected', '1');
+
+      component.set('activeTab', 'events');
+
+      component.set(
+        'pipeline',
+        EmberObject.create({
+          id: '1234'
+        })
+      );
+
+      component.set('reload', () => {
+        assert.ok(true);
+
+        return Promise.resolve({});
+      });
+
+      component.set('model', {
+        events: newArray()
+      });
+
+      const routerServiceMock = Service.extend({
+        transitionTo: (routeName, pipelineId) => {
+          assert.equal(routeName, 'pipeline');
+          assert.equal(pipelineId, 1234);
+        }
+      });
+
+      this.owner.unregister('service:router');
+      this.owner.register('service:router', routerServiceMock);
+
+      assert.notOk(component.isShowingModal);
+      component.send('startDetachedBuild', { name: 'deploy' });
+      assert.ok(component.isShowingModal);
+    });
+
+    await waitUntil(() => !component.isShowingModal);
+
+    const [request] = server.handledRequests;
+    const payload = JSON.parse(request.requestBody);
+
+    assert.notOk(component.isShowingModal);
+    assert.deepEqual(payload, {
+      pipelineId: '1234',
+      startFrom: 'deploy',
+      parentEventId: 1,
+      causeMessage: 'Manually started by apple',
+      startAction: 'RESTART_FROM_EVENT'
+    });
+  });
+
   test('it restarts a build', async function (assert) {
     assert.expect(7);
     server.get('http://localhost:8080/v4/events/2/builds', () => [


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Follow up https://github.com/screwdriver-cd/ui/pull/1573 .

There was no difference between "Restart pipeline from here" and "Start pipeline from here" before that PR merged.
But now, users cannot inherit metadata and build status from the parent event when they starts a detached job.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Fix the start action on V1 page.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

Issue - https://github.com/screwdriver-cd/screwdriver/issues/3491

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
