### PR TITLE
fix: show go to remote on tooltip when the node is remote join

### DIFF
--- a/app/utils/pipeline/graph/tooltip.js
+++ b/app/utils/pipeline/graph/tooltip.js
@@ -24,42 +24,38 @@ export const nodeCanShowTooltip = node => {
  * @param builds  Builds for the pipeline (API response from /pipelines/:id/builds)
  */
 export function getTooltipData(node, event, jobs = [], builds = []) {
-  const isTrigger = node.name.startsWith('~');
+  const externalTriggerMatch = node.name.match(EXTERNAL_TRIGGER_ALL);
+  const downstreamTriggerMatch = node.name.match(/^~sd-([\w-]+)-triggers$/);
 
-  if (isTrigger) {
-    const externalTriggerMatch = node.name.match(EXTERNAL_TRIGGER_ALL);
-    const downstreamTriggerMatch = node.name.match(/^~sd-([\w-]+)-triggers$/);
+  // Return external trigger data if relevant
+  if (externalTriggerMatch) {
+    const externalTrigger = {
+      pipelineId: externalTriggerMatch[1],
+      jobName: externalTriggerMatch[2]
+    };
 
-    // Add external trigger data if relevant
-    if (externalTriggerMatch) {
-      const externalTrigger = {
-        pipelineId: externalTriggerMatch[1],
-        jobName: externalTriggerMatch[2]
-      };
+    return {
+      externalTrigger
+    };
+  }
 
-      return {
-        externalTrigger
-      };
-    }
+  // Return downstream trigger data if relevant
+  if (downstreamTriggerMatch) {
+    const triggers = [];
 
-    // Add downstream trigger data if relevant
-    if (downstreamTriggerMatch) {
-      const triggers = [];
+    node.triggers.forEach(t => {
+      const downstreamTrigger = t.match(EXTERNAL_TRIGGER_ALL);
 
-      node.triggers.forEach(t => {
-        const downstreamTrigger = t.match(EXTERNAL_TRIGGER_ALL);
-
-        triggers.push({
-          triggerName: t,
-          pipelineId: downstreamTrigger[1],
-          jobName: downstreamTrigger[2]
-        });
+      triggers.push({
+        triggerName: t,
+        pipelineId: downstreamTrigger[1],
+        jobName: downstreamTrigger[2]
       });
+    });
 
-      return {
-        triggers
-      };
-    }
+    return {
+      triggers
+    };
   }
 
   const tooltip = {

--- a/tests/unit/utils/pipeline/graph/tooltip-test.js
+++ b/tests/unit/utils/pipeline/graph/tooltip-test.js
@@ -17,7 +17,16 @@ module('Unit | Utility | pipeline-graph | tooltip', function () {
   });
 
   test('it gets tooltip data for external trigger', function (assert) {
+    // Remote trigger
     assert.deepEqual(getTooltipData({ name: '~sd@123:main' }), {
+      externalTrigger: {
+        jobName: 'main',
+        pipelineId: '123'
+      }
+    });
+
+    // Remote join
+    assert.deepEqual(getTooltipData({ name: 'sd@123:main' }), {
       externalTrigger: {
         jobName: 'main',
         pipelineId: '123'


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

It does not show "Go to remote pipeline" on the tooltip if the remote trigger is join.

<img width="397" height="305" alt="eg" src="https://github.com/user-attachments/assets/a56b20f9-50a8-4ab8-acf2-4a56acd358eb" />

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Show "Go to remote pipeline" even when the trigger is join case.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
