### PR TITLE
fix: handle rerun payloads correctly for pr-closed events in v2 UI

### DIFF
--- a/app/components/pipeline/modal/confirm-action/util.js
+++ b/app/components/pipeline/modal/confirm-action/util.js
@@ -39,6 +39,17 @@ export function isParameterized(pipeline, defaultJobParameters, event) {
 }
 
 /**
+ * Detect whether an event originated from a pr-closed webhook or its restart lineage.
+ * @param {object} event Event object in the shape returned by the API
+ * @returns {boolean}
+ */
+function isPrClosedEventLineage(event) {
+  return Boolean(
+    event && (event.startFrom?.startsWith('~pr-closed') || event.meta?.sd?.pr)
+  );
+}
+
+/**
  * Build core post body for triggering an event
  * @param jobName {string} Name of the job to start from
  * @param startAction {string} Name of start type (start or restart)
@@ -48,6 +59,7 @@ export function isParameterized(pipeline, defaultJobParameters, event) {
  * @param parameters {object} Parameters to pass to the event
  * @returns {object}
  */
+// eslint-disable-next-line max-params
 export const buildPostBody = (
   jobName,
   startAction,
@@ -56,12 +68,13 @@ export const buildPostBody = (
   prNum,
   parameters
 ) => {
+  const usePrEventPayload = Boolean(prNum) && !isPrClosedEventLineage(event);
   const data = {
     startFrom: jobName,
     startAction
   };
 
-  if (prNum) {
+  if (usePrEventPayload) {
     data.prNum = prNum;
     data.parentEventId = event.id;
     data.groupEventId = event.groupEventId;

--- a/tests/integration/components/pipeline/modal/confirm-action/api-body-test.js
+++ b/tests/integration/components/pipeline/modal/confirm-action/api-body-test.js
@@ -468,5 +468,91 @@ module(
         })
       );
     });
+
+    test('it does not set PR payload for fresh run from pr-closed event job', async function (assert) {
+      getIsPrStub.returns(false);
+      event.prNum = prNum;
+      event.startFrom = '~pr-closed:main';
+      event.meta = {
+        sd: {
+          pr: {
+            merged: true,
+            number: prNum
+          }
+        }
+      };
+
+      getPipelineStub.returns(pipeline);
+
+      this.setProperties({
+        action: 'start',
+        event,
+        job,
+        closeModal
+      });
+      await render(
+        hbs`<Pipeline::Modal::ConfirmAction
+            @action={{this.action}}
+            @event={{this.event}}
+            @job={{this.job}}
+            @closeModal={{this.closeModal}}
+        />`
+      );
+      await click('#submit-action');
+
+      assert.true(
+        shuttleStub.calledWith('post', '/events', {
+          pipelineId,
+          causeMessage: `Manually started by ${username}`,
+          startFrom: job.name,
+          parentEventId: event.id,
+          groupEventId: event.groupEventId,
+          startAction: 'START_FROM_EVENT'
+        })
+      );
+    });
+
+    test('it does not set PR payload for inherited restart from pr-closed event lineage', async function (assert) {
+      getIsPrStub.returns(false);
+      event.prNum = prNum;
+      event.startFrom = 'main';
+      event.meta = {
+        sd: {
+          pr: {
+            merged: true,
+            number: prNum
+          }
+        }
+      };
+
+      getPipelineStub.returns(pipeline);
+
+      this.setProperties({
+        action: 'restart',
+        event,
+        job,
+        closeModal
+      });
+      await render(
+        hbs`<Pipeline::Modal::ConfirmAction
+            @action={{this.action}}
+            @event={{this.event}}
+            @job={{this.job}}
+            @closeModal={{this.closeModal}}
+        />`
+      );
+      await click('#submit-action');
+
+      assert.true(
+        shuttleStub.calledWith('post', '/events', {
+          pipelineId,
+          causeMessage: `Manually started by ${username}`,
+          startFrom: job.name,
+          parentEventId: event.id,
+          groupEventId: event.groupEventId,
+          startAction: 'RESTART_FROM_EVENT'
+        })
+      );
+    });
   }
 );

--- a/tests/unit/components/pipeline/modal/confirm-action/util-test.js
+++ b/tests/unit/components/pipeline/modal/confirm-action/util-test.js
@@ -167,6 +167,61 @@ module('Unit | Component | pipeline/modal/confirm-action/util', function () {
     );
   });
 
+  test('buildPostBody does not build PR payload for pr-closed event', function (assert) {
+    const prNum = 7;
+    const jobName = 'pull';
+    const event = {
+      id: 45,
+      groupEventId: 10,
+      startFrom: '~pr-closed:main',
+      meta: {
+        sd: {
+          pr: {
+            merged: true,
+            number: prNum
+          }
+        }
+      }
+    };
+
+    assert.deepEqual(
+      buildPostBody(jobName, 'START_FROM_EVENT', event, null, prNum),
+      {
+        startFrom: jobName,
+        startAction: 'START_FROM_EVENT',
+        parentEventId: event.id,
+        groupEventId: event.groupEventId
+      }
+    );
+  });
+
+  test('buildPostBody does not build PR payload for restarted pr-closed event lineage', function (assert) {
+    const prNum = 7;
+    const event = {
+      id: 45,
+      groupEventId: 10,
+      startFrom: 'main',
+      meta: {
+        sd: {
+          pr: {
+            merged: true,
+            number: prNum
+          }
+        }
+      }
+    };
+
+    assert.deepEqual(
+      buildPostBody('pull', 'RESTART_FROM_EVENT', event, null, prNum),
+      {
+        startFrom: 'pull',
+        startAction: 'RESTART_FROM_EVENT',
+        parentEventId: event.id,
+        groupEventId: event.groupEventId
+      }
+    );
+  });
+
   test('buildPostBody sets correct values for new event with parameters', function (assert) {
     const jobName = '~commit';
     const parameters = { param: 4 };


### PR DESCRIPTION
## Context

In the v2 UI, rerunning an event triggered by `~pr-closed` could fail because the UI sent `prNum` in the `/events` payload.
That caused the API to treat the request as a PR event and try to resolve PR-specific refs, which does not work for closed PR events.

## Objective

Stop treating `pr-closed` event reruns as PR event reruns in the v2 UI.

This PR:
- avoids including `prNum` in rerun payloads for `pr-closed` events and their restart lineage
- keeps normal PR event rerun behavior unchanged
- adds tests for fresh run and restart flows from `pr-closed` events

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
