### PR TITLE
Revert "feat(3527): fix error messages when the pipeline has been deleted"

### DIFF
--- a/app/components/pipeline/modal/confirm-action/component.js
+++ b/app/components/pipeline/modal/confirm-action/component.js
@@ -6,7 +6,6 @@ import {
   extractDefaultJobParameters,
   extractDefaultParameters
 } from 'screwdriver-ui/utils/pipeline/parameters';
-import { getPipelineErrorMessage } from 'screwdriver-ui/utils/pipeline';
 import {
   buildPostBody,
   capitalizeFirstLetter,
@@ -225,7 +224,8 @@ export default class PipelineModalConfirmActionComponent extends Component {
       })
       .catch(err => {
         this.wasActionSuccessful = false;
-        this.errorMessage = getPipelineErrorMessage(err);
+        this.errorMessage =
+          err?.payload?.message || err?.message || 'Unknown error';
 
         const statusCode = err?.payload?.statusCode || err?.status;
 

--- a/app/components/pipeline/modal/delete-pipeline/component.js
+++ b/app/components/pipeline/modal/delete-pipeline/component.js
@@ -2,7 +2,6 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
-import { getPipelineErrorMessage } from 'screwdriver-ui/utils/pipeline';
 
 export default class PipelineModalDeletePipelineComponent extends Component {
   @service router;
@@ -39,7 +38,7 @@ export default class PipelineModalDeletePipelineComponent extends Component {
       })
       .catch(err => {
         this.wasActionSuccessful = false;
-        this.errorMessage = getPipelineErrorMessage(err);
+        this.errorMessage = err.message;
       })
       .finally(() => {
         this.isAwaitingResponse = false;

--- a/app/components/pipeline/settings/main/modal/pipeline-alias/component.js
+++ b/app/components/pipeline/settings/main/modal/pipeline-alias/component.js
@@ -2,7 +2,6 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
-import { getPipelineErrorMessage } from 'screwdriver-ui/utils/pipeline';
 
 export default class PipelineSettingsMainModalPipelineAliasComponent extends Component {
   @service('shuttle') shuttle;
@@ -47,7 +46,7 @@ export default class PipelineSettingsMainModalPipelineAliasComponent extends Com
         this.args.closeModal(true);
       })
       .catch(err => {
-        this.errorMessage = getPipelineErrorMessage(err);
+        this.errorMessage = err.message;
         this.isAwaitingResponse = false;
       });
   }

--- a/app/components/pipeline/settings/main/modal/pipeline/component.js
+++ b/app/components/pipeline/settings/main/modal/pipeline/component.js
@@ -4,7 +4,6 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 
 import { getCheckoutUrl } from 'screwdriver-ui/utils/git';
-import { getPipelineErrorMessage } from 'screwdriver-ui/utils/pipeline';
 
 export default class PipelineSettingsMainModalPipelineComponent extends Component {
   @service('shuttle') shuttle;
@@ -61,7 +60,7 @@ export default class PipelineSettingsMainModalPipelineComponent extends Componen
         this.args.closeModal(true);
       })
       .catch(err => {
-        this.errorMessage = getPipelineErrorMessage(err);
+        this.errorMessage = err.message;
         this.isAwaitingResponse = false;
       });
   }

--- a/app/components/pipeline/settings/main/modal/sonar-badge/delete/component.js
+++ b/app/components/pipeline/settings/main/modal/sonar-badge/delete/component.js
@@ -2,7 +2,6 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
-import { getPipelineErrorMessage } from 'screwdriver-ui/utils/pipeline';
 
 export default class PipelineSettingsMainModalSonarBadgeDeleteComponent extends Component {
   @service('shuttle') shuttle;
@@ -35,7 +34,7 @@ export default class PipelineSettingsMainModalSonarBadgeDeleteComponent extends 
         this.args.closeModal(true);
       })
       .catch(err => {
-        this.errorMessage = getPipelineErrorMessage(err);
+        this.errorMessage = err.message;
         this.isAwaitingResponse = false;
       });
   }

--- a/app/components/pipeline/settings/main/modal/sonar-badge/edit/component.js
+++ b/app/components/pipeline/settings/main/modal/sonar-badge/edit/component.js
@@ -2,7 +2,6 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
-import { getPipelineErrorMessage } from 'screwdriver-ui/utils/pipeline';
 
 export default class PipelineSettingsMainModalSonarBadgeEditComponent extends Component {
   @service('shuttle') shuttle;
@@ -74,7 +73,7 @@ export default class PipelineSettingsMainModalSonarBadgeEditComponent extends Co
         this.args.closeModal(true);
       })
       .catch(err => {
-        this.errorMessage = getPipelineErrorMessage(err);
+        this.errorMessage = err.message;
         this.isAwaitingResponse = false;
       });
   }

--- a/app/components/pipeline/settings/main/modal/sync/component.js
+++ b/app/components/pipeline/settings/main/modal/sync/component.js
@@ -2,7 +2,6 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
-import { getPipelineErrorMessage } from 'screwdriver-ui/utils/pipeline';
 
 export default class PipelineSettingsMainModalSyncComponent extends Component {
   @service('shuttle') shuttle;
@@ -81,7 +80,7 @@ export default class PipelineSettingsMainModalSyncComponent extends Component {
       })
       .catch(err => {
         this.wasActionSuccessful = false;
-        this.errorMessage = getPipelineErrorMessage(err);
+        this.errorMessage = err.message;
       })
       .finally(() => {
         this.isAwaitingResponse = false;

--- a/app/components/pipeline/settings/main/modal/toggle-pipeline/component.js
+++ b/app/components/pipeline/settings/main/modal/toggle-pipeline/component.js
@@ -2,7 +2,6 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
-import { getPipelineErrorMessage } from 'screwdriver-ui/utils/pipeline';
 
 export default class PipelineSettingsMainModalTogglePipelineComponent extends Component {
   @service shuttle;
@@ -65,7 +64,7 @@ export default class PipelineSettingsMainModalTogglePipelineComponent extends Co
         this.args.closeModal(true);
       })
       .catch(err => {
-        this.errorMessage = getPipelineErrorMessage(err);
+        this.errorMessage = err.message;
         this.isSubmitting = false;
       });
   }

--- a/app/utils/pipeline.js
+++ b/app/utils/pipeline.js
@@ -102,16 +102,6 @@ const hasSonarBadge = pipeline => {
   return false;
 };
 
-const getPipelineErrorMessage = err => {
-  const statusCode = err?.payload?.statusCode || err?.status;
-
-  if (statusCode === 404) {
-    return 'The repository was not found. It might have been deleted.';
-  }
-
-  return err?.payload?.message ?? err?.message ?? 'Unknown error';
-};
-
 export {
   getStateIcon,
   isInactivePipeline,
@@ -121,6 +111,5 @@ export {
   isDisabledPipeline,
   hasDisabledPipelines,
   getDisabledPipelineMessage,
-  hasSonarBadge,
-  getPipelineErrorMessage
+  hasSonarBadge
 };

--- a/tests/integration/components/pipeline/modal/confirm-action/component-test.js
+++ b/tests/integration/components/pipeline/modal/confirm-action/component-test.js
@@ -364,11 +364,10 @@ module(
 
     test('it switches Yes to Close on 404 and closes modal', async function (assert) {
       const shuttle = this.owner.lookup('service:shuttle');
-      const errorMessage =
-        'The repository was not found. It might have been deleted.';
+      const errorMessage = 'Not found';
       const shuttleStub = sinon
         .stub(shuttle, 'fetchFromApi')
-        .rejects({ payload: { statusCode: 404, message: 'Not Found' } });
+        .rejects({ payload: { statusCode: 404, message: errorMessage } });
       const closeModalSpy = sinon.spy();
 
       this.setProperties({

--- a/tests/integration/components/pipeline/modal/delete-pipeline/component-test.js
+++ b/tests/integration/components/pipeline/modal/delete-pipeline/component-test.js
@@ -55,9 +55,7 @@ module(
     test('it sets error message when deleting pipeline fails', async function (assert) {
       const shuttle = this.owner.lookup('service:shuttle');
 
-      sinon
-        .stub(shuttle, 'fetchFromApi')
-        .rejects({ payload: { statusCode: 500, message: 'TEST ERROR' } });
+      sinon.stub(shuttle, 'fetchFromApi').rejects();
 
       this.setProperties({
         pipeline: { id: 123, name: 'test' },
@@ -74,34 +72,6 @@ module(
       await fillIn('#delete-repository-input', 'test');
       await click('#delete-pipeline-action');
       assert.dom('.alert').exists({ count: 1 });
-      assert.dom('.alert > span').hasText('TEST ERROR');
-    });
-
-    test('it sets error message when deleting pipeline fails with 404 error', async function (assert) {
-      const shuttle = this.owner.lookup('service:shuttle');
-
-      sinon
-        .stub(shuttle, 'fetchFromApi')
-        .rejects({ payload: { statusCode: 404, message: 'Not Found' } });
-
-      this.setProperties({
-        pipeline: { id: 123, name: 'test' },
-        closeModal: () => {}
-      });
-
-      await render(
-        hbs`<Pipeline::Modal::DeletePipeline
-            @pipeline={{this.pipeline}}
-            @closeModal={{this.closeModal}}
-        />`
-      );
-
-      await fillIn('#delete-repository-input', 'test');
-      await click('#delete-pipeline-action');
-      assert.dom('.alert').exists({ count: 1 });
-      assert
-        .dom('.alert > span')
-        .hasText('The repository was not found. It might have been deleted.');
     });
 
     test('it calls close callback with true when delete succeeds', async function (assert) {

--- a/tests/integration/components/pipeline/settings/main/modal/pipeline-alias/component-test.js
+++ b/tests/integration/components/pipeline/settings/main/modal/pipeline-alias/component-test.js
@@ -83,33 +83,6 @@ module(
       assert.dom('#submit-action').isEnabled();
     });
 
-    test('it handles 404 failed API call correctly', async function (assert) {
-      this.setProperties({
-        closeModal: () => {}
-      });
-
-      sinon.stub(shuttle, 'fetchFromApi').rejects({
-        payload: {
-          statusCode: 404,
-          message: 'Not Found'
-        }
-      });
-
-      await render(
-        hbs`<Pipeline::Settings::Main::Modal::PipelineAlias
-            @closeModal={{this.closeModal}}
-        />`
-      );
-      await fillIn('.configuration-container input', 'my-alias');
-      await click('#submit-action');
-
-      assert.dom('.modal-body .alert.alert-warning').exists();
-      assert
-        .dom('.modal-body .alert.alert-warning > span')
-        .hasText('The repository was not found. It might have been deleted.');
-      assert.dom('#submit-action').isEnabled();
-    });
-
     test('it handles successful API call correctly', async function (assert) {
       const pipelinePageStateSpy = sinon.spy(pipelinePageState, 'setPipeline');
       const closeModalSpy = sinon.spy();

--- a/tests/integration/components/pipeline/settings/main/modal/pipeline/component-test.js
+++ b/tests/integration/components/pipeline/settings/main/modal/pipeline/component-test.js
@@ -94,33 +94,6 @@ module(
       assert.dom('#submit-action').isEnabled();
     });
 
-    test('it handles 404 failed API call correctly', async function (assert) {
-      this.setProperties({
-        closeModal: () => {}
-      });
-
-      sinon.stub(shuttle, 'fetchFromApi').rejects({
-        payload: {
-          statusCode: 404,
-          message: 'Not Found'
-        }
-      });
-
-      await render(
-        hbs`<Pipeline::Settings::Main::Modal::Pipeline
-            @closeModal={{this.closeModal}}
-        />`
-      );
-      await fillIn('#source-directory-input', 'src');
-      await click('#submit-action');
-
-      assert.dom('.modal-body .alert.alert-warning').exists();
-      assert
-        .dom('.modal-body .alert.alert-warning > span')
-        .hasText('The repository was not found. It might have been deleted.');
-      assert.dom('#submit-action').isEnabled();
-    });
-
     test('it handles successful API call correctly', async function (assert) {
       const pipelinePageStateSpy = sinon.spy(pipelinePageState, 'setPipeline');
       const closeModalSpy = sinon.spy();

--- a/tests/integration/components/pipeline/settings/main/modal/sonar-badge/delete/component-test.js
+++ b/tests/integration/components/pipeline/settings/main/modal/sonar-badge/delete/component-test.js
@@ -72,32 +72,6 @@ module(
       assert.dom('#submit-action').isEnabled();
     });
 
-    test('it handles 404 failed API call correctly', async function (assert) {
-      this.setProperties({
-        closeModal: () => {}
-      });
-
-      sinon.stub(shuttle, 'fetchFromApi').rejects({
-        payload: {
-          statusCode: 404,
-          message: 'Not Found'
-        }
-      });
-
-      await render(
-        hbs`<Pipeline::Settings::Main::Modal::SonarBadge::Delete
-            @closeModal={{this.closeModal}}
-        />`
-      );
-      await click('#submit-action');
-
-      assert.dom('.modal-body .alert.alert-warning').exists();
-      assert
-        .dom('.modal-body .alert.alert-warning > span')
-        .hasText('The repository was not found. It might have been deleted.');
-      assert.dom('#submit-action').isEnabled();
-    });
-
     test('it handles successful API call correctly', async function (assert) {
       const setPipelineSpy = sinon.spy(pipelinePageState, 'setPipeline');
       const reloadHeaderSpy = sinon.spy(

--- a/tests/integration/components/pipeline/settings/main/modal/sonar-badge/edit/component-test.js
+++ b/tests/integration/components/pipeline/settings/main/modal/sonar-badge/edit/component-test.js
@@ -120,33 +120,6 @@ module(
       assert.dom('#submit-action').isEnabled();
     });
 
-    test('it handles 404 failed API call correctly', async function (assert) {
-      this.setProperties({
-        closeModal: () => {}
-      });
-
-      sinon.stub(shuttle, 'fetchFromApi').rejects({
-        payload: {
-          statusCode: 404,
-          message: 'Not Found'
-        }
-      });
-
-      await render(
-        hbs`<Pipeline::Settings::Main::Modal::SonarBadge::Edit
-            @closeModal={{this.closeModal}}
-        />`
-      );
-      await fillIn('#sonar-badge-name-input', 'updated');
-      await click('#submit-action');
-
-      assert.dom('.modal-body .alert.alert-warning').exists();
-      assert
-        .dom('.modal-body .alert.alert-warning > span')
-        .hasText('The repository was not found. It might have been deleted.');
-      assert.dom('#submit-action').isEnabled();
-    });
-
     test('it handles successful API call correctly', async function (assert) {
       const setPipelineSpy = sinon.spy(pipelinePageState, 'setPipeline');
       const reloadHeaderSpy = sinon.spy(

--- a/tests/integration/components/pipeline/settings/main/modal/sync/component-test.js
+++ b/tests/integration/components/pipeline/settings/main/modal/sync/component-test.js
@@ -61,35 +61,6 @@ module(
       assert.dom('#submit-sync-button').isNotDisabled();
     });
 
-    test('it handles 404 API error correctly', async function (assert) {
-      sinon.stub(shuttle, 'fetchFromApi').rejects({
-        payload: {
-          statusCode: 404,
-          message: 'Not Found'
-        }
-      });
-
-      this.setProperties({
-        syncType: 'webhooks',
-        closeModal: () => {}
-      });
-
-      await render(
-        hbs`<Pipeline::Settings::Main::Modal::Sync
-            @syncType={{this.syncType}}
-            @closeModal={{this.closeModal}}
-        />`
-      );
-
-      await click('#submit-sync-button');
-
-      assert.dom('#error-message').exists();
-      assert
-        .dom('#error-message')
-        .hasText('The repository was not found. It might have been deleted.');
-      assert.dom('#submit-sync-button').isNotDisabled();
-    });
-
     test('it handles API success correctly', async function (assert) {
       const closeModalSpy = sinon.spy();
 

--- a/tests/integration/components/pipeline/settings/main/modal/toggle-pipeline/component-test.js
+++ b/tests/integration/components/pipeline/settings/main/modal/toggle-pipeline/component-test.js
@@ -109,37 +109,6 @@ module(
       assert.dom('.alert').exists({ count: 1 });
     });
 
-    test('it handles 404 failed API call', async function (assert) {
-      const pipelineMock = {
-        id: 123,
-        name: 'myOrg/myRepo',
-        state: 'ACTIVE'
-      };
-
-      sinon.stub(pipelinePageState, 'getPipeline').returns(pipelineMock);
-      sinon.stub(shuttle, 'fetchFromApi').rejects({
-        payload: {
-          statusCode: 404,
-          message: 'Not Found'
-        }
-      });
-
-      this.setProperties({ closeModal: () => {} });
-
-      await render(
-        hbs`<Pipeline::Settings::Main::Modal::TogglePipeline
-            @closeModal={{this.closeModal}}
-        />`
-      );
-
-      await click('#toggle-pipeline-action');
-
-      assert.dom('.alert').exists({ count: 1 });
-      assert
-        .dom('.alert')
-        .hasText('The repository was not found. It might have been deleted.');
-    });
-
     test('it handles successful disable', async function (assert) {
       const pipelineMock = {
         id: 123,

--- a/tests/unit/utils/pipeline-test.js
+++ b/tests/unit/utils/pipeline-test.js
@@ -8,8 +8,7 @@ const {
   hasActivePipelines,
   isDisabledPipeline,
   hasDisabledPipelines,
-  hasSonarBadge,
-  getPipelineErrorMessage
+  hasSonarBadge
 } = pipeline;
 
 module('Unit | Utility | pipeline', function () {
@@ -129,52 +128,6 @@ module('Unit | Utility | pipeline', function () {
     assert.equal(
       hasSonarBadge({ badges: { sonar: { name: 'test', uri: 'test.com' } } }),
       true
-    );
-  });
-
-  test('it gets the right error message for pipeline', assert => {
-    const testErrorMessage = 'Test Error Message';
-    const notFoundErrMessage =
-      'The repository was not found. It might have been deleted.';
-
-    assert.equal(getPipelineErrorMessage(), 'Unknown error');
-    assert.equal(
-      getPipelineErrorMessage({ message: testErrorMessage }),
-      testErrorMessage
-    );
-    assert.equal(getPipelineErrorMessage({ status: 404 }), notFoundErrMessage);
-    assert.equal(
-      getPipelineErrorMessage({ status: 404, message: testErrorMessage }),
-      notFoundErrMessage
-    );
-    assert.equal(getPipelineErrorMessage({ status: 500 }), 'Unknown error');
-    assert.equal(
-      getPipelineErrorMessage({ status: 500, message: testErrorMessage }),
-      testErrorMessage
-    );
-    assert.equal(
-      getPipelineErrorMessage({ payload: { message: testErrorMessage } }),
-      testErrorMessage
-    );
-    assert.equal(
-      getPipelineErrorMessage({ payload: { statusCode: 404 } }),
-      notFoundErrMessage
-    );
-    assert.equal(
-      getPipelineErrorMessage({
-        payload: { statusCode: 404, message: testErrorMessage }
-      }),
-      notFoundErrMessage
-    );
-    assert.equal(
-      getPipelineErrorMessage({ payload: { statusCode: 500 } }),
-      'Unknown error'
-    );
-    assert.equal(
-      getPipelineErrorMessage({
-        payload: { statusCode: 500, message: testErrorMessage }
-      }),
-      testErrorMessage
     );
   });
 });


### PR DESCRIPTION
Reverts screwdriver-cd/ui#1593

API can return `404 No jobs to start` when user start the events on the pipeline which only has detached jobs.
But the warning message shows `The repository was not found. It might have been deleted.`.

We should consider if the 404 response code is properly for the `No jobs to start` case.
In the webhook endpoint, it returns 204.
https://github.com/search?q=org%3Ascrewdriver-cd+%22No+jobs+to+start%22&type=code

Issue - https://github.com/screwdriver-cd/screwdriver/issues/3527