### PR TITLE
fix(3508): Use explicit pipelineId when updating tokens

### DIFF
--- a/app/components/tokens/modal/edit/component.js
+++ b/app/components/tokens/modal/edit/component.js
@@ -9,8 +9,6 @@ export default class TokensModalEditComponent extends Component {
 
   @service('tokens') tokensService;
 
-  @service pipelinePageState;
-
   @tracked errorMessage;
 
   @tracked tokenName;
@@ -59,7 +57,7 @@ export default class TokensModalEditComponent extends Component {
     this.isAwaitingResponse = true;
 
     const updateUrl = `/tokens/${this.args.token.id}`;
-    const pipelineId = this.pipelinePageState.getPipelineId();
+    const { pipelineId } = this.args;
     const url = pipelineId ? `/pipelines/${pipelineId}${updateUrl}` : updateUrl;
 
     return this.shuttle

--- a/app/components/tokens/table/cell/actions/template.hbs
+++ b/app/components/tokens/table/cell/actions/template.hbs
@@ -11,6 +11,7 @@
     {{#if this.isEditTokenModalOpen}}
       <Tokens::Modal::Edit
         @token={{@record}}
+        @pipelineId={{@record.pipelineId}}
         @closeModal={{this.closeEditTokenModal}}
       />
     {{/if}}

--- a/app/components/tokens/table/component.js
+++ b/app/components/tokens/table/component.js
@@ -71,6 +71,7 @@ export default class TokensTableComponent extends Component {
         lastUsed: token.lastUsed,
         expiresAt: token.expiresAt,
         options: token.options,
+        pipelineId: this.args.pipelineId,
         type: this.args.type,
         onSuccess: this.mapTokens
       };

--- a/app/components/tokens/template.hbs
+++ b/app/components/tokens/template.hbs
@@ -49,6 +49,7 @@
     <Tokens::Table
       @tokens={{this.tokens}}
       @type={{@type}}
+      @pipelineId={{@pipelineId}}
     />
   </div>
 </div>

--- a/tests/integration/components/tokens/modal/edit/component-test.js
+++ b/tests/integration/components/tokens/modal/edit/component-test.js
@@ -19,12 +19,14 @@ module('Integration | Component | tokens/modal/edit', function (hooks) {
 
     this.setProperties({
       token: {
+        id: 123,
         name: 'test',
         description: 'test-description',
         expiresAt: '2026-08-02T03:14:08.131Z',
         options: { permission: 'read' },
         type: 'pipeline'
       },
+      pipelineId: 1,
       closeModal: () => {}
     });
 
@@ -35,6 +37,7 @@ module('Integration | Component | tokens/modal/edit', function (hooks) {
     await render(
       hbs`<Tokens::Modal::Edit
         @token={{this.token}}
+        @pipelineId={{this.pipelineId}}
         @closeModal={{this.closeModal}}
       />`
     );
@@ -55,6 +58,7 @@ module('Integration | Component | tokens/modal/edit', function (hooks) {
     await render(
       hbs`<Tokens::Modal::Edit
         @token={{this.token}}
+        @pipelineId={{this.pipelineId}}
         @closeModal={{this.closeModal}}
       />`
     );
@@ -79,6 +83,7 @@ module('Integration | Component | tokens/modal/edit', function (hooks) {
     await render(
       hbs`<Tokens::Modal::Edit
         @token={{this.token}}
+        @pipelineId={{this.pipelineId}}
         @closeModal={{this.closeModal}}
       />`
     );
@@ -87,6 +92,52 @@ module('Integration | Component | tokens/modal/edit', function (hooks) {
 
     assert.dom('#error-message').exists({ count: 1 });
     assert.dom('#submit-token').isEnabled();
+  });
+
+  test('it uses the user token endpoint when pipelineId is not provided', async function (assert) {
+    const fetchStub = sinon.stub(shuttle, 'fetchFromApi').resolves({});
+
+    this.setProperties({
+      token: {
+        id: 456,
+        name: 'user-token',
+        description: 'description',
+        options: { permission: 'read' },
+        type: 'user'
+      },
+      pipelineId: undefined
+    });
+
+    await render(
+      hbs`<Tokens::Modal::Edit
+        @token={{this.token}}
+        @pipelineId={{this.pipelineId}}
+        @closeModal={{this.closeModal}}
+      />`
+    );
+
+    await fillIn('#token-name-input', 'updated');
+    await click('#submit-token');
+
+    assert.strictEqual(fetchStub.firstCall.args[0], 'put');
+    assert.strictEqual(fetchStub.firstCall.args[1], '/tokens/456');
+  });
+
+  test('it uses the pipeline token endpoint when pipelineId is provided', async function (assert) {
+    const fetchStub = sinon.stub(shuttle, 'fetchFromApi').resolves({});
+
+    await render(
+      hbs`<Tokens::Modal::Edit
+        @token={{this.token}}
+        @pipelineId={{this.pipelineId}}
+        @closeModal={{this.closeModal}}
+      />`
+    );
+
+    await fillIn('#token-name-input', 'updated');
+    await click('#submit-token');
+
+    assert.strictEqual(fetchStub.firstCall.args[1], '/pipelines/1/tokens/123');
   });
 
   test('it handles API success', async function (assert) {
@@ -103,6 +154,7 @@ module('Integration | Component | tokens/modal/edit', function (hooks) {
     await render(
       hbs`<Tokens::Modal::Edit
         @token={{this.token}}
+        @pipelineId={{this.pipelineId}}
         @closeModal={{this.closeModal}}
       />`
     );


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
When a user visits a Pipeline page and then navigates to User Settings, the previous Pipeline ID may remain in pipelinePageState.
Updating a User Token can therefore incorrectly target the Pipeline Token endpoint.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Update Token endpoint selection to use the explicitly passed pipelineId from the Token context instead of the global
pipelinePageState.
 - Use /tokens/:id when no pipelineId is provided.
 - Use /pipelines/:pipelineId/tokens/:id for Pipeline Tokens.
 - Add regression tests covering both User Token and Pipeline Token update endpoints.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
screwdriver-cd/screwdriver#3508

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
