### PR TITLE
feat(3508): add expires and permission input form for tokens [2]

### DIFF
--- a/app/components/tokens/modal/create/component.js
+++ b/app/components/tokens/modal/create/component.js
@@ -16,6 +16,10 @@ export default class TokensModalCreateComponent extends Component {
 
   @tracked tokenDescription;
 
+  @tracked tokenExpires = '1day';
+
+  @tracked tokenPermission = 'read';
+
   @tracked isAwaitingResponse;
 
   @tracked wasActionSuccessful;
@@ -23,6 +27,18 @@ export default class TokensModalCreateComponent extends Component {
   @tracked isCopyButtonDisabled;
 
   @tracked newToken;
+
+  expiresList = {
+    '1day': date => date.setDate(date.getDate() + 1),
+    '30days': date => date.setDate(date.getDate() + 30),
+    '90days': date => date.setDate(date.getDate() + 90),
+    '1year': date => date.setFullYear(date.getFullYear() + 1),
+    'No expiration': () => null
+  };
+
+  expiresOptions = Object.keys(this.expiresList);
+
+  tokenPremissionOptions = ['read', 'execute', 'write', 'all'];
 
   constructor() {
     super(...arguments);
@@ -34,6 +50,18 @@ export default class TokensModalCreateComponent extends Component {
 
   isTokenNameInvalid() {
     return this.tokensService.tokenNames.includes(this.tokenName);
+  }
+
+  calculateExpiresAt() {
+    if (this.tokenExpires === 'No expiration') {
+      return '';
+    }
+
+    const date = new Date();
+
+    this.expiresList[this.tokenExpires](date);
+
+    return date.toISOString();
   }
 
   get inputClass() {
@@ -64,6 +92,16 @@ export default class TokensModalCreateComponent extends Component {
   }
 
   @action
+  setTokenExpires(tokenExpires) {
+    this.tokenExpires = tokenExpires;
+  }
+
+  @action
+  setTokenPermission(tokenPermission) {
+    this.tokenPermission = tokenPermission;
+  }
+
+  @action
   async createToken() {
     this.isAwaitingResponse = true;
 
@@ -75,7 +113,11 @@ export default class TokensModalCreateComponent extends Component {
     return this.shuttle
       .fetchFromApi('post', url, {
         name: this.tokenName,
-        description: this.tokenDescription
+        description: this.tokenDescription,
+        expiresAt: this.calculateExpiresAt(),
+        options: {
+          permission: this.tokenPermission
+        }
       })
       .then(response => {
         this.newToken = response;

--- a/app/components/tokens/modal/create/component.js
+++ b/app/components/tokens/modal/create/component.js
@@ -4,6 +4,55 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 
 export default class TokensModalCreateComponent extends Component {
+  expiresOptions = [
+    {
+      label: '1 day',
+      getExpiresAt: () => {
+        const now = new Date();
+
+        now.setDate(now.getDate() + 1);
+
+        return now.toISOString();
+      }
+    },
+    {
+      label: '30 days',
+      getExpiresAt: () => {
+        const now = new Date();
+
+        now.setDate(now.getDate() + 30);
+
+        return now.toISOString();
+      }
+    },
+    {
+      label: '90 days',
+      getExpiresAt: () => {
+        const now = new Date();
+
+        now.setDate(now.getDate() + 90);
+
+        return now.toISOString();
+      }
+    },
+    {
+      label: '1 year',
+      getExpiresAt: () => {
+        const now = new Date();
+
+        now.setFullYear(now.getFullYear() + 1);
+
+        return now.toISOString();
+      }
+    },
+    {
+      label: 'No expiration',
+      getExpiresAt: () => ''
+    }
+  ];
+
+  tokenPermissionOptions = ['read', 'execute', 'write', 'all'];
+
   @service shuttle;
 
   @service pipelinePageState;
@@ -16,9 +65,11 @@ export default class TokensModalCreateComponent extends Component {
 
   @tracked tokenDescription;
 
-  @tracked tokenExpires = '1day';
+  // Initial value should be '1 day'
+  @tracked tokenExpires = this.expiresOptions[0];
 
-  @tracked tokenPermission = 'read';
+  // Initial value should be 'read'
+  @tracked tokenPermission = this.tokenPermissionOptions[0];
 
   @tracked isAwaitingResponse;
 
@@ -27,18 +78,6 @@ export default class TokensModalCreateComponent extends Component {
   @tracked isCopyButtonDisabled;
 
   @tracked newToken;
-
-  expiresList = {
-    '1day': date => date.setDate(date.getDate() + 1),
-    '30days': date => date.setDate(date.getDate() + 30),
-    '90days': date => date.setDate(date.getDate() + 90),
-    '1year': date => date.setFullYear(date.getFullYear() + 1),
-    'No expiration': () => null
-  };
-
-  expiresOptions = Object.keys(this.expiresList);
-
-  tokenPremissionOptions = ['read', 'execute', 'write', 'all'];
 
   constructor() {
     super(...arguments);
@@ -50,18 +89,6 @@ export default class TokensModalCreateComponent extends Component {
 
   isTokenNameInvalid() {
     return this.tokensService.tokenNames.includes(this.tokenName);
-  }
-
-  calculateExpiresAt() {
-    if (this.tokenExpires === 'No expiration') {
-      return '';
-    }
-
-    const date = new Date();
-
-    this.expiresList[this.tokenExpires](date);
-
-    return date.toISOString();
   }
 
   get inputClass() {
@@ -92,8 +119,8 @@ export default class TokensModalCreateComponent extends Component {
   }
 
   @action
-  setTokenExpires(tokenExpires) {
-    this.tokenExpires = tokenExpires;
+  setTokenExpires(option) {
+    this.tokenExpires = option;
   }
 
   @action
@@ -114,7 +141,7 @@ export default class TokensModalCreateComponent extends Component {
       .fetchFromApi('post', url, {
         name: this.tokenName,
         description: this.tokenDescription,
-        expiresAt: this.calculateExpiresAt(),
+        expiresAt: this.tokenExpires.getExpiresAt(),
         options: {
           permission: this.tokenPermission
         }

--- a/app/components/tokens/modal/create/styles.scss
+++ b/app/components/tokens/modal/create/styles.scss
@@ -38,6 +38,23 @@
                 }
               }
             }
+
+            .powerselect-wrap {
+              display: flex;
+              margin-bottom: 0.5rem;
+
+              > div {
+                width: 6rem;
+              }
+
+              .ember-basic-dropdown {
+                flex: 1;
+
+                .ember-power-select-trigger {
+                  width: 100%;
+                }
+              }
+            }
           }
         }
       }

--- a/app/components/tokens/modal/create/template.hbs
+++ b/app/components/tokens/modal/create/template.hbs
@@ -63,6 +63,34 @@
           disabled={{this.inputDisabled}}
         />
       </label>
+      <div class="powerselect-wrap">
+        <div>Expires in:</div>
+        <PowerSelect
+          id="expires-select"
+          @options={{this.expiresOptions}}
+          @renderInPlace={{true}}
+          @selected={{this.tokenExpires}}
+          @onChange={{this.setTokenExpires}}
+          @disabled={{this.inputDisabled}}
+          as |selectedValue|
+        >
+          {{selectedValue}}
+        </PowerSelect>
+      </div>
+      <div class="powerselect-wrap">
+        <div>Permission:</div>
+        <PowerSelect
+          id="token-permission-select"
+          @options={{this.tokenPremissionOptions}}
+          @renderInPlace={{true}}
+          @selected={{this.tokenPermission}}
+          @onChange={{this.setTokenPermission}}
+          @disabled={{this.inputDisabled}}
+          as |selectedValue|
+        >
+          {{selectedValue}}
+        </PowerSelect>
+      </div>
     </div>
   </modal.body>
   <modal.footer>

--- a/app/components/tokens/modal/create/template.hbs
+++ b/app/components/tokens/modal/create/template.hbs
@@ -57,6 +57,7 @@
       <label>
         <div>Description:</div>
         <Input
+          id="token-description-input"
           @type="text"
           @value={{this.tokenDescription}}
           placeholder="Optional"

--- a/app/components/tokens/modal/create/template.hbs
+++ b/app/components/tokens/modal/create/template.hbs
@@ -73,23 +73,23 @@
           @selected={{this.tokenExpires}}
           @onChange={{this.setTokenExpires}}
           @disabled={{this.inputDisabled}}
-          as |selectedValue|
+          as |option|
         >
-          {{selectedValue}}
+          {{option.label}}
         </PowerSelect>
       </div>
       <div class="powerselect-wrap">
         <div>Permission:</div>
         <PowerSelect
           id="token-permission-select"
-          @options={{this.tokenPremissionOptions}}
+          @options={{this.tokenPermissionOptions}}
           @renderInPlace={{true}}
           @selected={{this.tokenPermission}}
           @onChange={{this.setTokenPermission}}
           @disabled={{this.inputDisabled}}
-          as |selectedValue|
+          as |option|
         >
-          {{selectedValue}}
+          {{option}}
         </PowerSelect>
       </div>
     </div>

--- a/app/components/tokens/modal/edit/component.js
+++ b/app/components/tokens/modal/edit/component.js
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
+import { toCustomLocaleString } from 'screwdriver-ui/utils/time-range';
 
 export default class TokensModalEditComponent extends Component {
   @service shuttle;
@@ -43,6 +44,14 @@ export default class TokensModalEditComponent extends Component {
     return (
       this.isTokenNameInvalid() || (!this.tokenName && !this.tokenDescription)
     );
+  }
+
+  get expiresDate() {
+    if (this.args.token.expiresAt) {
+      return toCustomLocaleString(new Date(this.args.token.expiresAt));
+    }
+
+    return 'No expiration';
   }
 
   @action

--- a/app/components/tokens/modal/edit/template.hbs
+++ b/app/components/tokens/modal/edit/template.hbs
@@ -39,6 +39,24 @@
           disabled={{this.inputDisabled}}
         />
       </label>
+      <label>
+        <div>Expires at:</div>
+        <Input
+          id="token-expires-input"
+          @type="text"
+          @value={{this.expiresDate}}
+          disabled={{true}}
+        />
+      </label>
+      <label>
+        <div>Permission:</div>
+        <Input
+          id="token-permission-input"
+          @type="text"
+          @value={{@token.options.permission}}
+          disabled={{true}}
+        />
+      </label>
     </div>
   </modal.body>
   <modal.footer>

--- a/app/components/tokens/table/cell/expires/component.js
+++ b/app/components/tokens/table/cell/expires/component.js
@@ -1,0 +1,17 @@
+import Component from '@glimmer/component';
+
+export default class TokensTableCellExpiresComponent extends Component {
+  get isExpiredToken() {
+    const { expiresAt } = this.args.record;
+
+    // No expiration
+    if (!expiresAt) {
+      return false;
+    }
+
+    const now = new Date();
+    const exp = new Date(expiresAt);
+
+    return exp < now;
+  }
+}

--- a/app/components/tokens/table/cell/expires/template.hbs
+++ b/app/components/tokens/table/cell/expires/template.hbs
@@ -1,0 +1,9 @@
+{{#if @record.expiresAt}}
+  {{#if this.isExpiredToken}}
+    This token has expired
+  {{else}}
+    {{moment-from-now @record.expiresAt}}
+  {{/if}}
+{{else}}
+  No expiration
+{{/if}}

--- a/app/components/tokens/table/component.js
+++ b/app/components/tokens/table/component.js
@@ -26,6 +26,16 @@ export default class TokensTableComponent extends Component {
         filteredBy: 'description'
       },
       {
+        title: 'EXPIRES',
+        className: 'expires-column',
+        component: 'expiresCell'
+      },
+      {
+        title: 'PERMISSION',
+        className: 'permission-column',
+        propertyName: 'options.permission'
+      },
+      {
         title: 'LAST USED',
         className: 'last-used-column',
         component: 'lastUsedCell'
@@ -59,6 +69,8 @@ export default class TokensTableComponent extends Component {
         name: token.name,
         description: token.description,
         lastUsed: token.lastUsed,
+        expiresAt: token.expiresAt,
+        options: token.options,
         type: this.args.type,
         onSuccess: this.mapTokens
       };

--- a/app/components/tokens/table/template.hbs
+++ b/app/components/tokens/table/template.hbs
@@ -3,6 +3,7 @@
   @data={{this.data}}
   @columns={{this.columns}}
   @columnComponents={{hash
+    expiresCell=(component "tokens/table/cell/expires")
     lastUsedCell=(component "tokens/table/cell/last-used")
     actionsCell=(component "tokens/table/cell/actions")
   }}

--- a/app/token/model.js
+++ b/app/token/model.js
@@ -6,6 +6,16 @@ export default Model.extend({
   name: attr('string'),
   description: attr('string', { defaultValue: '' }),
   lastUsed: attr('string'),
+  expiresAt: attr('string'),
+  issuerId: attr('string'),
+  options: attr({
+    defaultValue() {
+      return {
+        permission: '',
+        resources: {}
+      };
+    }
+  }),
   value: attr('string'),
   action: attr('string')
 });

--- a/app/user-settings/access-tokens/template.hbs
+++ b/app/user-settings/access-tokens/template.hbs
@@ -1,10 +1,5 @@
 {{page-title "Access Tokens"}}
 
-<TokenList
-  @tokens={{this.tokens}}
-  @newToken={{this.newToken}}
-  @onCreateToken={{action "createToken"}}
-  @onRefreshToken={{action "refreshToken"}}
-  @tokenName="User access"
-  @tokenScope="your account"
+<Tokens
+  @type="user"
 />

--- a/tests/acceptance/tokens-test.js
+++ b/tests/acceptance/tokens-test.js
@@ -14,7 +14,11 @@ module('Acceptance | tokens', function (hooks) {
           id: '1',
           name: 'foo',
           description: 'bar',
-          lastUsed: '2016-09-15T23:12:23.760Z'
+          lastUsed: '2016-09-15T23:12:23.760Z',
+          expiresAt: '2017-09-15T23:12:23.760Z',
+          options: {
+            permission: 'read'
+          }
         },
         {
           id: '2',
@@ -26,7 +30,7 @@ module('Acceptance | tokens', function (hooks) {
 
     await visit('/user-settings/access-tokens');
 
-    assert.dom('.token-list tbody tr').exists({ count: 2 });
+    assert.dom('#tokens-table tbody tr').exists({ count: 2 });
     assert.equal(
       getPageTitle(),
       'User Settings > Access Tokens',

--- a/tests/integration/components/tokens/modal/create/component-test.js
+++ b/tests/integration/components/tokens/modal/create/component-test.js
@@ -39,6 +39,8 @@ module('Integration | Component | tokens/modal/create', function (hooks) {
     assert.dom('.create-new-token').exists({ count: 1 });
     assert.dom('.create-new-token input').exists({ count: 2 });
     assert.dom('#token-name-input').exists({ count: 1 });
+    assert.dom('#expires-select').exists({ count: 1 });
+    assert.dom('#token-permission-select').exists({ count: 1 });
     assert.dom('#submit-token').exists({ count: 1 });
     assert.dom('#submit-token').isDisabled();
 
@@ -132,11 +134,27 @@ module('Integration | Component | tokens/modal/create', function (hooks) {
       />`
     );
     await fillIn('#token-name-input', 'new-token');
+    await fillIn('#token-description-input', 'new-description');
 
     assert.equal(tokensService.tokens.length, 0);
     assert.equal(tokensService.tokenNames.length, 0);
 
     await click('#submit-token');
+
+    const [method, path, body] = shuttle.fetchFromApi.firstCall.args;
+
+    assert.strictEqual(method, 'post');
+    assert.strictEqual(path, '/pipelines/1/tokens');
+    assert.strictEqual(body.name, 'new-token');
+    assert.strictEqual(body.description, 'new-description');
+    assert.strictEqual(body.options.permission, 'read');
+    assert.ok(body.expiresAt);
+
+    // expiresAt should be next day
+    const expected = new Date();
+
+    expected.setDate(expected.getDate() + 1);
+    assert.ok(expected.getTime() - new Date(body.expiresAt).getTime() < 60000); // delta 60sec
 
     assert.dom('#submit-token').isDisabled();
     assert.dom('#error-message').doesNotExist();

--- a/tests/integration/components/tokens/modal/edit/component-test.js
+++ b/tests/integration/components/tokens/modal/edit/component-test.js
@@ -20,6 +20,9 @@ module('Integration | Component | tokens/modal/edit', function (hooks) {
     this.setProperties({
       token: {
         name: 'test',
+        description: 'test-description',
+        expiresAt: '2026-08-02T03:14:08.131Z',
+        options: { permission: 'read' },
         type: 'pipeline'
       },
       closeModal: () => {}
@@ -39,6 +42,12 @@ module('Integration | Component | tokens/modal/edit', function (hooks) {
     assert.dom('.modal-header').hasText('Edit a pipeline token ×');
     assert.dom('#error-message').doesNotExist();
     assert.dom('#submit-token').exists({ count: 1 });
+    assert.dom('#token-name-input').hasAttribute('placeholder', 'test');
+    assert
+      .dom('#token-description-input')
+      .hasAttribute('placeholder', 'test-description');
+    assert.dom('#token-expires-input').hasValue('08/02/2026, 03:14 AM UTC');
+    assert.dom('#token-permission-input').hasValue('read');
     assert.dom('#submit-token').isDisabled();
   });
 

--- a/tests/integration/components/tokens/table/cell/expires/component-test.js
+++ b/tests/integration/components/tokens/table/cell/expires/component-test.js
@@ -1,0 +1,59 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+
+module('Integration | Component | tokens/table/cell/expires', function (hooks) {
+  setupRenderingTest(hooks);
+  let clock;
+
+  hooks.beforeEach(() => {
+    clock = sinon.useFakeTimers({
+      now: new Date('2026-01-01T00:00:00Z')
+    });
+  });
+
+  hooks.afterEach(() => {
+    clock.restore();
+  });
+
+  test('it renders', async function (assert) {
+    this.setProperties({
+      record: {}
+    });
+    await render(
+      hbs`<Tokens::Table::Cell::Expires
+            @record={{this.record}}
+        />`
+    );
+
+    assert.dom(this.element).hasText('No expiration');
+  });
+
+  test('it renders expired token', async function (assert) {
+    this.setProperties({
+      record: { expiresAt: '2020-01-01T00:00:00.000Z' }
+    });
+    await render(
+      hbs`<Tokens::Table::Cell::Expires
+            @record={{this.record}}
+        />`
+    );
+
+    assert.dom(this.element).hasText('This token has expired');
+  });
+
+  test('it renders valid token', async function (assert) {
+    this.setProperties({
+      record: { expiresAt: '2026-01-02T00:00:00Z' }
+    });
+    await render(
+      hbs`<Tokens::Table::Cell::Expires
+            @record={{this.record}}
+        />`
+    );
+
+    assert.dom(this.element).hasText('in a day');
+  });
+});


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

https://github.com/screwdriver-cd/screwdriver/issues/3508

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Add input forms for `expiresAt` and `permission` on the tokens modal.

<img width="1413" height="639" alt="table" src="https://github.com/user-attachments/assets/018a4777-1312-4fb6-82d6-e2d9ad1ca72d" />
<img width="760" height="309" alt="modal" src="https://github.com/user-attachments/assets/c9ad9a4e-c5f2-4f0b-862c-e16320035c37" />

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

- issue - https://github.com/screwdriver-cd/screwdriver/issues/3508

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
