### PR TITLE
fix: reduce redundant latestCommitEvent requests

### DIFF
--- a/app/components/pipeline-events-list/component.js
+++ b/app/components/pipeline-events-list/component.js
@@ -7,7 +7,6 @@ import moment from 'moment';
 
 export default Component.extend({
   router: service(),
-  shuttle: service(),
   store: service(),
   errorMessage: '',
   isGroupedEvents: computed('pipeline.settings.groupedEvents', {
@@ -22,10 +21,6 @@ export default Component.extend({
   }),
   eventsList: computed('events.[]', 'pipeline.id', {
     get() {
-      this.shuttle.getLatestCommitEvent(this.get('pipeline.id')).then(event => {
-        this.set('latestCommit', event);
-      });
-
       return this.events;
     }
   }),

--- a/app/components/pipeline-events/component.js
+++ b/app/components/pipeline-events/component.js
@@ -51,7 +51,7 @@ export async function stopBuild(givenEvent, job) {
   }
 }
 
-// eslint-disable-next-line require-jsdoc
+// eslint-disable-next-line require-jsdoc, default-param-last
 export async function startDetachedBuild(job, options = {}, stage) {
   this.set('isShowingModal', true);
 
@@ -352,6 +352,10 @@ export default Component.extend(ModelReloaderMixin, {
       let newModelEvents = [];
       const newPipelineId = this.get('pipeline.id');
 
+      this.shuttle.getLatestCommitEvent(newPipelineId).then(event => {
+        this.set('latestCommit', event);
+      });
+
       // purge unmatched pipeline events
       if (previousModelEvents.some(e => e.pipelineId !== newPipelineId)) {
         newModelEvents = [...currentModelEvents];
@@ -397,10 +401,6 @@ export default Component.extend(ModelReloaderMixin, {
         const selectedEventId = this.selected;
 
         let filteredEvents = pipelineEvents;
-
-        this.shuttle.getLatestCommitEvent(pipelineId).then(event => {
-          this.set('latestCommit', event);
-        });
 
         // filter events for no builds
         if (this.isFilteredEventsForNoBuilds) {

--- a/app/components/pipeline/event/card/component.js
+++ b/app/components/pipeline/event/card/component.js
@@ -38,8 +38,6 @@ export default class PipelineEventCardComponent extends Component {
 
   @tracked builds;
 
-  @tracked latestCommitEvent;
-
   @tracked status;
 
   @tracked aggregateStatus;
@@ -102,10 +100,6 @@ export default class PipelineEventCardComponent extends Component {
   willDestroy() {
     super.willDestroy(...arguments);
 
-    this.workflowDataReload.removeLatestCommitEventCallback(
-      this.queueName,
-      this.event.id
-    );
     this.workflowDataReload.removeBuildsCallback(this.queueName, this.event.id);
 
     if (this.durationIntervalId) {
@@ -148,11 +142,6 @@ export default class PipelineEventCardComponent extends Component {
   @action
   initialize() {
     this.isBuildsCallbackCalled = false;
-    this.workflowDataReload.registerLatestCommitEventCallback(
-      this.queueName,
-      this.event.id,
-      this.latestCommitEventCallback
-    );
     this.workflowDataReload.registerBuildsCallback(
       this.queueName,
       this.event.id,
@@ -162,10 +151,6 @@ export default class PipelineEventCardComponent extends Component {
 
   @action
   update(element, [event]) {
-    this.workflowDataReload.removeLatestCommitEventCallback(
-      this.queueName,
-      this.event.id
-    );
     this.workflowDataReload.removeBuildsCallback(this.queueName, this.event.id);
 
     if (this.event.id !== event.id) {
@@ -181,28 +166,11 @@ export default class PipelineEventCardComponent extends Component {
     this.durationText = null;
     this.firstCreateTime = null;
 
-    this.workflowDataReload.registerLatestCommitEventCallback(
-      this.queueName,
-      this.event.id,
-      this.latestCommitEventCallback
-    );
     this.workflowDataReload.registerBuildsCallback(
       this.queueName,
       this.event.id,
       this.buildsCallback
     );
-  }
-
-  @action
-  latestCommitEventCallback(latestCommitEvent) {
-    this.latestCommitEvent = latestCommitEvent;
-
-    if (this.latestCommitEvent && this.latestCommitEvent.id !== this.event.id) {
-      this.workflowDataReload.removeLatestCommitEventCallback(
-        this.queueName,
-        this.event.id
-      );
-    }
   }
 
   @action
@@ -366,6 +334,13 @@ export default class PipelineEventCardComponent extends Component {
 
   get isLatestCommit() {
     return this.latestCommitEvent?.sha === this.event.sha;
+  }
+
+  get latestCommitEvent() {
+    return (
+      this.args.latestCommitEvent ||
+      this.workflowDataReload.getLatestCommitEvent()
+    );
   }
 
   get isLastSuccessfulEvent() {

--- a/app/components/pipeline/event/card/template.hbs
+++ b/app/components/pipeline/event/card/template.hbs
@@ -251,6 +251,7 @@
               @isPR={{this.isPR}}
               @closeModal={{this.closeEventHistoryModal}}
               @lastSuccessfulEvent={{@lastSuccessfulEvent}}
+              @latestCommitEvent={{this.latestCommitEvent}}
             />
           {{/if}}
         </BsButton>

--- a/app/components/pipeline/jobs/table/cell/actions/component.js
+++ b/app/components/pipeline/jobs/table/cell/actions/component.js
@@ -48,10 +48,7 @@ export default class PipelineJobsTableCellActionsComponent extends Component {
   }
 
   async fetchLatestCommitEvent() {
-    return this.shuttle.fetchFromApi(
-      'get',
-      `/pipelines/${this.pipeline.id}/latestCommitEvent`
-    );
+    return this.shuttle.getLatestCommitEvent(this.pipeline.id);
   }
 
   async fetchRestartEvent() {

--- a/app/components/pipeline/modal/event-group-history/template.hbs
+++ b/app/components/pipeline/modal/event-group-history/template.hbs
@@ -21,6 +21,7 @@
           @queueName="eventGroupModal"
           @onClick={{fn @closeModal}}
           @lastSuccessfulEvent={{@lastSuccessfulEvent}}
+          @latestCommitEvent={{@latestCommitEvent}}
         />
       </VerticalCollection>
     {{/if}}

--- a/app/components/pipeline/modal/search-event/template.hbs
+++ b/app/components/pipeline/modal/search-event/template.hbs
@@ -48,6 +48,7 @@
             @event={{event}}
             @queueName="searchResults"
             @lastSuccessfulEvent={{@lastSuccessfulEvent}}
+            @latestCommitEvent={{@latestCommitEvent}}
           />
         </VerticalCollection>
         {{#if this.isLoading}}

--- a/app/components/pipeline/workflow/event-rail/component.js
+++ b/app/components/pipeline/workflow/event-rail/component.js
@@ -6,6 +6,7 @@ import ENV from 'screwdriver-ui/config/environment';
 import { isActivePipeline } from 'screwdriver-ui/utils/pipeline';
 
 const EVENT_BATCH_SIZE = 10;
+const LATEST_COMMIT_EVENT_QUEUE_NAME = 'eventRailLatestCommitEvent';
 
 export default class PipelineWorkflowEventRailComponent extends Component {
   @service router;
@@ -28,6 +29,8 @@ export default class PipelineWorkflowEventRailComponent extends Component {
 
   @tracked lastSuccessfulEvent;
 
+  @tracked latestCommitEvent;
+
   collectionApi;
 
   prNums;
@@ -46,6 +49,11 @@ export default class PipelineWorkflowEventRailComponent extends Component {
 
   willDestroy() {
     super.willDestroy();
+
+    this.workflowDataReload.removeLatestCommitEventCallback(
+      LATEST_COMMIT_EVENT_QUEUE_NAME,
+      this.pipelinePageState.getPipelineId()
+    );
 
     if (this.intervalId) {
       clearInterval(this.intervalId);
@@ -68,12 +76,16 @@ export default class PipelineWorkflowEventRailComponent extends Component {
   @action
   async initialize() {
     const { event } = this.args;
+    const pipelineId = this.pipelinePageState.getPipelineId();
+
+    this.workflowDataReload.registerLatestCommitEventCallback(
+      LATEST_COMMIT_EVENT_QUEUE_NAME,
+      pipelineId,
+      this.latestCommitEventCallback
+    );
 
     await this.shuttle
-      .fetchFromApi(
-        'get',
-        `/pipelines/${this.pipelinePageState.getPipelineId()}/lastSuccessfulEvent`
-      )
+      .fetchFromApi('get', `/pipelines/${pipelineId}/lastSuccessfulEvent`)
       .then(lastSuccessfulEvent => {
         this.lastSuccessfulEvent = lastSuccessfulEvent;
       })
@@ -268,5 +280,10 @@ export default class PipelineWorkflowEventRailComponent extends Component {
     if (event.status === 'SUCCESS' && event.id > this.lastSuccessfulEvent?.id) {
       this.lastSuccessfulEvent = event;
     }
+  }
+
+  @action
+  latestCommitEventCallback(latestCommitEvent) {
+    this.latestCommitEvent = latestCommitEvent;
   }
 }

--- a/app/components/pipeline/workflow/event-rail/template.hbs
+++ b/app/components/pipeline/workflow/event-rail/template.hbs
@@ -17,6 +17,7 @@
         <Pipeline::Modal::SearchEvent
           @closeModal={{this.closeSearchEventModal}}
           @lastSuccessfulEvent={{this.lastSuccessfulEvent}}
+          @latestCommitEvent={{this.latestCommitEvent}}
         />
       {{/if}}
     </BsButton>
@@ -34,6 +35,7 @@
         <Pipeline::Modal::ConfirmAction
           @action="start"
           @closeModal={{this.closeStartEventModal}}
+          @latestCommitEvent={{this.latestCommitEvent}}
         />
       {{/if}}
     {{/if}}
@@ -59,6 +61,7 @@
           @showEventGroup={{true}}
           @handleFilter={{true}}
           @lastSuccessfulEvent={{this.lastSuccessfulEvent}}
+          @latestCommitEvent={{this.latestCommitEvent}}
           @onEventUpdated={{this.onEventUpdated}}
         />
       </VerticalCollection>

--- a/app/workflow-data-reload/latestCommitEventReloader.js
+++ b/app/workflow-data-reload/latestCommitEventReloader.js
@@ -9,7 +9,7 @@ export default class LatestCommitEventReloader extends DataReloader {
 
   async fetchDataForId() {
     return this.shuttle
-      .fetchFromApi('get', `/pipelines/${this.pipelineId}/latestCommitEvent`)
+      .getLatestCommitEvent(this.pipelineId)
       .then(latestCommitEvent => {
         return latestCommitEvent;
       })

--- a/tests/integration/components/pipeline/event/card/component-test.js
+++ b/tests/integration/components/pipeline/event/card/component-test.js
@@ -13,8 +13,6 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
 
   let workflowDataReload;
 
-  let registerLatestCommitEventCallbackStub;
-
   let registerBuildsCallbackStub;
 
   let event;
@@ -39,12 +37,6 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
     lastSuccessfulEvent = { id: 11 };
 
     sinon.stub(settings, 'getSettings').returns({});
-
-    registerLatestCommitEventCallbackStub = sinon.stub(
-      workflowDataReload,
-      'registerLatestCommitEventCallback'
-    );
-    registerLatestCommitEventCallbackStub.callsFake(() => {});
 
     registerBuildsCallbackStub = sinon.stub(
       workflowDataReload,
@@ -346,24 +338,20 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
   test('it renders latest commit badge', async function (assert) {
     const latestCommitSha = 'abc123def456';
 
-    registerLatestCommitEventCallbackStub.reset();
-    registerLatestCommitEventCallbackStub.callsFake(
-      (queueName, id, callback) => {
-        callback({ sha: latestCommitSha });
-      }
-    );
     registerBuildsCallbackStub.reset();
     registerBuildsCallbackStub.callsFake((queueName, id, callback) => {
       callback([{ status: 'SUCCESS' }]);
     });
 
     this.setProperties({
-      event
+      event,
+      latestCommitEvent: { sha: latestCommitSha }
     });
 
     await render(
       hbs`<Pipeline::Event::Card
         @event={{this.event}}
+        @latestCommitEvent={{this.latestCommitEvent}}
       />`
     );
 
@@ -372,12 +360,6 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
   });
 
   test('it does not throw when latestCommitEvent is null', async function (assert) {
-    registerLatestCommitEventCallbackStub.reset();
-    registerLatestCommitEventCallbackStub.callsFake(
-      (queueName, id, callback) => {
-        callback(null);
-      }
-    );
     registerBuildsCallbackStub.reset();
     registerBuildsCallbackStub.callsFake((queueName, id, callback) => {
       callback([{ status: 'SUCCESS' }]);

--- a/tests/integration/components/pipeline/jobs/table/cell/actions/component-test.js
+++ b/tests/integration/components/pipeline/jobs/table/cell/actions/component-test.js
@@ -16,6 +16,8 @@ module(
 
     let shuttleStub;
 
+    let latestCommitEventStub;
+
     hooks.beforeEach(async function () {
       await authenticateSession({ username: 'test-user' });
 
@@ -29,6 +31,9 @@ module(
       sinon.stub(pipelinePageState, 'getIsPr').returns(false);
       pipelinePageState.route = 'v2.pipeline.jobs';
       shuttleStub = sinon.stub(shuttle, 'fetchFromApi').resolves({});
+      latestCommitEventStub = sinon
+        .stub(shuttle, 'getLatestCommitEvent')
+        .resolves({});
     });
 
     test('it renders', async function (assert) {
@@ -158,9 +163,7 @@ module(
 
       shuttleStub.withArgs('get', '/builds/999').resolves({ eventId: 456 });
       shuttleStub.withArgs('get', '/events/456').resolves(latestEvent);
-      shuttleStub
-        .withArgs('get', `/pipelines/${pipelineId}/latestCommitEvent`)
-        .resolves(latestCommitEvent);
+      latestCommitEventStub.withArgs(pipelineId).resolves(latestCommitEvent);
 
       this.setProperties({
         record: {
@@ -207,9 +210,7 @@ module(
 
       shuttleStub.withArgs('get', '/builds/999').resolves({ eventId: 456 });
       shuttleStub.withArgs('get', '/events/456').resolves(restartEvent);
-      shuttleStub
-        .withArgs('get', `/pipelines/${pipelineId}/latestCommitEvent`)
-        .resolves(latestCommitEvent);
+      latestCommitEventStub.withArgs(pipelineId).resolves(latestCommitEvent);
       shuttleStub.withArgs('post', '/events').resolves({ id: 1000 });
 
       this.setProperties({

--- a/tests/unit/workflow-data-reload/latestCommitEventReloader-test.js
+++ b/tests/unit/workflow-data-reload/latestCommitEventReloader-test.js
@@ -16,7 +16,7 @@ module(
       const latestCommitEventReloader = new LatestCommitEventReloader(shuttle);
 
       latestCommitEventReloader.setPipelineId(pipelineId);
-      sinon.stub(shuttle, 'fetchFromApi').resolves(fakeResponse);
+      sinon.stub(shuttle, 'getLatestCommitEvent').resolves(fakeResponse);
 
       const response = await latestCommitEventReloader.fetchDataForId(
         pipelineId
@@ -32,7 +32,7 @@ module(
       const latestCommitEventReloader = new LatestCommitEventReloader(shuttle);
 
       latestCommitEventReloader.setPipelineId(pipelineId);
-      sinon.stub(shuttle, 'fetchFromApi').rejects();
+      sinon.stub(shuttle, 'getLatestCommitEvent').rejects();
 
       const response = await latestCommitEventReloader.fetchDataForId(
         pipelineId


### PR DESCRIPTION
## Context

`GET /pipelines/{id}/latestCommitEvent` was being called more often than necessary in the UI.

There were two main patterns:

- Legacy events UI triggered extra calls when selecting event cards.
- Workflow/event card paths had multiple consumers that could request the same data through separate paths.

This caused avoidable API traffic without adding value to user-visible behavior.

## Objective

Reduce redundant latestCommitEvent API calls while preserving meaningful refresh behavior and existing UX.

### What this PR changes

- Legacy events UI:
  - Move latestCommitEvent fetch out of the selected-sensitive computed path.
  - Remove duplicate fetch from pipeline-events-list and rely on parent-provided data.

- Workflow UI:
  - Stop card-level latest-commit callback registration.
  - Centralize latest-commit subscription in workflow/event-rail.
  - Pass latestCommitEvent down to cards and related modals (search-event, event-group-history, confirm-action path).

- Request path consistency:
  - Route latestCommitEventReloader and jobs table actions through shuttle.getLatestCommitEvent(...) instead of direct endpoint calls.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
