### PR TITLE
feat(3527): refix error messages when the pipeline has been deleted and no jobs to start message [2]

### DIFF
--- a/app/components/pipeline/modal/confirm-action/component.js
+++ b/app/components/pipeline/modal/confirm-action/component.js
@@ -6,6 +6,7 @@ import {
   extractDefaultJobParameters,
   extractDefaultParameters
 } from 'screwdriver-ui/utils/pipeline/parameters';
+import { getPipelineErrorMessage } from 'screwdriver-ui/utils/pipeline';
 import {
   buildPostBody,
   capitalizeFirstLetter,
@@ -224,8 +225,7 @@ export default class PipelineModalConfirmActionComponent extends Component {
       })
       .catch(err => {
         this.wasActionSuccessful = false;
-        this.errorMessage =
-          err?.payload?.message || err?.message || 'Unknown error';
+        this.errorMessage = getPipelineErrorMessage(err);
 
         const statusCode = err?.payload?.statusCode || err?.status;
 

--- a/app/components/pipeline/modal/confirm-action/component.js
+++ b/app/components/pipeline/modal/confirm-action/component.js
@@ -33,7 +33,11 @@ export default class PipelineModalConfirmActionComponent extends Component {
 
   @tracked isNotFoundError = false;
 
+  @tracked isNoJobsToStart = false;
+
   @tracked reason = '';
+
+  eventToTransitionTo = null;
 
   pipeline;
 
@@ -149,6 +153,10 @@ export default class PipelineModalConfirmActionComponent extends Component {
       return false;
     }
 
+    if (this.isNoJobsToStart) {
+      return false;
+    }
+
     if (this.wasActionSuccessful || this.isAwaitingResponse) {
       return true;
     }
@@ -158,6 +166,10 @@ export default class PipelineModalConfirmActionComponent extends Component {
     }
 
     return false;
+  }
+
+  get isCloseAction() {
+    return this.isNotFoundError || this.isNoJobsToStart;
   }
 
   get pendingAction() {
@@ -170,9 +182,29 @@ export default class PipelineModalConfirmActionComponent extends Component {
   }
 
   @action
+  onConfirm() {
+    if (this.isNoJobsToStart) {
+      this.args.closeModal();
+      this.transitionToEvent(this.eventToTransitionTo);
+
+      return;
+    }
+
+    if (this.isCloseAction) {
+      this.args.closeModal();
+
+      return;
+    }
+
+    this.startBuild();
+  }
+
+  @action
   async startBuild() {
     this.isAwaitingResponse = true;
     this.isNotFoundError = false;
+    this.isNoJobsToStart = false;
+    this.eventToTransitionTo = null;
 
     const event =
       this.args.action === 'start' &&
@@ -206,21 +238,25 @@ export default class PipelineModalConfirmActionComponent extends Component {
     };
 
     await this.shuttle
-      .fetchFromApi('post', '/events', data)
-      .then(newEvent => {
+      .fetchFromApi('post', '/events', data, true)
+      .then(raw => {
+        const newEvent = raw.response;
+        const statusMessage = raw.jqXHR.getResponseHeader('X-Status-Message');
+
+        if (statusMessage !== null) {
+          this.wasActionSuccessful = false;
+          this.errorMessage = statusMessage;
+          this.isNoJobsToStart = true;
+          this.eventToTransitionTo = newEvent;
+
+          return;
+        }
         this.args.closeModal();
 
         if (this.pipelinePageState.route !== 'v2.pipeline.jobs') {
-          const route = this.pipelinePageState.getIsPr()
-            ? 'v2.pipeline.pulls.show'
-            : 'v2.pipeline.events.show';
-
           // When restarting a build from the "v2.pipeline.jobs" tab, it does not automatically transition to the 'v2.pipeline.events' tab.
-          this.router.transitionTo(route, {
-            event: newEvent,
-            reloadEventRail: true,
-            id: newEvent.id
-          });
+
+          this.transitionToEvent(newEvent);
         }
       })
       .catch(err => {
@@ -236,5 +272,21 @@ export default class PipelineModalConfirmActionComponent extends Component {
       .finally(() => {
         this.isAwaitingResponse = false;
       });
+  }
+
+  transitionToEvent(event) {
+    if (!event) {
+      return;
+    }
+
+    const route = this.pipelinePageState.getIsPr()
+      ? 'v2.pipeline.pulls.show'
+      : 'v2.pipeline.events.show';
+
+    this.router.transitionTo(route, {
+      event,
+      reloadEventRail: true,
+      id: event.id
+    });
   }
 }

--- a/app/components/pipeline/modal/confirm-action/template.hbs
+++ b/app/components/pipeline/modal/confirm-action/template.hbs
@@ -104,11 +104,11 @@
   <modal.footer>
     <BsButton
       id="submit-action"
-      disabled={{if this.isNotFoundError false this.isSubmitButtonDisabled}}
+      disabled={{this.isSubmitButtonDisabled}}
       @type="primary"
-      @defaultText={{if this.isNotFoundError "Close" "Yes"}}
-      @pendingText={{unless this.isNotFoundError this.pendingAction}}
-      @onClick={{if this.isNotFoundError (fn @closeModal) (fn this.startBuild)}}
+      @defaultText={{if this.isCloseAction "Close" "Yes"}}
+      @pendingText={{unless this.isCloseAction this.pendingAction}}
+      @onClick={{this.onConfirm}}
     />
   </modal.footer>
 </BsModal>

--- a/app/components/pipeline/modal/delete-pipeline/component.js
+++ b/app/components/pipeline/modal/delete-pipeline/component.js
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
+import { getPipelineErrorMessage } from 'screwdriver-ui/utils/pipeline';
 
 export default class PipelineModalDeletePipelineComponent extends Component {
   @service router;
@@ -38,7 +39,7 @@ export default class PipelineModalDeletePipelineComponent extends Component {
       })
       .catch(err => {
         this.wasActionSuccessful = false;
-        this.errorMessage = err.message;
+        this.errorMessage = getPipelineErrorMessage(err);
       })
       .finally(() => {
         this.isAwaitingResponse = false;

--- a/app/components/pipeline/settings/main/modal/pipeline-alias/component.js
+++ b/app/components/pipeline/settings/main/modal/pipeline-alias/component.js
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
+import { getPipelineErrorMessage } from 'screwdriver-ui/utils/pipeline';
 
 export default class PipelineSettingsMainModalPipelineAliasComponent extends Component {
   @service('shuttle') shuttle;
@@ -46,7 +47,7 @@ export default class PipelineSettingsMainModalPipelineAliasComponent extends Com
         this.args.closeModal(true);
       })
       .catch(err => {
-        this.errorMessage = err.message;
+        this.errorMessage = getPipelineErrorMessage(err);
         this.isAwaitingResponse = false;
       });
   }

--- a/app/components/pipeline/settings/main/modal/pipeline/component.js
+++ b/app/components/pipeline/settings/main/modal/pipeline/component.js
@@ -4,6 +4,7 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 
 import { getCheckoutUrl } from 'screwdriver-ui/utils/git';
+import { getPipelineErrorMessage } from 'screwdriver-ui/utils/pipeline';
 
 export default class PipelineSettingsMainModalPipelineComponent extends Component {
   @service('shuttle') shuttle;
@@ -60,7 +61,7 @@ export default class PipelineSettingsMainModalPipelineComponent extends Componen
         this.args.closeModal(true);
       })
       .catch(err => {
-        this.errorMessage = err.message;
+        this.errorMessage = getPipelineErrorMessage(err);
         this.isAwaitingResponse = false;
       });
   }

--- a/app/components/pipeline/settings/main/modal/sonar-badge/delete/component.js
+++ b/app/components/pipeline/settings/main/modal/sonar-badge/delete/component.js
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
+import { getPipelineErrorMessage } from 'screwdriver-ui/utils/pipeline';
 
 export default class PipelineSettingsMainModalSonarBadgeDeleteComponent extends Component {
   @service('shuttle') shuttle;
@@ -34,7 +35,7 @@ export default class PipelineSettingsMainModalSonarBadgeDeleteComponent extends 
         this.args.closeModal(true);
       })
       .catch(err => {
-        this.errorMessage = err.message;
+        this.errorMessage = getPipelineErrorMessage(err);
         this.isAwaitingResponse = false;
       });
   }

--- a/app/components/pipeline/settings/main/modal/sonar-badge/edit/component.js
+++ b/app/components/pipeline/settings/main/modal/sonar-badge/edit/component.js
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
+import { getPipelineErrorMessage } from 'screwdriver-ui/utils/pipeline';
 
 export default class PipelineSettingsMainModalSonarBadgeEditComponent extends Component {
   @service('shuttle') shuttle;
@@ -73,7 +74,7 @@ export default class PipelineSettingsMainModalSonarBadgeEditComponent extends Co
         this.args.closeModal(true);
       })
       .catch(err => {
-        this.errorMessage = err.message;
+        this.errorMessage = getPipelineErrorMessage(err);
         this.isAwaitingResponse = false;
       });
   }

--- a/app/components/pipeline/settings/main/modal/sync/component.js
+++ b/app/components/pipeline/settings/main/modal/sync/component.js
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
+import { getPipelineErrorMessage } from 'screwdriver-ui/utils/pipeline';
 
 export default class PipelineSettingsMainModalSyncComponent extends Component {
   @service('shuttle') shuttle;
@@ -80,7 +81,7 @@ export default class PipelineSettingsMainModalSyncComponent extends Component {
       })
       .catch(err => {
         this.wasActionSuccessful = false;
-        this.errorMessage = err.message;
+        this.errorMessage = getPipelineErrorMessage(err);
       })
       .finally(() => {
         this.isAwaitingResponse = false;

--- a/app/components/pipeline/settings/main/modal/toggle-pipeline/component.js
+++ b/app/components/pipeline/settings/main/modal/toggle-pipeline/component.js
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
+import { getPipelineErrorMessage } from 'screwdriver-ui/utils/pipeline';
 
 export default class PipelineSettingsMainModalTogglePipelineComponent extends Component {
   @service shuttle;
@@ -64,7 +65,7 @@ export default class PipelineSettingsMainModalTogglePipelineComponent extends Co
         this.args.closeModal(true);
       })
       .catch(err => {
-        this.errorMessage = err.message;
+        this.errorMessage = getPipelineErrorMessage(err);
         this.isSubmitting = false;
       });
   }

--- a/app/utils/pipeline.js
+++ b/app/utils/pipeline.js
@@ -102,6 +102,16 @@ const hasSonarBadge = pipeline => {
   return false;
 };
 
+const getPipelineErrorMessage = err => {
+  const statusCode = err?.payload?.statusCode || err?.status;
+
+  if (statusCode === 404) {
+    return 'The repository was not found. It might have been deleted.';
+  }
+
+  return err?.payload?.message ?? err?.message ?? 'Unknown error';
+};
+
 export {
   getStateIcon,
   isInactivePipeline,
@@ -111,5 +121,6 @@ export {
   isDisabledPipeline,
   hasDisabledPipelines,
   getDisabledPipelineMessage,
-  hasSonarBadge
+  hasSonarBadge,
+  getPipelineErrorMessage
 };

--- a/tests/integration/components/pipeline/modal/confirm-action/component-test.js
+++ b/tests/integration/components/pipeline/modal/confirm-action/component-test.js
@@ -364,10 +364,11 @@ module(
 
     test('it switches Yes to Close on 404 and closes modal', async function (assert) {
       const shuttle = this.owner.lookup('service:shuttle');
-      const errorMessage = 'Not found';
+      const errorMessage =
+        'The repository was not found. It might have been deleted.';
       const shuttleStub = sinon
         .stub(shuttle, 'fetchFromApi')
-        .rejects({ payload: { statusCode: 404, message: errorMessage } });
+        .rejects({ payload: { statusCode: 404, message: 'Not Found' } });
       const closeModalSpy = sinon.spy();
 
       this.setProperties({

--- a/tests/integration/components/pipeline/modal/confirm-action/component-test.js
+++ b/tests/integration/components/pipeline/modal/confirm-action/component-test.js
@@ -397,5 +397,68 @@ module(
       assert.equal(closeModalSpy.calledOnce, true);
       assert.equal(shuttleStub.calledOnce, true, 'no additional API call');
     });
+
+    test('it switches Close to transition to the created event when no jobs are started', async function (assert) {
+      const shuttle = this.owner.lookup('service:shuttle');
+      const router = this.owner.lookup('service:router');
+      const newEvent = { id: 456 };
+      const statusMessage = 'No jobs to start';
+      const shuttleStub = sinon.stub(shuttle, 'fetchFromApi').resolves({
+        response: newEvent,
+        jqXHR: {
+          getResponseHeader: sinon
+            .stub()
+            .withArgs('X-Status-Message')
+            .returns(statusMessage),
+          getAllResponseHeaders: sinon.stub().returns('')
+        }
+      });
+      const transitionToStub = sinon.stub(router, 'transitionTo');
+      const closeModalSpy = sinon.spy();
+
+      this.setProperties({
+        action: 'start',
+        closeModal: closeModalSpy
+      });
+
+      await render(
+        hbs`<Pipeline::Modal::ConfirmAction
+            @action={{this.action}}
+            @closeModal={{this.closeModal}}
+        />`
+      );
+
+      assert.dom('#submit-action').hasText('Yes');
+
+      await click('#submit-action');
+
+      assert.equal(shuttleStub.calledOnce, true);
+      assert.dom('#confirm-action-error').exists({ count: 1 });
+      assert.dom('#confirm-action-error .alert > span').hasText(statusMessage);
+      assert.dom('#submit-action').hasText('Close');
+
+      await click('#submit-action');
+
+      assert.equal(shuttleStub.calledOnce, true, 'no additional API call');
+      assert.equal(
+        closeModalSpy.calledOnce,
+        true,
+        'modal is closed before transition'
+      );
+      assert.equal(
+        transitionToStub.calledOnce,
+        true,
+        'transitions to the created event'
+      );
+      assert.equal(
+        transitionToStub.firstCall.args[0],
+        'v2.pipeline.events.show'
+      );
+      assert.deepEqual(transitionToStub.firstCall.args[1], {
+        event: newEvent,
+        reloadEventRail: true,
+        id: newEvent.id
+      });
+    });
   }
 );

--- a/tests/integration/components/pipeline/modal/confirm-action/component-test.js
+++ b/tests/integration/components/pipeline/modal/confirm-action/component-test.js
@@ -310,7 +310,18 @@ module(
 
     test('it closes modal on success', async function (assert) {
       const shuttle = this.owner.lookup('service:shuttle');
-      const shuttleStub = sinon.stub(shuttle, 'fetchFromApi').resolves();
+      const router = this.owner.lookup('service:router');
+      const shuttleStub = sinon.stub(shuttle, 'fetchFromApi').resolves({
+        response: { id: 456 },
+        jqXHR: {
+          getResponseHeader: sinon
+            .stub()
+            .withArgs('X-Status-Message')
+            .returns(null),
+          getAllResponseHeaders: sinon.stub().returns('')
+        }
+      });
+      const transitionToStub = sinon.stub(router, 'transitionTo');
       const closeModalSpy = sinon.spy();
 
       this.setProperties({
@@ -331,6 +342,7 @@ module(
 
       assert.equal(shuttleStub.calledOnce, true);
       assert.equal(closeModalSpy.calledOnce, true);
+      assert.equal(transitionToStub.calledOnce, true);
     });
 
     test('it displays error message when API call fails', async function (assert) {

--- a/tests/integration/components/pipeline/modal/delete-pipeline/component-test.js
+++ b/tests/integration/components/pipeline/modal/delete-pipeline/component-test.js
@@ -55,7 +55,9 @@ module(
     test('it sets error message when deleting pipeline fails', async function (assert) {
       const shuttle = this.owner.lookup('service:shuttle');
 
-      sinon.stub(shuttle, 'fetchFromApi').rejects();
+      sinon
+        .stub(shuttle, 'fetchFromApi')
+        .rejects({ payload: { statusCode: 500, message: 'TEST ERROR' } });
 
       this.setProperties({
         pipeline: { id: 123, name: 'test' },
@@ -72,6 +74,34 @@ module(
       await fillIn('#delete-repository-input', 'test');
       await click('#delete-pipeline-action');
       assert.dom('.alert').exists({ count: 1 });
+      assert.dom('.alert > span').hasText('TEST ERROR');
+    });
+
+    test('it sets error message when deleting pipeline fails with 404 error', async function (assert) {
+      const shuttle = this.owner.lookup('service:shuttle');
+
+      sinon
+        .stub(shuttle, 'fetchFromApi')
+        .rejects({ payload: { statusCode: 404, message: 'Not Found' } });
+
+      this.setProperties({
+        pipeline: { id: 123, name: 'test' },
+        closeModal: () => {}
+      });
+
+      await render(
+        hbs`<Pipeline::Modal::DeletePipeline
+            @pipeline={{this.pipeline}}
+            @closeModal={{this.closeModal}}
+        />`
+      );
+
+      await fillIn('#delete-repository-input', 'test');
+      await click('#delete-pipeline-action');
+      assert.dom('.alert').exists({ count: 1 });
+      assert
+        .dom('.alert > span')
+        .hasText('The repository was not found. It might have been deleted.');
     });
 
     test('it calls close callback with true when delete succeeds', async function (assert) {

--- a/tests/integration/components/pipeline/settings/main/modal/pipeline-alias/component-test.js
+++ b/tests/integration/components/pipeline/settings/main/modal/pipeline-alias/component-test.js
@@ -83,6 +83,33 @@ module(
       assert.dom('#submit-action').isEnabled();
     });
 
+    test('it handles 404 failed API call correctly', async function (assert) {
+      this.setProperties({
+        closeModal: () => {}
+      });
+
+      sinon.stub(shuttle, 'fetchFromApi').rejects({
+        payload: {
+          statusCode: 404,
+          message: 'Not Found'
+        }
+      });
+
+      await render(
+        hbs`<Pipeline::Settings::Main::Modal::PipelineAlias
+            @closeModal={{this.closeModal}}
+        />`
+      );
+      await fillIn('.configuration-container input', 'my-alias');
+      await click('#submit-action');
+
+      assert.dom('.modal-body .alert.alert-warning').exists();
+      assert
+        .dom('.modal-body .alert.alert-warning > span')
+        .hasText('The repository was not found. It might have been deleted.');
+      assert.dom('#submit-action').isEnabled();
+    });
+
     test('it handles successful API call correctly', async function (assert) {
       const pipelinePageStateSpy = sinon.spy(pipelinePageState, 'setPipeline');
       const closeModalSpy = sinon.spy();

--- a/tests/integration/components/pipeline/settings/main/modal/pipeline/component-test.js
+++ b/tests/integration/components/pipeline/settings/main/modal/pipeline/component-test.js
@@ -94,6 +94,33 @@ module(
       assert.dom('#submit-action').isEnabled();
     });
 
+    test('it handles 404 failed API call correctly', async function (assert) {
+      this.setProperties({
+        closeModal: () => {}
+      });
+
+      sinon.stub(shuttle, 'fetchFromApi').rejects({
+        payload: {
+          statusCode: 404,
+          message: 'Not Found'
+        }
+      });
+
+      await render(
+        hbs`<Pipeline::Settings::Main::Modal::Pipeline
+            @closeModal={{this.closeModal}}
+        />`
+      );
+      await fillIn('#source-directory-input', 'src');
+      await click('#submit-action');
+
+      assert.dom('.modal-body .alert.alert-warning').exists();
+      assert
+        .dom('.modal-body .alert.alert-warning > span')
+        .hasText('The repository was not found. It might have been deleted.');
+      assert.dom('#submit-action').isEnabled();
+    });
+
     test('it handles successful API call correctly', async function (assert) {
       const pipelinePageStateSpy = sinon.spy(pipelinePageState, 'setPipeline');
       const closeModalSpy = sinon.spy();

--- a/tests/integration/components/pipeline/settings/main/modal/sonar-badge/delete/component-test.js
+++ b/tests/integration/components/pipeline/settings/main/modal/sonar-badge/delete/component-test.js
@@ -72,6 +72,32 @@ module(
       assert.dom('#submit-action').isEnabled();
     });
 
+    test('it handles 404 failed API call correctly', async function (assert) {
+      this.setProperties({
+        closeModal: () => {}
+      });
+
+      sinon.stub(shuttle, 'fetchFromApi').rejects({
+        payload: {
+          statusCode: 404,
+          message: 'Not Found'
+        }
+      });
+
+      await render(
+        hbs`<Pipeline::Settings::Main::Modal::SonarBadge::Delete
+            @closeModal={{this.closeModal}}
+        />`
+      );
+      await click('#submit-action');
+
+      assert.dom('.modal-body .alert.alert-warning').exists();
+      assert
+        .dom('.modal-body .alert.alert-warning > span')
+        .hasText('The repository was not found. It might have been deleted.');
+      assert.dom('#submit-action').isEnabled();
+    });
+
     test('it handles successful API call correctly', async function (assert) {
       const setPipelineSpy = sinon.spy(pipelinePageState, 'setPipeline');
       const reloadHeaderSpy = sinon.spy(

--- a/tests/integration/components/pipeline/settings/main/modal/sonar-badge/edit/component-test.js
+++ b/tests/integration/components/pipeline/settings/main/modal/sonar-badge/edit/component-test.js
@@ -120,6 +120,33 @@ module(
       assert.dom('#submit-action').isEnabled();
     });
 
+    test('it handles 404 failed API call correctly', async function (assert) {
+      this.setProperties({
+        closeModal: () => {}
+      });
+
+      sinon.stub(shuttle, 'fetchFromApi').rejects({
+        payload: {
+          statusCode: 404,
+          message: 'Not Found'
+        }
+      });
+
+      await render(
+        hbs`<Pipeline::Settings::Main::Modal::SonarBadge::Edit
+            @closeModal={{this.closeModal}}
+        />`
+      );
+      await fillIn('#sonar-badge-name-input', 'updated');
+      await click('#submit-action');
+
+      assert.dom('.modal-body .alert.alert-warning').exists();
+      assert
+        .dom('.modal-body .alert.alert-warning > span')
+        .hasText('The repository was not found. It might have been deleted.');
+      assert.dom('#submit-action').isEnabled();
+    });
+
     test('it handles successful API call correctly', async function (assert) {
       const setPipelineSpy = sinon.spy(pipelinePageState, 'setPipeline');
       const reloadHeaderSpy = sinon.spy(

--- a/tests/integration/components/pipeline/settings/main/modal/sync/component-test.js
+++ b/tests/integration/components/pipeline/settings/main/modal/sync/component-test.js
@@ -61,6 +61,35 @@ module(
       assert.dom('#submit-sync-button').isNotDisabled();
     });
 
+    test('it handles 404 API error correctly', async function (assert) {
+      sinon.stub(shuttle, 'fetchFromApi').rejects({
+        payload: {
+          statusCode: 404,
+          message: 'Not Found'
+        }
+      });
+
+      this.setProperties({
+        syncType: 'webhooks',
+        closeModal: () => {}
+      });
+
+      await render(
+        hbs`<Pipeline::Settings::Main::Modal::Sync
+            @syncType={{this.syncType}}
+            @closeModal={{this.closeModal}}
+        />`
+      );
+
+      await click('#submit-sync-button');
+
+      assert.dom('#error-message').exists();
+      assert
+        .dom('#error-message')
+        .hasText('The repository was not found. It might have been deleted.');
+      assert.dom('#submit-sync-button').isNotDisabled();
+    });
+
     test('it handles API success correctly', async function (assert) {
       const closeModalSpy = sinon.spy();
 

--- a/tests/integration/components/pipeline/settings/main/modal/toggle-pipeline/component-test.js
+++ b/tests/integration/components/pipeline/settings/main/modal/toggle-pipeline/component-test.js
@@ -109,6 +109,37 @@ module(
       assert.dom('.alert').exists({ count: 1 });
     });
 
+    test('it handles 404 failed API call', async function (assert) {
+      const pipelineMock = {
+        id: 123,
+        name: 'myOrg/myRepo',
+        state: 'ACTIVE'
+      };
+
+      sinon.stub(pipelinePageState, 'getPipeline').returns(pipelineMock);
+      sinon.stub(shuttle, 'fetchFromApi').rejects({
+        payload: {
+          statusCode: 404,
+          message: 'Not Found'
+        }
+      });
+
+      this.setProperties({ closeModal: () => {} });
+
+      await render(
+        hbs`<Pipeline::Settings::Main::Modal::TogglePipeline
+            @closeModal={{this.closeModal}}
+        />`
+      );
+
+      await click('#toggle-pipeline-action');
+
+      assert.dom('.alert').exists({ count: 1 });
+      assert
+        .dom('.alert')
+        .hasText('The repository was not found. It might have been deleted.');
+    });
+
     test('it handles successful disable', async function (assert) {
       const pipelineMock = {
         id: 123,

--- a/tests/unit/utils/pipeline-test.js
+++ b/tests/unit/utils/pipeline-test.js
@@ -8,7 +8,8 @@ const {
   hasActivePipelines,
   isDisabledPipeline,
   hasDisabledPipelines,
-  hasSonarBadge
+  hasSonarBadge,
+  getPipelineErrorMessage
 } = pipeline;
 
 module('Unit | Utility | pipeline', function () {
@@ -128,6 +129,52 @@ module('Unit | Utility | pipeline', function () {
     assert.equal(
       hasSonarBadge({ badges: { sonar: { name: 'test', uri: 'test.com' } } }),
       true
+    );
+  });
+
+  test('it gets the right error message for pipeline', assert => {
+    const testErrorMessage = 'Test Error Message';
+    const notFoundErrMessage =
+      'The repository was not found. It might have been deleted.';
+
+    assert.equal(getPipelineErrorMessage(), 'Unknown error');
+    assert.equal(
+      getPipelineErrorMessage({ message: testErrorMessage }),
+      testErrorMessage
+    );
+    assert.equal(getPipelineErrorMessage({ status: 404 }), notFoundErrMessage);
+    assert.equal(
+      getPipelineErrorMessage({ status: 404, message: testErrorMessage }),
+      notFoundErrMessage
+    );
+    assert.equal(getPipelineErrorMessage({ status: 500 }), 'Unknown error');
+    assert.equal(
+      getPipelineErrorMessage({ status: 500, message: testErrorMessage }),
+      testErrorMessage
+    );
+    assert.equal(
+      getPipelineErrorMessage({ payload: { message: testErrorMessage } }),
+      testErrorMessage
+    );
+    assert.equal(
+      getPipelineErrorMessage({ payload: { statusCode: 404 } }),
+      notFoundErrMessage
+    );
+    assert.equal(
+      getPipelineErrorMessage({
+        payload: { statusCode: 404, message: testErrorMessage }
+      }),
+      notFoundErrMessage
+    );
+    assert.equal(
+      getPipelineErrorMessage({ payload: { statusCode: 500 } }),
+      'Unknown error'
+    );
+    assert.equal(
+      getPipelineErrorMessage({
+        payload: { statusCode: 500, message: testErrorMessage }
+      }),
+      testErrorMessage
     );
   });
 });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Fix: #1593, #1595

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

This PR brings back the fix for deleted repository error messages from #1593 (reverted in #1595).
It also changes the "no jobs to start" behavior, which caused the revert in #1595, as follows:

- API
  - Returns the created event with a 201 status as usual, because the event is actually created.
  - Sends the "no jobs to start" message in a custom header.
- UI
  - Shows the message in a modal if the custom header exists.
  - Moves to the created event page when you click "Close" on the confirmation button.
<img width="877" height="429" alt="スクリーンショット 2026-09-11 16 47 21" src="https://github.com/user-attachments/assets/3a082a74-cdb9-446f-81bb-f0a5a384ba66" />

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

https://github.com/screwdriver-cd/screwdriver/issues/3527

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
