### PR TITLE
fix: show job state toggle link on the tooltip even if manualStartEnabled is false

### DIFF
--- a/app/components/pipeline-workflow/component.js
+++ b/app/components/pipeline-workflow/component.js
@@ -146,6 +146,7 @@ export default Component.extend({
       : this.get('pipeline.jobParameters');
   },
 
+  // eslint-disable-next-line default-param-last
   mergeDefaultAndEventParameters(defaultParameters = {}, eventParameters) {
     const defaultParameterNames = Object.keys(defaultParameters);
     const mergedParameters = copy(defaultParameters, true);
@@ -284,7 +285,8 @@ export default Component.extend({
           );
 
           if (originalJob) {
-            job.isDisabled = originalJob.isDisabled;
+            set(job, 'isDisabled', originalJob.isDisabled);
+            set(job, 'stateChanger', originalJob.stateChanger);
           } else {
             delete job.isDisabled;
           }

--- a/app/components/pipeline/workflow/tooltip/template.hbs
+++ b/app/components/pipeline/workflow/tooltip/template.hbs
@@ -39,96 +39,88 @@
       Go to build metrics
     </LinkTo>
 
-    {{#if this.tooltipData.job.isDisabled}}
-      {{#if this.tooltipData.job.manualStartDisabled}}
-        <p>
-          Disabled by annotation
+    {{#if (and (not this.tooltipData.job.manualStartDisabled) (not this.tooltipData.job.isDisabled))}}
+      {{#if (and this.displayRestartButton this.canJobStartFromView)}}
+        <p id="run-job-label">
+          Run job at {{this.truncatedSha}}
         </p>
-      {{else}}
+        <ul id="run-job-block">
+          <li>
+            <a
+              id="restart-job-link"
+              class="run-job-help"
+              href="#"
+              {{on "click" (fn this.openConfirmActionModal "restart")}}
+            >
+              <FaIcon
+                @icon="rotate-right"
+                @fixedWidth="true"
+                @prefix="fas"
+              />
+              Restart (Inherit)
+            </a>
+            <BsTooltip
+              @placement="right"
+              @triggerElement="#restart-job-link"
+              @renderInPlace={{false}}
+              @delayHide="100"
+            >
+              Use this event's metadata and build statuses.
+            </BsTooltip>
+          </li>
+          <li>
+            <a
+              id="start-job-link"
+              class="run-job-help"
+              href="#"
+              {{on "click" (fn this.openConfirmActionModal "start")}}
+            >
+              <FaIcon
+                @icon="circle-play"
+                @fixedWidth="true"
+                @prefix="far"
+              />
+              New Run (Fresh)
+            </a>
+            <BsTooltip
+              @placement="right"
+              @triggerElement="#start-job-link"
+              @renderInPlace={{false}}
+              @delayHide="100"
+            >
+              Clean start from this job. No metadata or build statuses.
+            </BsTooltip>
+          </li>
+        </ul>
+      {{/if}}
+    {{else}}
+      {{#if this.tooltipData.job.isDisabled}}
         <p
           title={{this.tooltipData.job.stateChangeMessage}}
         >
           {{this.stateChangerMessage}}
         </p>
-        <a
-          id="toggle-job-link"
-          href="#"
-          {{on "click" (fn this.openToggleJobModal "Enable")}}
-        >
-          Enable this job
-        </a>
+      {{else}}
+        <p>Disabled manually starting by annotation</p>
       {{/if}}
+    {{/if}}
+
+    {{#if this.tooltipData.job.isDisabled}}
+      <a
+        id="toggle-job-link"
+        href="#"
+        {{on "click" (fn this.openToggleJobModal "Enable")}}
+      >
+        Enable this job
+      </a>
     {{else}}
-      {{#if this.displayRestartButton}}
-        {{#if this.tooltipData.job.manualStartDisabled}}
-            <p>
-              Disabled manually starting
-            </p>
-        {{else}}
-          {{#if this.canJobStartFromView}}
-            <p id="run-job-label">
-              Run job at {{this.truncatedSha}}
-            </p>
-            <ul id="run-job-block">
-              <li>
-                <a
-                  id="restart-job-link"
-                  class="run-job-help"
-                  href="#"
-                  {{on "click" (fn this.openConfirmActionModal "restart")}}
-                >
-                  <FaIcon
-                    @icon="rotate-right"
-                    @fixedWidth="true"
-                    @prefix="fas"
-                  />
-                  Restart (Inherit)
-                </a>
-                <BsTooltip
-                  @placement="right"
-                  @triggerElement="#restart-job-link"
-                  @renderInPlace={{false}}
-                  @delayHide="100"
-                >
-                  Use this event's metadata and build statuses.
-                </BsTooltip>
-              </li>
-              <li>
-                <a
-                  id="start-job-link"
-                  class="run-job-help"
-                  href="#"
-                  {{on "click" (fn this.openConfirmActionModal "start")}}
-                >
-                  <FaIcon
-                    @icon="circle-play"
-                    @fixedWidth="true"
-                    @prefix="far"
-                  />
-                  New Run (Fresh)
-                </a>
-                <BsTooltip
-                  @placement="right"
-                  @triggerElement="#start-job-link"
-                  @renderInPlace={{false}}
-                  @delayHide="100"
-                >
-                  Clean start from this job. No metadata or build statuses.
-                </BsTooltip>
-              </li>
-            </ul>
-          {{/if}}
-        {{/if}}
-      {{/if}}
-      {{#if (eq this.tooltipData.job.isDisabled false)}}
-        <a
-          id="toggle-job-link"
-          href="#"
-          {{on "click" (fn this.openToggleJobModal "Disable")}}
-        >
-          Disable this job
-        </a>
-      {{/if}}
+      <a
+        id="toggle-job-link"
+        href="#"
+        {{on "click" (fn this.openToggleJobModal "Disable")}}
+      >
+        Disable this job
+      </a>
     {{/if}}
   {{/if}}
 

--- a/app/components/workflow-tooltip/component.js
+++ b/app/components/workflow-tooltip/component.js
@@ -36,6 +36,15 @@ export default Component.extend({
       description.length > this.viewDescriptionMaxLength
     );
   },
+  originalJob: computed(
+    'pipeline.jobs',
+    'tooltipData.job.name',
+    function originalJob() {
+      const jobName = get(this, 'tooltipData.job.name');
+
+      return this.get('pipeline.jobs')?.find(j => j.name === jobName);
+    }
+  ),
   jobState: computed('tooltipData.job.isDisabled', function jobState() {
     const isDisabled = get(this, 'tooltipData.job.isDisabled');
 
@@ -58,13 +67,19 @@ export default Component.extend({
       return description;
     }
   ),
+  stateChangerMessage: computed(
+    'tooltipData.job.isDisabled',
+    function stateChangerMessage() {
+      const job = get(this, 'tooltipData.job');
+      const jobState = job.isDisabled ? 'Disabled' : 'Enabled';
+
+      return job.stateChanger ? `${jobState} by ${job.stateChanger}` : jobState;
+    }
+  ),
   actions: {
     toggleJob(toggleJobName) {
       const state = this.jobState;
-
-      const originalJob = this.get('pipeline.jobs').find(
-        j => j.name === toggleJobName
-      );
+      const { originalJob } = this;
 
       this.set('toggleJobName', toggleJobName);
       this.set(
@@ -72,13 +87,16 @@ export default Component.extend({
         state[0].toUpperCase() + state.slice(1, -1).toLowerCase()
       );
 
-      this.set('originalJobId', originalJob.id);
+      this.set('originalJobId', originalJob?.id);
       this.set('showToggleModal', true);
     },
     updateMessage(message) {
       const { originalJobId, jobState } = this;
 
-      this.setJobState(originalJobId, jobState, message || ' ');
+      if (originalJobId) {
+        this.setJobState(originalJobId, jobState, message || ' ');
+      }
+
       this.set('showToggleModal', false);
       this.set('showTooltip', false);
     },

--- a/app/components/workflow-tooltip/template.hbs
+++ b/app/components/workflow-tooltip/template.hbs
@@ -23,38 +23,32 @@
         Go to build metrics
       </LinkTo>
 
-      {{#if this.tooltipData.job.isDisabled}}
-        {{#if this.tooltipData.job.manualStartDisabled}}
-          <p>
-            Disabled by annotation
-          </p>
-        {{else}}
-          <p>
-            {{this.tooltipData.job.stateChangeMessage}}
-          </p>
-          <a href="#" {{action "toggleJob" this.tooltipData.job.name}}>
-            Enable this job
+      {{#if (and (not this.tooltipData.job.manualStartDisabled) (not this.tooltipData.job.isDisabled))}}
+        {{#if (and this.canRestartPipeline this.canJobStartFromView)}}
+          <a href="#" {{action this.confirmStartBuild}}>
+            {{if this.tooltipData.job.status "Restart" "Start"}} pipeline from here
           </a>
         {{/if}}
       {{else}}
-        {{#if this.canRestartPipeline}}
-          {{#if this.tooltipData.job.manualStartDisabled}}
-            <p>
-              Disabled manually starting
-            </p>
-          {{else}}
-            {{#if (eq this.canJobStartFromView true)}}
-              <a href="#" {{action this.confirmStartBuild}}>
-                {{if this.tooltipData.job.status "Restart" "Start"}} pipeline from here
-              </a>
-            {{/if}}
-          {{/if}}
+        {{#if this.tooltipData.job.isDisabled}}
+          <p
+            title={{this.tooltipData.job.stateChangeMessage}}
+          >
+            {{this.stateChangerMessage}}
+          </p>
+        {{else}}
+          <p>Disabled manually starting by annotation</p>
         {{/if}}
-        {{#if (eq this.tooltipData.job.isDisabled false)}}
-          <a href="#" {{action "toggleJob" this.tooltipData.job.name}}>
-            Disable this job
-          </a>
-        {{/if}}
+      {{/if}}
+
+      {{#if this.tooltipData.job.isDisabled}}
+        <a href="#" {{action "toggleJob" this.tooltipData.job.name}}>
+          Enable this job
+        </a>
+      {{else if this.originalJob}}
+        <a href="#" {{action "toggleJob" this.tooltipData.job.name}}>
+          Disable this job
+        </a>
       {{/if}}
 
       {{#if this.tooltipData.displayStop}}

--- a/app/utils/graph-tools.js
+++ b/app/utils/graph-tools.js
@@ -902,13 +902,9 @@ const decorateGraph = ({
       // Set build status to disabled if job is disabled
       if (n.isDisabled) {
         const { state, stateChanger } = originalJob;
-        const stateWithCapitalization =
-          state[0].toUpperCase() + state.substring(1).toLowerCase();
 
         n.status = state;
-        n.stateChangeMessage = stateChanger
-          ? `${stateWithCapitalization} by ${stateChanger}`
-          : stateWithCapitalization;
+        n.stateChanger = stateChanger;
       }
 
       // Set manualStartEnabled on the node

--- a/tests/integration/components/pipeline/workflow/tooltip/component-test.js
+++ b/tests/integration/components/pipeline/workflow/tooltip/component-test.js
@@ -204,7 +204,7 @@ module('Integration | Component | pipeline/workflow/tooltip', function (hooks) {
         node: {
           name: 'main',
           manualStartDisabled: true,
-          isDisabled: true
+          isDisabled: false
         },
         d3Event: { clientX: 0, clientY: 0 },
         sizes: { ICON_SIZE: 0 }
@@ -221,8 +221,38 @@ module('Integration | Component | pipeline/workflow/tooltip', function (hooks) {
       />`
     );
 
-    assert.dom('#toggle-job-link').doesNotExist();
-    assert.dom('p').hasText('Disabled by annotation');
+    assert.dom('#toggle-job-link').exists({ count: 1 });
+    assert.dom('p').hasText('Disabled manually starting by annotation');
+  });
+
+  test('it renders disabled by users when it disabled manually starting', async function (assert) {
+    authenticateSession();
+
+    this.setProperties({
+      d3Data: {
+        node: {
+          name: 'main',
+          manualStartDisabled: true,
+          isDisabled: true,
+          stateChanger: 'test'
+        },
+        d3Event: { clientX: 0, clientY: 0 },
+        sizes: { ICON_SIZE: 0 }
+      },
+      event: {},
+      builds: []
+    });
+
+    await render(
+      hbs`<Pipeline::Workflow::Tooltip
+        @d3Data={{this.d3Data}}
+        @event={{this.event}}
+        @builds={{this.builds}}
+      />`
+    );
+
+    assert.dom('#toggle-job-link').exists({ count: 1 });
+    assert.dom('p').hasText('Disabled by test');
   });
 
   test('it renders stop build link', async function (assert) {

--- a/tests/integration/components/workflow-tooltip/component-test.js
+++ b/tests/integration/components/workflow-tooltip/component-test.js
@@ -7,15 +7,26 @@ import hbs from 'htmlbars-inline-precompile';
 module('Integration | Component | workflow tooltip', function (hooks) {
   setupRenderingTest(hooks);
 
+  hooks.beforeEach(function () {
+    const pipelineMock = EmberObject.create({
+      jobs: [
+        { id: 1, name: 'batmobile' },
+        { id: 2, name: 'foo' }
+      ]
+    });
+
+    this.set('pipeline', pipelineMock);
+  });
+
   test('it renders', async function (assert) {
-    await render(hbs`<WorkflowTooltip/>`);
+    await render(hbs`<WorkflowTooltip @pipeline={{this.pipeline}}/>`);
 
     assert.dom('a:nth-of-type(1)').hasText('Go to build details');
     assert.dom('a:nth-of-type(2)').hasText('Go to build metrics');
 
     // Template block usage:
     await render(hbs`
-        <WorkflowTooltip/>
+        <WorkflowTooltip @pipeline={{this.pipeline}}/>
         "template block text"
       `);
 
@@ -34,7 +45,9 @@ module('Integration | Component | workflow tooltip', function (hooks) {
 
     this.set('data', data);
 
-    await render(hbs`<WorkflowTooltip @tooltipData={{this.data}} />`);
+    await render(
+      hbs`<WorkflowTooltip @pipeline={{this.pipeline}} @tooltipData={{this.data}} />`
+    );
 
     assert.dom('.content a').exists({ count: 3 });
     assert.dom('a:nth-of-type(1)').hasText('Go to build details');
@@ -43,7 +56,7 @@ module('Integration | Component | workflow tooltip', function (hooks) {
   });
 
   test('it renders disabled build detail link', async function (assert) {
-    await render(hbs`<WorkflowTooltip />`);
+    await render(hbs`<WorkflowTooltip @pipeline={{this.pipeline}} />`);
 
     assert.dom('a:nth-of-type(1)').hasText('Go to build details');
     assert.dom('a:nth-of-type(1)').hasClass('disabled');
@@ -59,7 +72,9 @@ module('Integration | Component | workflow tooltip', function (hooks) {
     };
 
     this.set('data', data);
-    await render(hbs`<WorkflowTooltip @tooltipData={{this.data}} />`);
+    await render(
+      hbs`<WorkflowTooltip @pipeline={{this.pipeline}} @tooltipData={{this.data}} />`
+    );
 
     assert.dom('a:nth-of-type(1)').hasText('Go to build details');
     assert.dom('a:nth-of-type(1)').hasClass('disabled');
@@ -73,7 +88,9 @@ module('Integration | Component | workflow tooltip', function (hooks) {
     };
 
     this.set('data', data);
-    await render(hbs`<WorkflowTooltip @tooltipData={{this.data}} />`);
+    await render(
+      hbs`<WorkflowTooltip @pipeline={{this.pipeline}} @tooltipData={{this.data}} />`
+    );
 
     assert.dom('a:nth-of-type(1)').hasText('Go to build details');
     assert.dom('a:nth-of-type(1)').hasClass('disabled');
@@ -89,7 +106,9 @@ module('Integration | Component | workflow tooltip', function (hooks) {
 
     this.set('data', data);
 
-    await render(hbs`<WorkflowTooltip @tooltipData={{this.data}} />`);
+    await render(
+      hbs`<WorkflowTooltip @pipeline={{this.pipeline}} @tooltipData={{this.data}} />`
+    );
 
     assert.dom('.content a').exists({ count: 1 });
     assert.dom(this.element).hasText('Go to remote pipeline');
@@ -113,7 +132,9 @@ module('Integration | Component | workflow tooltip', function (hooks) {
 
     this.set('data', data);
 
-    await render(hbs`<WorkflowTooltip @tooltipData={{this.data}} />`);
+    await render(
+      hbs`<WorkflowTooltip @pipeline={{this.pipeline}} @tooltipData={{this.data}} />`
+    );
 
     assert.dom('.content a').exists({ count: 2 });
     assert
@@ -128,8 +149,7 @@ module('Integration | Component | workflow tooltip', function (hooks) {
       job: {
         buildId: 1234,
         name: 'batmobile',
-        manualStartDisabled: true,
-        isDisabled: true
+        manualStartDisabled: true
       }
     };
 
@@ -137,16 +157,49 @@ module('Integration | Component | workflow tooltip', function (hooks) {
     this.set('confirmStartBuild', () => {});
 
     await render(hbs`<WorkflowTooltip
+        @pipeline={{this.pipeline}}
         @tooltipData={{this.data}}
         @canRestartPipeline={{true}}
         @confirmStartBuild={{this.confirmStartBuild}}
       />`);
 
-    assert.dom('.content a').exists({ count: 2 });
+    assert.dom('.content a').exists({ count: 3 });
     assert.dom('.content p').exists({ count: 1 });
     assert.dom('a:nth-of-type(1)').hasText('Go to build details');
     assert.dom('a:nth-of-type(2)').hasText('Go to build metrics');
-    assert.dom('p:nth-of-type(1)').hasText('Disabled by annotation');
+    assert.dom('a:nth-of-type(3)').hasText('Disable this job');
+    assert
+      .dom('p:nth-of-type(1)')
+      .hasText('Disabled manually starting by annotation');
+  });
+
+  test('it renders disabled by users when it disabled manually starting', async function (assert) {
+    const data = {
+      job: {
+        buildId: 1234,
+        name: 'batmobile',
+        manualStartDisabled: true,
+        isDisabled: true,
+        stateChanger: 'test'
+      }
+    };
+
+    this.set('data', data);
+    this.set('confirmStartBuild', () => {});
+
+    await render(hbs`<WorkflowTooltip
+        @pipeline={{this.pipeline}}
+        @tooltipData={{this.data}}
+        @canRestartPipeline={{true}}
+        @confirmStartBuild={{this.confirmStartBuild}}
+      />`);
+
+    assert.dom('.content a').exists({ count: 3 });
+    assert.dom('.content p').exists({ count: 1 });
+    assert.dom('a:nth-of-type(1)').hasText('Go to build details');
+    assert.dom('a:nth-of-type(2)').hasText('Go to build metrics');
+    assert.dom('a:nth-of-type(3)').hasText('Enable this job');
+    assert.dom('p:nth-of-type(1)').hasText('Disabled by test');
   });
 
   test('it renders start link', async function (assert) {
@@ -163,6 +216,7 @@ module('Integration | Component | workflow tooltip', function (hooks) {
     this.set('canJobStartFromView', true);
 
     await render(hbs`<WorkflowTooltip
+        @pipeline={{this.pipeline}}
         @tooltipData={{this.data}}
         @canRestartPipeline={{true}}
         @confirmStartBuild={{this.confirmStartBuild}}
@@ -191,6 +245,7 @@ module('Integration | Component | workflow tooltip', function (hooks) {
     this.set('canJobStartFromView', true);
 
     await render(hbs`<WorkflowTooltip
+        @pipeline={{this.pipeline}}
         @tooltipData={{this.data}}
         @canRestartPipeline={{true}}
         @confirmStartBuild={{this.confirmStartBuild}}
@@ -218,6 +273,7 @@ module('Integration | Component | workflow tooltip', function (hooks) {
     this.set('canJobStartFromView', true);
 
     await render(hbs`<WorkflowTooltip
+        @pipeline={{this.pipeline}}
         @tooltipData={{this.data}}
         @canRestartPipeline={{true}}
         @confirmStartBuild={{this.confirmStartBuild}}
@@ -246,6 +302,7 @@ module('Integration | Component | workflow tooltip', function (hooks) {
     this.set('canJobStartFromView', false);
 
     await render(hbs`<WorkflowTooltip
+        @pipeline={{this.pipeline}}
         @tooltipData={{this.data}}
         @canRestartPipeline={{true}}
         @confirmStartBuild={{this.confirmStartBuild}}
@@ -273,6 +330,7 @@ module('Integration | Component | workflow tooltip', function (hooks) {
     this.set('canJobStartFromView', false);
 
     await render(hbs`<WorkflowTooltip
+        @pipeline={{this.pipeline}}
         @tooltipData={{this.data}}
         @canRestartPipeline={{true}}
         @confirmStartBuild={{this.confirmStartBuild}}
@@ -300,6 +358,7 @@ module('Integration | Component | workflow tooltip', function (hooks) {
     this.set('canJobStartFromView', true);
 
     await render(hbs`<WorkflowTooltip
+        @pipeline={{this.pipeline}}
         @tooltipData={{this.data}}
         @canRestartPipeline={{true}}
         @confirmStartBuild={{this.confirmStartBuild}}
@@ -329,6 +388,7 @@ module('Integration | Component | workflow tooltip', function (hooks) {
     this.set('canJobStartFromView', true);
 
     await render(hbs`<WorkflowTooltip
+        @pipeline={{this.pipeline}}
         @tooltipData={{this.data}}
         @canRestartPipeline={{true}}
         @confirmStartBuild={{this.confirmStartBuild}}
@@ -358,6 +418,7 @@ module('Integration | Component | workflow tooltip', function (hooks) {
     this.set('action', () => {});
 
     await render(hbs`<WorkflowTooltip
+        @pipeline={{this.pipeline}}
         @tooltipData={{this.data}}
         @stopBuild={{this.stopBuild}}
         @action={{this.action}}
@@ -385,6 +446,7 @@ module('Integration | Component | workflow tooltip', function (hooks) {
     this.set('canJobStartFromView', true);
 
     await render(hbs`<WorkflowTooltip
+        @pipeline={{this.pipeline}}
         @tooltipData={{this.data}}
         @canRestartPipeline={{true}}
         @confirmStartBuild={{this.confirmStartBuild}}
@@ -403,6 +465,7 @@ module('Integration | Component | workflow tooltip', function (hooks) {
     this.set('pos', 'left');
 
     await render(hbs`<WorkflowTooltip
+        @pipeline={{this.pipeline}}
         @showTooltip={{this.show}}
         @showTooltipPosition={{this.pos}}
       />`);
@@ -427,21 +490,7 @@ module('Integration | Component | workflow tooltip', function (hooks) {
       }
     };
 
-    const pipelineMock = EmberObject.create({
-      jobs: [
-        {
-          id: 1,
-          name: 'batmobile'
-        },
-        {
-          id: 2,
-          name: 'foo'
-        }
-      ]
-    });
-
     this.set('data', data);
-    this.set('pipeline', pipelineMock);
 
     await render(hbs`<WorkflowTooltip
         @tooltipData={{this.data}}
@@ -467,21 +516,7 @@ module('Integration | Component | workflow tooltip', function (hooks) {
       }
     };
 
-    const pipelineMock = EmberObject.create({
-      jobs: [
-        {
-          id: 1,
-          name: 'batmobile'
-        },
-        {
-          id: 2,
-          name: 'foo'
-        }
-      ]
-    });
-
     this.set('data', data);
-    this.set('pipeline', pipelineMock);
 
     await render(hbs`<WorkflowTooltip
         @tooltipData={{this.data}}
@@ -511,16 +546,18 @@ module('Integration | Component | workflow tooltip', function (hooks) {
     this.set('canJobStartFromView', true);
 
     await render(hbs`<WorkflowTooltip
+        @pipeline={{this.pipeline}}
         @tooltipData={{this.data}}
         @canRestartPipeline={{true}}
         @confirmStartBuild={{this.confirmStartBuild}}
         @canJobStartFromView={{this.canJobStartFromView}}
       />`);
 
-    assert.dom('.content a').exists({ count: 3 });
+    assert.dom('.content a').exists({ count: 4 });
     assert.dom('a:nth-of-type(1)').hasText('Go to build details');
     assert.dom('a:nth-of-type(2)').hasText('Go to build metrics');
     assert.dom('a:nth-of-type(3)').hasText('Start pipeline from here');
+    assert.dom('a:nth-of-type(4)').hasText('Disable this job');
     assert.dom('span').hasText('Test');
   });
 
@@ -543,6 +580,7 @@ module('Integration | Component | workflow tooltip', function (hooks) {
     this.set('enableHiddenDescription', true);
 
     await render(hbs`<WorkflowTooltip
+        @pipeline={{this.pipeline}}
         @tooltipData={{this.data}}
         @canRestartPipeline={{true}}
         @confirmStartBuild={{this.confirmStartBuild}}
@@ -550,10 +588,11 @@ module('Integration | Component | workflow tooltip', function (hooks) {
         @enableHiddenDescription={{this.enableHiddenDescription}}
       />`);
 
-    assert.dom('.content a').exists({ count: 3 });
+    assert.dom('.content a').exists({ count: 4 });
     assert.dom('a:nth-of-type(1)').hasText('Go to build details');
     assert.dom('a:nth-of-type(2)').hasText('Go to build metrics');
     assert.dom('a:nth-of-type(3)').hasText('Start pipeline from here');
+    assert.dom('a:nth-of-type(4)').hasText('Disable this job');
     assert.dom('span').hasText(`${description}`);
 
     await click('span');
@@ -576,6 +615,7 @@ module('Integration | Component | workflow tooltip', function (hooks) {
     this.set('canJobStartFromView', true);
 
     await render(hbs`<WorkflowTooltip
+        @pipeline={{this.pipeline}}
         @tooltipData={{this.data}}
         @canRestartPipeline={{true}}
         @confirmStartBuild={{this.confirmStartBuild}}

--- a/tests/unit/utils/graph-tools-test.js
+++ b/tests/unit/utils/graph-tools-test.js
@@ -354,6 +354,7 @@ module('Unit | Utility | graph tools', function () {
         id: 2,
         isDisabled: true,
         state: 'DISABLED',
+        stateChanger: 'TEST user',
         permutations: [
           { annotations: { 'screwdriver.cd/manualStartEnabled': true } }
         ]
@@ -393,7 +394,7 @@ module('Unit | Utility | graph tools', function () {
           id: 2,
           isDisabled: true,
           manualStartDisabled: false,
-          stateChangeMessage: 'Disabled',
+          stateChanger: 'TEST user',
           status: 'DISABLED',
           pos: { x: 2, y: 0 }
         },


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Currently, the "Enable this job" link on the tooltip does not appear when it has the annotation `manualStartEnabled: false`.
However, the job having `manualStartEnabled: false` is triggered on the webhook events and "Start a new event" button.
Users wants to toggle the job state to switch job execution on that cases.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Display the job toggle link(Enable this job / Disable this job) even if the annotation is `manualStartEnabled: false`.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
