### PR TITLE
fix: show jobs on settings page even if the jobs have "manualStartEnabled: false" annotation

### DIFF
--- a/app/components/pipeline-options/component.js
+++ b/app/components/pipeline-options/component.js
@@ -57,15 +57,7 @@ export default Component.extend({
     const prRegex = /PR-\d+:.*/;
 
     return (this.jobs === undefined ? [] : this.jobs)
-      .filter(j => {
-        const annotations = j.permutations?.[0].annotations || {};
-
-        if (annotations['screwdriver.cd/manualStartEnabled'] === false) {
-          return false;
-        }
-
-        return !j.name.match(prRegex);
-      })
+      .filter(j => !j.name.match(prRegex))
       .sortBy('name');
   }),
   isInvalid: not('isValid'),

--- a/app/components/pipeline/settings/jobs/table/component.js
+++ b/app/components/pipeline/settings/jobs/table/component.js
@@ -148,12 +148,6 @@ export default class PipelineSettingsJobsTableComponent extends Component {
           return false;
         }
 
-        const annotations = job.permutations?.[0].annotations || {};
-
-        if (annotations['screwdriver.cd/manualStartEnabled'] === false) {
-          return false;
-        }
-
         if (this.args.isToggleMultiple) {
           const jobState = this.args.isEnable ? 'DISABLED' : 'ENABLED';
 

--- a/tests/integration/components/pipeline/settings/jobs/component-test.js
+++ b/tests/integration/components/pipeline/settings/jobs/component-test.js
@@ -10,7 +10,30 @@ module('Integration | Component | pipeline/settings/jobs', function (hooks) {
   hooks.beforeEach(function () {
     const pipelinePageState = this.owner.lookup('service:pipelinePageState');
 
-    sinon.stub(pipelinePageState, 'getJobs').returns([]);
+    sinon.stub(pipelinePageState, 'getJobs').returns([
+      {
+        id: 1,
+        name: 'test-a',
+        permutations: [
+          {
+            annotations: {
+              'screwdriver.cd/manualStartEnabled': false
+            }
+          }
+        ]
+      },
+      {
+        id: 2,
+        name: 'test-b',
+        permutations: [
+          {
+            annotations: {
+              'screwdriver.cd/manualStartEnabled': true
+            }
+          }
+        ]
+      }
+    ]);
   });
 
   test('it renders', async function (assert) {
@@ -19,6 +42,14 @@ module('Integration | Component | pipeline/settings/jobs', function (hooks) {
     assert.dom('.section').exists();
     assert.dom('#enable-jobs-button').exists();
     assert.dom('#disable-jobs-button').exists();
+    assert.dom('td.job-column').exists({ count: 2 });
+    assert
+      .dom(this.element.querySelectorAll('td.job-column')[0])
+      .hasText('test-a');
+    assert
+      .dom(this.element.querySelectorAll('td.job-column')[1])
+      .hasText('test-b');
+    assert.dom('.job-toggle-container').exists({ count: 2 });
   });
 
   test('it toggles cancel button correctly', async function (assert) {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Same as https://github.com/screwdriver-cd/ui/pull/1583 .

Users wants to toggle the job state if the job has the `manualStartEnabled: false` annotation since the job is triggered on the webhook events.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Show the jobs on settings page.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

https://github.com/screwdriver-cd/ui/pull/1583

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
