### PR TITLE
fix: add padding to workflow graph for tooltip display

### DIFF
--- a/app/components/pipeline/workflow/graph/styles.scss
+++ b/app/components/pipeline/workflow/graph/styles.scss
@@ -12,6 +12,11 @@
 
 @mixin styles {
   #workflow-graph {
+    width: max-content;
+    height: max-content;
+    padding-right: 50%;
+    padding-bottom: 50%;
+
     .graph-label.selected-job {
       fill: colors.$sd-failure;
     }

--- a/app/components/pipeline/workflow/tooltip/styles.scss
+++ b/app/components/pipeline/workflow/tooltip/styles.scss
@@ -11,6 +11,7 @@
     font-size: 16px;
     padding: 1rem;
     position: absolute;
+    width: max-content;
 
     .triangle {
       border: 13px solid transparent;


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Tooltip on the right node is shrinking.

<img width="400" alt="before" src="https://github.com/user-attachments/assets/664b047f-d083-4045-afb2-8d19cc25e729" />

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Add right and bottom paddings to workflow for tooltip display.

<img width="300" alt="ex1" src="https://github.com/user-attachments/assets/2df4e24c-5b8f-4146-afa0-680066db379c" />
<img width="300" alt="ex2" src="https://github.com/user-attachments/assets/fd7510cd-2e83-455a-b73f-20a629c22ead" />

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
