### PR TITLE
fix: disable start actions for disabled pipelines

### DIFF
--- a/app/components/pipeline/event/card/component.js
+++ b/app/components/pipeline/event/card/component.js
@@ -9,6 +9,7 @@ import {
   isSkipped
 } from 'screwdriver-ui/utils/pipeline/event';
 import { getTruncatedSha } from 'screwdriver-ui/utils/git';
+import { isActivePipeline } from 'screwdriver-ui/utils/pipeline';
 import {
   getDurationText,
   getExternalPipelineId,
@@ -286,6 +287,10 @@ export default class PipelineEventCardComponent extends Component {
 
   get isPR() {
     return this.event.type === 'pr';
+  }
+
+  get isStartButtonDisabled() {
+    return !isActivePipeline(this.pipelinePageState.getPipeline());
   }
 
   get prTitle() {

--- a/app/components/pipeline/event/card/template.hbs
+++ b/app/components/pipeline/event/card/template.hbs
@@ -68,6 +68,7 @@
           @type="primary"
           @outline={{true}}
           @onClick={{fn this.openStartEventModal}}
+          disabled={{this.isStartButtonDisabled}}
           title="Start PR event"
         >
           <FaIcon

--- a/app/components/pipeline/jobs/table/cell/actions/component.js
+++ b/app/components/pipeline/jobs/table/cell/actions/component.js
@@ -2,7 +2,7 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { isInactivePipeline } from 'screwdriver-ui/utils/pipeline';
+import { isActivePipeline } from 'screwdriver-ui/utils/pipeline';
 import { isStartButtonDisabled, isStopButtonDisabled } from './util';
 
 export default class PipelineJobsTableCellActionsComponent extends Component {
@@ -16,8 +16,6 @@ export default class PipelineJobsTableCellActionsComponent extends Component {
 
   pipeline;
 
-  isPipelineInactive = true;
-
   @tracked confirmAction;
 
   @tracked event = null;
@@ -28,7 +26,10 @@ export default class PipelineJobsTableCellActionsComponent extends Component {
     super(...arguments);
 
     this.pipeline = this.pipelinePageState.getPipeline();
-    this.isPipelineInactive = isInactivePipeline(this.pipeline);
+  }
+
+  get isPipelineActive() {
+    return isActivePipeline(this.pipeline);
   }
 
   get startEventTitle() {
@@ -37,7 +38,7 @@ export default class PipelineJobsTableCellActionsComponent extends Component {
 
   get startButtonDisabled() {
     return isStartButtonDisabled(
-      this.isPipelineInactive,
+      this.isPipelineActive,
       this.args.record.canStartFromView,
       this.args.record.job
     );

--- a/app/components/pipeline/jobs/table/cell/actions/util.js
+++ b/app/components/pipeline/jobs/table/cell/actions/util.js
@@ -19,17 +19,17 @@ export const canJobBeTriggered = job => {
 
 /**
  * Check if the start button should be disabled
- * @param isPipelineInactive {boolean} Boolean indicating if the pipeline is inactive
+ * @param isPipelineActive {boolean} Boolean indicating if the pipeline is active
  * @param canStartFromView {boolean} Boolean indicating if the job can be started from the current view
  * @param job {object} Job object in the shape returned by the API
  * @returns {boolean}
  */
 export const isStartButtonDisabled = (
-  isPipelineInactive,
+  isPipelineActive,
   canStartFromView,
   job
 ) => {
-  if (isPipelineInactive || !canStartFromView) {
+  if (!isPipelineActive || !canStartFromView) {
     return true;
   }
 

--- a/app/components/pipeline/workflow/tooltip/stage/component.js
+++ b/app/components/pipeline/workflow/tooltip/stage/component.js
@@ -2,12 +2,15 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
+import { isActivePipeline } from 'screwdriver-ui/utils/pipeline';
 import { canJobStart } from 'screwdriver-ui/utils/pipeline-workflow';
 
 export default class PipelineWorkflowTooltipStageComponent extends Component {
   @service router;
 
   @service session;
+
+  @service('pipeline-page-state') pipelinePageState;
 
   @tracked showConfirmActionModal = false;
 
@@ -18,10 +21,13 @@ export default class PipelineWorkflowTooltipStageComponent extends Component {
       ? 'events'
       : 'pulls';
 
-    return canJobStart(
-      activeTab,
-      this.args.workflowGraph,
-      this.args.d3Data.stage.setup.name
+    return (
+      isActivePipeline(this.pipelinePageState.getPipeline()) &&
+      canJobStart(
+        activeTab,
+        this.args.workflowGraph,
+        this.args.d3Data.stage.setup.name
+      )
     );
   }
 

--- a/tests/integration/components/pipeline/event/card/component-test.js
+++ b/tests/integration/components/pipeline/event/card/component-test.js
@@ -21,9 +21,11 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
 
   hooks.beforeEach(function () {
     const settings = this.owner.lookup('service:settings');
+    const pipelinePageState = this.owner.lookup('service:pipeline-page-state');
 
     router = this.owner.lookup('service:router');
     workflowDataReload = this.owner.lookup('service:workflow-data-reload');
+    pipelinePageState.setPipeline({ id: 1, state: 'ACTIVE' });
 
     event = {
       id: 11,
@@ -505,6 +507,30 @@ module('Integration | Component | pipeline/event/card', function (hooks) {
     );
 
     assert.dom('.event-card-title .start-event-button').exists();
+    assert.dom('.event-card-title .start-event-button').isNotDisabled();
+  });
+
+  test('it disables start event button for PR when pipeline is disabled', async function (assert) {
+    const pipelinePageState = this.owner.lookup('service:pipeline-page-state');
+
+    routerStub.reset();
+    routerStub.value('/pipelines/1/pulls/2');
+    pipelinePageState.setPipeline({ id: 1, state: 'DISABLED' });
+
+    event.type = 'pr';
+    event.prNum = 4;
+    this.setProperties({
+      event
+    });
+
+    await render(
+      hbs`<Pipeline::Event::Card
+        @event={{this.event}}
+        @allowEventAction={{true}}
+      />`
+    );
+
+    assert.dom('.event-card-title .start-event-button').isDisabled();
   });
 
   test('it renders card outline', async function (assert) {

--- a/tests/integration/components/pipeline/jobs/table/cell/actions/component-test.js
+++ b/tests/integration/components/pipeline/jobs/table/cell/actions/component-test.js
@@ -12,6 +12,8 @@ module(
 
     const pipelineId = 123;
 
+    let pipeline;
+
     let pipelinePageState;
 
     let shuttleStub;
@@ -24,9 +26,9 @@ module(
       pipelinePageState = this.owner.lookup('service:pipeline-page-state');
       const shuttle = this.owner.lookup('service:shuttle');
 
-      sinon
-        .stub(pipelinePageState, 'getPipeline')
-        .returns({ id: pipelineId, state: 'ACTIVE', parameters: {} });
+      pipeline = { id: pipelineId, state: 'ACTIVE', parameters: {} };
+
+      sinon.stub(pipelinePageState, 'getPipeline').returns(pipeline);
       sinon.stub(pipelinePageState, 'getJobs').returns([]);
       sinon.stub(pipelinePageState, 'getIsPr').returns(false);
       pipelinePageState.route = 'v2.pipeline.jobs';
@@ -54,6 +56,30 @@ module(
       );
 
       assert.dom('button').exists({ count: 3 });
+    });
+
+    test('it disables start actions when the pipeline is disabled', async function (assert) {
+      const job = { id: 123, name: 'main', state: 'ENABLED' };
+
+      pipeline.state = 'DISABLED';
+
+      this.setProperties({
+        record: {
+          job,
+          canStartFromView: true,
+          onCreate: () => {},
+          onDestroy: () => {}
+        }
+      });
+
+      await render(
+        hbs`<Pipeline::Jobs::Table::Cell::Actions
+            @record={{this.record}}
+        />`
+      );
+
+      assert.dom('button:nth-of-type(1)').isDisabled();
+      assert.dom('button:nth-of-type(3)').isDisabled();
     });
 
     test('it renders with start and restart modals', async function (assert) {

--- a/tests/integration/components/pipeline/workflow/tooltip/stage/component-test.js
+++ b/tests/integration/components/pipeline/workflow/tooltip/stage/component-test.js
@@ -9,6 +9,12 @@ module(
   function (hooks) {
     setupRenderingTest(hooks);
 
+    hooks.beforeEach(function () {
+      this.owner
+        .lookup('service:pipeline-page-state')
+        .setPipeline({ id: 123, state: 'ACTIVE' });
+    });
+
     test('it renders an empty stage tooltip', async function (assert) {
       const router = this.owner.lookup('service:router');
 
@@ -89,6 +95,50 @@ module(
       assert
         .dom('#restart-stage-link')
         .hasText('Restart pipeline from this stage');
+    });
+
+    test('it does not render stage actions for a disabled pipeline', async function (assert) {
+      const router = this.owner.lookup('service:router');
+      const pipelinePageState = this.owner.lookup(
+        'service:pipeline-page-state'
+      );
+
+      sinon.stub(router, 'currentRoute').value({
+        name: 'events'
+      });
+      pipelinePageState.setPipeline({ id: 123, state: 'DISABLED' });
+
+      this.setProperties({
+        d3Data: {
+          d3Event: { target: null },
+          stage: {
+            setup: {
+              name: 'setup'
+            }
+          }
+        },
+        event: {},
+        builds: [],
+        workflowGraph: {
+          nodes: [],
+          edges: []
+        }
+      });
+
+      await render(
+        hbs`<Pipeline::Workflow::Tooltip::Stage
+            @d3Data={{this.d3Data}}
+            @event={{this.event}}
+            @builds={{this.builds}}
+            @workflowGraph={{this.workflowGraph}}
+        />`
+      );
+
+      assert.dom('#start-stage-link').doesNotExist();
+      assert.dom('#restart-stage-link').doesNotExist();
+      assert
+        .dom('#workflow-graph-tooltip')
+        .hasText('Can not start/restart stage');
     });
   }
 );

--- a/tests/unit/components/pipeline/jobs/table/cell/action/util-test.js
+++ b/tests/unit/components/pipeline/jobs/table/cell/action/util-test.js
@@ -24,11 +24,15 @@ module('Unit | Component | pipeline/jobs/table/cell/action/util', function () {
     assert.equal(isStartButtonDisabled(true, false, null), true);
     assert.equal(isStartButtonDisabled(false, false, null), true);
     assert.equal(
-      isStartButtonDisabled(false, true, { state: 'DISABLED' }),
+      isStartButtonDisabled(false, true, { state: 'ENABLED' }),
       true
     );
     assert.equal(
-      isStartButtonDisabled(false, true, { state: 'ENABLED' }),
+      isStartButtonDisabled(true, true, { state: 'DISABLED' }),
+      true
+    );
+    assert.equal(
+      isStartButtonDisabled(true, true, { state: 'ENABLED' }),
       false
     );
   });

--- a/tests/unit/utils/pipeline-test.js
+++ b/tests/unit/utils/pipeline-test.js
@@ -35,6 +35,8 @@ module('Unit | Utility | pipeline', function () {
 
     assert.notOk(isInactivePipeline(ACTIVE_PIPELINE_1));
     assert.notOk(isInactivePipeline(ACTIVE_PIPELINE_2));
+    assert.notOk(isInactivePipeline(DISABLED_PIPELINE_1));
+    assert.notOk(isInactivePipeline(DISABLED_PIPELINE_2));
   });
 
   test('it checks if inactive pipeline exists', assert => {
@@ -55,6 +57,8 @@ module('Unit | Utility | pipeline', function () {
 
     assert.notOk(isActivePipeline(INACTIVE_PIPELINE_1));
     assert.notOk(isActivePipeline(INACTIVE_PIPELINE_2));
+    assert.notOk(isActivePipeline(DISABLED_PIPELINE_1));
+    assert.notOk(isActivePipeline(DISABLED_PIPELINE_2));
   });
 
   test('it checks if active pipeline exists', assert => {


### PR DESCRIPTION
## Context

Some start and restart actions remain available when a pipeline is disabled.
The API rejects event creation for non-active pipelines, but users can still open the confirmation modal from these actions.

## Objective

Disable start and restart actions unless the pipeline is active in the following views:

- job list view
- stage tooltip
- PR event card

## References

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
