### PR TITLE
fix: expand clickable area for workflow graph

### DIFF
--- a/app/components/pipeline/workflow/graph/component.js
+++ b/app/components/pipeline/workflow/graph/component.js
@@ -20,11 +20,16 @@ import {
   updateStageEdgeStatuses
 } from 'screwdriver-ui/utils/pipeline/graph/d3-graph-util';
 import { nodeCanShowTooltip } from 'screwdriver-ui/utils/pipeline/graph/tooltip';
+import { tracked } from '@glimmer/tracking';
 
 export default class PipelineWorkflowGraphComponent extends Component {
   @service('pipeline-page-state') pipelinePageState;
 
   @service('settings') settings;
+
+  @tracked overflowX = false;
+
+  @tracked overflowY = false;
 
   event;
 
@@ -241,6 +246,13 @@ export default class PipelineWorkflowGraphComponent extends Component {
     );
 
     this.applySelectedJobLabel();
+
+    const container = element.closest('#display-container');
+
+    if (container) {
+      this.overflowX = container.scrollWidth > container.clientWidth;
+      this.overflowY = container.scrollHeight > container.clientHeight;
+    }
   }
 
   @action

--- a/app/components/pipeline/workflow/graph/styles.scss
+++ b/app/components/pipeline/workflow/graph/styles.scss
@@ -12,11 +12,6 @@
 
 @mixin styles {
   #workflow-graph {
-    width: max-content;
-    height: max-content;
-    padding-right: 50%;
-    padding-bottom: 50%;
-
     .graph-label.selected-job {
       fill: colors.$sd-failure;
     }

--- a/app/components/pipeline/workflow/graph/template.hbs
+++ b/app/components/pipeline/workflow/graph/template.hbs
@@ -1,4 +1,5 @@
 <div id="workflow-graph"
   {{did-insert this.draw}}
   {{did-update this.redraw @workflowGraph @builds @stageBuilds @event @collapsedStages @selectedJobId this.pipelinePageState.jobs}}
+  class="{{if this.overflowX 'overflow-x'}} {{if this.overflowY 'overflow-y'}}"
 />

--- a/app/components/pipeline/workflow/styles.scss
+++ b/app/components/pipeline/workflow/styles.scss
@@ -103,12 +103,22 @@
         overflow: auto;
 
         #workflow-graph {
+          width: 100%;
           height: 100%;
+          min-width: max-content;
+          min-height: max-content;
 
           svg {
             min-width: 100%;
             min-height: 100%;
           }
+        }
+
+        #workflow-graph.overflow-x {
+          padding-right: 50%;
+        }
+        #workflow-graph.overflow-y {
+          padding-bottom: 50%;
         }
 
         @include graph.styles;


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Follow up https://github.com/screwdriver-cd/ui/pull/1579 .

After https://github.com/screwdriver-cd/ui/pull/1579 merged, clickable area of workflow graph is shrinking.

<img width="300" alt="before" src="https://github.com/user-attachments/assets/4c98b4cb-10d5-4463-a7c2-f8714d5d2677" />

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

It should add padding only when workflow graph is scrollable.
(It is able to add margin instead of padding, but then it will be always scrollable.)

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

PR - https://github.com/screwdriver-cd/ui/pull/1579

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
