### PR TITLE
fix: show related jobs on the event job list view

### DIFF
--- a/app/components/pipeline/jobs/table/component.js
+++ b/app/components/pipeline/jobs/table/component.js
@@ -183,17 +183,35 @@ export default class PipelineJobsTableComponent extends Component {
     this.dataReloader.start(this.event?.id);
   }
 
+  getJobsFromWorkflowGraph(workflowGraph) {
+    const latestJobs = {};
+
+    this.pipelinePageState.getJobs().forEach(job => {
+      latestJobs[job.id] = job;
+    });
+
+    return workflowGraph.nodes
+      .filter(node => node.id && !node.name.startsWith('sd@'))
+      .map(job => latestJobs[job.id] || job);
+  }
+
   setJobs() {
     this.jobs = new Map();
 
-    const jobs =
-      this.view === 'pulls'
-        ? this.workflowDataReload.getJobsForPr(this.event.prNum)
-        : this.pipelinePageState.getJobs();
-    const workflowGraph =
-      this.view === 'pulls'
-        ? this.event.workflowGraph
-        : this.pipelinePageState.getPipeline().workflowGraph;
+    let jobs;
+
+    let workflowGraph;
+
+    if (this.view === 'pulls') {
+      workflowGraph = this.event.workflowGraph;
+      jobs = this.workflowDataReload.getJobsForPr(this.event.prNum);
+    } else if (this.event) {
+      workflowGraph = this.event.workflowGraph;
+      jobs = this.getJobsFromWorkflowGraph(workflowGraph);
+    } else {
+      workflowGraph = this.pipelinePageState.getPipeline().workflowGraph;
+      jobs = this.pipelinePageState.getJobs();
+    }
 
     jobs.forEach(job => {
       this.jobs.set(job.id, {
@@ -213,11 +231,16 @@ export default class PipelineJobsTableComponent extends Component {
   @action
   update(element, [pipelineId, event]) {
     this.data = [];
-
     this.dataReloader.stop(this.event.id);
-    this.event = event;
 
-    if (this.pipelineId !== pipelineId) {
+    const pipelineChanged = this.pipelineId !== pipelineId;
+    const eventChanged = this.event?.id !== event?.id;
+
+    if (pipelineChanged || eventChanged) {
+      this.pipelineId = pipelineId;
+      this.event = event;
+      this.previousBuilds = new Map();
+      this.previousEventBuilds = [];
       this.initialize();
 
       return;

--- a/tests/integration/components/pipeline/jobs/table/component-test.js
+++ b/tests/integration/components/pipeline/jobs/table/component-test.js
@@ -1,0 +1,176 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'screwdriver-ui/tests/helpers';
+import { render, settled } from '@ember/test-helpers';
+import sinon from 'sinon';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | pipeline/jobs/table', function (hooks) {
+  setupRenderingTest(hooks);
+  let pipeline;
+
+  let shuttle;
+
+  let pipelinePageState;
+
+  let workflowDataReload;
+
+  hooks.beforeEach(function () {
+    pipeline = {
+      id: 1,
+      workflowGraph: {
+        nodes: [{ name: 'main', id: 123 }],
+        edges: []
+      }
+    };
+
+    shuttle = this.owner.lookup('service:shuttle');
+    pipelinePageState = this.owner.lookup('service:pipeline-page-state');
+    workflowDataReload = this.owner.lookup('service:workflow-data-reload');
+
+    sinon.stub(pipelinePageState, 'getIsPr').returns(false);
+    sinon.stub(pipelinePageState, 'getPipeline').returns(pipeline);
+    sinon.stub(workflowDataReload, 'getBuildsForEvent').returns([]);
+    sinon.stub(workflowDataReload, 'removeBuildsCallback').callsFake(() => {});
+    sinon
+      .stub(workflowDataReload, 'registerBuildsCallback')
+      .callsFake((_queueName, _eventId, callback) => {
+        callback([]);
+      });
+  });
+
+  test('it renders', async function (assert) {
+    sinon.stub(shuttle, 'fetchFromApi').resolves([
+      {
+        jobId: 123,
+        builds: [{ id: 111, jobId: 123, status: 'SUCCESS' }]
+      }
+    ]);
+    sinon.stub(pipelinePageState, 'getJobs').returns([
+      {
+        id: 123,
+        name: 'main'
+      }
+    ]);
+
+    this.setProperties({
+      pipelineId: 1
+    });
+
+    await render(hbs`
+        <Pipeline::Jobs::Table
+          @pipelineId={{this.pipelineId}}
+        />
+      `);
+
+    assert.dom('.job-name').exists({ count: 1 });
+    assert.dom('.job-name').hasText('main');
+  });
+
+  test('it displays jobs from event workflow graph', async function (assert) {
+    const latestJobs = [
+      {
+        id: 1,
+        name: 'foo',
+        pipelineId: 1,
+        state: 'DISABLED'
+      },
+      {
+        id: 3,
+        name: 'latest-only-job',
+        pipelineId: 1
+      }
+    ];
+
+    sinon.stub(pipelinePageState, 'getJobs').returns(latestJobs);
+
+    this.setProperties({
+      pipelineId: 1,
+      event: {
+        id: 100,
+        workflowGraph: {
+          nodes: [
+            {
+              id: 1,
+              name: 'foo',
+              pipelineId: 1
+            },
+            {
+              id: 2,
+              name: 'bar',
+              pipelineId: 1
+            },
+            {
+              name: 'sd@123:external'
+            }
+          ],
+          edges: []
+        }
+      }
+    });
+
+    await render(hbs`
+        <Pipeline::Jobs::Table
+          @pipelineId={{this.pipelineId}}
+          @event={{this.event}}
+        />
+      `);
+
+    assert.dom('.job-name').exists({ count: 2 });
+    assert.dom('tbody tr:nth-child(1) .job-name').hasText('bar');
+    assert.dom('tbody tr:nth-child(2) .job-name').hasText('foo');
+    assert.dom('tbody tr:nth-child(2) .actions-cell button').isDisabled();
+  });
+
+  test('it updates jobs when event changes', async function (assert) {
+    sinon.stub(pipelinePageState, 'getJobs').returns([]);
+
+    const event1 = {
+      id: 100,
+      workflowGraph: {
+        nodes: [
+          {
+            id: 1,
+            name: 'event-1-job',
+            pipelineId: 1
+          }
+        ],
+        edges: []
+      }
+    };
+
+    const event2 = {
+      id: 101,
+      workflowGraph: {
+        nodes: [
+          {
+            id: 2,
+            name: 'event-2-job',
+            pipelineId: 1
+          }
+        ],
+        edges: []
+      }
+    };
+
+    this.setProperties({
+      pipelineId: 1,
+      event: event1
+    });
+
+    await render(hbs`
+        <Pipeline::Jobs::Table
+          @pipelineId={{this.pipelineId}}
+          @event={{this.event}}
+        />
+      `);
+
+    assert.dom('.job-name').hasText('event-1-job');
+    assert.dom('.job-name').doesNotIncludeText('event-2-job');
+
+    this.set('event', event2);
+    await settled();
+
+    assert.dom('.job-name').hasText('event-2-job');
+    assert.dom('.job-name').doesNotIncludeText('event-1-job');
+  });
+});


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

There is a job list view on the workflow page, but its event list is always lates jobs list of the pipeline.
Users wants to see the jobs related the opened event on there.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Show the jobs related the opened event on the event job list view.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
