### PR TITLE
feat: highlight opened artifacts name

### DIFF
--- a/app/components/artifact-tree-content/style.scss
+++ b/app/components/artifact-tree-content/style.scss
@@ -8,3 +8,6 @@ a:visited {
   color: inherit;
   text-decoration: none;
 }
+a.active {
+  font-weight: bold;
+}


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

It is hard to find which file is opened on artifacts tree.

<img width="251" height="168" alt="before" src="https://github.com/user-attachments/assets/9c069667-39f6-4efc-9d71-d0086a2d1c83" />

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

- Highlight the opened file name to find it easily.

<img width="250" height="172" alt="after" src="https://github.com/user-attachments/assets/714aa3be-4a96-455b-b3c7-39f9c5065c79" />

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
