### PR TITLE
fix(3508): Show previous token permission to all

### DIFF
--- a/app/components/tokens/table/component.js
+++ b/app/components/tokens/table/component.js
@@ -70,7 +70,10 @@ export default class TokensTableComponent extends Component {
         description: token.description,
         lastUsed: token.lastUsed,
         expiresAt: token.expiresAt,
-        options: token.options,
+        options: {
+          ...(token.options || {}),
+          permission: token.options?.permission || 'all'
+        },
         type: this.args.type,
         onSuccess: this.mapTokens
       };

--- a/tests/acceptance/tokens-test.js
+++ b/tests/acceptance/tokens-test.js
@@ -31,6 +31,12 @@ module('Acceptance | tokens', function (hooks) {
     await visit('/user-settings/access-tokens');
 
     assert.dom('#tokens-table tbody tr').exists({ count: 2 });
+    assert
+      .dom('#tokens-table tbody tr:nth-child(1) .permission-column')
+      .hasText('read');
+    assert
+      .dom('#tokens-table tbody tr:nth-child(2) .permission-column')
+      .hasText('all');
     assert.equal(
       getPageTitle(),
       'User Settings > Access Tokens',


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Tokens issued in the past do not have a permission value set, but they have permissions equivalent to `all` for newly issued tokens.
For backward compatibility, display the permission of previously issued tokens as `all` in the UI.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Display the permission of previously issued tokens as `all`.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
screwdriver-cd/screwdriver#3508

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
